### PR TITLE
fix(adjudication): complete materialization + publish-final gates (#1078)

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,8 @@ The pipeline has three stages:
 
 `calibrate-reward` validates a pinned calibration bundle and emits a deterministic, versioned reward-calibration artifact (input wire format: [docs/calibration.md](docs/calibration.md)).
 
+`corpus adjudicate publish-final` constructs and publishes the immutable, per-finding annotation bundle (annotations, sessions, observation history, report, generated lineage) to the private Hub — use `--dry-run` to validate the staging bundle without uploading. The full operator sequence, from hydration through corpus-v2 projection on a fresh VM, is in [docs/runbooks/annotation-final-publish.md](docs/runbooks/annotation-final-publish.md).
+
 The harvest stage clones the target repository into a local cache before scoring. Setting `DAYDREAM_GIT_TOKEN` (for example, a GitHub PAT with read access) authenticates clones of private repos. The token is injected out-of-band via git config environment variables (`http.extraHeader`). It is never embedded in the remote URL and never on the command line. Without the token, the harvest stage performs a plain clone via the ambient credential helper. A failed clone emits a warning and never blocks the harvest run. The token is only needed for private repos. See docs/runbooks/credential-remediation.md for operational guidance.
 
 The build stage applies a temporal-leakage guard. It prevents future data from leaking into the past. It applies C5, C8, and C9 filters. It stratifies the corpus by stack.

--- a/daydream/cli.py
+++ b/daydream/cli.py
@@ -25,7 +25,7 @@ top-level ``TARGET`` positional):
     - ``corpus hydrate-hub`` — turn a pinned private-Hub trajectory snapshot into a
       verified, sanitized, harvestable local staging archive and publish it additively
       back to the Hub under ``curated/<curation-id>/``
-    - ``corpus adjudicate <build|show|label|export|report>`` — per-finding
+    - ``corpus adjudicate <build|show|label|export|report|...|publish-final>`` — per-finding
       human-label workflow: build the deterministic adjudication queue, show
       unresolved items grouped by disposition, record provenance-complete
       human observations, export the projector-shape rows (with ``--dry-run``
@@ -2061,7 +2061,9 @@ _CORPUS_USAGE = (
     "  label     record an authoritative human outcome label that overrides automated ones\n"
     "  hydrate-hub  hydrate a pinned Hub snapshot into a sanitized, verified staging archive\n"
     "  calibrate-reward  validate a calibration bundle and emit a deterministic reward-calibration artifact\n"
-    "  adjudicate  per-finding human-label workflow: build/show/label/export/report the adjudication queue"
+    "  adjudicate  per-finding human-label workflow: build/show/label/export/report, then"
+    "\n"
+    "  materialize/harvest/publish the annotation snapshot"
 )
 
 _EXT_USAGE = (

--- a/daydream/training/adjudication/canonical.py
+++ b/daydream/training/adjudication/canonical.py
@@ -1,7 +1,10 @@
 """Canonical harvest of per-finding annotations into the archive (issue #1055).
 
-Re-verifies the materialized preview snapshot against a freshly built queue
-over the hydrated index, merges human observations under three-tier
+Re-verifies the materialized preview snapshot (every disposition — automatic
+decisive, human-decisive, and non-decisive) against a freshly built
+*complete* queue — ``build_queue(..., include_decisive=True)`` — over the
+hydrated index, so the automatic decisive records drift-check too. It merges
+human observations under three-tier
 precedence, appends exactly one ``label_observations`` row per session via
 ``archive.index.append_label_observation`` (the auto dedup key keys on the
 pin's ``snapshot_id`` plus the archived ``rubric_json`` — fed through
@@ -134,7 +137,8 @@ def run_canonical_harvest(
 ) -> dict[str, Any]:
     """Harvest the materialized preview snapshot into canonical annotation storage.
 
-    1. Re-derives the fresh queue over the hydrated index and verifies every
+    1. Re-derives the fresh complete queue over the hydrated index
+       (``build_queue(..., include_decisive=True)``) and verifies every
        materialized record's ``evidence_digest`` against the fresh queue
        **before any write**; drift raises :class:`AnnotationDriftError`
        listing the drifted ``record_id``s.
@@ -172,7 +176,16 @@ def run_canonical_harvest(
         # was built from instead of feeding the materialize dir back and
         # comparing each digest against itself (tautological).
         sessions, _index_revision = _sessions_from_hydrated_stage(index_root)
-    fresh_by_record_id = {str(item["record_id"]): item for item in build_queue(sessions)}
+    # The complete set is the drift authority: widened materialization emits a
+    # record for every disposition, so the fresh queue must include the
+    # automatic decisive records too — an unresolved-only queue would
+    # fail-closed on every decisive finding. Unchanged automatic decisive
+    # records are preserved verbatim by the merge loop below: no observation
+    # group ⇒ disposition untouched; ``human_labeler``/``human_role`` are only
+    # set by the three-tier precedence branch.
+    fresh_by_record_id = {
+        str(item["record_id"]): item for item in build_queue(sessions, include_decisive=True)
+    }
 
     # Fail-closed drift gate: verify BEFORE any write.
     drifted: list[str] = []

--- a/daydream/training/adjudication/cli.py
+++ b/daydream/training/adjudication/cli.py
@@ -512,12 +512,17 @@ def _report_items(
     dispositions, and the outcome-bearing fields ``tier``/``posterior_eligible``/
     ``evidence_after_as_of``, computed with the same authority as the export
     rows (``classify_tier`` + ``effective_adjudication`` gold-eligibility) so
-    the 80% gate sees real adjudication state on the CLI path. Shares one
-    implementation with the final bundle's coverage report
-    (``final_bundle._enrich_report_items``) so both gates agree."""
+    the 80% gate sees real adjudication state on the CLI path. The queue is
+    the **complete** set (``include_decisive=True``), matching the final
+    bundle's coverage report, so a human observation on an automatically
+    adjudicated decisive record lands in the queue instead of raising, and
+    the CLI's ``outcome_coverage`` cannot be structurally ~0 while the
+    published gate passes. Shares one implementation with the final bundle's
+    coverage report (``final_bundle._enrich_report_items``) so both gates
+    agree."""
     from daydream.training.adjudication.final_bundle import _enrich_report_items
 
-    items = build_queue(_load_sessions_for_index(index_root))
+    items = build_queue(_load_sessions_for_index(index_root), include_decisive=True)
     observations = load_observations(state_dir / _OBSERVATIONS_FILENAME)
     return _enrich_report_items(items, observations, as_of=as_of)
 
@@ -655,10 +660,12 @@ def handle_publish_final(argv: list[str]) -> int:
     Both paths share ``build_final_bundle`` entirely: the staging bundle is
     constructed into ``<materialize-dir>/final-bundle`` and fully validated
     before any Hub interaction. With ``--dry-run`` the handler prints the
-    per-file record counts + per-disposition summary and returns 0 without
-    ever constructing a client; otherwise the bundle is published via
-    :func:`publish_final_annotation_bundle` (private-repo gate, secret scan,
-    SHA256SUMS, additive upload, clean-download verify, ``_SUCCESS`` last).
+    per-file record counts + per-disposition summary, the 80%
+    human-adjudication admission-gate verdict from the written coverage
+    report, and returns 0 without ever constructing a client; otherwise the
+    bundle is published via :func:`publish_final_annotation_bundle`
+    (private-repo gate, 80% admission-gate refusal, secret scan, SHA256SUMS,
+    additive upload, clean-download verify, ``_SUCCESS`` last).
     """
     from daydream.training.adjudication.final_bundle import build_final_bundle
     from daydream.training.adjudication.publish import publish_final_annotation_bundle
@@ -682,11 +689,23 @@ def handle_publish_final(argv: list[str]) -> int:
         counts = " ".join(
             f"{disposition}={count}" for disposition, count in summary["disposition_counts"].items()
         )
+        try:
+            report = json.loads(
+                (bundle_dir / "coverage-report.json").read_text(encoding="utf-8")
+            )
+            gate = report["admission_gate"]
+            coverage = report["outcome_coverage"]
+        except (OSError, ValueError, KeyError) as exc:
+            print_error(create_console(), "adjudicate publish-final failed", str(exc))
+            return 1
         print_success(
             create_console(),
             f"Dry-run: final bundle validated at {bundle_dir} — "
             f"{summary['record_count']} record(s) across "
-            f"{', '.join(summary['files'])} ({counts}); nothing published",
+            f"{', '.join(summary['files'])} ({counts}); "
+            f"80% admission gate {'PASS' if gate['passes_80pct'] else 'FAIL'} "
+            f"({coverage['adjudicated']}/{coverage['total']} outcome-bearing "
+            f"adjudicated); nothing published",
         )
         return 0
     try:
@@ -695,11 +714,17 @@ def handle_publish_final(argv: list[str]) -> int:
             client, bundle_dir, manifest=args.materialize_dir / "preview-manifest.json",
             verify_download=True,
         )
+        # The snapshot-id label for the success message is read here, inside
+        # the publish try/except, so a missing/corrupt manifest can never
+        # escape the handler as an uncaught exception after a successful
+        # publish — every handler must return an int exit code.
+        manifest = json.loads(
+            (args.materialize_dir / "preview-manifest.json").read_text(encoding="utf-8")
+        )
+        snapshot_id = manifest.get("snapshot_id", "")
     except (ValueError, HubUnavailableError, HydrationError, PublicDestinationError, FileNotFoundError) as exc:
         print_error(create_console(), "adjudicate publish-final failed", str(exc))
         return 1
-    manifest = json.loads((args.materialize_dir / "preview-manifest.json").read_text(encoding="utf-8"))
-    snapshot_id = manifest.get("snapshot_id", "")
     print_success(
         create_console(),
         f"Published final annotation bundle ({summary['record_count']} record(s)) "

--- a/daydream/training/adjudication/cli.py
+++ b/daydream/training/adjudication/cli.py
@@ -27,6 +27,10 @@ deterministic adjudication queue:
 - ``harvest-snapshot`` — canonical harvest of the materialized preview
   snapshot: drift gate, precedence merge, exactly-once
   ``label_observations`` append, and ``annotations.jsonl`` emission.
+- ``publish-final`` — construct the final annotation staging bundle from
+  pipeline state (no hand-authored files) and publish it additively to the
+  private Hub under ``annotations/<curation-id>/<snapshot-id>/final/``;
+  ``--dry-run`` builds and validates the bundle without constructing a client.
 
 Every handler returns an int exit code (never calls ``sys.exit`` itself);
 argparse converts malformed invocations into ``SystemExit(2)``. Unknown
@@ -308,6 +312,23 @@ def _build_adjudicate_parser() -> argparse.ArgumentParser:
                            help="Archive directory holding the SQLite label-observations index")
     p_harvest.add_argument("--state-dir", type=Path, required=True, metavar="PATH",
                            help="Adjudication state directory (observations.jsonl source)")
+
+    p_publish_final = sub.add_parser(
+        "publish-final",
+        help="Construct and publish the final annotation bundle (immutable snapshot).",
+    )
+    p_publish_final.add_argument("--index-root", type=Path, required=True, metavar="PATH",
+                                 help="Hydrated index root containing sessions.jsonl")
+    p_publish_final.add_argument("--materialize-dir", type=Path, required=True, metavar="PATH",
+                                 help="Directory produced by `materialize` (manifest + sessions.jsonl)")
+    p_publish_final.add_argument("--archive-dir", type=Path, required=True, metavar="PATH",
+                                 help="Archive directory holding the SQLite label-observations index")
+    p_publish_final.add_argument("--curation-bundle-dir", type=Path, required=True, metavar="PATH",
+                                 help="Curation bundle root digested into lineage.json's batch_fileset_digest")
+    p_publish_final.add_argument("--hub-repo", type=str, default=_ANNOTATION_HUB_REPO, metavar="REPO",
+                                 help=f"Private Hub dataset repo (default: {_ANNOTATION_HUB_REPO})")
+    p_publish_final.add_argument("--dry-run", action="store_true",
+                                 help="Build and validate the staging bundle without publishing to the Hub")
 
     return parser
 
@@ -669,6 +690,65 @@ def handle_resume_state(argv: list[str]) -> int:
     return 0
 
 
+def handle_publish_final(argv: list[str]) -> int:
+    """Handle ``corpus adjudicate publish-final`` (issue #1078, M4-M6).
+
+    Both paths share ``build_final_bundle`` entirely: the staging bundle is
+    constructed into ``<materialize-dir>/final-bundle`` and fully validated
+    before any Hub interaction. With ``--dry-run`` the handler prints the
+    per-file record counts + per-disposition summary and returns 0 without
+    ever constructing a client; otherwise the bundle is published via
+    :func:`publish_final_annotation_bundle` (private-repo gate, secret scan,
+    SHA256SUMS, additive upload, clean-download verify, ``_SUCCESS`` last).
+    """
+    from daydream.training.adjudication.final_bundle import build_final_bundle
+    from daydream.training.adjudication.publish import publish_final_annotation_bundle
+    from daydream.ui import create_console, print_error, print_success
+
+    args = _build_adjudicate_parser().parse_args(["publish-final", *argv])
+    bundle_dir = args.materialize_dir / "final-bundle"
+    try:
+        summary = build_final_bundle(
+            index_root=args.index_root,
+            materialize_dir=args.materialize_dir,
+            archive_dir=args.archive_dir,
+            out_dir=bundle_dir,
+            curation_bundle_dir=args.curation_bundle_dir,
+        )
+    except (ValueError, HubUnavailableError, HydrationError, PublicDestinationError, FileNotFoundError) as exc:
+        print_error(create_console(), "adjudicate publish-final failed", str(exc))
+        return 1
+    if args.dry_run:
+        counts = " ".join(
+            f"{disposition}={count}" for disposition, count in summary["disposition_counts"].items()
+        )
+        print_success(
+            create_console(),
+            f"Dry-run: final bundle validated at {bundle_dir} — "
+            f"{summary['record_count']} record(s) across "
+            f"{', '.join(summary['files'])} ({counts}); nothing published",
+        )
+        return 0
+    try:
+        client = _make_client(args.hub_repo)
+        result = publish_final_annotation_bundle(
+            client, bundle_dir, manifest=args.materialize_dir / "preview-manifest.json",
+            verify_download=True,
+        )
+    except (ValueError, HubUnavailableError, HydrationError, PublicDestinationError, FileNotFoundError) as exc:
+        print_error(create_console(), "adjudicate publish-final failed", str(exc))
+        return 1
+    manifest = json.loads((args.materialize_dir / "preview-manifest.json").read_text(encoding="utf-8"))
+    snapshot_id = manifest.get("snapshot_id", "")
+    print_success(
+        create_console(),
+        f"Published final annotation bundle ({summary['record_count']} record(s)) "
+        f"under {result['prefix']} (hub commit {result['hub_commit_sha']}, "
+        f"snapshot {snapshot_id})",
+    )
+    return 0
+
+
 def handle_harvest_snapshot(argv: list[str]) -> int:
     """Handle ``corpus adjudicate harvest-snapshot --index-root --materialize-dir ...``."""
     from daydream.ui import create_console, print_error, print_success
@@ -704,6 +784,7 @@ _HANDLERS = {
     "publish-state": handle_publish_state,
     "resume-state": handle_resume_state,
     "harvest-snapshot": handle_harvest_snapshot,
+    "publish-final": handle_publish_final,
 }
 
 

--- a/daydream/training/adjudication/cli.py
+++ b/daydream/training/adjudication/cli.py
@@ -49,7 +49,7 @@ from pathlib import Path
 from typing import Any
 
 from daydream.archive.hydrate import HubUnavailableError, HydrationError, PublicDestinationError, _make_client
-from daydream.training.adjudication.canonical import _evidence_after_as_of, run_canonical_harvest
+from daydream.training.adjudication.canonical import run_canonical_harvest
 from daydream.training.adjudication.export import validate_export_rows, write_export_rows
 from daydream.training.adjudication.harvest import build_export_entries
 from daydream.training.adjudication.materialize import run_materialize
@@ -57,7 +57,7 @@ from daydream.training.adjudication.observations import (
     append_observation,
     load_observations,
 )
-from daydream.training.adjudication.precedence import DECISIVE_DISPOSITIONS, effective_adjudication, has_rater_conflict
+from daydream.training.adjudication.precedence import has_rater_conflict
 from daydream.training.adjudication.preview import run_preview
 from daydream.training.adjudication.publish import (
     publish_annotation_state,
@@ -65,7 +65,6 @@ from daydream.training.adjudication.publish import (
 )
 from daydream.training.adjudication.queue import build_queue
 from daydream.training.adjudication.report import build_report
-from daydream.training.corpus_v2.tiers import classify_tier
 from daydream.training.labeler_versions import (
     ADJUDICATION_LABELER_VERSION,
     REPLY_CLASSIFIER_VERSION,
@@ -321,6 +320,7 @@ def _build_adjudicate_parser() -> argparse.ArgumentParser:
                                  help="Hydrated index root containing sessions.jsonl")
     p_publish_final.add_argument("--materialize-dir", type=Path, required=True, metavar="PATH",
                                  help="Directory produced by `materialize` (manifest + sessions.jsonl)")
+    _add_state_dir(p_publish_final)
     p_publish_final.add_argument("--archive-dir", type=Path, required=True, metavar="PATH",
                                  help="Archive directory holding the SQLite label-observations index")
     p_publish_final.add_argument("--curation-bundle-dir", type=Path, required=True, metavar="PATH",
@@ -512,55 +512,14 @@ def _report_items(
     dispositions, and the outcome-bearing fields ``tier``/``posterior_eligible``/
     ``evidence_after_as_of``, computed with the same authority as the export
     rows (``classify_tier`` + ``effective_adjudication`` gold-eligibility) so
-    the 80% gate sees real adjudication state on the CLI path."""
+    the 80% gate sees real adjudication state on the CLI path. Shares one
+    implementation with the final bundle's coverage report
+    (``final_bundle._enrich_report_items``) so both gates agree."""
+    from daydream.training.adjudication.final_bundle import _enrich_report_items
+
     items = build_queue(_load_sessions_for_index(index_root))
     observations = load_observations(state_dir / _OBSERVATIONS_FILENAME)
-    queue_ids = {str(item["record_id"]) for item in items}
-    grouped: dict[str, list[dict[str, Any]]] = {}
-    for obs in observations:
-        record_id = str(obs["record_id"])
-        if record_id not in queue_ids:
-            raise ValueError(
-                f"observation references record_id {record_id!r} which is not in the "
-                f"adjudication queue over the hydrated index"
-            )
-        grouped.setdefault(record_id, []).append(obs)
-
-    enriched: list[dict[str, Any]] = []
-    for item in items:
-        enriched_item = dict(item)
-        record_obs = grouped.get(str(item["record_id"]), [])
-        enriched_item["observations"] = record_obs
-        gold_eligible = False
-        if record_obs:
-            resolved = effective_adjudication(record_obs)
-            gold_eligible = resolved["gold_eligible"]
-            if (
-                resolved["role"] in ("rater", "adjudicator")
-                and resolved["evidence_digest"] == str(item["evidence_digest"])
-                and resolved["disposition"] in DECISIVE_DISPOSITIONS
-            ):
-                enriched_item["disposition"] = resolved["disposition"]
-        # Stamp the temporal axis FIRST so classify_tier sees it, matching the
-        # canonical serializer and the corpus projection (tiers.py C5/M9): an
-        # evidence-after-as_of record must classify "silver" here exactly as it
-        # does on the canonical record — never gold/posterior_eligible.
-        enriched_item["evidence_after_as_of"] = _evidence_after_as_of(
-            enriched_item, as_of
-        )
-        # Outcome-bearing fields mirroring build_export_entries: the gold gate
-        # has one implementation (classify_tier), and gold-eligibility comes
-        # from the human-observation resolution (conflict/review-required
-        # decisive judgments stay out of the gold tier).
-        tier = classify_tier(enriched_item)
-        if tier == "gold" and not gold_eligible:
-            tier = "task-only"
-        enriched_item["tier"] = tier
-        enriched_item["posterior_eligible"] = tier == "gold" and str(
-            enriched_item["profile"]
-        ) == "pr_review"
-        enriched.append(enriched_item)
-    return enriched
+    return _enrich_report_items(items, observations, as_of=as_of)
 
 
 def handle_report(argv: list[str]) -> int:
@@ -714,6 +673,7 @@ def handle_publish_final(argv: list[str]) -> int:
             archive_dir=args.archive_dir,
             out_dir=bundle_dir,
             curation_bundle_dir=args.curation_bundle_dir,
+            observations_path=args.state_dir / _OBSERVATIONS_FILENAME,
         )
     except (ValueError, HubUnavailableError, HydrationError, PublicDestinationError, FileNotFoundError) as exc:
         print_error(create_console(), "adjudicate publish-final failed", str(exc))

--- a/daydream/training/adjudication/dispositions.py
+++ b/daydream/training/adjudication/dispositions.py
@@ -1,0 +1,17 @@
+"""Single source of truth for adjudication disposition classification (issue #1078).
+
+Shared by the adjudication queue builder, the materialization step, and the
+corpus v2 tier classifier so the decisive/non-decisive split is defined once.
+"""
+
+from typing import Final
+
+__all__ = ["DECISIVE_DISPOSITIONS", "NON_DECISIVE_DISPOSITIONS", "is_decisive"]
+
+NON_DECISIVE_DISPOSITIONS: Final[frozenset[str]] = frozenset({"ambiguous", "unanswered", "missing"})
+DECISIVE_DISPOSITIONS: Final[frozenset[str]] = frozenset({"accepted", "rejected"})
+
+
+def is_decisive(disposition: str) -> bool:
+    """Return True when ``disposition`` is a decisive outcome (accepted/rejected)."""
+    return disposition in DECISIVE_DISPOSITIONS

--- a/daydream/training/adjudication/dispositions.py
+++ b/daydream/training/adjudication/dispositions.py
@@ -1,17 +1,14 @@
 """Single source of truth for adjudication disposition classification (issue #1078).
 
-Shared by the adjudication queue builder, the materialization step, and the
-corpus v2 tier classifier so the decisive/non-decisive split is defined once.
+Re-export shim: the source of truth now lives at ``daydream.training.dispositions``
+so the corpus v2 tier classifier can consume it without triggering this package's
+eager import chain. Kept for backward-compatible imports.
 """
 
-from typing import Final
+from daydream.training.dispositions import (
+    DECISIVE_DISPOSITIONS,
+    NON_DECISIVE_DISPOSITIONS,
+    is_decisive,
+)
 
 __all__ = ["DECISIVE_DISPOSITIONS", "NON_DECISIVE_DISPOSITIONS", "is_decisive"]
-
-NON_DECISIVE_DISPOSITIONS: Final[frozenset[str]] = frozenset({"ambiguous", "unanswered", "missing"})
-DECISIVE_DISPOSITIONS: Final[frozenset[str]] = frozenset({"accepted", "rejected"})
-
-
-def is_decisive(disposition: str) -> bool:
-    """Return True when ``disposition`` is a decisive outcome (accepted/rejected)."""
-    return disposition in DECISIVE_DISPOSITIONS

--- a/daydream/training/adjudication/final_bundle.py
+++ b/daydream/training/adjudication/final_bundle.py
@@ -10,14 +10,18 @@ directory this function produces, so ``--dry-run`` and the real publish share
 
 Determinism: every file is written as canonical JSON (sorted keys, compact
 separators), so identical pipeline state produces byte-identical bundles
-across re-runs. Every missing or invalid input raises ``ValueError`` /
-``FileNotFoundError`` naming the artifact — no fallback defaults, no silent
-skips (the lineage file must never contain a fabricated field).
+across re-runs, and atomically (temp file + ``os.replace``), so a torn write
+can never leave a truncated contract file in the staged ``out_dir`` (the
+deterministic-atomic-writes convention). Every missing or invalid input
+raises ``ValueError`` / ``FileNotFoundError`` naming the artifact — no
+fallback defaults, no silent skips (the lineage file must never contain a
+fabricated field).
 """
 
 from __future__ import annotations
 
 import json
+import os
 from collections import Counter
 from collections.abc import Mapping, Sequence
 from pathlib import Path
@@ -78,6 +82,22 @@ _LINEAGE_PIN_FIELDS = (
 
 def _canonical(payload: Any) -> str:
     return json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+def _write_atomic(out_path: Path, payload: str) -> None:
+    """Temp-file + ``os.replace`` write, mirroring ``materialize._write_atomic``
+    (deterministic-atomic-writes convention): a torn write can never leave a
+    truncated contract file in the staged ``out_dir``."""
+    tmp_path = out_path.with_name(out_path.name + ".tmp")
+    tmp_path.write_text(payload, encoding="utf-8")
+    os.replace(tmp_path, out_path)
+
+
+def _write_atomic_bytes(out_path: Path, payload: bytes) -> None:
+    """Byte twin of :func:`_write_atomic` for the verbatim materialized copies."""
+    tmp_path = out_path.with_name(out_path.name + ".tmp")
+    tmp_path.write_bytes(payload)
+    os.replace(tmp_path, out_path)
 
 
 def _load_materialized_records(materialize_dir: Path) -> list[dict[str, Any]]:
@@ -164,10 +184,13 @@ def _enrich_report_items(
     adjudication (a human decisive judgment whose evidence digest matches the
     fresh item overrides the disposition), stamps the temporal axis first, and
     classifies ``tier``/``posterior_eligible`` with the corpus-v2 authority.
-    Gold eligibility requires a human decision, so automatic decisive records
-    without one are demoted to task-only and never count as adjudicated. An
-    observation referencing a record_id absent from ``items`` raises
-    ``ValueError`` naming it (fail-closed, mirroring the CLI twin).
+    Gold eligibility requires a human decision made against the item's fresh
+    evidence digest, so automatic decisive records without one — and decisive
+    records whose only human observation was made against older evidence, a
+    judgment the canonical merge refuses to reuse (digest mismatch) — are
+    demoted to task-only and never count as adjudicated. An observation
+    referencing a record_id absent from ``items`` raises ``ValueError`` naming
+    it (fail-closed, mirroring the CLI twin).
     """
     queue_ids = {str(item["record_id"]) for item in items}
     grouped: dict[str, list[Mapping[str, Any]]] = {}
@@ -188,10 +211,18 @@ def _enrich_report_items(
         gold_eligible = False
         if record_obs:
             resolved = effective_adjudication(record_obs)
-            gold_eligible = resolved["gold_eligible"]
+            # A human judgment made against different evidence is never
+            # silently reused (the queue's digest-drift rule); gold
+            # eligibility therefore holds only when the effective
+            # observation's evidence_digest equals the item's fresh digest —
+            # mirroring the disposition override two lines below and the
+            # canonical merge's digest-match guard (canonical.py).
+            fresh_match = resolved["evidence_digest"] == str(item["evidence_digest"])
+            if fresh_match:
+                gold_eligible = resolved["gold_eligible"]
             if (
-                resolved["role"] in ("rater", "adjudicator")
-                and resolved["evidence_digest"] == str(item["evidence_digest"])
+                fresh_match
+                and resolved["role"] in ("rater", "adjudicator")
                 and resolved["disposition"] in DECISIVE_DISPOSITIONS
             ):
                 enriched_item["disposition"] = resolved["disposition"]
@@ -294,11 +325,13 @@ def build_final_bundle(
     # 1. annotations.jsonl + sessions.jsonl: verbatim copies of the canonical
     #    materialized artifacts (already canonical JSONL — re-serializing
     #    would be a second code path for the same bytes).
-    (out_dir / _ANNOTATIONS_FILENAME).write_bytes(
-        (materialize_dir / _ANNOTATIONS_FILENAME).read_bytes()
+    _write_atomic_bytes(
+        out_dir / _ANNOTATIONS_FILENAME,
+        (materialize_dir / _ANNOTATIONS_FILENAME).read_bytes(),
     )
-    (out_dir / _SESSIONS_OUT_FILENAME).write_bytes(
-        (materialize_dir / _SESSIONS_OUT_FILENAME).read_bytes()
+    _write_atomic_bytes(
+        out_dir / _SESSIONS_OUT_FILENAME,
+        (materialize_dir / _SESSIONS_OUT_FILENAME).read_bytes(),
     )
 
     # 2. label-observations.jsonl: the archive's per-session observation
@@ -309,8 +342,9 @@ def build_final_bundle(
     for session_id in snapshot_session_ids:
         history_rows.extend(label_observation_history(archive_dir, session_id))
     history_rows.sort(key=lambda row: (str(row.get("observed_at")), str(row.get("session_id"))))
-    (out_dir / _OBSERVATIONS_FILENAME).write_text(
-        "".join(_canonical(row) + "\n" for row in history_rows), encoding="utf-8"
+    _write_atomic(
+        out_dir / _OBSERVATIONS_FILENAME,
+        "".join(_canonical(row) + "\n" for row in history_rows),
     )
 
     # 3. coverage-report.json over the fresh complete queue, enriched exactly
@@ -333,7 +367,7 @@ def build_final_bundle(
     report["strata"] = {
         f"{stack}/{profile}": count for (stack, profile), count in report["strata"].items()
     }
-    (out_dir / _REPORT_FILENAME).write_text(_canonical(report) + "\n", encoding="utf-8")
+    _write_atomic(out_dir / _REPORT_FILENAME, _canonical(report) + "\n")
 
     # 4. lineage.json: generated from the pin — every field must be present.
     lineage: dict[str, Any] = {
@@ -355,7 +389,7 @@ def build_final_bundle(
         )
     as_of = manifest["as_of"]
     lineage["as_of"] = "" if as_of is None else str(as_of)
-    (out_dir / _LINEAGE_FILENAME).write_text(_canonical(lineage) + "\n", encoding="utf-8")
+    _write_atomic(out_dir / _LINEAGE_FILENAME, _canonical(lineage) + "\n")
 
     written = sorted(path.name for path in out_dir.iterdir() if path.is_file())
     missing = [name for name in _BUNDLE_FILES if name not in written]

--- a/daydream/training/adjudication/final_bundle.py
+++ b/daydream/training/adjudication/final_bundle.py
@@ -19,24 +19,27 @@ from __future__ import annotations
 
 import json
 from collections import Counter
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from pathlib import Path
 from typing import Any
 
 from daydream.archive.index import label_observation_history
 from daydream.archive.sanitize import _derivative_digest
-from daydream.training.adjudication.dispositions import (
-    DECISIVE_DISPOSITIONS,
-    NON_DECISIVE_DISPOSITIONS,
-)
+from daydream.training.adjudication.canonical import _evidence_after_as_of
 from daydream.training.adjudication.materialize import (
     _SESSIONS_OUT_FILENAME,
     _sessions_from_hydrated_stage,
 )
+from daydream.training.adjudication.observations import load_observations
+from daydream.training.adjudication.precedence import effective_adjudication
 from daydream.training.adjudication.preview import _load_sessions
 from daydream.training.adjudication.queue import build_queue
 from daydream.training.adjudication.report import build_report
 from daydream.training.corpus_v2.tiers import classify_tier
+from daydream.training.dispositions import (
+    DECISIVE_DISPOSITIONS,
+    NON_DECISIVE_DISPOSITIONS,
+)
 from daydream.training.labeler_versions import ANNOTATION_SNAPSHOT_SCHEMA_VERSION
 
 __all__ = ["build_final_bundle"]
@@ -54,6 +57,12 @@ _BUNDLE_FILES = (
     _REPORT_FILENAME,
     _LINEAGE_FILENAME,
 )
+
+# publish.py stages upload payloads into ``<bundle-dir>/.publish-stage`` and
+# leaves the scratch dir behind after a real publish; it is publish-internal,
+# never bundle content, so a re-construction over the same out_dir tolerates it
+# (re-publish idempotence).
+_PUBLISH_STAGE_DIRNAME = ".publish-stage"
 
 # The lineage fields that must be present and non-empty in the pin/manifest —
 # a missing field is a hard error naming the field, never a fallback default.
@@ -76,7 +85,7 @@ def _load_materialized_records(materialize_dir: Path) -> list[dict[str, Any]]:
     if not annotations_path.is_file():
         raise FileNotFoundError(
             f"materialized annotations not found (run `corpus adjudicate materialize` and "
-            f"`corpus adjudicate harvest` first): {annotations_path}"
+            f"`corpus adjudicate harvest-snapshot` first): {annotations_path}"
         )
     try:
         return [
@@ -140,6 +149,77 @@ def _lineage_field(manifest: Mapping[str, Any], field: str, manifest_path: Path)
     return value
 
 
+def _enrich_report_items(
+    items: Sequence[Mapping[str, Any]],
+    observations: Sequence[Mapping[str, Any]],
+    *,
+    as_of: str | None = None,
+) -> list[dict[str, Any]]:
+    """Enrich queue items into report items — the single shared implementation
+    behind both the CLI report path (``cli._report_items``) and the final
+    bundle's coverage report, so the published 80% admission gate sees exactly
+    the same human-decision state as ``corpus adjudicate report``.
+
+    Attaches each record's observations, applies three-tier effective
+    adjudication (a human decisive judgment whose evidence digest matches the
+    fresh item overrides the disposition), stamps the temporal axis first, and
+    classifies ``tier``/``posterior_eligible`` with the corpus-v2 authority.
+    Gold eligibility requires a human decision, so automatic decisive records
+    without one are demoted to task-only and never count as adjudicated. An
+    observation referencing a record_id absent from ``items`` raises
+    ``ValueError`` naming it (fail-closed, mirroring the CLI twin).
+    """
+    queue_ids = {str(item["record_id"]) for item in items}
+    grouped: dict[str, list[Mapping[str, Any]]] = {}
+    for obs in observations:
+        record_id = str(obs["record_id"])
+        if record_id not in queue_ids:
+            raise ValueError(
+                f"observation references record_id {record_id!r} which is not in the "
+                f"adjudication queue over the hydrated index"
+            )
+        grouped.setdefault(record_id, []).append(obs)
+
+    enriched: list[dict[str, Any]] = []
+    for item in items:
+        enriched_item = dict(item)
+        record_obs = grouped.get(str(item["record_id"]), [])
+        enriched_item["observations"] = record_obs
+        gold_eligible = False
+        if record_obs:
+            resolved = effective_adjudication(record_obs)
+            gold_eligible = resolved["gold_eligible"]
+            if (
+                resolved["role"] in ("rater", "adjudicator")
+                and resolved["evidence_digest"] == str(item["evidence_digest"])
+                and resolved["disposition"] in DECISIVE_DISPOSITIONS
+            ):
+                enriched_item["disposition"] = resolved["disposition"]
+        # Stamp the temporal axis FIRST so classify_tier sees it, matching the
+        # canonical serializer and the corpus projection (tiers.py C5/M9): an
+        # evidence-after-as_of record must classify "silver" here exactly as it
+        # does on the canonical record — never gold/posterior_eligible.
+        enriched_item["evidence_after_as_of"] = _evidence_after_as_of(enriched_item, as_of)
+        # The gold gate has one implementation (classify_tier); gold-eligibility
+        # comes from the human-observation resolution (conflict/review-required
+        # decisive judgments stay out of the gold tier). A classifier failure
+        # fail-closes naming the record, never a silent skip.
+        try:
+            tier = classify_tier(enriched_item)
+        except Exception as exc:
+            raise ValueError(
+                f"cannot classify tier for record_id {str(item['record_id'])!r}: {exc}"
+            ) from exc
+        if tier == "gold" and not gold_eligible:
+            tier = "task-only"
+        enriched_item["tier"] = tier
+        enriched_item["posterior_eligible"] = tier == "gold" and str(
+            enriched_item["profile"]
+        ) == "pr_review"
+        enriched.append(enriched_item)
+    return enriched
+
+
 def build_final_bundle(
     *,
     index_root: Path,
@@ -147,6 +227,7 @@ def build_final_bundle(
     archive_dir: Path,
     out_dir: Path,
     curation_bundle_dir: Path | None = None,
+    observations_path: Path | None = None,
 ) -> dict[str, Any]:
     """Construct the final annotation staging bundle into a fresh ``out_dir``.
 
@@ -163,10 +244,14 @@ def build_final_bundle(
       bundle files as part of the SHA256SUMS file set, so this extra file is
       additive-safe.
     - ``coverage-report.json``: ``report.build_report`` over a fresh complete
-      queue (``build_queue(..., include_decisive=True)``) whose dispositions
-      and as-of flags are reconciled against the materialized (merge-applied)
-      records, with ``tier``/``posterior_eligible`` classified via the shared
-      ``corpus_v2.tiers.classify_tier``.
+      queue (``build_queue(..., include_decisive=True)``) enriched by the
+      shared :func:`_enrich_report_items` — the same observations/
+      effective-adjudication/gold-eligibility enrichment the CLI report twin
+      (``cli._report_items``) applies — so the published 80% admission gate
+      counts human-adjudicated outcome-bearing records only, never every
+      automatic decisive record. ``observations_path`` (the ``--state-dir``
+      observations store; a missing file is an empty store) supplies the
+      human observations; empty when not given.
     - ``lineage.json``: generated from the preview manifest's pin fields —
       never hand-authored, never defaulted. ``batch_fileset_digest`` is
       ``_derivative_digest`` over ``curation_bundle_dir`` (default: the index
@@ -179,14 +264,19 @@ def build_final_bundle(
     byte-identical; any foreign file (a previous run's ``_SUCCESS``, editor
     droppings, a partial publish) raises ``ValueError`` naming the directory,
     because a stale or published staging dir must never be silently mixed
-    with fresh content.
+    with fresh content. The ``.publish-stage`` scratch dir a real publish
+    leaves behind is publish-internal, not foreign content, so a re-publish
+    over the same dir is tolerated.
 
     Returns a summary dict with ``disposition_counts`` covering all five
     dispositions (``accepted``/``rejected``/``ambiguous``/``unanswered``/
     ``missing``) plus ``record_count`` and the written file names.
     """
     if out_dir.exists():
-        foreign = sorted(p.name for p in out_dir.iterdir() if p.name not in _BUNDLE_FILES)
+        foreign = sorted(
+            p.name for p in out_dir.iterdir()
+            if p.name not in _BUNDLE_FILES and p.name != _PUBLISH_STAGE_DIRNAME
+        )
         if foreign:
             raise ValueError(
                 f"final-bundle staging dir {out_dir} contains foreign content "
@@ -223,27 +313,20 @@ def build_final_bundle(
         "".join(_canonical(row) + "\n" for row in history_rows), encoding="utf-8"
     )
 
-    # 3. coverage-report.json over the fresh complete queue, reconciled with
-    #    the merge-applied materialized records so the report reflects the
-    #    dispositions that will actually publish.
-    merged_by_record_id = {str(r["record_id"]): r for r in records}
-    report_items: list[dict[str, Any]] = []
-    for item in build_queue(_index_sessions(index_root), include_decisive=True):
-        record_id = str(item["record_id"])
-        merged = merged_by_record_id.get(record_id)
-        enriched = dict(item)
-        if merged is not None:
-            enriched["disposition"] = merged["disposition"]
-            enriched["evidence_after_as_of"] = bool(merged.get("evidence_after_as_of"))
-        try:
-            tier = classify_tier(enriched)
-        except Exception as exc:  # GoldGateError / TypeError: fail closed naming the record
-            raise ValueError(
-                f"final bundle: cannot classify tier for record_id {record_id!r}: {exc}"
-            ) from exc
-        enriched["tier"] = tier
-        enriched["posterior_eligible"] = tier == "gold"
-        report_items.append(enriched)
+    # 3. coverage-report.json over the fresh complete queue, enriched exactly
+    #    like the CLI report twin (``cli._report_items`` -> shared
+    #    ``_enrich_report_items``): observations attached per record, three-tier
+    #    effective adjudication applied, and gold records without a human
+    #    decision demoted to task-only, so the published 80% admission gate
+    #    sees real human adjudication state instead of counting every automatic
+    #    decisive record as adjudicated. ``as_of`` comes from the preview
+    #    manifest (empty when unpinned).
+    observations = load_observations(observations_path) if observations_path is not None else []
+    report_items = _enrich_report_items(
+        build_queue(_index_sessions(index_root), include_decisive=True),
+        observations,
+        as_of=manifest.get("as_of"),
+    )
     report = build_report(report_items)
     # ``strata`` keys are (stack, profile) tuples in memory; the on-disk report
     # is JSON, so flatten them to ``"stack/profile"`` (deterministic order).
@@ -264,15 +347,17 @@ def build_final_bundle(
         )
     lineage["batch_fileset_digest"] = _derivative_digest(bundle_root)
     # ``as_of`` is pin-required but legitimately empty when unpinned (mirroring
-    # ``snapshot.snapshot_id``'s as-of edge) — a *missing* key is an error.
+    # ``snapshot.snapshot_id``'s as-of edge) — a *missing* key is an error, and
+    # a null/empty value is the unpinned edge, never the fabricated "None".
     if "as_of" not in manifest:
         raise ValueError(
             f"preview manifest at {manifest_path} is missing required lineage field 'as_of'"
         )
-    lineage["as_of"] = str(manifest["as_of"])
+    as_of = manifest["as_of"]
+    lineage["as_of"] = "" if as_of is None else str(as_of)
     (out_dir / _LINEAGE_FILENAME).write_text(_canonical(lineage) + "\n", encoding="utf-8")
 
-    written = sorted(path.name for path in out_dir.iterdir())
+    written = sorted(path.name for path in out_dir.iterdir() if path.is_file())
     missing = [name for name in _BUNDLE_FILES if name not in written]
     if missing:
         raise ValueError(f"final bundle at {out_dir} is missing contract files: {missing}")

--- a/daydream/training/adjudication/final_bundle.py
+++ b/daydream/training/adjudication/final_bundle.py
@@ -172,18 +172,26 @@ def build_final_bundle(
       ``_derivative_digest`` over ``curation_bundle_dir`` (default: the index
       root when it *is* the curation bundle root), validated to exist.
 
-    ``out_dir`` must not already exist or must be empty; a non-empty directory
-    raises ``ValueError`` naming it (a stale staging dir must never be
-    silently mixed with fresh content).
+    ``out_dir`` must not exist, must be empty, or may contain only the
+    five contract files from a prior (deterministic) construction — e.g. a
+    ``--dry-run`` validation immediately followed by a real publish over the
+    same state. Construction is deterministic, so re-writing those files is
+    byte-identical; any foreign file (a previous run's ``_SUCCESS``, editor
+    droppings, a partial publish) raises ``ValueError`` naming the directory,
+    because a stale or published staging dir must never be silently mixed
+    with fresh content.
 
     Returns a summary dict with ``disposition_counts`` covering all five
     dispositions (``accepted``/``rejected``/``ambiguous``/``unanswered``/
     ``missing``) plus ``record_count`` and the written file names.
     """
-    if out_dir.exists() and any(out_dir.iterdir()):
-        raise ValueError(
-            f"final-bundle staging dir {out_dir} is not empty; remove it or pass a fresh path"
-        )
+    if out_dir.exists():
+        foreign = sorted(p.name for p in out_dir.iterdir() if p.name not in _BUNDLE_FILES)
+        if foreign:
+            raise ValueError(
+                f"final-bundle staging dir {out_dir} contains foreign content "
+                f"({', '.join(foreign)}); remove it or pass a fresh path"
+            )
     out_dir.mkdir(parents=True, exist_ok=True)
 
     records = _load_materialized_records(materialize_dir)

--- a/daydream/training/adjudication/final_bundle.py
+++ b/daydream/training/adjudication/final_bundle.py
@@ -1,0 +1,284 @@
+"""Staging final-bundle constructor (issue #1078, M4 core).
+
+Assembles the publish-ready annotation staging bundle — ``annotations.jsonl``,
+``sessions.jsonl``, ``label-observations.jsonl``, ``coverage-report.json`` and
+a **generated** ``lineage.json`` — from pipeline state alone (the
+materialization dir, the hydrated index, and the archive). Pure construction:
+no Hub I/O, no publishing; :func:`publish_final_annotation_bundle` consumes the
+directory this function produces, so ``--dry-run`` and the real publish share
+100% of the construction/validation code (M6).
+
+Determinism: every file is written as canonical JSON (sorted keys, compact
+separators), so identical pipeline state produces byte-identical bundles
+across re-runs. Every missing or invalid input raises ``ValueError`` /
+``FileNotFoundError`` naming the artifact — no fallback defaults, no silent
+skips (the lineage file must never contain a fabricated field).
+"""
+
+from __future__ import annotations
+
+import json
+from collections import Counter
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from daydream.archive.index import label_observation_history
+from daydream.archive.sanitize import _derivative_digest
+from daydream.training.adjudication.dispositions import (
+    DECISIVE_DISPOSITIONS,
+    NON_DECISIVE_DISPOSITIONS,
+)
+from daydream.training.adjudication.materialize import (
+    _SESSIONS_OUT_FILENAME,
+    _sessions_from_hydrated_stage,
+)
+from daydream.training.adjudication.preview import _load_sessions
+from daydream.training.adjudication.queue import build_queue
+from daydream.training.adjudication.report import build_report
+from daydream.training.corpus_v2.tiers import classify_tier
+from daydream.training.labeler_versions import ANNOTATION_SNAPSHOT_SCHEMA_VERSION
+
+__all__ = ["build_final_bundle"]
+
+_ANNOTATIONS_FILENAME = "annotations.jsonl"
+_OBSERVATIONS_FILENAME = "label-observations.jsonl"
+_REPORT_FILENAME = "coverage-report.json"
+_LINEAGE_FILENAME = "lineage.json"
+_MANIFEST_FILENAME = "preview-manifest.json"
+
+_BUNDLE_FILES = (
+    _ANNOTATIONS_FILENAME,
+    _SESSIONS_OUT_FILENAME,
+    _OBSERVATIONS_FILENAME,
+    _REPORT_FILENAME,
+    _LINEAGE_FILENAME,
+)
+
+# The lineage fields that must be present and non-empty in the pin/manifest —
+# a missing field is a hard error naming the field, never a fallback default.
+_LINEAGE_PIN_FIELDS = (
+    "curation_id",
+    "sanitized_hub_commit",
+    "snapshot_id",
+    "labeler_version",
+    "rubric_version",
+    "classifier_version",
+)
+
+
+def _canonical(payload: Any) -> str:
+    return json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+def _load_materialized_records(materialize_dir: Path) -> list[dict[str, Any]]:
+    annotations_path = materialize_dir / _ANNOTATIONS_FILENAME
+    if not annotations_path.is_file():
+        raise FileNotFoundError(
+            f"materialized annotations not found (run `corpus adjudicate materialize` and "
+            f"`corpus adjudicate harvest` first): {annotations_path}"
+        )
+    try:
+        return [
+            json.loads(line)
+            for line in annotations_path.read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        ]
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValueError(f"unreadable materialized annotations at {annotations_path}: {exc}") from exc
+
+
+def _load_sessions_output(materialize_dir: Path) -> list[dict[str, Any]]:
+    sessions_path = materialize_dir / _SESSIONS_OUT_FILENAME
+    if not sessions_path.is_file():
+        raise FileNotFoundError(
+            f"materialized preview snapshot not found (run `corpus adjudicate materialize` "
+            f"first): {sessions_path}"
+        )
+    try:
+        return [
+            json.loads(line)
+            for line in sessions_path.read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        ]
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValueError(f"unreadable materialized snapshot at {sessions_path}: {exc}") from exc
+
+
+def _load_manifest(materialize_dir: Path) -> dict[str, Any]:
+    manifest_path = materialize_dir / _MANIFEST_FILENAME
+    if not manifest_path.is_file():
+        raise FileNotFoundError(
+            f"preview manifest not found (run `corpus adjudicate materialize` first): "
+            f"{manifest_path}"
+        )
+    try:
+        manifest: dict[str, Any] = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValueError(f"unreadable preview manifest at {manifest_path}: {exc}") from exc
+    if not isinstance(manifest, dict):
+        raise ValueError(f"preview manifest at {manifest_path} is not a JSON object")
+    return manifest
+
+
+def _index_sessions(index_root: Path) -> list[dict[str, Any]]:
+    """Load the segmented sessions the fresh queue is built over, mirroring
+    ``canonical.run_canonical_harvest``'s source selection."""
+    if (index_root / _SESSIONS_OUT_FILENAME).is_file():
+        sessions, _index_revision = _load_sessions(index_root)
+    else:
+        sessions, _index_revision = _sessions_from_hydrated_stage(index_root)
+    return sessions
+
+
+def _lineage_field(manifest: Mapping[str, Any], field: str, manifest_path: Path) -> str:
+    value = manifest.get(field)
+    if not isinstance(value, str) or not value:
+        raise ValueError(
+            f"preview manifest at {manifest_path} is missing required lineage field {field!r}"
+        )
+    return value
+
+
+def build_final_bundle(
+    *,
+    index_root: Path,
+    materialize_dir: Path,
+    archive_dir: Path,
+    out_dir: Path,
+    curation_bundle_dir: Path | None = None,
+) -> dict[str, Any]:
+    """Construct the final annotation staging bundle into a fresh ``out_dir``.
+
+    Writes exactly the five contract files (``_BUNDLE_FILES``) and never
+    publishes: the caller feeds the directory to
+    :func:`daydream.training.adjudication.publish.publish_final_annotation_bundle`.
+
+    - ``annotations.jsonl`` / ``sessions.jsonl``: copied byte-for-byte from the
+      materialization dir (missing file raises ``FileNotFoundError`` naming it).
+    - ``label-observations.jsonl``: the archive's immutable per-session
+      observation history (``archive.index.label_observation_history``) for
+      every session in the snapshot, flattened and sorted chronologically by
+      ``observed_at``. The projector's bundle verification treats unknown
+      bundle files as part of the SHA256SUMS file set, so this extra file is
+      additive-safe.
+    - ``coverage-report.json``: ``report.build_report`` over a fresh complete
+      queue (``build_queue(..., include_decisive=True)``) whose dispositions
+      and as-of flags are reconciled against the materialized (merge-applied)
+      records, with ``tier``/``posterior_eligible`` classified via the shared
+      ``corpus_v2.tiers.classify_tier``.
+    - ``lineage.json``: generated from the preview manifest's pin fields —
+      never hand-authored, never defaulted. ``batch_fileset_digest`` is
+      ``_derivative_digest`` over ``curation_bundle_dir`` (default: the index
+      root when it *is* the curation bundle root), validated to exist.
+
+    ``out_dir`` must not already exist or must be empty; a non-empty directory
+    raises ``ValueError`` naming it (a stale staging dir must never be
+    silently mixed with fresh content).
+
+    Returns a summary dict with ``disposition_counts`` covering all five
+    dispositions (``accepted``/``rejected``/``ambiguous``/``unanswered``/
+    ``missing``) plus ``record_count`` and the written file names.
+    """
+    if out_dir.exists() and any(out_dir.iterdir()):
+        raise ValueError(
+            f"final-bundle staging dir {out_dir} is not empty; remove it or pass a fresh path"
+        )
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    records = _load_materialized_records(materialize_dir)
+    # Validate the materialized sessions output exists and parses (the bundle
+    # copies it verbatim below).
+    _load_sessions_output(materialize_dir)
+    manifest_path = materialize_dir / _MANIFEST_FILENAME
+    manifest = _load_manifest(materialize_dir)
+
+    # 1. annotations.jsonl + sessions.jsonl: verbatim copies of the canonical
+    #    materialized artifacts (already canonical JSONL — re-serializing
+    #    would be a second code path for the same bytes).
+    (out_dir / _ANNOTATIONS_FILENAME).write_bytes(
+        (materialize_dir / _ANNOTATIONS_FILENAME).read_bytes()
+    )
+    (out_dir / _SESSIONS_OUT_FILENAME).write_bytes(
+        (materialize_dir / _SESSIONS_OUT_FILENAME).read_bytes()
+    )
+
+    # 2. label-observations.jsonl: the archive's per-session observation
+    #    history, chronological by ``observed_at`` (per-session rows are
+    #    already ordered; the cross-session flatten re-sorts for determinism).
+    snapshot_session_ids = sorted({str(r["session_id"]) for r in records})
+    history_rows: list[dict[str, Any]] = []
+    for session_id in snapshot_session_ids:
+        history_rows.extend(label_observation_history(archive_dir, session_id))
+    history_rows.sort(key=lambda row: (str(row.get("observed_at")), str(row.get("session_id"))))
+    (out_dir / _OBSERVATIONS_FILENAME).write_text(
+        "".join(_canonical(row) + "\n" for row in history_rows), encoding="utf-8"
+    )
+
+    # 3. coverage-report.json over the fresh complete queue, reconciled with
+    #    the merge-applied materialized records so the report reflects the
+    #    dispositions that will actually publish.
+    merged_by_record_id = {str(r["record_id"]): r for r in records}
+    report_items: list[dict[str, Any]] = []
+    for item in build_queue(_index_sessions(index_root), include_decisive=True):
+        record_id = str(item["record_id"])
+        merged = merged_by_record_id.get(record_id)
+        enriched = dict(item)
+        if merged is not None:
+            enriched["disposition"] = merged["disposition"]
+            enriched["evidence_after_as_of"] = bool(merged.get("evidence_after_as_of"))
+        try:
+            tier = classify_tier(enriched)
+        except Exception as exc:  # GoldGateError / TypeError: fail closed naming the record
+            raise ValueError(
+                f"final bundle: cannot classify tier for record_id {record_id!r}: {exc}"
+            ) from exc
+        enriched["tier"] = tier
+        enriched["posterior_eligible"] = tier == "gold"
+        report_items.append(enriched)
+    report = build_report(report_items)
+    # ``strata`` keys are (stack, profile) tuples in memory; the on-disk report
+    # is JSON, so flatten them to ``"stack/profile"`` (deterministic order).
+    report["strata"] = {
+        f"{stack}/{profile}": count for (stack, profile), count in report["strata"].items()
+    }
+    (out_dir / _REPORT_FILENAME).write_text(_canonical(report) + "\n", encoding="utf-8")
+
+    # 4. lineage.json: generated from the pin — every field must be present.
+    lineage: dict[str, Any] = {
+        field: _lineage_field(manifest, field, manifest_path) for field in _LINEAGE_PIN_FIELDS
+    }
+    lineage["schema_version"] = f"annotation-snapshot/{ANNOTATION_SNAPSHOT_SCHEMA_VERSION}"
+    bundle_root = curation_bundle_dir if curation_bundle_dir is not None else index_root
+    if not bundle_root.is_dir():
+        raise FileNotFoundError(
+            f"curation bundle dir for the batch fileset digest not found: {bundle_root}"
+        )
+    lineage["batch_fileset_digest"] = _derivative_digest(bundle_root)
+    # ``as_of`` is pin-required but legitimately empty when unpinned (mirroring
+    # ``snapshot.snapshot_id``'s as-of edge) — a *missing* key is an error.
+    if "as_of" not in manifest:
+        raise ValueError(
+            f"preview manifest at {manifest_path} is missing required lineage field 'as_of'"
+        )
+    lineage["as_of"] = str(manifest["as_of"])
+    (out_dir / _LINEAGE_FILENAME).write_text(_canonical(lineage) + "\n", encoding="utf-8")
+
+    written = sorted(path.name for path in out_dir.iterdir())
+    missing = [name for name in _BUNDLE_FILES if name not in written]
+    if missing:
+        raise ValueError(f"final bundle at {out_dir} is missing contract files: {missing}")
+
+    counts = Counter(str(r["disposition"]) for r in records)
+    disposition_counts = {
+        **{d: counts[d] for d in sorted(DECISIVE_DISPOSITIONS | NON_DECISIVE_DISPOSITIONS)},
+        **{k: v for k, v in sorted(counts.items())
+           if k not in DECISIVE_DISPOSITIONS and k not in NON_DECISIVE_DISPOSITIONS},
+    }
+    return {
+        "disposition_counts": disposition_counts,
+        "record_count": len(records),
+        "observation_history_rows": len(history_rows),
+        "files": written,
+        "out_dir": str(out_dir),
+    }

--- a/daydream/training/adjudication/materialize.py
+++ b/daydream/training/adjudication/materialize.py
@@ -19,9 +19,6 @@ from pathlib import Path
 from typing import Any, cast, get_args
 
 from daydream.archive.hydrate import HubUnavailableError
-from daydream.training.adjudication.dispositions import (
-    NON_DECISIVE_DISPOSITIONS as _NON_DECISIVE_DISPOSITIONS,
-)
 from daydream.training.adjudication.preview import _load_sessions
 from daydream.training.adjudication.snapshot import build_canonical_record, snapshot_id
 from daydream.training.labeler_signals import PerFindingDisposition, PerFindingResolution
@@ -152,7 +149,8 @@ def run_materialize(
     Loads the hydrated index's sessions (via ``preview._load_sessions`` —
     raises the ``HydrationError`` family on a missing/unreadable index and
     ``MovingBranchError`` on a symbolic index revision), builds one canonical
-    record per non-decisive finding, and emits:
+    record per finding (every disposition — automatic decisive, human-decisive,
+    and non-decisive), and emits:
 
     - ``out_dir/sessions.jsonl``: canonical-JSON records sorted by
       ``record_id``, written atomically. Identical index + pin ⇒
@@ -189,8 +187,6 @@ def run_materialize(
             if not isinstance(row, dict):
                 raise ValueError(f"materialize: non-object resolution row in session data: {row!r}")
             resolution = _resolution_from_row(row)
-            if resolution.disposition not in _NON_DECISIVE_DISPOSITIONS:
-                continue
             records.append(
                 build_canonical_record(
                     session,

--- a/daydream/training/adjudication/materialize.py
+++ b/daydream/training/adjudication/materialize.py
@@ -19,8 +19,10 @@ from pathlib import Path
 from typing import Any, cast, get_args
 
 from daydream.archive.hydrate import HubUnavailableError
+from daydream.training.adjudication.dispositions import (
+    NON_DECISIVE_DISPOSITIONS as _NON_DECISIVE_DISPOSITIONS,
+)
 from daydream.training.adjudication.preview import _load_sessions
-from daydream.training.adjudication.queue import _NON_DECISIVE_DISPOSITIONS
 from daydream.training.adjudication.snapshot import build_canonical_record, snapshot_id
 from daydream.training.labeler_signals import PerFindingDisposition, PerFindingResolution
 

--- a/daydream/training/adjudication/publish.py
+++ b/daydream/training/adjudication/publish.py
@@ -264,6 +264,44 @@ def _bundle_payloads(bundle_dir: Path) -> dict[str, bytes]:
     return payloads
 
 
+def _enforce_admission_gate(bundle_dir: Path) -> None:
+    """Refuse to publish a bundle whose own coverage report fails the 80%
+    human-adjudication admission gate (issue #336 finding 2).
+
+    The gate is read from the bundle's ``coverage-report.json`` (written by
+    ``final_bundle.build_final_bundle`` over the same enrichment as
+    ``corpus adjudicate report``): fails closed with
+    :class:`PublicDestinationError` before any byte is uploaded when the
+    report is missing, unreadable, or says ``passes_80pct`` is not true — so
+    publish-final can never upload identically to a fully adjudicated run.
+    """
+    report_path = bundle_dir / "coverage-report.json"
+    if not report_path.is_file():
+        raise PublicDestinationError(
+            f"refusing to publish: final bundle has no coverage report at {report_path} "
+            "(run `daydream corpus adjudicate publish-final --dry-run` to build and "
+            "inspect the bundle first)"
+        )
+    try:
+        report = json.loads(report_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:
+        raise PublicDestinationError(
+            f"refusing to publish: unreadable coverage report at {report_path}: {exc}"
+        ) from exc
+    if not isinstance(report, dict):
+        raise PublicDestinationError(
+            f"refusing to publish: coverage report at {report_path} is not a JSON object"
+        )
+    gate = report.get("admission_gate")
+    passes_80pct = gate.get("passes_80pct") if isinstance(gate, dict) else None
+    if passes_80pct is not True:
+        raise PublicDestinationError(
+            "refusing to publish: final bundle fails the 80% human-adjudication "
+            f"admission gate (coverage report at {report_path}); complete the "
+            "outcome-bearing adjudication backlog or re-materialize before publishing"
+        )
+
+
 def _resolve_hub_commit(client: HubClient, manifest_data: Mapping[str, Any], sums_bytes: bytes) -> str:
     """Resolve the Hub commit SHA under the pinned-revision policy (M6).
 
@@ -292,17 +330,21 @@ def publish_final_annotation_bundle(
     Strict order, each step fail-closed before anything is uploaded:
 
     1. :class:`PublicDestinationError` when the Hub repo is not private.
-    2. S1 secret scan over every bundle file (a hit raises naming the file).
-    3. ``SHA256SUMS`` over the file set, self-excluded (mirror
+    2. 80% human-adjudication admission gate read from the bundle's
+       ``coverage-report.json`` (:func:`_enforce_admission_gate`) — a missing,
+       unreadable, or failing report refuses publication (issue #336 finding 2),
+       before any byte is uploaded.
+    3. S1 secret scan over every bundle file (a hit raises naming the file).
+    4. ``SHA256SUMS`` over the file set, self-excluded (mirror
        ``hydrate.publish_batches``).
-    4. Additive upload of the bundle + manifest + sums.
-    5. Clean-download verification: every uploaded file is read back, re-hashed
+    5. Additive upload of the bundle + manifest + sums.
+    6. Clean-download verification: every uploaded file is read back, re-hashed
        and compared (``_download_verifier`` replaces this step when injected;
        returning ``False`` raises ``ValueError``).
-    6. Hub commit SHA resolved via :func:`hydrate.resolve_source_revision`
+    7. Hub commit SHA resolved via :func:`hydrate.resolve_source_revision`
        (pinned-revision policy) — a resolution failure propagates and
        ``_SUCCESS`` is never uploaded.
-    7. ``_SUCCESS`` uploaded **last** — its presence is the commitment that the
+    8. ``_SUCCESS`` uploaded **last** — its presence is the commitment that the
        bundle is complete and verified.
 
     Immutability (C2): publication is additive; re-publishing identical bytes
@@ -317,6 +359,12 @@ def publish_final_annotation_bundle(
     prefix = f"{annotation_prefix(manifest)}{_FINAL_SEGMENT}/"
     bundle_dir = Path(bundle_dir)
     manifest_data = _read_manifest_data(manifest)
+
+    # 80% admission gate (issue #336 finding 2): refuse before any byte is
+    # uploaded — and before any Hub revision lookup — when the bundle's own
+    # coverage report says the gate fails or is missing, so a half-adjudicated
+    # snapshot can never be committed under the final/ prefix.
+    _enforce_admission_gate(bundle_dir)
 
     payloads = _bundle_payloads(bundle_dir)
     for name, data in payloads.items():

--- a/daydream/training/adjudication/queue.py
+++ b/daydream/training/adjudication/queue.py
@@ -12,6 +12,9 @@ from typing import Any
 from daydream.training.adjudication.dispositions import (
     NON_DECISIVE_DISPOSITIONS as _NON_DECISIVE_DISPOSITIONS,
 )
+from daydream.training.adjudication.dispositions import (
+    is_decisive,
+)
 from daydream.training.adjudication.precedence import reopen_on_digest_change
 from daydream.training.corpus_v2.identity import record_id
 from daydream.training.corpus_v2.projector import project_findings
@@ -62,14 +65,25 @@ def build_queue(
     *,
     rubric_version: str = ADJUDICATION_LABELER_VERSION,
     prior_observations: Mapping[str, Mapping[str, Any]] | None = None,
+    include_decisive: bool = False,
 ) -> list[dict[str, object]]:
     """Build the adjudication queue items for the given segmented sessions.
 
     Each non-decisive (task-only) adjudication entry becomes one queue item
     keyed by the recomputed ``record_id``. Decisive/gold resolutions never
-    enter the queue: only the projector's adjudication set is consumed, and
-    every entry's disposition is additionally asserted to be non-decisive —
-    a violation raises ``ValueError`` naming the fingerprint (fail-closed).
+    enter the operator queue: only the projector's adjudication set is
+    consumed, and every entry's disposition is additionally asserted to be
+    non-decisive — a violation raises ``ValueError`` naming the fingerprint
+    (fail-closed).
+
+    Pass ``include_decisive=True`` to widen the queue to the complete record
+    set: decisive entries are enumerated from ``project_findings``' first
+    return value (they never appear in the adjudication set) and become queue
+    items with the same ``_ITEM_KEYS``, ``status="open"``, and their decisive
+    disposition carried verbatim. This is for the complete-set drift gate, not
+    the operator labeling path; the default (False) preserves the CLI contract
+    byte-for-byte. Re-open/digest-drift logic applies to decisive items
+    identically — they flow through the same ``prior_observations`` block.
 
     The queue is rebuilt deterministically, not immutable once built: when
     ``prior_observations`` (``record_id`` -> stored observation) contains a
@@ -86,7 +100,14 @@ def build_queue(
     """
     items: list[dict[str, object]] = []
     for session in sessions:
-        _, adjudication = project_findings(session, return_adjudication=True)
+        if include_decisive:
+            records, adjudication = project_findings(session, return_adjudication=True)
+            entries = adjudication + [
+                r for r in records if is_decisive(str(r.get("disposition")))
+            ]
+        else:
+            _, adjudication = project_findings(session, return_adjudication=True)
+            entries = adjudication
         session_id = str(session.get("session_id"))
         trajectory_id = str(session.get("trajectory_id"))
         segment_id = str(session.get("segment_id"))
@@ -95,10 +116,12 @@ def build_queue(
         for raw in resolutions if isinstance(resolutions, list) else []:
             if isinstance(raw, Mapping) and raw.get("fingerprint"):
                 by_fingerprint[str(raw["fingerprint"])] = raw
-        for entry in adjudication:
-            fingerprint = str(entry["fingerprint"])
+        for entry in entries:
+            fingerprint = str(
+                entry.get("fingerprint") or entry.get("finding_fingerprint")
+            )
             disposition = entry["disposition"]
-            if disposition not in _NON_DECISIVE_DISPOSITIONS:
+            if not include_decisive and disposition not in _NON_DECISIVE_DISPOSITIONS:
                 raise ValueError(
                     f"build_queue: adjudication entry for fingerprint {fingerprint!r} has "
                     f"non-queue disposition {disposition!r}; expected one of "

--- a/daydream/training/adjudication/queue.py
+++ b/daydream/training/adjudication/queue.py
@@ -9,16 +9,16 @@ non-decisive set, so the queue builder adds no second filtering pass.
 from collections.abc import Mapping, Sequence
 from typing import Any
 
-from daydream.training.adjudication.dispositions import (
-    NON_DECISIVE_DISPOSITIONS as _NON_DECISIVE_DISPOSITIONS,
-)
-from daydream.training.adjudication.dispositions import (
-    is_decisive,
-)
 from daydream.training.adjudication.precedence import reopen_on_digest_change
 from daydream.training.corpus_v2.identity import record_id
 from daydream.training.corpus_v2.projector import project_findings
 from daydream.training.corpus_v2.provenance import extract_provenance
+from daydream.training.dispositions import (
+    NON_DECISIVE_DISPOSITIONS as _NON_DECISIVE_DISPOSITIONS,
+)
+from daydream.training.dispositions import (
+    is_decisive,
+)
 from daydream.training.labeler_versions import ADJUDICATION_LABELER_VERSION
 
 __all__ = ["build_queue", "_NON_DECISIVE_DISPOSITIONS"]

--- a/daydream/training/adjudication/queue.py
+++ b/daydream/training/adjudication/queue.py
@@ -9,15 +9,16 @@ non-decisive set, so the queue builder adds no second filtering pass.
 from collections.abc import Mapping, Sequence
 from typing import Any
 
+from daydream.training.adjudication.dispositions import (
+    NON_DECISIVE_DISPOSITIONS as _NON_DECISIVE_DISPOSITIONS,
+)
 from daydream.training.adjudication.precedence import reopen_on_digest_change
 from daydream.training.corpus_v2.identity import record_id
 from daydream.training.corpus_v2.projector import project_findings
 from daydream.training.corpus_v2.provenance import extract_provenance
 from daydream.training.labeler_versions import ADJUDICATION_LABELER_VERSION
 
-__all__ = ["build_queue"]
-
-_NON_DECISIVE_DISPOSITIONS = frozenset({"ambiguous", "unanswered", "missing"})
+__all__ = ["build_queue", "_NON_DECISIVE_DISPOSITIONS"]
 
 _HUMAN_ROLES = frozenset({"rater", "adjudicator"})
 

--- a/daydream/training/corpus_v2/tiers.py
+++ b/daydream/training/corpus_v2/tiers.py
@@ -8,10 +8,10 @@ imports nothing from ``daydream.training.reward``.
 
 from typing import Literal, Mapping
 
-from daydream.training.adjudication.dispositions import (
+from daydream.training.dispositions import (
     DECISIVE_DISPOSITIONS as _DECISIVE_DISPOSITIONS,
 )
-from daydream.training.adjudication.dispositions import (
+from daydream.training.dispositions import (
     NON_DECISIVE_DISPOSITIONS as _NON_DECISIVE_DISPOSITIONS,
 )
 

--- a/daydream/training/corpus_v2/tiers.py
+++ b/daydream/training/corpus_v2/tiers.py
@@ -8,13 +8,16 @@ imports nothing from ``daydream.training.reward``.
 
 from typing import Literal, Mapping
 
-__all__ = ["GoldGateError", "classify_tier"]
+from daydream.training.adjudication.dispositions import (
+    DECISIVE_DISPOSITIONS as _DECISIVE_DISPOSITIONS,
+)
+from daydream.training.adjudication.dispositions import (
+    NON_DECISIVE_DISPOSITIONS as _NON_DECISIVE_DISPOSITIONS,
+)
+
+__all__ = ["GoldGateError", "classify_tier", "_NON_DECISIVE_DISPOSITIONS"]
 
 Tier = Literal["gold", "silver", "task-only"]
-
-_DECISIVE_DISPOSITIONS = frozenset({"accepted", "rejected"})
-_NON_DECISIVE_DISPOSITIONS = frozenset({"ambiguous", "unanswered", "missing"})
-
 
 class GoldGateError(ValueError):
     """Raised when a decisive disposition lacks human/developer evidence.

--- a/daydream/training/dispositions.py
+++ b/daydream/training/dispositions.py
@@ -1,0 +1,21 @@
+"""Single source of truth for adjudication disposition classification (issue #1078).
+
+Shared by the adjudication queue builder, the materialization step, and the
+corpus v2 tier classifier so the decisive/non-decisive split is defined once.
+
+Lives at ``daydream.training`` (not under ``adjudication``) so the corpus v2
+tier classifier can consume it without triggering the adjudication package's
+eager import chain.
+"""
+
+from typing import Final
+
+__all__ = ["DECISIVE_DISPOSITIONS", "NON_DECISIVE_DISPOSITIONS", "is_decisive"]
+
+NON_DECISIVE_DISPOSITIONS: Final[frozenset[str]] = frozenset({"ambiguous", "unanswered", "missing"})
+DECISIVE_DISPOSITIONS: Final[frozenset[str]] = frozenset({"accepted", "rejected"})
+
+
+def is_decisive(disposition: str) -> bool:
+    """Return True when ``disposition`` is a decisive outcome (accepted/rejected)."""
+    return disposition in DECISIVE_DISPOSITIONS

--- a/docs/runbooks/annotation-final-publish.md
+++ b/docs/runbooks/annotation-final-publish.md
@@ -1,0 +1,141 @@
+# Annotation Final-Publish Runbook (issue #1078, M9)
+
+This runbook walks the daydream operator through publishing the immutable,
+per-finding annotation snapshot to the private Hub and projecting it into a
+corpus-v2 training bundle — entirely from the `daydream corpus adjudicate`
+CLI. There are no hand-authored JSON files and no `python -c` imports: every
+artifact in the chain is produced and validated by a supported command.
+
+Audience: the daydream operator on a fresh VM, holding the private Hub dataset
+repo name and provider credentials in their environment.
+
+Two operator-safety constraints frame every step:
+
+- **Success is defined only by the end of step 8.** A run is finished when a
+  clean-download verification passes and the bundle's `_SUCCESS` marker is
+  present. Anything before that — including a green `--dry-run` — is not
+  success.
+- **The VM is expendable; the Hub checkpoint is not.** Step 2 recovers all
+  published adjudication state from the Hub after VM loss. Re-run it any time
+  you are unsure the local state is intact.
+
+Every command below is a literal, single-line CLI invocation that parses against the real parser (enforced by
+`tests/test_cli_adjudicate.py::test_runbook_commands_parse_against_real_parser`).
+
+---
+
+## 1. Hydrate the source index
+
+Bring the producer's archived run bundles down from the Hub into a local,
+normalized index root:
+
+```bash
+daydream corpus hydrate-hub --source-repo org/run-bundles --source-revision <commit-sha> --destination-repo org/run-bundles --stage-dir /tmp/daydream-hydrate
+```
+
+The resulting `downloads/<revision>/` tree is the hydrated index root this
+runbook refers to as `INDEX_ROOT`. It must contain `sessions.jsonl`.
+
+## 2. Restore adjudication state after VM loss
+
+If you are resuming on a fresh VM (or doubt the local state), restore the
+published adjudication state — digest-verified — from the Hub checkpoint:
+
+```bash
+daydream corpus adjudicate resume-state --manifest /tmp/state/preview-manifest.json --stage-dir /tmp/state
+```
+
+The manifest is the `preview-manifest.json` written by the last
+`publish-state` run; pin it with the state (keep it outside the expendable VM
+path, e.g. in the Hub repo or an operator-controlled store). After this step
+`/tmp/state` holds the restored observations and queue.
+
+## 3. Materialize the annotation snapshot
+
+Materialize one record per finding — automatic decisive, human-decisive, and
+non-decisive alike — into the snapshot directory:
+
+```bash
+daydream corpus adjudicate materialize --index-root /tmp/daydream-hydrate/downloads/<revision> --out-dir /tmp/snapshot
+```
+
+`/tmp/snapshot` receives `sessions.jsonl` and the `preview-manifest.json` that
+pins it. This snapshot is the input to both the canonical harvest (step 5) and
+the final bundle (steps 6–7).
+
+## 4. Build, label, and publish the human queue
+
+Build the unresolved-only operator queue, record human observations, and push
+state back to the Hub. These three commands repeat per labeling session:
+
+```bash
+daydream corpus adjudicate build --index-root /tmp/daydream-hydrate/downloads/<revision> --state-dir /tmp/state
+```
+
+```bash
+daydream corpus adjudicate label --state-dir /tmp/state --batch 10 --disposition accepted --rationale verified-against-diff-context --labeler alice
+```
+
+```bash
+daydream corpus adjudicate publish-state --state-dir /tmp/state --manifest /tmp/snapshot/preview-manifest.json
+```
+
+`build` never shows decisive records — those are adjudicated automatically.
+`label` records provenance (who, why, when) that the final bundle carries
+forward. `publish-state` uploads additively, so it is safe to re-run.
+
+## 5. Canonical harvest with the drift gate
+
+Run the canonical harvest: the drift gate checks the complete record set
+(decisive records included) against the queue, merges precedence, and appends
+label observations to the archive index:
+
+```bash
+daydream corpus adjudicate harvest-snapshot --index-root /tmp/daydream-hydrate/downloads/<revision> --materialize-dir /tmp/snapshot --archive-dir /tmp/archive --state-dir /tmp/state
+```
+
+A drift failure here means the snapshot and the queue disagree; fix the
+upstream labeling rather than bypassing the gate.
+
+## 6. Construct and validate the final bundle (dry run)
+
+Build the staging bundle — annotations, sessions, observation history,
+coverage report, and generated lineage — and validate every gate without
+publishing:
+
+```bash
+daydream corpus adjudicate publish-final --index-root /tmp/daydream-hydrate/downloads/<revision> --materialize-dir /tmp/snapshot --archive-dir /tmp/archive --curation-bundle-dir /tmp/daydream-hydrate/downloads/<revision> --hub-repo org/annotation-snapshot --dry-run
+```
+
+The private-repo gate, secret scan, and SHA256SUMS construction all run here.
+Only proceed when the dry run is green.
+
+## 7. Publish the final bundle
+
+Repeat the same command without `--dry-run` to upload the bundle additively to
+the Hub (the `_SUCCESS` marker is written last):
+
+```bash
+daydream corpus adjudicate publish-final --index-root /tmp/daydream-hydrate/downloads/<revision> --materialize-dir /tmp/snapshot --archive-dir /tmp/archive --curation-bundle-dir /tmp/daydream-hydrate/downloads/<revision> --hub-repo org/annotation-snapshot
+```
+
+## 8. Verify by clean download
+
+Success is defined only here. Re-download the published revision from the Hub
+(e.g. a clean clone of the dataset repo), re-run the same command with
+`--dry-run` against the downloaded tree, and confirm the bundle's `_SUCCESS`
+marker is present in the published layout. If either check fails, the publish
+is not done — re-run step 7.
+
+## 9. Project corpus v2
+
+Project the curated bundle and the verified annotation bundle into the frozen
+corpus-v2 training records:
+
+```bash
+daydream corpus build-v2 --bundle-root /tmp/daydream-hydrate/downloads/<revision> --annotation-bundle-root /tmp/annotation-bundle --out /tmp/corpus-v2/corpus-v2.jsonl
+```
+
+`build-v2` self-verifies and cross-links the annotation bundle before
+projecting, applies per-tier caps, and writes the split manifests and lineage
+beside the output. A green run here is the end of the pipeline.

--- a/docs/runbooks/annotation-final-publish.md
+++ b/docs/runbooks/annotation-final-publish.md
@@ -33,8 +33,12 @@ normalized index root:
 daydream corpus hydrate-hub --source-repo org/run-bundles --source-revision <commit-sha> --destination-repo org/run-bundles --stage-dir /tmp/daydream-hydrate
 ```
 
-The resulting `downloads/<revision>/` tree is the hydrated index root this
-runbook refers to as `INDEX_ROOT`. It must contain `sessions.jsonl`.
+The stage dir itself is the hydrated index root this runbook refers to as
+`INDEX_ROOT`: hydration writes the SQLite index (`index.db`) and one sanitized
+per-run trajectory (`runs/<session_id>/trajectory.json`) at the stage root,
+with the pinned source snapshot under `downloads/<revision>`. A hydrated
+staging archive has no `sessions.jsonl` — the commands below derive sessions
+from the index plus trajectories.
 
 ## 2. Restore adjudication state after VM loss
 
@@ -56,7 +60,7 @@ Materialize one record per finding — automatic decisive, human-decisive, and
 non-decisive alike — into the snapshot directory:
 
 ```bash
-daydream corpus adjudicate materialize --index-root /tmp/daydream-hydrate/downloads/<revision> --out-dir /tmp/snapshot
+daydream corpus adjudicate materialize --index-root /tmp/daydream-hydrate --out-dir /tmp/snapshot
 ```
 
 `/tmp/snapshot` receives `sessions.jsonl` and the `preview-manifest.json` that
@@ -69,7 +73,7 @@ Build the unresolved-only operator queue, record human observations, and push
 state back to the Hub. These three commands repeat per labeling session:
 
 ```bash
-daydream corpus adjudicate build --index-root /tmp/daydream-hydrate/downloads/<revision> --state-dir /tmp/state
+daydream corpus adjudicate build --index-root /tmp/snapshot --state-dir /tmp/state
 ```
 
 ```bash
@@ -80,7 +84,9 @@ daydream corpus adjudicate label --state-dir /tmp/state --batch 10 --disposition
 daydream corpus adjudicate publish-state --state-dir /tmp/state --manifest /tmp/snapshot/preview-manifest.json
 ```
 
-`build` never shows decisive records — those are adjudicated automatically.
+`build` consumes the materialized snapshot (the hydrated stage root has no
+`sessions.jsonl`; the snapshot written by step 3 does) and never shows
+decisive records — those are adjudicated automatically.
 `label` records provenance (who, why, when) that the final bundle carries
 forward. `publish-state` uploads additively, so it is safe to re-run.
 
@@ -88,10 +94,12 @@ forward. `publish-state` uploads additively, so it is safe to re-run.
 
 Run the canonical harvest: the drift gate checks the complete record set
 (decisive records included) against the queue, merges precedence, and appends
-label observations to the archive index:
+label observations to the hydrated stage's archive index (`--archive-dir` is
+the same `index.db` hydration wrote the runs into — no separate archive
+directory is materialized):
 
 ```bash
-daydream corpus adjudicate harvest-snapshot --index-root /tmp/daydream-hydrate/downloads/<revision> --materialize-dir /tmp/snapshot --archive-dir /tmp/archive --state-dir /tmp/state
+daydream corpus adjudicate harvest-snapshot --index-root /tmp/daydream-hydrate --materialize-dir /tmp/snapshot --archive-dir /tmp/daydream-hydrate --state-dir /tmp/state
 ```
 
 A drift failure here means the snapshot and the queue disagree; fix the
@@ -104,11 +112,17 @@ coverage report, and generated lineage — and validate every gate without
 publishing:
 
 ```bash
-daydream corpus adjudicate publish-final --index-root /tmp/daydream-hydrate/downloads/<revision> --materialize-dir /tmp/snapshot --archive-dir /tmp/archive --curation-bundle-dir /tmp/daydream-hydrate/downloads/<revision> --hub-repo org/annotation-snapshot --dry-run
+daydream corpus adjudicate publish-final --index-root /tmp/daydream-hydrate --materialize-dir /tmp/snapshot --archive-dir /tmp/daydream-hydrate --curation-bundle-dir /tmp/daydream-hydrate/curated/<curation-id> --hub-repo org/annotation-snapshot --state-dir /tmp/state --dry-run
 ```
 
-The private-repo gate, secret scan, and SHA256SUMS construction all run here.
-Only proceed when the dry run is green.
+The dry run validates the staging bundle's construction, coverage, and lineage
+only; the private-repo gate, secret scan, and SHA256SUMS construction run at
+real publish time (step 7). Only proceed when the dry run is green.
+
+`--curation-bundle-dir` is the hydration-produced curated bundle root — the
+single `cur-*` directory under `/tmp/daydream-hydrate/curated/` (the curation
+id is derived deterministically from the pinned source commit and is recorded
+as `curation_id` in `/tmp/snapshot/preview-manifest.json`).
 
 ## 7. Publish the final bundle
 
@@ -116,16 +130,18 @@ Repeat the same command without `--dry-run` to upload the bundle additively to
 the Hub (the `_SUCCESS` marker is written last):
 
 ```bash
-daydream corpus adjudicate publish-final --index-root /tmp/daydream-hydrate/downloads/<revision> --materialize-dir /tmp/snapshot --archive-dir /tmp/archive --curation-bundle-dir /tmp/daydream-hydrate/downloads/<revision> --hub-repo org/annotation-snapshot
+daydream corpus adjudicate publish-final --index-root /tmp/daydream-hydrate --materialize-dir /tmp/snapshot --archive-dir /tmp/daydream-hydrate --curation-bundle-dir /tmp/daydream-hydrate/curated/<curation-id> --hub-repo org/annotation-snapshot --state-dir /tmp/state
 ```
 
 ## 8. Verify by clean download
 
-Success is defined only here. Re-download the published revision from the Hub
-(e.g. a clean clone of the dataset repo), re-run the same command with
-`--dry-run` against the downloaded tree, and confirm the bundle's `_SUCCESS`
-marker is present in the published layout. If either check fails, the publish
-is not done — re-run step 7.
+Success is defined only here. Clean-download the published final bundle tree —
+`annotations/<curation-id>/<snapshot-id>/final/` in the dataset repo (the ids
+come from `/tmp/snapshot/preview-manifest.json`) — into a fresh directory
+(e.g. `/tmp/annotation-bundle`, which step 9 consumes), verify every file
+against the bundle's published `SHA256SUMS`, and confirm the `_SUCCESS` marker
+is present in that layout. Any checksum mismatch or a missing `_SUCCESS` means
+the publish is not done — re-run step 7.
 
 ## 9. Project corpus v2
 
@@ -133,9 +149,14 @@ Project the curated bundle and the verified annotation bundle into the frozen
 corpus-v2 training records:
 
 ```bash
-daydream corpus build-v2 --bundle-root /tmp/daydream-hydrate/downloads/<revision> --annotation-bundle-root /tmp/annotation-bundle --out /tmp/corpus-v2/corpus-v2.jsonl
+daydream corpus build-v2 --bundle-root /tmp/daydream-hydrate/curated/<curation-id> --annotation-bundle-root /tmp/annotation-bundle --out /tmp/corpus-v2/corpus-v2.jsonl
 ```
 
-`build-v2` self-verifies and cross-links the annotation bundle before
-projecting, applies per-tier caps, and writes the split manifests and lineage
-beside the output. A green run here is the end of the pipeline.
+`build-v2` self-verifies the annotation bundle (`_SUCCESS`, `SHA256SUMS`,
+`lineage.json`, `annotations.jsonl`) and cross-links it against the curated
+bundle root before projecting — `--bundle-root` is the hydration-produced
+curated bundle (`/tmp/daydream-hydrate/curated/<curation-id>/`, which carries
+`_SUCCESS`, `SHA256SUMS`, and `curation-manifest.json`), not the raw
+`downloads/<revision>` snapshot tree. It applies per-tier caps and writes the
+split manifests and lineage beside the output. A green run here is the end of
+the pipeline.

--- a/docs/runbooks/annotation-final-publish.md
+++ b/docs/runbooks/annotation-final-publish.md
@@ -46,7 +46,7 @@ If you are resuming on a fresh VM (or doubt the local state), restore the
 published adjudication state — digest-verified — from the Hub checkpoint:
 
 ```bash
-daydream corpus adjudicate resume-state --manifest /tmp/state/preview-manifest.json --stage-dir /tmp/state
+daydream corpus adjudicate resume-state --manifest /tmp/state/preview-manifest.json --stage-dir /tmp/state --hub-repo org/annotation-snapshot
 ```
 
 The manifest is the `preview-manifest.json` written by the last
@@ -60,8 +60,18 @@ Materialize one record per finding — automatic decisive, human-decisive, and
 non-decisive alike — into the snapshot directory:
 
 ```bash
-daydream corpus adjudicate materialize --index-root /tmp/daydream-hydrate --out-dir /tmp/snapshot
+daydream corpus adjudicate materialize --index-root /tmp/daydream-hydrate --out-dir /tmp/snapshot --curation-id <curation-id> --sanitized-hub-commit <commit-sha> --source-hub-commit <commit-sha> --archive-index-digest <archive-index-digest> --evidence-observed-at <evidence-observed-at>
 ```
+
+All five pin components are mandatory — a missing one is an exit-1 data
+problem, not a usage error, and nothing is written. `--curation-id` is the
+single `cur-*` directory hydration wrote under
+`/tmp/daydream-hydrate/curated/` (recorded as `curation_id` in that
+directory's `curation-manifest.json`); `--source-hub-commit` is the pinned
+`<commit-sha>` from step 1 (recorded as `source_hub_commit` in the same
+curation manifest), and `--sanitized-hub-commit` is the same pinned revision.
+`--archive-index-digest` is the 64-hex sha256 of the hydrated archive index;
+`--evidence-observed-at` is the ISO-8601 observation timestamp.
 
 `/tmp/snapshot` receives `sessions.jsonl` and the `preview-manifest.json` that
 pins it. This snapshot is the input to both the canonical harvest (step 5) and
@@ -81,7 +91,7 @@ daydream corpus adjudicate label --state-dir /tmp/state --batch 10 --disposition
 ```
 
 ```bash
-daydream corpus adjudicate publish-state --state-dir /tmp/state --manifest /tmp/snapshot/preview-manifest.json
+daydream corpus adjudicate publish-state --state-dir /tmp/state --manifest /tmp/snapshot/preview-manifest.json --hub-repo org/annotation-snapshot
 ```
 
 `build` consumes the materialized snapshot (the hydrated stage root has no
@@ -116,8 +126,12 @@ daydream corpus adjudicate publish-final --index-root /tmp/daydream-hydrate --ma
 ```
 
 The dry run validates the staging bundle's construction, coverage, and lineage
-only; the private-repo gate, secret scan, and SHA256SUMS construction run at
-real publish time (step 7). Only proceed when the dry run is green.
+only, and prints the 80% human-adjudication admission-gate verdict (PASS/FAIL
+over the outcome-bearing numerator/denominator). The private-repo gate, the
+admission-gate refusal, the secret scan, and SHA256SUMS construction run at
+real publish time (step 7). Only proceed when the dry run is green — a red
+gate means more outcome-bearing records must be adjudicated and the bundle
+rebuilt before the Hub can ever see it.
 
 `--curation-bundle-dir` is the hydration-produced curated bundle root — the
 single `cur-*` directory under `/tmp/daydream-hydrate/curated/` (the curation
@@ -127,7 +141,10 @@ as `curation_id` in `/tmp/snapshot/preview-manifest.json`).
 ## 7. Publish the final bundle
 
 Repeat the same command without `--dry-run` to upload the bundle additively to
-the Hub (the `_SUCCESS` marker is written last):
+the Hub (the `_SUCCESS` marker is written last). A bundle whose coverage
+report fails the 80% human-adjudication admission gate is refused (the
+handler exits 1) before any byte is uploaded: adjudicate more outcome-bearing
+records and rebuild before re-publishing.
 
 ```bash
 daydream corpus adjudicate publish-final --index-root /tmp/daydream-hydrate --materialize-dir /tmp/snapshot --archive-dir /tmp/daydream-hydrate --curation-bundle-dir /tmp/daydream-hydrate/curated/<curation-id> --hub-repo org/annotation-snapshot --state-dir /tmp/state

--- a/tests/fixtures/training/build_snapshot_decisive.py
+++ b/tests/fixtures/training/build_snapshot_decisive.py
@@ -1,0 +1,85 @@
+"""Decisive-finding fake-Hub snapshot for the end-to-end annotation pipeline.
+
+Extends :mod:`tests.fixtures.training.build_hub_snapshot` with exactly one
+delta: each session's per-finding resolution carries a disposition mix that
+exercises every materialization class — sess-a automatic ``accepted``,
+sess-b automatic ``rejected``, sess-c ``unanswered`` (human-resolved by the
+label step). Ids, manifests, curation derivation, and FakeHub wiring are
+unchanged; the evidence digest is recomputed per the shared serializer
+contract, and the profile/stack fields mirror ``_snapshot_trajectory``.
+"""
+
+from __future__ import annotations
+
+import json
+
+from daydream.archive.hydrate_client import FakeHub
+from daydream.archive.hydrate_rules import (
+    ADMISSION_POLICY_VERSION,
+    HYDRATION_INDEX_SCHEMA_VERSION,
+    SANITIZER_VERSION,
+    derive_curation_id,
+)
+from tests.fixtures.training.build_archive import FIXTURE_SESSIONS
+from tests.fixtures.training.build_hub_snapshot import (
+    REPO_ID,
+    SNAPSHOT_REVISION,
+    _snapshot_manifest,
+)
+
+__all__ = ["REPO_ID", "SNAPSHOT_REVISION", "build_snapshot_decisive"]
+
+# One decisive class per session: automatic accepted, automatic rejected,
+# human-resolved (label step) — the §9 alias ids from the base snapshot.
+_DECISIVE_DISPOSITIONS = {"sess-a": "accepted", "sess-b": "rejected", "sess-c": "unanswered"}
+
+
+def _snapshot_trajectory_decisive(session_id: str) -> dict[str, object]:
+    """The base snapshot trajectory with the session's disposition applied."""
+    from tests.fixtures.training.build_hub_snapshot import _snapshot_trajectory
+
+    trajectory = _snapshot_trajectory(session_id)
+    resolutions = trajectory["resolutions"]
+    assert isinstance(resolutions, list) and len(resolutions) == 1
+    resolution = dict(resolutions[0])
+    resolution["disposition"] = _DECISIVE_DISPOSITIONS[session_id]
+    trajectory["resolutions"] = [resolution]
+    return trajectory
+
+
+def build_snapshot_decisive(*, hostile: bool = False) -> FakeHub:
+    """Materialize the pinned three-session snapshot as an in-memory FakeHub."""
+    files: dict[str, bytes] = {}
+    for session_id, session in zip(
+        ("sess-a", "sess-b", "sess-c"), FIXTURE_SESSIONS, strict=False
+    ):
+        manifest = _snapshot_manifest(
+            session_id, session.repo_slug, session.skill, session.outcome_labels
+        )
+        files[f"{session_id}/manifest.json"] = json.dumps(
+            manifest.to_dict(), indent=2
+        ).encode()
+        files[f"{session_id}/trajectory.json"] = json.dumps(
+            _snapshot_trajectory_decisive(session_id), indent=2
+        ).encode()
+    # Non-run metadata and derived outputs: hydration must ignore them.
+    files["README.md"] = b"production trajectory archive\n"
+    files["dataset_info.json"] = b'{"dataset": "daydream-trajectories"}\n'
+    files["curated/cur-old/batches/old/manifest.json"] = b'{"derived": true}\n'
+    files["annotations/latest/sessions.jsonl"] = b'{"derived": true}\n'
+    files["bronze/manifest.json"] = b'{"bronze": true}\n'
+    curation_id = derive_curation_id(
+        SNAPSHOT_REVISION,
+        SANITIZER_VERSION,
+        HYDRATION_INDEX_SCHEMA_VERSION,
+        ADMISSION_POLICY_VERSION,
+    )
+    files[f"curated/{curation_id}/resume/ledger.jsonl"] = b""
+
+    if hostile:
+        files["../../escape.txt"] = b"pwned"
+        files["/etc/daydream-escape"] = b"pwned"
+
+    hub = FakeHub(repo_id=REPO_ID, private=True, files=files)
+    hub.commit_revision(SNAPSHOT_REVISION)
+    return hub

--- a/tests/test_annotation_pipeline_integration.py
+++ b/tests/test_annotation_pipeline_integration.py
@@ -108,7 +108,10 @@ def test_full_annotation_pipeline_survives_vm_loss(
     final_prefix = f"annotations/{curation_id}/{snapshot_id}/final/"
     assert hub.files[f"{final_prefix}_SUCCESS"] == b""
 
-    # 7. clean download into a fresh dir verifies checksums
+    # 7. clean download into a fresh dir verifies checksums. Copying the
+    # published files off the (fake) Hub is fixture transport — the bundle
+    # itself was constructed and uploaded exclusively by the CLI above; this
+    # loop only materializes the download side of the runbook's verify step.
     clean = tmp_path / "clean-download"
     clean.mkdir()
     for key, data in hub.files.items():

--- a/tests/test_annotation_pipeline_integration.py
+++ b/tests/test_annotation_pipeline_integration.py
@@ -95,15 +95,18 @@ def test_full_annotation_pipeline_survives_vm_loss(
     for session_id in ("sess-a", "sess-b", "sess-c"):
         assert len(label_observation_history(stage, session_id)) == 1
 
-    # 6-7. final bundle: CLI only — build + dry-run + publish
+    # 6-7. final bundle: CLI only — build + dry-run + publish (the resumed
+    # state dir is the observations source the coverage report's gate reads).
     assert handle_adjudicate([
         "publish-final", "--index-root", str(stage), "--materialize-dir", str(mat),
         "--archive-dir", str(stage), "--curation-bundle-dir", str(stage / "curated" / curation_id),
+        "--state-dir", str(fresh),
         "--hub-repo", "org/private-ds", "--dry-run"]) == 0
     assert handle_adjudicate([
         "publish-final", "--index-root", str(stage), "--materialize-dir", str(mat),
         "--archive-dir", str(stage),
         "--curation-bundle-dir", str(stage / "curated" / curation_id),
+        "--state-dir", str(fresh),
         "--hub-repo", "org/private-ds"]) == 0
     final_prefix = f"annotations/{curation_id}/{snapshot_id}/final/"
     assert hub.files[f"{final_prefix}_SUCCESS"] == b""

--- a/tests/test_annotation_pipeline_integration.py
+++ b/tests/test_annotation_pipeline_integration.py
@@ -86,7 +86,7 @@ def test_full_annotation_pipeline_survives_vm_loss(
     # 5. canonical harvest: drift-checked, appends label_observations exactly
     #    once per session into the hydrated stage's SQLite index
     harvest = run_canonical_harvest(
-        index_root=mat, materialize_dir=mat, archive_dir=stage,
+        index_root=stage, materialize_dir=mat, archive_dir=stage,
         observations_path=fresh / "observations.jsonl")
     assert harvest["appended_sessions"] == 3
     assert harvest["human_adjudicated"] == 1

--- a/tests/test_annotation_pipeline_integration.py
+++ b/tests/test_annotation_pipeline_integration.py
@@ -1,30 +1,42 @@
 """AC 7 end-to-end: hydrate -> preview -> adjudication -> VM-loss resume ->
-canonical harvest -> publication -> clean download -> build-v2 dry run.
+canonical harvest -> CLI-only final publish -> clean download -> build-v2.
 
 Fake-Hub only (K6, mirrors test_archive_hydrate_integration.py) — no network.
+Every post-hydration publication step goes through the supported CLI
+(``handle_adjudicate``); no hand-authored bundle files anywhere (M7).
 """
 from __future__ import annotations
 
 import json
 from pathlib import Path
 
+import pytest
+
 from daydream.archive import hydrate
-from daydream.archive.sanitize import _derivative_digest
 from daydream.training.adjudication.canonical import run_canonical_harvest
 from daydream.training.adjudication.cli import handle_adjudicate
 from daydream.training.adjudication.materialize import run_materialize
 from daydream.training.adjudication.preview import run_preview
 from daydream.training.adjudication.publish import (
     publish_annotation_state,
-    publish_final_annotation_bundle,
     resume_annotation_state,
 )
-from daydream.training.labeler_versions import ANNOTATION_SNAPSHOT_SCHEMA_VERSION
-from tests.fixtures.training.build_hub_snapshot import SNAPSHOT_REVISION, build_snapshot
+from tests.fixtures.training.build_snapshot_decisive import (
+    SNAPSHOT_REVISION,
+    build_snapshot_decisive,
+)
 
 
-def test_full_annotation_pipeline_survives_vm_loss(tmp_path: Path) -> None:
-    hub = build_snapshot()
+def test_full_annotation_pipeline_survives_vm_loss(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from daydream.training.adjudication import cli as adjudication_cli
+
+    hub = build_snapshot_decisive()
+    # Route the CLI's Hub client factory at the in-memory FakeHub (the
+    # documented _make_client monkeypatch seam) — the test itself stays
+    # CLI-only.
+    monkeypatch.setattr(adjudication_cli, "_make_client", lambda repo_id: hub)
 
     # 1. hydrate: VM-local SQLite index over the fake Hub snapshot
     stage = tmp_path / "stage"
@@ -47,10 +59,11 @@ def test_full_annotation_pipeline_survives_vm_loss(tmp_path: Path) -> None:
     mat = tmp_path / "mat"
     result = run_materialize(stage, mat, pin=pin)
     snapshot_id = result["snapshot_id"]
-    assert result["record_count"] == 3  # one unanswered finding per fixture session
+    assert result["record_count"] == 3  # one finding per fixture session
 
-    # 3. adjudication: build the queue over the materialized snapshot, label one
-    #    batch, then publish the durable state (queue + ledger + observations).
+    # 3. adjudication: build the queue over the materialized snapshot (only
+    #    the unresolved item remains — the automatic decisive findings are
+    #    already adjudicated), label it, then publish the durable state.
     state = tmp_path / "state"
     assert handle_adjudicate([
         "build", "--index-root", str(mat), "--state-dir", str(state)]) == 0
@@ -82,68 +95,59 @@ def test_full_annotation_pipeline_survives_vm_loss(tmp_path: Path) -> None:
     for session_id in ("sess-a", "sess-b", "sess-c"):
         assert len(label_observation_history(stage, session_id)) == 1
 
-    # 6. publish the final annotation bundle (SHA256SUMS + _SUCCESS last)
-    bundle_root = mat / "final-bundle"
-    bundle_root.mkdir()
-    (bundle_root / "annotations.jsonl").write_bytes(
-        (mat / "annotations.jsonl").read_bytes())
-    (bundle_root / "sessions.jsonl").write_bytes(
-        (mat / "sessions.jsonl").read_bytes())
-    (bundle_root / "lineage.json").write_text(json.dumps({
-        "curation_id": curation_id, "sanitized_hub_commit": SNAPSHOT_REVISION,
-        "snapshot_id": snapshot_id,
-        "schema_version": f"annotation-snapshot/{ANNOTATION_SNAPSHOT_SCHEMA_VERSION}",
-        # the curation bundle is finalized by hydrate and never mutated
-        # afterward (K3), so its canonical file-set digest is stable at
-        # publication time and matches what the build-v2 gate recomputes
-        "batch_fileset_digest": _derivative_digest(stage / "curated" / curation_id),
-        "labeler_version": pin["labeler_version"],
-        "rubric_version": pin["rubric_version"],
-        "classifier_version": pin["classifier_version"],
-        "as_of": pin["as_of"],
-    }, sort_keys=True) + "\n", encoding="utf-8")
-    final = publish_final_annotation_bundle(
-        hub, bundle_root, manifest=mat / "preview-manifest.json", verify_download=True)
-    assert final["hub_commit_sha"]
+    # 6-7. final bundle: CLI only — build + dry-run + publish
+    assert handle_adjudicate([
+        "publish-final", "--index-root", str(stage), "--materialize-dir", str(mat),
+        "--archive-dir", str(stage), "--curation-bundle-dir", str(stage / "curated" / curation_id),
+        "--hub-repo", "org/private-ds", "--dry-run"]) == 0
+    assert handle_adjudicate([
+        "publish-final", "--index-root", str(stage), "--materialize-dir", str(mat),
+        "--archive-dir", str(stage),
+        "--curation-bundle-dir", str(stage / "curated" / curation_id),
+        "--hub-repo", "org/private-ds"]) == 0
+    final_prefix = f"annotations/{curation_id}/{snapshot_id}/final/"
+    assert hub.files[f"{final_prefix}_SUCCESS"] == b""
 
     # 7. clean download into a fresh dir verifies checksums
     clean = tmp_path / "clean-download"
     clean.mkdir()
-    prefix = final["prefix"]
     for key, data in hub.files.items():
-        if key.startswith(prefix):
-            rel = Path(key[len(prefix):])
+        if key.startswith(final_prefix):
+            rel = Path(key[len(final_prefix):])
             rel.parent.mkdir(parents=True, exist_ok=True)
             (clean / rel).write_bytes(data)
     from daydream.training.corpus_v2.bundle import _verify_sha256sums
 
     _verify_sha256sums(clean, "")  # raises on any corruption
 
-    # 8. corpus-v2 build over the curation bundle + the downloaded annotation
-    #    bundle (the hydrated stage's curated/ dir is the curation bundle)
+    # 8. corpus-v2: both automatic gold classes + the human-adjudicated record.
+    # The human rater's decisive label is merged into the annotation row
+    # before publication, so the human-adjudicated finding is gold too
+    # (decisive + evidence); task-only findings never reach corpus.jsonl —
+    # the projector routes them to adjudication-report.json (D8) and
+    # summary["total"] counts emitted records only.
     from daydream.training.corpus_v2.projector import (
         BuildCorpusV2Config,
         run_build_corpus_v2,
     )
 
     summary = run_build_corpus_v2(BuildCorpusV2Config(
-        out_dir=tmp_path / "corpus-out",
-        bundle_dir=stage / "curated" / curation_id,
-        annotation_bundle_dir=clean,
-    ))
+        out_dir=tmp_path / "corpus-out", bundle_dir=stage / "curated" / curation_id,
+        annotation_bundle_dir=clean))
     assert (tmp_path / "corpus-out" / "_SUCCESS").is_file()
-    # exactly one decisive record: one of the three fixture findings was
-    # human-adjudicated to `accepted`, the other two remain unanswered
-    assert summary["total"] == 1
-    # The gold record must carry the canonical record's nested profile block
-    # verbatim (Req 8: profile values never dropped at the projection
-    # boundary) — annotation rows are build_canonical_record output with the
-    # profile nested under "profile", not flat profile_* keys.
     records = [json.loads(line) for line in
                (tmp_path / "corpus-out" / "corpus.jsonl").read_text().splitlines() if line]
-    assert len(records) == 1
-    assert records[0]["profile"] == {
-        "profile_schema_version": 2, "profile_name": "pr_review",
-        "profile_source_kind": "builtin", "profile_digest": "d" * 64,
-    }
-    assert records[0]["stack"] == "python"
+    assert summary["total"] == 3
+    assert sorted(r["tier"] for r in records) == ["gold", "gold", "gold"]
+    assert {r["session_id"] for r in records} == {"sess-a", "sess-b", "sess-c"}
+    # The canonical records must carry the nested profile block verbatim
+    # (Req 8: profile values never dropped at the projection boundary) —
+    # annotation rows are build_canonical_record output with the profile
+    # nested under "profile", not flat profile_* keys.
+    for record in records:
+        assert record["profile"] == {
+            "profile_schema_version": 2, "profile_name": "pr_review",
+            "profile_source_kind": "builtin", "profile_digest": "d" * 64,
+        }
+        assert record["stack"] == "python"
+

--- a/tests/test_cli_adjudicate.py
+++ b/tests/test_cli_adjudicate.py
@@ -385,22 +385,92 @@ from tests.test_training_adjudication_final_bundle import seed_final_bundle_stat
 
 
 def test_publish_final_dry_run_validates_and_publishes_nothing(
-        tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        tmp_path: Path, capsys: pytest.CaptureFixture[str],
+        monkeypatch: pytest.MonkeyPatch) -> None:
+    from daydream.training.adjudication import cli as adjudication_cli
+    from daydream.training.corpus_v2.identity import record_id
+
     hub = build_snapshot()
+    # Route the CLI's Hub client factory at this in-memory hub (the documented
+    # _make_client monkeypatch seam), so the "nothing was published" assertion
+    # observes the exact hub the CLI would publish to. The fixture index pins
+    # the ``a*40`` revision, so the hub must know that commit for a real
+    # publish's pinned-revision resolution to succeed (mirrors the integration
+    # fixture, whose hub carries its committed SNAPSHOT_REVISION).
+    hub.commit_revision("a" * 40)
+    monkeypatch.setattr(adjudication_cli, "_make_client", lambda repo_id: hub)
     index_root, mat, archive_dir, pin = seed_final_bundle_state(tmp_path)
+    state = tmp_path / "state"
+    state.mkdir()
+    # The human adjudication state the final bundle's coverage report must see
+    # for the 80% admission gate to pass (the same shape the CLI `label` verb
+    # records): alice decisive on the s1 finding, evidence digest matching the
+    # materialized record.
+    (state / "observations.jsonl").write_text(json.dumps({
+        "record_id": record_id("s1", "s1-t", "s1-seg", "fp-1"),
+        "disposition": "accepted",
+        "evidence_digest": "d" * 32,
+        "evidence": [{"reply_id": 1, "body_sha256": "abc",
+                       "created_at": "2026-01-01T00:00:00+00:00"}],
+        "labeler": "alice", "role": "rater",
+        "rationale": "clear maintainer approval",
+        "valid_at": "2026-02-02T00:00:00+00:00",
+        "observed_at": "2026-02-02T00:00:00+00:00",
+        "rubric_version": "v1",
+    }) + "\n", encoding="utf-8")
+    run_canonical_harvest(index_root, mat, archive_dir,
+                          observations_path=state / "observations.jsonl")
+    rc = handle_adjudicate([
+        "publish-final", "--index-root", str(index_root),
+        "--materialize-dir", str(mat), "--archive-dir", str(archive_dir),
+        "--curation-bundle-dir", str(index_root),
+        "--state-dir", str(state),
+        "--hub-repo", "org/private-ds", "--dry-run"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "annotations.jsonl" in out and "record" in out.lower()
+    # nothing was published: the dry-run validated the bundle without ever
+    # constructing a client, so the wired hub still carries no final/ keys
+    assert not any(k.startswith("annotations/") and "/final/" in k for k in hub.files)
+
+    # Contrast experiment: the same invocation without --dry-run publishes
+    # through the very same wired hub and the final/ keys appear, proving the
+    # "nothing was published" assertion above is not structurally blind.
+    assert handle_adjudicate([
+        "publish-final", "--index-root", str(index_root),
+        "--materialize-dir", str(mat), "--archive-dir", str(archive_dir),
+        "--curation-bundle-dir", str(index_root),
+        "--state-dir", str(state),
+        "--hub-repo", "org/private-ds"]) == 0
+    assert any(k.startswith("annotations/") and "/final/" in k for k in hub.files)
+
+
+def test_publish_final_refuses_when_admission_gate_not_met(
+        tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The real (non-dry-run) publish path must refuse a bundle whose own
+    coverage report fails the 80% human-adjudication admission gate: with no
+    human observations the bundle's report says passes_80pct=false, and the
+    handler must exit 1 without any byte reaching the Hub (issue #336 finding
+    2 — publish-final must not upload identically to a fully adjudicated
+    run)."""
+    from daydream.training.adjudication import cli as adjudication_cli
+
+    hub = build_snapshot()
+    hub.commit_revision("a" * 40)
+    monkeypatch.setattr(adjudication_cli, "_make_client", lambda repo_id: hub)
+    index_root, mat, archive_dir, pin = seed_final_bundle_state(tmp_path)
+    # canonical harvest with no human observations anywhere: the coverage
+    # report's gate has a 0/0 outcome-bearing numerator/denominator
     run_canonical_harvest(index_root, mat, archive_dir, observations_path=None)
     rc = handle_adjudicate([
         "publish-final", "--index-root", str(index_root),
         "--materialize-dir", str(mat), "--archive-dir", str(archive_dir),
         "--curation-bundle-dir", str(index_root),
         "--state-dir", str(tmp_path / "state"),
-        "--hub-repo", "org/private-ds", "--dry-run"])
-    assert rc == 0
-    out = capsys.readouterr().out
-    assert "annotations.jsonl" in out and "record" in out.lower()
-    # nothing was published: the hub object carries no final/ prefix
-    assert not any(k.startswith("annotations/") and "/final/" in k
-                   for k in getattr(hub, "files", {}))
+        "--hub-repo", "org/private-ds"])
+    assert rc == 1
+    assert not any(k.startswith("annotations/") and "/final/" in k for k in hub.files)
+
 
 def test_publish_final_missing_artifact_exits_nonzero(
         tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:

--- a/tests/test_cli_adjudicate.py
+++ b/tests/test_cli_adjudicate.py
@@ -384,7 +384,8 @@ from tests.fixtures.training.build_hub_snapshot import build_snapshot  # noqa: E
 from tests.test_training_adjudication_final_bundle import seed_final_bundle_state  # noqa: E402
 
 
-def test_publish_final_dry_run_validates_and_publishes_nothing(tmp_path, capsys):
+def test_publish_final_dry_run_validates_and_publishes_nothing(
+        tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
     hub = build_snapshot()
     index_root, mat, archive_dir, pin = seed_final_bundle_state(tmp_path)
     run_canonical_harvest(index_root, mat, archive_dir, observations_path=None)
@@ -400,7 +401,8 @@ def test_publish_final_dry_run_validates_and_publishes_nothing(tmp_path, capsys)
     assert not any(k.startswith("annotations/") and "/final/" in k
                    for k in getattr(hub, "files", {}))
 
-def test_publish_final_missing_artifact_exits_nonzero(tmp_path, capsys):
+def test_publish_final_missing_artifact_exits_nonzero(
+        tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
     index_root, mat, archive_dir, pin = seed_final_bundle_state(tmp_path)
     ann = mat / "annotations.jsonl"
     if ann.exists():
@@ -421,6 +423,7 @@ def test_publish_final_missing_artifact_exits_nonzero(tmp_path, capsys):
 
 def test_runbook_commands_parse_against_real_parser() -> None:
     import re
+
     from daydream.training.adjudication.cli import _build_adjudicate_parser
     text = (Path(__file__).parents[1] / "docs" / "runbooks" /
             "annotation-final-publish.md").read_text()

--- a/tests/test_cli_adjudicate.py
+++ b/tests/test_cli_adjudicate.py
@@ -417,3 +417,22 @@ def test_publish_final_missing_artifact_exits_nonzero(tmp_path, capsys):
     # the unsplittable path token
     flattened = "".join(captured.out.split()).replace("║", "")
     assert "annotations.jsonl" in flattened + captured.err
+
+
+def test_runbook_commands_parse_against_real_parser() -> None:
+    import re
+    from daydream.training.adjudication.cli import _build_adjudicate_parser
+    text = (Path(__file__).parents[1] / "docs" / "runbooks" /
+            "annotation-final-publish.md").read_text()
+    cmds = re.findall(r"daydream corpus adjudicate [^\s`].*", text)
+    assert cmds, "runbook must contain literal CLI commands"
+    for cmd in cmds:
+        argv = cmd.split()[3:]
+        if "--help" in argv:
+            continue
+        parser = _build_adjudicate_parser()
+        # parse-check only; unknown flags/sub-verbs raise SystemExit(2)
+        try:
+            parser.parse_args(argv)
+        except SystemExit as exc:
+            raise AssertionError(f"runbook command not parseable: {cmd}") from exc

--- a/tests/test_cli_adjudicate.py
+++ b/tests/test_cli_adjudicate.py
@@ -393,6 +393,7 @@ def test_publish_final_dry_run_validates_and_publishes_nothing(
         "publish-final", "--index-root", str(index_root),
         "--materialize-dir", str(mat), "--archive-dir", str(archive_dir),
         "--curation-bundle-dir", str(index_root),
+        "--state-dir", str(tmp_path / "state"),
         "--hub-repo", "org/private-ds", "--dry-run"])
     assert rc == 0
     out = capsys.readouterr().out
@@ -410,8 +411,9 @@ def test_publish_final_missing_artifact_exits_nonzero(
     rc = handle_adjudicate([
         "publish-final", "--index-root", str(index_root),
         "--materialize-dir", str(mat), "--archive-dir", str(archive_dir),
-        "--curation-bundle-dir", str(index_root), "--hub-repo", "org/private-ds",
-        "--dry-run"])
+        "--curation-bundle-dir", str(index_root),
+        "--state-dir", str(tmp_path / "state"),
+        "--hub-repo", "org/private-ds", "--dry-run"])
     assert rc == 1
     captured = capsys.readouterr()
     # the panel hard-folds long messages mid-word (with the right border

--- a/tests/test_cli_adjudicate.py
+++ b/tests/test_cli_adjudicate.py
@@ -375,3 +375,45 @@ def test_cli_publish_state_missing_state_file_exits_1(
     captured = capsys.readouterr()
     assert "publish-state failed" in captured.out + captured.err
     assert "No such file or directory" in captured.out + captured.err  # FileNotFoundError rendered, not a traceback
+
+
+# ---- final publish verb (issue #1078, task 6 / M4-M6) ----
+
+from daydream.training.adjudication.canonical import run_canonical_harvest  # noqa: E402
+from tests.fixtures.training.build_hub_snapshot import build_snapshot  # noqa: E402
+from tests.test_training_adjudication_final_bundle import seed_final_bundle_state  # noqa: E402
+
+
+def test_publish_final_dry_run_validates_and_publishes_nothing(tmp_path, capsys):
+    hub = build_snapshot()
+    index_root, mat, archive_dir, pin = seed_final_bundle_state(tmp_path)
+    run_canonical_harvest(index_root, mat, archive_dir, observations_path=None)
+    rc = handle_adjudicate([
+        "publish-final", "--index-root", str(index_root),
+        "--materialize-dir", str(mat), "--archive-dir", str(archive_dir),
+        "--curation-bundle-dir", str(index_root),
+        "--hub-repo", "org/private-ds", "--dry-run"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "annotations.jsonl" in out and "record" in out.lower()
+    # nothing was published: the hub object carries no final/ prefix
+    assert not any(k.startswith("annotations/") and "/final/" in k
+                   for k in getattr(hub, "files", {}))
+
+def test_publish_final_missing_artifact_exits_nonzero(tmp_path, capsys):
+    index_root, mat, archive_dir, pin = seed_final_bundle_state(tmp_path)
+    ann = mat / "annotations.jsonl"
+    if ann.exists():
+        ann.unlink()  # the canonical-harvest output when present; either way the artifact is missing
+    rc = handle_adjudicate([
+        "publish-final", "--index-root", str(index_root),
+        "--materialize-dir", str(mat), "--archive-dir", str(archive_dir),
+        "--curation-bundle-dir", str(index_root), "--hub-repo", "org/private-ds",
+        "--dry-run"])
+    assert rc == 1
+    captured = capsys.readouterr()
+    # the panel hard-folds long messages mid-word (with the right border
+    # character interleaved); stripping borders and whitespace reconstitutes
+    # the unsplittable path token
+    flattened = "".join(captured.out.split()).replace("║", "")
+    assert "annotations.jsonl" in flattened + captured.err

--- a/tests/test_training_adjudication_canonical.py
+++ b/tests/test_training_adjudication_canonical.py
@@ -187,6 +187,49 @@ def test_canonical_harvest_fails_closed_on_unreadable_materialized_outputs(
     assert not (mat / "annotations.jsonl").exists()
 
 
+def _seed_decisive_fixture(tmp_path: Path) -> tuple[Path, Path, Path]:
+    """Index + archive + materialize-dir fixture whose index carries one
+    ``accepted``, one ``rejected``, and one ``unanswered`` finding — the complete
+    disposition set the widened materialize emits and the drift gate must
+    re-derive via ``build_queue(..., include_decisive=True)``."""
+    root = tmp_path / "index"
+    root.mkdir(exist_ok=True)
+    resolutions = [
+        {
+            "fingerprint": f"fp-{n}", "disposition": disposition,
+            "evidence": [{"reply_id": n, "body_sha256": "abc",
+                          "created_at": "2026-01-01T00:00:00+00:00"}],
+            "evidence_digest": "d" * 32, "profile": "pr_review", "stack": "python",
+            "comment_id": 7,
+        }
+        for n, disposition in enumerate(("accepted", "rejected", "unanswered"), start=1)
+    ]
+    sessions = [
+        {
+            "session_id": f"s{n}", "trajectory_id": f"s{n}-t", "segment_id": f"s{n}-seg",
+            "resolutions": [resolution],
+        }
+        for n, resolution in enumerate(resolutions, start=1)
+    ]
+    (root / "sessions.jsonl").write_text(
+        "".join(json.dumps(s, sort_keys=True) + "\n" for s in sessions), encoding="utf-8"
+    )
+    (root / "index-revision.txt").write_text("a" * 40, encoding="utf-8")
+    archive = tmp_path / "archive"
+    _seed_archive(archive)
+    conn = _get_connection(archive)
+    for n in (2, 3):
+        conn.execute(
+            "INSERT INTO runs (session_id, archived_at, run_flow, archive_path) "
+            f"VALUES ('s{n}', '2026-01-01T00:00:00+00:00', 'deep', 'archive/s{n}')"
+        )
+    conn.commit()
+    conn.close()
+    mat = tmp_path / "mat"
+    run_materialize(root, mat, pin=_PIN)
+    return root, archive, mat
+
+
 def test_canonical_harvest_merges_human_observations_by_precedence(tmp_path: Path) -> None:
     root = _index(tmp_path)
     archive = tmp_path / "archive"
@@ -437,3 +480,25 @@ def test_canonical_harvest_label_preserving_overlay_change_skips_nothing(
     )
     assert out3["appended_sessions"] == 0
     assert len(label_observation_history(archive, "s1")) == 2
+
+
+def test_canonical_harvest_complete_set_is_idempotent_and_exactly_once(
+    tmp_path: Path,
+) -> None:
+    """The drift gate re-derives the *complete* record set (decisive included)
+    via ``build_queue(..., include_decisive=True)``: harvesting a widened
+    materialization succeeds, preserves unchanged automatic decisive
+    dispositions verbatim (no observation group ⇒ untouched), and an identical
+    re-run is byte-identical with no new generation (exactly-once)."""
+    stage, archive, mat = _seed_decisive_fixture(tmp_path)
+    run_canonical_harvest(stage, mat, archive, observations_path=None)
+    first = (mat / "annotations.jsonl").read_bytes()
+    dispositions = [json.loads(ln)["disposition"] for ln in
+                    first.splitlines() if ln]
+    assert sorted(dispositions) == ["accepted", "rejected", "unanswered"]
+
+    # Re-run with identical inputs: identical annotations.jsonl, no new generation
+    summary2 = run_canonical_harvest(stage, mat, archive, observations_path=None)
+    assert (mat / "annotations.jsonl").read_bytes() == first
+    assert summary2["appended_sessions"] == 0
+    assert summary2["skipped_sessions"] == 3

--- a/tests/test_training_adjudication_final_bundle.py
+++ b/tests/test_training_adjudication_final_bundle.py
@@ -69,10 +69,28 @@ def seed_final_bundle_state(tmp_path: Path) -> tuple[Path, Path, Path, dict[str,
 
 def test_build_final_bundle_constructs_complete_staging_dir(tmp_path: Path) -> None:
     index_root, mat, archive_dir, pin = seed_final_bundle_state(tmp_path)
-    run_canonical_harvest(index_root, mat, archive_dir, observations_path=None)
+    # The human adjudication state the final bundle's report must see: alice
+    # accepts the s1 finding (the same shape the CLI `label` verb records).
+    from daydream.training.corpus_v2.identity import record_id
+
+    obs_path = tmp_path / "observations.jsonl"
+    obs_path.write_text(json.dumps({
+        "record_id": record_id("s1", "s1-t", "s1-seg", "fp-1"),
+        "disposition": "accepted",
+        "evidence_digest": "d" * 32,
+        "evidence": [{"reply_id": 1, "body_sha256": "abc",
+                       "created_at": "2026-01-01T00:00:00+00:00"}],
+        "labeler": "alice", "role": "rater",
+        "rationale": "clear maintainer approval",
+        "valid_at": "2026-02-02T00:00:00+00:00",
+        "observed_at": "2026-02-02T00:00:00+00:00",
+        "rubric_version": "v1",
+    }) + "\n", encoding="utf-8")
+    run_canonical_harvest(index_root, mat, archive_dir, observations_path=obs_path)
     out = tmp_path / "final-bundle"
     summary = build_final_bundle(
-        index_root=index_root, materialize_dir=mat, archive_dir=archive_dir, out_dir=out
+        index_root=index_root, materialize_dir=mat, archive_dir=archive_dir, out_dir=out,
+        observations_path=obs_path,
     )
     for name in ("annotations.jsonl", "sessions.jsonl", "label-observations.jsonl",
                  "coverage-report.json", "lineage.json"):
@@ -88,9 +106,71 @@ def test_build_final_bundle_constructs_complete_staging_dir(tmp_path: Path) -> N
     assert lineage["rubric_version"] == pin["rubric_version"]
     assert lineage["classifier_version"] == pin["classifier_version"]
     report = json.loads((out / "coverage-report.json").read_text())
-    assert report["outcome_coverage"]["total"] >= 1
+    # The admission gate counts human-adjudicated outcome-bearing records only:
+    # alice's accepted finding is adjudicated; the automatic decisive records
+    # carry no human observation, so gold-eligibility demotion keeps them out
+    # of the outcome-bearing numerator/denominator (issue #336 findings 1-2).
+    assert report["outcome_coverage"] == {"adjudicated": 1, "total": 1}
+    assert report["unresolved"] == 0
+    assert report["admission_gate"]["passes_80pct"] is True
     counts = summary["disposition_counts"]
     assert set(counts) == {"accepted", "rejected", "ambiguous", "unanswered", "missing"}
+
+
+def test_build_final_bundle_gate_fails_without_human_adjudication(tmp_path: Path) -> None:
+    """With no human observations the 80% admission gate must FAIL, not pass
+    trivially on every automatic decisive record (issue #336 finding 1)."""
+    index_root, mat, archive_dir, _pin = seed_final_bundle_state(tmp_path)
+    run_canonical_harvest(index_root, mat, archive_dir, observations_path=None)
+    out = tmp_path / "final-bundle"
+    build_final_bundle(
+        index_root=index_root, materialize_dir=mat, archive_dir=archive_dir, out_dir=out
+    )
+    report = json.loads((out / "coverage-report.json").read_text())
+    assert report["outcome_coverage"] == {"adjudicated": 0, "total": 0}
+    assert report["unresolved"] == 0
+    assert report["admission_gate"]["passes_80pct"] is False
+
+
+def test_build_final_bundle_tolerates_publish_stage_leftover(tmp_path: Path) -> None:
+    """A real publish leaves ``.publish-stage/`` in the bundle dir; the next
+    construction/dry-run over the same dir must treat it as publish scratch,
+    never foreign content (issue #336 finding 5)."""
+    index_root, mat, archive_dir, _pin = seed_final_bundle_state(tmp_path)
+    run_canonical_harvest(index_root, mat, archive_dir, observations_path=None)
+    out = tmp_path / "final-bundle"
+    build_final_bundle(
+        index_root=index_root, materialize_dir=mat, archive_dir=archive_dir, out_dir=out
+    )
+    stage = out / ".publish-stage"
+    stage.mkdir()
+    (stage / "annotations.jsonl").write_text("stale-stage", encoding="utf-8")
+    (stage / "_SUCCESS").write_text("", encoding="utf-8")
+    summary = build_final_bundle(
+        index_root=index_root, materialize_dir=mat, archive_dir=archive_dir, out_dir=out
+    )
+    assert ".publish-stage" not in summary["files"]
+    for name in ("annotations.jsonl", "sessions.jsonl", "label-observations.jsonl",
+                 "coverage-report.json", "lineage.json"):
+        assert (out / name).is_file(), name
+
+
+def test_build_final_bundle_unpinned_as_of_emits_empty_not_none(tmp_path: Path) -> None:
+    """A null (unpinned) manifest ``as_of`` must serialize into lineage.json as
+    the empty unpinned-edge string, never the fabricated "None" (issue #336
+    finding 4)."""
+    index_root, mat, archive_dir, _pin = seed_final_bundle_state(tmp_path)
+    run_canonical_harvest(index_root, mat, archive_dir, observations_path=None)
+    manifest_path = mat / "preview-manifest.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["as_of"] = None
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+    out = tmp_path / "final-bundle"
+    build_final_bundle(
+        index_root=index_root, materialize_dir=mat, archive_dir=archive_dir, out_dir=out
+    )
+    lineage = json.loads((out / "lineage.json").read_text())
+    assert lineage["as_of"] == ""
 
 
 def test_build_final_bundle_is_byte_identical_on_re_run(tmp_path: Path) -> None:

--- a/tests/test_training_adjudication_final_bundle.py
+++ b/tests/test_training_adjudication_final_bundle.py
@@ -1,0 +1,137 @@
+"""Final-bundle staging constructor tests (issue #1078, Task 5 / M4 core).
+
+``build_final_bundle`` must assemble the complete publish-ready staging
+directory (annotations, sessions, observation history, coverage report,
+generated lineage) from pipeline state alone — no hand-authored lineage file —
+without touching the Hub.
+"""
+
+import json
+from pathlib import Path
+
+from daydream.archive.sanitize import _derivative_digest
+from daydream.training.adjudication.canonical import run_canonical_harvest
+from daydream.training.adjudication.final_bundle import build_final_bundle
+from daydream.training.adjudication.materialize import run_materialize
+from daydream.training.labeler_versions import ANNOTATION_SNAPSHOT_SCHEMA_VERSION
+
+_PIN = {
+    "curation_id": "cur-1", "sanitized_hub_commit": "a" * 40,
+    "source_hub_commit": "b" * 40, "archive_index_digest": "c" * 64,
+    "evidence_observed_at": "2026-01-01T00:00:00+00:00",
+    "as_of": "2026-02-01T00:00:00+00:00",
+    "labeler_version": "v1", "rubric_version": "v1", "classifier_version": "v1",
+}
+
+
+def seed_final_bundle_state(tmp_path: Path) -> tuple[Path, Path, Path, dict[str, str]]:
+    """Index + archive + materialize-dir fixture whose index carries one
+    ``accepted``, one ``rejected``, and one ``unanswered`` finding (the same
+    seed shape as the canonical-harvest decisive fixture)."""
+    from daydream.archive.index import _get_connection
+
+    root = tmp_path / "index"
+    root.mkdir(exist_ok=True)
+    resolutions = [
+        {
+            "fingerprint": f"fp-{n}", "disposition": disposition,
+            "evidence": [{"reply_id": n, "body_sha256": "abc",
+                          "created_at": "2026-01-01T00:00:00+00:00"}],
+            "evidence_digest": "d" * 32, "profile": "pr_review", "stack": "python",
+            "comment_id": 7,
+        }
+        for n, disposition in enumerate(("accepted", "rejected", "unanswered"), start=1)
+    ]
+    sessions = [
+        {
+            "session_id": f"s{n}", "trajectory_id": f"s{n}-t", "segment_id": f"s{n}-seg",
+            "resolutions": [resolution],
+        }
+        for n, resolution in enumerate(resolutions, start=1)
+    ]
+    (root / "sessions.jsonl").write_text(
+        "".join(json.dumps(s, sort_keys=True) + "\n" for s in sessions), encoding="utf-8"
+    )
+    (root / "index-revision.txt").write_text("a" * 40, encoding="utf-8")
+    archive = tmp_path / "archive"
+    conn = _get_connection(archive)
+    for n in (1, 2, 3):
+        conn.execute(
+            "INSERT INTO runs (session_id, archived_at, run_flow, archive_path) "
+            f"VALUES ('s{n}', '2026-01-01T00:00:00+00:00', 'deep', 'archive/s{n}')"
+        )
+    conn.commit()
+    conn.close()
+    mat = tmp_path / "mat"
+    run_materialize(root, mat, pin=_PIN)
+    return root, mat, archive, _PIN
+
+
+def test_build_final_bundle_constructs_complete_staging_dir(tmp_path: Path) -> None:
+    index_root, mat, archive_dir, pin = seed_final_bundle_state(tmp_path)
+    run_canonical_harvest(index_root, mat, archive_dir, observations_path=None)
+    out = tmp_path / "final-bundle"
+    summary = build_final_bundle(
+        index_root=index_root, materialize_dir=mat, archive_dir=archive_dir, out_dir=out
+    )
+    for name in ("annotations.jsonl", "sessions.jsonl", "label-observations.jsonl",
+                 "coverage-report.json", "lineage.json"):
+        assert (out / name).is_file(), name
+    lineage = json.loads((out / "lineage.json").read_text())
+    assert lineage["curation_id"] == pin["curation_id"]
+    assert lineage["sanitized_hub_commit"] == pin["sanitized_hub_commit"]
+    assert lineage["snapshot_id"]
+    assert lineage["batch_fileset_digest"] == _derivative_digest(index_root)
+    assert lineage["schema_version"] == f"annotation-snapshot/{ANNOTATION_SNAPSHOT_SCHEMA_VERSION}"
+    assert lineage["as_of"] == pin["as_of"]
+    assert lineage["labeler_version"] == pin["labeler_version"]
+    assert lineage["rubric_version"] == pin["rubric_version"]
+    assert lineage["classifier_version"] == pin["classifier_version"]
+    report = json.loads((out / "coverage-report.json").read_text())
+    assert report["outcome_coverage"]["total"] >= 1
+    counts = summary["disposition_counts"]
+    assert set(counts) == {"accepted", "rejected", "ambiguous", "unanswered", "missing"}
+
+
+def test_build_final_bundle_is_byte_identical_on_re_run(tmp_path: Path) -> None:
+    index_root, mat, archive_dir, _pin = seed_final_bundle_state(tmp_path)
+    run_canonical_harvest(index_root, mat, archive_dir, observations_path=None)
+    out_one = tmp_path / "bundle-one"
+    out_two = tmp_path / "bundle-two"
+    build_final_bundle(
+        index_root=index_root, materialize_dir=mat, archive_dir=archive_dir, out_dir=out_one
+    )
+    build_final_bundle(
+        index_root=index_root, materialize_dir=mat, archive_dir=archive_dir, out_dir=out_two
+    )
+    for name in ("annotations.jsonl", "sessions.jsonl", "label-observations.jsonl",
+                 "coverage-report.json", "lineage.json"):
+        assert (out_one / name).read_bytes() == (out_two / name).read_bytes(), name
+
+
+def test_build_final_bundle_refuses_non_empty_out_dir(tmp_path: Path) -> None:
+    index_root, mat, archive_dir, _pin = seed_final_bundle_state(tmp_path)
+    out = tmp_path / "final-bundle"
+    out.mkdir()
+    (out / "stale.txt").write_text("stale", encoding="utf-8")
+    import pytest
+
+    with pytest.raises(ValueError, match="final-bundle"):
+        build_final_bundle(
+            index_root=index_root, materialize_dir=mat, archive_dir=archive_dir, out_dir=out
+        )
+
+
+def test_build_final_bundle_fails_closed_on_missing_materialized_outputs(
+    tmp_path: Path,
+) -> None:
+    index_root, mat, archive_dir, _pin = seed_final_bundle_state(tmp_path)
+    empty = tmp_path / "empty-mat"
+    empty.mkdir()
+    import pytest
+
+    with pytest.raises(FileNotFoundError, match="annotations.jsonl"):
+        build_final_bundle(
+            index_root=index_root, materialize_dir=empty, archive_dir=archive_dir,
+            out_dir=tmp_path / "out",
+        )

--- a/tests/test_training_adjudication_materialize.py
+++ b/tests/test_training_adjudication_materialize.py
@@ -1,3 +1,4 @@
+import hashlib
 import json
 from pathlib import Path
 
@@ -93,3 +94,39 @@ def test_materialize_drift_yields_new_snapshot_id(tmp_path: Path) -> None:
     sessions_path.write_text(json.dumps(s, sort_keys=True) + "\n", encoding="utf-8")
     r2 = run_materialize(root, tmp_path / "o2", pin=_PIN)
     assert r2["snapshot_id"] != r1["snapshot_id"]
+
+
+def _index_all_dispositions(tmp_path: Path) -> Path:
+    root = tmp_path / "index"
+    root.mkdir()
+    evidence = [{"reply_id": 1, "body_sha256": "abc"}]
+    digest = hashlib.sha256(json.dumps(evidence, sort_keys=True).encode()).hexdigest()
+    dispositions = ["accepted", "rejected", "ambiguous", "unanswered", "missing"]
+    resolutions = [
+        {
+            "fingerprint": f"fp-{i}", "disposition": d,
+            "evidence": evidence, "evidence_digest": digest,
+            "profile": "pr_review", "stack": "python", "comment_id": 7,
+        }
+        for i, d in enumerate(dispositions, start=1)
+    ]
+    sessions = [{
+        "session_id": "s1", "trajectory_id": "s1-t", "segment_id": "s1-seg",
+        "resolutions": resolutions,
+    }]
+    (root / "sessions.jsonl").write_text(
+        "".join(json.dumps(s, sort_keys=True) + "\n" for s in sessions), encoding="utf-8"
+    )
+    (root / "index-revision.txt").write_text("a" * 40, encoding="utf-8")
+    return root
+
+
+def test_materialize_emits_every_disposition(tmp_path: Path) -> None:
+    root = _index_all_dispositions(tmp_path)  # one session, five dispositions
+    result = run_materialize(root, tmp_path / "out", pin=_PIN)
+    assert result["record_count"] == 5
+    rows = [json.loads(ln) for ln in
+            (tmp_path / "out" / "sessions.jsonl").read_text().splitlines() if ln]
+    assert {r["disposition"] for r in rows} == {
+        "accepted", "rejected", "ambiguous", "unanswered", "missing"}
+    assert len({r["record_id"] for r in rows}) == 5  # no silent dedup across classes

--- a/tests/test_training_adjudication_publish.py
+++ b/tests/test_training_adjudication_publish.py
@@ -255,3 +255,21 @@ def test_resume_on_empty_disk_restores_byte_identical_state(tmp_path: Path) -> N
     hub.files[f"annotations/cur-1/{'e' * 64}/observations.jsonl"] += b"tampered\n"
     with pytest.raises(ValueError, match="digest"):
         resume_annotation_state(hub, manifest=_manifest(tmp_path), stage_dir=tmp_path / "fresh-2")
+
+
+def test_final_publish_verifier_failure_leaves_no_success_marker(tmp_path: Path) -> None:
+    from daydream.training.adjudication.publish import publish_final_annotation_bundle
+
+    hub = _FakeHub()
+    root = tmp_path / "bundle"
+    root.mkdir()
+    (root / "annotations.jsonl").write_text('{"record_id": "r1"}\n', encoding="utf-8")
+    (root / "sessions.jsonl").write_text('{"session_id": "s1"}\n', encoding="utf-8")
+    with pytest.raises(ValueError, match="download verification failed"):
+        publish_final_annotation_bundle(
+            hub, root, manifest={"curation_id": "c", "snapshot_id": "s"},
+            verify_download=True, _download_verifier=lambda _prefix: False,
+        )
+    prefix = "annotations/c/s/final/"
+    assert f"{prefix}_SUCCESS" not in hub.files
+    assert f"{prefix}SHA256SUMS" in hub.files  # uploaded, but not committed

--- a/tests/test_training_adjudication_publish.py
+++ b/tests/test_training_adjudication_publish.py
@@ -71,6 +71,21 @@ def _state(tmp_path: Path) -> Path:
     return state
 
 
+def _add_passing_gate_report(root: Path) -> None:
+    """A publish-stage bundle must carry its own ``coverage-report.json``;
+    passing-gate state is the fixture's valid default (the gate refusal itself
+    is exercised by ``test_final_bundle_refuses_when_admission_gate_not_met``
+    and ``test_final_bundle_refuses_missing_coverage_report``)."""
+    (root / "coverage-report.json").write_text(
+        json.dumps({
+            "admission_gate": {"passes_80pct": True, "total": 1,
+                               "outcome_bearing_total": 1, "gate_version": 1},
+            "outcome_coverage": {"adjudicated": 1, "total": 1},
+        }),
+        encoding="utf-8",
+    )
+
+
 def _manifest(tmp_path: Path) -> Path:
     p = tmp_path / "preview-manifest.json"
     p.write_text(
@@ -171,6 +186,7 @@ def test_publish_final_bundle_success_last_and_verified_commit_required(tmp_path
     (root / "annotations.jsonl").write_text('{"record_id": "r1"}\n', encoding="utf-8")
     (root / "sessions.jsonl").write_text('{"session_id": "s1"}\n', encoding="utf-8")
     (root / "lineage.json").write_text("{}", encoding="utf-8")
+    _add_passing_gate_report(root)
     result = publish_final_annotation_bundle(
         hub, root, manifest=_manifest(tmp_path), verify_download=True,
     )
@@ -197,6 +213,7 @@ def test_final_bundle_unknown_index_revision_fails_closed(tmp_path: Path) -> Non
     root = tmp_path / "bundle"
     root.mkdir()
     (root / "annotations.jsonl").write_text('{"record_id": "r1"}\n', encoding="utf-8")
+    _add_passing_gate_report(root)
     with pytest.raises(HydrationError):
         publish_final_annotation_bundle(hub, root, manifest=_manifest(tmp_path))
     # fail-closed: an unverifiable commit means _SUCCESS is never uploaded
@@ -210,6 +227,7 @@ def test_final_bundle_clean_download_verifies_or_refuses(tmp_path: Path) -> None
     root = tmp_path / "bundle"
     root.mkdir()
     (root / "annotations.jsonl").write_text('{"record_id": "r1"}\n', encoding="utf-8")
+    _add_passing_gate_report(root)
     with pytest.raises(ValueError, match="download"):
         publish_final_annotation_bundle(
             hub, root, manifest=_manifest(tmp_path),
@@ -226,6 +244,7 @@ def test_final_bundle_refuses_secret_in_payload(tmp_path: Path) -> None:
     root = tmp_path / "bundle"
     root.mkdir()
     (root / "annotations.jsonl").write_text('{"hf_token": "hf_abc123secret"}\n', encoding="utf-8")
+    _add_passing_gate_report(root)
     prefix = f"annotations/cur-1/{'e' * 64}/final/"
     with pytest.raises(PublicDestinationError, match="credential-shaped"):  # S1 secret scan
         publish_final_annotation_bundle(hub, root, manifest=_manifest(tmp_path))
@@ -265,6 +284,7 @@ def test_final_publish_verifier_failure_leaves_no_success_marker(tmp_path: Path)
     root.mkdir()
     (root / "annotations.jsonl").write_text('{"record_id": "r1"}\n', encoding="utf-8")
     (root / "sessions.jsonl").write_text('{"session_id": "s1"}\n', encoding="utf-8")
+    _add_passing_gate_report(root)
     with pytest.raises(ValueError, match="download verification failed"):
         publish_final_annotation_bundle(
             hub, root, manifest={"curation_id": "c", "snapshot_id": "s"},
@@ -273,3 +293,40 @@ def test_final_publish_verifier_failure_leaves_no_success_marker(tmp_path: Path)
     prefix = "annotations/c/s/final/"
     assert f"{prefix}_SUCCESS" not in hub.files
     assert f"{prefix}SHA256SUMS" in hub.files  # uploaded, but not committed
+
+
+def test_final_bundle_refuses_when_admission_gate_not_met(tmp_path: Path) -> None:
+    from daydream.training.adjudication.publish import publish_final_annotation_bundle
+
+    hub = _FakeHub()
+    root = tmp_path / "bundle"
+    root.mkdir()
+    (root / "annotations.jsonl").write_text('{"record_id": "r1"}\n', encoding="utf-8")
+    (root / "sessions.jsonl").write_text('{"session_id": "s1"}\n', encoding="utf-8")
+    (root / "coverage-report.json").write_text(
+        json.dumps({
+            # a bundle whose own report says passes_80pct=false — the exact
+            # shape the enforce-80%-or-refuse finding targets (issue #336)
+            "admission_gate": {"passes_80pct": False, "total": 1,
+                               "outcome_bearing_total": 1, "gate_version": 1},
+            "outcome_coverage": {"adjudicated": 0, "total": 1},
+        }),
+        encoding="utf-8",
+    )
+    prefix = f"annotations/cur-1/{'e' * 64}/final/"
+    with pytest.raises(PublicDestinationError, match="admission gate"):
+        publish_final_annotation_bundle(hub, root, manifest=_manifest(tmp_path))
+    # fail-closed before any upload: nothing under the final/ prefix
+    assert not any(k.startswith(prefix) for k in hub.files)
+
+
+def test_final_bundle_refuses_missing_coverage_report(tmp_path: Path) -> None:
+    from daydream.training.adjudication.publish import publish_final_annotation_bundle
+
+    hub = _FakeHub()
+    root = tmp_path / "bundle"
+    root.mkdir()
+    (root / "annotations.jsonl").write_text('{"record_id": "r1"}\n', encoding="utf-8")
+    with pytest.raises(PublicDestinationError, match="coverage report"):
+        publish_final_annotation_bundle(hub, root, manifest=_manifest(tmp_path))
+    assert not any(k.endswith("/final/") for k in hub.files)

--- a/tests/test_training_adjudication_queue.py
+++ b/tests/test_training_adjudication_queue.py
@@ -81,3 +81,21 @@ def test_decisive_adjudication_entry_fails_closed(monkeypatch: pytest.MonkeyPatc
     monkeypatch.setattr(queue_module, "project_findings", _forge_decisive)
     with pytest.raises(ValueError, match="fp-a"):
         build_queue([session])
+
+
+def test_disposition_sets_are_single_sourced() -> None:
+    from daydream.training.adjudication.dispositions import (
+        NON_DECISIVE_DISPOSITIONS,
+        is_decisive,
+    )
+    from daydream.training.adjudication.queue import (
+        _NON_DECISIVE_DISPOSITIONS as queue_set,
+    )
+    from daydream.training.corpus_v2.tiers import (
+        _NON_DECISIVE_DISPOSITIONS as tiers_set,
+    )
+
+    assert queue_set is NON_DECISIVE_DISPOSITIONS
+    assert tiers_set is NON_DECISIVE_DISPOSITIONS
+    assert is_decisive("accepted") and is_decisive("rejected")
+    assert not is_decisive("ambiguous")

--- a/tests/test_training_adjudication_queue.py
+++ b/tests/test_training_adjudication_queue.py
@@ -1,4 +1,6 @@
 """Adjudication queue build: deterministic ordering over projector adjudication entries."""
+from pathlib import Path
+
 import pytest
 
 from daydream.training.adjudication.queue import build_queue
@@ -16,6 +18,24 @@ def _session(
             "evidence_digest": digest, "profile": "pr_review", "stack": "python",
         }],
     }
+
+def _sessions_with_accepted_and_unanswered() -> list[dict[str, object]]:  # existing-shape helper
+    return [
+        _session("s1", "fp-a", "accepted", "d-gold"),
+        _session("s2", "fp-b", "unanswered", "d2"),
+    ]
+
+
+def test_build_queue_include_decisive_returns_complete_set(tmp_path: Path) -> None:
+    sessions = _sessions_with_accepted_and_unanswered()
+    open_only = build_queue(sessions)
+    assert [i["disposition"] for i in open_only] == ["unanswered"]
+
+    complete = build_queue(sessions, include_decisive=True)
+    assert sorted(str(i["disposition"]) for i in complete) == ["accepted", "unanswered"]
+    # decisive entries carry the same record_id derivation as materialize
+    assert {str(i["status"]) for i in complete} <= {"open", "reopened"}
+
 
 def test_queue_is_deterministic_and_covers_all_non_decisive_states() -> None:
     # NOTE: 'accepted' disposition with evidence would be gold — the queue must EXCLUDE it.


### PR DESCRIPTION
## Summary
- Materialize every finding disposition incl. automatic decisive findings
- Staging final-bundle constructor with generated lineage + corpus adjudicate publish-final (--dry-run)
- publish-final refuses below the 80% adjudication gate; final bundle gate requires human adjudication; atomic bundle writes
- Fresh-VM final-publish operator runbook; CLI-only end-to-end tests with automatic decisive findings retained

Closes #1078