### PR TITLE
feat(archive): import observations from archive backups for adjudication (#1082)

### DIFF
--- a/daydream/archive/hydrate_rules.py
+++ b/daydream/archive/hydrate_rules.py
@@ -27,9 +27,10 @@ REASON_CODE_IDENTITY_COLLISION = "identity_collision"
 REASON_CODE_PATH_TRAVERSAL = "path_traversal"
 
 # Import-specific reason codes (issue #1082 local-observation importer, fixed
-# registry). Every imported observation row maps to exactly one of these six
-# buckets; the sum over the buckets always equals the source row inventory
-# count (M7) and the codes are stable strings (KD5).
+# registry). Every surviving observation row maps to exactly one of these six
+# buckets; byte-identical duplicates dropped by the dedupe are never bucket-
+# accounted, so ``sum(accounting) + deduped_count`` equals the source row
+# inventory count (M7) and the codes are stable strings (KD5).
 REASON_CODE_IMPORT_UNMATCHED_SESSION = "import_unmatched_session"
 REASON_CODE_IMPORT_IDENTITY_CONFLICT = "import_identity_conflict"
 REASON_CODE_IMPORT_STALE_EVIDENCE = "import_stale_evidence"

--- a/daydream/archive/hydrate_rules.py
+++ b/daydream/archive/hydrate_rules.py
@@ -36,6 +36,7 @@ REASON_CODE_IMPORT_STALE_EVIDENCE = "import_stale_evidence"
 REASON_CODE_IMPORT_INVALID_VERSION = "import_invalid_version"
 REASON_CODE_IMPORT_DECISIVE_PER_FINDING = "import_decisive_per_finding"
 REASON_CODE_IMPORT_RUN_LEVEL_ONLY = "import_run_level_only"
+REASON_CODE_IMPORT_UNREDACTABLE_METADATA = "import_unredactable_metadata"
 
 # ---------------------------------------------------------------------------
 # Curation-id derivation (Task 3)

--- a/daydream/archive/hydrate_rules.py
+++ b/daydream/archive/hydrate_rules.py
@@ -26,6 +26,17 @@ REASON_CODE_SANITIZE_FAILED = "sanitize_failed"
 REASON_CODE_IDENTITY_COLLISION = "identity_collision"
 REASON_CODE_PATH_TRAVERSAL = "path_traversal"
 
+# Import-specific reason codes (issue #1082 local-observation importer, fixed
+# registry). Every imported observation row maps to exactly one of these six
+# buckets; the sum over the buckets always equals the source row inventory
+# count (M7) and the codes are stable strings (KD5).
+REASON_CODE_IMPORT_UNMATCHED_SESSION = "import_unmatched_session"
+REASON_CODE_IMPORT_IDENTITY_CONFLICT = "import_identity_conflict"
+REASON_CODE_IMPORT_STALE_EVIDENCE = "import_stale_evidence"
+REASON_CODE_IMPORT_INVALID_VERSION = "import_invalid_version"
+REASON_CODE_IMPORT_DECISIVE_PER_FINDING = "import_decisive_per_finding"
+REASON_CODE_IMPORT_RUN_LEVEL_ONLY = "import_run_level_only"
+
 # ---------------------------------------------------------------------------
 # Curation-id derivation (Task 3)
 # ---------------------------------------------------------------------------

--- a/daydream/archive/importer.py
+++ b/daydream/archive/importer.py
@@ -1,0 +1,100 @@
+"""Pure core for importing surviving local archive/backup label observations.
+
+The importer's logic is deterministic and wall-clock-free; the CLI shell owns
+all I/O beyond the read-only SQLite connects performed by the inventory. This
+module currently provides identity linkage (M2): every imported session is
+resolved to a Hub session — via the hydrated staging index join on
+``session_id`` + derivative content digest, falling back to
+``repo_slug`` + ``base_sha`` + ``head_sha`` — and every unresolvable session
+lands in a reason-coded bucket. Nothing is silently dropped (M2): the result
+always accounts for every record.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+__all__ = ["link_session_identity"]
+
+_REASON_UNMATCHED = "no_hub_entry"
+_REASON_CONFLICT = "derivative_digest_conflict"
+
+
+def link_session_identity(
+    records: list[dict[str, Any]],
+    *,
+    hydrated_index: dict[str, dict[str, Any]],
+    repo_slug_sha_lookup: dict[tuple[str, str, str], Any],
+) -> dict[str, dict[str, Any]]:
+    """Resolve each imported record to a Hub session identity.
+
+    Args:
+        records: Inventory rows, each carrying ``session_id``, an optional
+            ``derivative_digest``, and the optional fallback fields
+            ``repo_slug`` / ``base_sha`` / ``head_sha``.
+        hydrated_index: ``{session_id: {"derivative_digest": ..., "record_id": ...}}``
+            — the hydrate import-ledger join shape.
+        repo_slug_sha_lookup: ``{(repo_slug, base_sha, head_sha): hub_session_id}``
+            (a dict with ``"hub_session_id"`` is also accepted).
+
+    Returns:
+        ``{"linked": {sid: {"hub_session_id", "matched_by"}},
+        "unmatched": {sid: reason}, "identity_conflict": {sid: reason}}``.
+
+    Primary rule: ``session_id`` present in ``hydrated_index`` with a matching
+    derivative content digest links ``by session_id``. Fallback rule: the
+    session_id is absent (or the digest conflicts) and the record carries
+    ``repo_slug`` + ``base_sha`` + ``head_sha`` matching the lookup, links
+    ``by repo_slug_sha``. A session matching with a conflicting digest routes
+    to ``identity_conflict``; a session matching neither routes to
+    ``unmatched`` — both with distinct reason strings, never silently skipped.
+
+    Raises:
+        ValueError: When a record is unresolvable via the primary rule and is
+            missing the session fields required for the fallback — no
+            placeholder linkage is produced.
+    """
+    linked: dict[str, dict[str, str]] = {}
+    unmatched: dict[str, str] = {}
+    identity_conflict: dict[str, str] = {}
+
+    def _hub_id_from_lookup(value: Any) -> str:
+        if isinstance(value, dict):
+            return str(value["hub_session_id"])
+        return str(value)
+
+    for record in records:
+        session_id = str(record["session_id"])
+        digest = record.get("derivative_digest")
+        hub_entry = hydrated_index.get(session_id)
+
+        if hub_entry is not None:
+            hub_digest = hub_entry.get("derivative_digest")
+            if hub_digest is not None and hub_digest == digest:
+                linked[session_id] = {"hub_session_id": session_id, "matched_by": "session_id"}
+                continue
+            if hub_digest is not None and digest is not None and hub_digest != digest:
+                identity_conflict[session_id] = _REASON_CONFLICT
+                continue
+
+        # Fallback: repo_slug + base_sha + head_sha must all be present.
+        repo_slug = record.get("repo_slug")
+        base_sha = record.get("base_sha")
+        head_sha = record.get("head_sha")
+        if not repo_slug or not base_sha or not head_sha:
+            msg = (
+                f"session {session_id!r} has no Hub index entry and is missing "
+                "the repo_slug/base_sha/head_sha fields required for the "
+                "identity fallback"
+            )
+            raise ValueError(msg)
+        fallback = repo_slug_sha_lookup.get((str(repo_slug), str(base_sha), str(head_sha)))
+        if fallback is None:
+            unmatched[session_id] = _REASON_UNMATCHED
+        else:
+            linked[session_id] = {
+                "hub_session_id": _hub_id_from_lookup(fallback),
+                "matched_by": "repo_slug_sha",
+            }
+
+    return {"linked": linked, "unmatched": unmatched, "identity_conflict": identity_conflict}

--- a/daydream/archive/importer.py
+++ b/daydream/archive/importer.py
@@ -17,17 +17,41 @@ import json
 from pathlib import Path
 from typing import Any
 
+from daydream.archive.hydrate_rules import (
+    HYDRATION_INDEX_SCHEMA_VERSION,
+    REASON_CODE_IMPORT_DECISIVE_PER_FINDING,
+    REASON_CODE_IMPORT_IDENTITY_CONFLICT,
+    REASON_CODE_IMPORT_INVALID_VERSION,
+    REASON_CODE_IMPORT_RUN_LEVEL_ONLY,
+    REASON_CODE_IMPORT_STALE_EVIDENCE,
+    REASON_CODE_IMPORT_UNMATCHED_SESSION,
+)
 from daydream.archive.index import append_label_observation
 from daydream.archive.known_versions import KNOWN_LABELER_VERSIONS, STALE_LEGACY
 
 __all__ = [
+    "IMPORT_REASON_CODES",
+    "accounting",
+    "build_import_ledger",
     "canonical_payload_digest",
     "classify_run_level",
     "dedupe_observations",
     "gold_eligible",
     "link_session_identity",
     "merge_imported_observations",
+    "run_pure_import",
 ]
+
+# The fixed six-bucket import accounting registry (M7): every imported
+# observation row lands in exactly one of these stable reason codes.
+IMPORT_REASON_CODES = (
+    REASON_CODE_IMPORT_UNMATCHED_SESSION,
+    REASON_CODE_IMPORT_IDENTITY_CONFLICT,
+    REASON_CODE_IMPORT_STALE_EVIDENCE,
+    REASON_CODE_IMPORT_INVALID_VERSION,
+    REASON_CODE_IMPORT_DECISIVE_PER_FINDING,
+    REASON_CODE_IMPORT_RUN_LEVEL_ONLY,
+)
 
 # Writer columns consumed by append_label_observation; every other key on an
 # import row (legacy, payload_digest, ...) is importer metadata, not payload.
@@ -428,6 +452,187 @@ def classify_run_level(
         "per_finding": per_finding,
         "run_level_only": run_level_only,
         "ambiguous_run_mapping": ambiguous,
+    }
+
+
+def _row_reason_codes(
+    merged_rows: list[dict[str, Any]],
+    *,
+    content_conflict: list[dict[str, Any]],
+    link_result: dict[str, Any],
+    run_level_result: dict[str, Any],
+) -> list[tuple[dict[str, Any], str]]:
+    """Classify every row into exactly one import reason code (M7).
+
+    Precedence: dedupe/identity conflicts first (the row never got a home),
+    then the version gate, then the run-level routing. Raises ``ValueError``
+    naming any row that cannot be classified — never an implicit drop.
+    """
+    conflict_ids = {id(row) for row in content_conflict}
+    per_finding_ids = {
+        id(row)
+        for rows in run_level_result["per_finding"].values()
+        for row in rows
+    }
+    unmatched_sids = set(link_result["unmatched"])
+    link_conflict_sids = set(link_result["identity_conflict"])
+    run_level_only_sids = set(run_level_result["run_level_only"])
+    ambiguous_sids = set(run_level_result["ambiguous_run_mapping"])
+
+    classified: list[tuple[dict[str, Any], str]] = []
+    for row in (*content_conflict, *merged_rows):
+        session_id = str(row["session_id"])
+        if id(row) in conflict_ids or session_id in link_conflict_sids:
+            code = REASON_CODE_IMPORT_IDENTITY_CONFLICT
+        elif session_id in unmatched_sids:
+            code = REASON_CODE_IMPORT_UNMATCHED_SESSION
+        elif not gold_eligible(row):
+            code = REASON_CODE_IMPORT_INVALID_VERSION
+        elif id(row) in per_finding_ids:
+            code = REASON_CODE_IMPORT_DECISIVE_PER_FINDING
+        elif session_id in run_level_only_sids:
+            code = REASON_CODE_IMPORT_RUN_LEVEL_ONLY
+        elif session_id in ambiguous_sids:
+            code = REASON_CODE_IMPORT_STALE_EVIDENCE
+        else:
+            msg = (
+                f"imported observation for session {session_id!r} at "
+                f"{row.get('observed_at')!r} cannot be classified into an "
+                "import bucket; refusing to drop the row silently"
+            )
+            raise ValueError(msg)
+        classified.append((row, code))
+    return classified
+
+
+def accounting(
+    merged_rows: list[dict[str, Any]],
+    *,
+    content_conflict: list[dict[str, Any]],
+    link_result: dict[str, Any],
+    run_level_result: dict[str, Any],
+) -> dict[str, int]:
+    """Map every merged inventory row to exactly one import reason code (M7).
+
+    Args:
+        merged_rows: The surviving deduped rows (from
+            :func:`dedupe_observations`), each carrying ``session_id``.
+        content_conflict: Rows routed to the dedupe content-conflict bucket —
+            their evidence identity is ambiguous, so they account as
+            ``import_identity_conflict``.
+        link_result: The :func:`link_session_identity` result.
+        run_level_result: The :func:`classify_run_level` result.
+
+    Returns:
+        ``{reason_code: row_count}`` over :data:`IMPORT_REASON_CODES` whose
+        values sum to ``len(merged_rows) + len(content_conflict)``.
+
+    Raises:
+        ValueError: When a row cannot be classified into a named bucket —
+            never an implicit drop.
+    """
+    counts = {code: 0 for code in IMPORT_REASON_CODES}
+    for _row, code in _row_reason_codes(
+        merged_rows,
+        content_conflict=content_conflict,
+        link_result=link_result,
+        run_level_result=run_level_result,
+    ):
+        counts[code] += 1
+    return counts
+
+
+def run_pure_import(
+    inventories: list[list[dict[str, Any]]],
+    *,
+    hydrated_index: dict[str, dict[str, Any]],
+    repo_slug_sha_lookup: dict[tuple[str, str, str], Any],
+    projector_findings: dict[str, list[dict[str, Any]]],
+) -> dict[str, Any]:
+    """Compose the pure import pipeline: dedupe -> link -> run-level -> accounting.
+
+    Args:
+        inventories: One list of ``label_observations`` rows per backup root.
+        hydrated_index: See :func:`link_session_identity`.
+        repo_slug_sha_lookup: See :func:`link_session_identity`.
+        projector_findings: See :func:`classify_run_level`.
+
+    Returns:
+        ``{"rows", "deduped_count", "content_conflict", "link",
+        "run_level", "accounting", "ledger"}`` — the deterministic pipeline
+        result, where ``accounting`` sums to the full source row inventory
+        count (deduped rows + dedupe conflicts) and ``ledger`` is the
+        :func:`build_import_ledger` shape.
+    """
+    merged = dedupe_observations(inventories)
+    link_result = link_session_identity(
+        merged["rows"],
+        hydrated_index=hydrated_index,
+        repo_slug_sha_lookup=repo_slug_sha_lookup,
+    )
+    run_level_result = classify_run_level(
+        merged["rows"], projector_findings=projector_findings
+    )
+    counts = accounting(
+        merged["rows"],
+        content_conflict=merged["content_conflict"],
+        link_result=link_result,
+        run_level_result=run_level_result,
+    )
+    result: dict[str, Any] = {
+        "rows": merged["rows"],
+        "deduped_count": merged["deduped_count"],
+        "content_conflict": merged["content_conflict"],
+        "link": link_result,
+        "run_level": run_level_result,
+        "accounting": counts,
+    }
+    result["ledger"] = build_import_ledger(result)
+    return result
+
+
+def build_import_ledger(result: dict[str, Any]) -> dict[str, Any]:
+    """Shape the import result into the hydrate import-ledger format (KD5).
+
+    Mirrors ``daydream/archive/hydrate.py``'s ledger shape — a fixed schema
+    version plus ``{session_id, reason_code, ...}`` entries — so existing
+    ledger consumers see one format. Every source row appears exactly once;
+    the accounting sum is re-verified here and any mismatch raises (M7:
+    no silent drops).
+
+    Raises:
+        ValueError: When the bucket sum does not equal the accounted
+            observation count.
+    """
+    accounting = result["accounting"]
+    observations = sorted(
+        (
+            {
+                "session_id": str(row["session_id"]),
+                "observed_at": str(row["observed_at"]),
+                "source": str(row.get("source", "")),
+                "reason_code": code,
+            }
+            for row, code in _row_reason_codes(
+                result["rows"],
+                content_conflict=result["content_conflict"],
+                link_result=result["link"],
+                run_level_result=result["run_level"],
+            )
+        ),
+        key=lambda entry: (entry["session_id"], entry["observed_at"], entry["source"]),
+    )
+    if sum(accounting.values()) != len(observations):
+        msg = (
+            f"import accounting mismatch: buckets account for "
+            f"{sum(accounting.values())} row(s) but the ledger carries "
+            f"{len(observations)} observation(s)"
+        )
+        raise ValueError(msg)
+    return {
+        "schema_version": HYDRATION_INDEX_SCHEMA_VERSION,
+        "accounting": dict(accounting),
+        "observations": observations,
     }
 
 

--- a/daydream/archive/importer.py
+++ b/daydream/archive/importer.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import hashlib
 import json
 import re
+from datetime import datetime
 from pathlib import Path
 from typing import Any
 
@@ -29,7 +30,7 @@ from daydream.archive.hydrate_rules import (
     REASON_CODE_IMPORT_UNREDACTABLE_METADATA,
 )
 from daydream.archive.index import append_label_observation
-from daydream.archive.known_versions import KNOWN_LABELER_VERSIONS
+from daydream.archive.known_versions import KNOWN_LABELER_VERSIONS, STALE_LEGACY
 from daydream.archive.sanitize import _sanitize_json_value
 from daydream.archive.scan import scan_run_dir
 from daydream.trajectory import redact_value
@@ -49,8 +50,10 @@ __all__ = [
     "run_pure_import",
 ]
 
-# The fixed six-bucket import accounting registry (M7): every imported
-# observation row lands in exactly one of these stable reason codes.
+# The fixed six-bucket import accounting registry (M7): every surviving
+# imported observation row lands in exactly one of these stable reason codes;
+# byte-identical duplicates dropped by the dedupe are not bucket-accounted, so
+# ``sum(accounting) + deduped_count`` equals the full source row inventory count.
 IMPORT_REASON_CODES = (
     REASON_CODE_IMPORT_UNMATCHED_SESSION,
     REASON_CODE_IMPORT_IDENTITY_CONFLICT,
@@ -71,8 +74,11 @@ REDACTED_PATH = "[REDACTED_PATH]"
 # startswith("/") check in :func:`_redact_path_string`.
 _EMBEDDED_ABSOLUTE_PATH_RE = re.compile(r"(?<![:/\w])(/[\w.-]+(?:/[\w.-]+)+)")
 
-# Writer columns consumed by append_label_observation; every other key on an
-# import row (legacy, payload_digest, ...) is importer metadata, not payload.
+# Writer columns consumed by append_label_observation (the
+# labeler_policy_version axis is carried verbatim so a policy bump or the
+# legacy sentinel survives the merge); every other key on an import row
+# (payload_digest, remote_url, ...) is importer metadata, not payload.
+# ``legacy`` is derived separately in ``_planned_append``.
 _WRITER_FIELDS = (
     "labels",
     "pr_state",
@@ -88,6 +94,7 @@ _WRITER_FIELDS = (
     "source",
     "reply_classifier_version",
     "reply_evidence_digest",
+    "labeler_policy_version",
 )
 
 _REASON_UNMATCHED = "no_hub_entry"
@@ -264,6 +271,14 @@ def _planned_append(row: dict[str, Any]) -> dict[str, Any]:
                 ) from exc
         plan[field] = value
     plan["has_posterior"] = bool(plan["has_posterior"])
+    # Legacy marker: carried verbatim when the source row has one; rows from a
+    # legacy schema (missing the column) stamp "legacy" exactly when the policy
+    # axis is the "legacy" sentinel, so the writer persists the canonical
+    # NULL-policy + legacy representation the corpus gold gate excludes.
+    legacy = row.get("legacy")
+    if legacy is None:
+        legacy = "legacy" if row.get("labeler_policy_version") == STALE_LEGACY else "auto"
+    plan["legacy"] = legacy
     return plan
 
 
@@ -304,8 +319,10 @@ def merge_imported_observations(
         ValueError: Fail-closed, before any write, when a row's recomputed
             canonical payload digest disagrees with its inventory-time
             ``payload_digest`` (evidence drifted between inventory and merge),
-            when a row's JSON list columns are malformed, or when the writer
-            rejects the row (unknown session, non-ISO-8601 ``observed_at``) —
+            when a row's JSON list columns are malformed, when a row's
+            ``observed_at``/``valid_at`` is not a parseable aware ISO-8601
+            timestamp (checked by the pre-write gate, not per-row mid-merge),
+            or when the writer rejects the row (unknown session) —
             each error names the offending row. Never silently defaulted.
     """
     imports = list(linked_imports)
@@ -336,6 +353,30 @@ def merge_imported_observations(
                 f"(expected {row['payload_digest']}, recomputed {fresh}); "
                 f"re-inventory the source before merging"
             )
+
+    # Fail-closed timestamp gate before any write (S2/M9): ``observed_at`` and
+    # ``valid_at`` must be parseable aware ISO-8601, exactly as the writer
+    # enforces per row — hoisted here so a malformed stamp aborts the whole
+    # merge up front instead of surfacing mid-append after run seeds or a
+    # prefix of rows were already committed.
+    for row in imports:
+        for field in ("observed_at", "valid_at"):
+            value = row.get(field)
+            if value is None:
+                continue
+            try:
+                parsed = datetime.fromisoformat(str(value))
+            except ValueError:
+                raise ValueError(
+                    f"imported observation for session {row['session_id']!r} at "
+                    f"{row['observed_at']!r} has a non-ISO-8601 {field}: {value!r}"
+                ) from None
+            if parsed.tzinfo is None or parsed.utcoffset() is None:
+                raise ValueError(
+                    f"imported observation for session {row['session_id']!r} at "
+                    f"{row['observed_at']!r} has a naive {field} ({value!r}): "
+                    "an explicit UTC offset is required"
+                )
 
     planned = [_planned_append(row) for row in imports]
     if dry_run:
@@ -713,8 +754,10 @@ def run_pure_import(
     Returns:
         ``{"rows", "deduped_count", "content_conflict", "link",
         "run_level", "accounting", "ledger"}`` — the deterministic pipeline
-        result, where ``accounting`` sums to the full source row inventory
-        count (deduped rows + dedupe conflicts) and ``ledger`` is the
+        result, where ``accounting`` sums to the surviving rows (``rows`` +
+        ``content_conflict``) and ``sum(accounting) + deduped_count`` equals
+        the full source row inventory count (deduped rows are dropped as
+        byte-identical duplicates, never bucket-accounted); ``ledger`` is the
         :func:`build_import_ledger` shape.
     """
     merged = dedupe_observations(inventories)

--- a/daydream/archive/importer.py
+++ b/daydream/archive/importer.py
@@ -20,6 +20,7 @@ from daydream.archive.known_versions import KNOWN_LABELER_VERSIONS, STALE_LEGACY
 
 __all__ = [
     "canonical_payload_digest",
+    "classify_run_level",
     "dedupe_observations",
     "gold_eligible",
     "link_session_identity",
@@ -27,6 +28,8 @@ __all__ = [
 
 _REASON_UNMATCHED = "no_hub_entry"
 _REASON_CONFLICT = "derivative_digest_conflict"
+_REASON_RUN_LEVEL_ONLY = "no_projected_findings"
+_REASON_AMBIGUOUS = "ambiguous_finding_mapping"
 
 # The writer's versioned auto-dedup tuple (daydream/archive/index.py): the
 # evidence identity key. A policy-version bump, reward-version bump, or
@@ -203,6 +206,100 @@ def link_session_identity(
             }
 
     return {"linked": linked, "unmatched": unmatched, "identity_conflict": identity_conflict}
+
+
+def classify_run_level(
+    records: list[dict[str, Any]],
+    *,
+    projector_findings: dict[str, list[dict[str, Any]]],
+) -> dict[str, Any]:
+    """Partition session-scoped rows into run-level vs per-finding evidence (M5, AC2).
+
+    Args:
+        records: Merged inventory rows. A row without a truthy ``record_id``
+            is a run-level (session-scoped) label; a row carrying one is
+            already per-finding evidence.
+        projector_findings: ``{session_id: [finding, ...]}`` mirroring the
+            ``corpus_v2.projector.project_findings`` enumeration — the single
+            authority for the non-decisive set. Each finding dict must carry
+            ``record_id`` and ``evidence_sha``.
+
+    Returns:
+        ``{"per_finding": {sid: [obs, ...]}, "run_level_only":
+        {sid: reason}, "ambiguous_run_mapping": {sid: reason}}`` — a
+        deterministic partition accounting for every input row (M7).
+
+    Behavior:
+        A run-level label is emitted as **run-level evidence only** — never
+        copied onto every finding of the run (AC2). A row with no projected
+        findings for its session is run-level-only. A row whose session has
+        multiple candidate findings with no unique decisive match on identity
+        + evidence digest routes to ``ambiguous_run_mapping`` — feeding the
+        per-finding adjudication queue, not a fan-out. Only a row whose
+        ``evidence_sha`` matches exactly one projected finding lands in
+        ``per_finding`` (the sole path into the ``_is_admitted_outcome_gold``
+        / ``_rubric_decisive_only`` semantics).
+
+    Raises:
+        ValueError: When a row's ``labels`` field is malformed JSON (naming
+            the session_id), or when a referenced ``projector_findings``
+            entry is missing ``record_id``/``evidence_sha`` — never silently
+            substituted.
+    """
+    per_finding: dict[str, list[dict[str, Any]]] = {}
+    run_level_only: dict[str, str] = {}
+    ambiguous: dict[str, str] = {}
+
+    for record in records:
+        session_id = str(record["session_id"])
+        if record.get("record_id"):
+            # Already per-finding evidence: accounted in per_finding, never
+            # routed through the run-level buckets.
+            per_finding.setdefault(session_id, []).append(record)
+            continue
+
+        labels = record.get("labels")
+        if isinstance(labels, str):
+            try:
+                labels = json.loads(labels)
+            except json.JSONDecodeError as exc:
+                msg = f"session {session_id!r} has malformed labels JSON: {exc}"
+                raise ValueError(msg) from exc
+        if not isinstance(labels, list):
+            msg = f"session {session_id!r} has non-list labels field: {labels!r}"
+            raise ValueError(msg)
+
+        findings = projector_findings.get(session_id)
+        if not findings:
+            run_level_only[session_id] = _REASON_RUN_LEVEL_ONLY
+            continue
+
+        evidence_sha = record.get("evidence_sha")
+        matches = []
+        for finding in findings:
+            if "record_id" not in finding or "evidence_sha" not in finding:
+                msg = (
+                    f"session {session_id!r} references a malformed projected "
+                    f"finding (missing 'record_id'/'evidence_sha'): {finding!r}"
+                )
+                raise ValueError(msg)
+            if finding["evidence_sha"] == evidence_sha:
+                matches.append(finding)
+
+        if len(matches) == 1:
+            # Decisive identity+evidence-digest match on exactly one finding.
+            per_finding.setdefault(session_id, []).append(record)
+        else:
+            # No match, or the digest matches more than one finding: the
+            # run<->finding mapping is ambiguous — adjudication queue, not a
+            # fan-out.
+            ambiguous[session_id] = _REASON_AMBIGUOUS
+
+    return {
+        "per_finding": per_finding,
+        "run_level_only": run_level_only,
+        "ambiguous_run_mapping": ambiguous,
+    }
 
 
 def gold_eligible(observation: dict[str, Any]) -> bool:

--- a/daydream/archive/importer.py
+++ b/daydream/archive/importer.py
@@ -29,7 +29,7 @@ from daydream.archive.hydrate_rules import (
     REASON_CODE_IMPORT_UNREDACTABLE_METADATA,
 )
 from daydream.archive.index import append_label_observation
-from daydream.archive.known_versions import KNOWN_LABELER_VERSIONS, STALE_LEGACY
+from daydream.archive.known_versions import KNOWN_LABELER_VERSIONS
 from daydream.archive.sanitize import _sanitize_json_value
 from daydream.archive.scan import scan_run_dir
 from daydream.trajectory import redact_value
@@ -45,6 +45,7 @@ __all__ = [
     "gold_eligible",
     "link_session_identity",
     "merge_imported_observations",
+    "redact_metadata_value",
     "run_pure_import",
 ]
 
@@ -114,10 +115,17 @@ def canonical_payload_digest(row: dict[str, Any], *, include_observed_at: bool) 
     evidence captured by two overlapping backups at different capture times
     must dedupe regardless of ``observed_at`` (the SQLite PK
     ``(session_id, observed_at)`` in the target handles identical-timestamp
-    overlap). Human rows include it: they are never auto-deduped by the
-    writer, so only byte-identical human rows collapse.
+    overlap). The collapsed ``valid_at`` stamp is excluded alongside it: the
+    writer folds ``valid_at=None`` onto ``observed_at`` (index.py), so two
+    captures of identical auto evidence carry byte-different ``valid_at``
+    values that must not split the dedupe into a content conflict. Human rows
+    include both stamps: they are never auto-deduped by the writer, so only
+    byte-identical human rows collapse.
     """
-    payload = {k: v for k, v in row.items() if include_observed_at or k != "observed_at"}
+    excluded = set()
+    if not include_observed_at:
+        excluded |= {"observed_at", "valid_at"}
+    payload = {k: v for k, v in row.items() if k not in excluded}
     canonical = json.dumps(payload, sort_keys=True, default=str)
     return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
 
@@ -170,6 +178,19 @@ def _redact_json_blob(value: Any, *, field: str, session_id: str) -> Any:
     return redacted
 
 
+def redact_metadata_value(value: Any) -> Any:
+    """Redact one credential-bearing metadata field (URL userinfo, absolute paths).
+
+    Applies the same ``sanitize`` + ``redact_value`` chain
+    :func:`redact_imported_metadata` uses per row field, so a persisted runs
+    row's ``remote_url``/``source_path`` carry the same fail-closed scrubbing
+    the observation rows do. Non-string values pass through unchanged.
+    """
+    if isinstance(value, str):
+        return redact_value(_redact_path_string(_sanitize_json_value(value)))
+    return value
+
+
 def redact_imported_metadata(rows: list[dict[str, Any]], *, scan_dir: Path) -> dict[str, Any]:
     """Redact pre-publication metadata and fail closed on uncleanable rows (M9, AC6).
 
@@ -199,9 +220,7 @@ def redact_imported_metadata(rows: list[dict[str, Any]], *, scan_dir: Path) -> d
         session_id = str(row.get("session_id", ""))
         redacted = dict(row)
         for field in ("remote_url", "source_path"):
-            value = redacted.get(field)
-            if isinstance(value, str):
-                redacted[field] = redact_value(_redact_path_string(_sanitize_json_value(value)))
+            redacted[field] = redact_metadata_value(redacted.get(field))
         redacted["rubric_json"] = _redact_json_blob(
             redacted.get("rubric_json"), field="rubric_json", session_id=session_id
         )
@@ -334,7 +353,7 @@ def merge_imported_observations(
 
 def _dedup_tuple(row: dict[str, Any]) -> tuple[Any, ...]:
     return (
-        row["source"],
+        row.get("source", "auto"),
         *(row.get(field) for field in _TUPLE_FIELDS),
     )
 
@@ -369,7 +388,7 @@ def dedupe_observations(inventories: list[list[dict[str, Any]]]) -> dict[str, An
     groups: dict[tuple[Any, ...], list[tuple[dict[str, Any], str]]] = {}
     for inventory in inventories:
         for row in inventory:
-            human = row["source"] != "auto"
+            human = row.get("source", "auto") != "auto"
             key = _dedup_tuple(row)
             if human:
                 # Human rows are never auto-deduped by the writer: only
@@ -396,8 +415,8 @@ def dedupe_observations(inventories: list[list[dict[str, Any]]]) -> dict[str, An
         rows.append(ordered[0][0])
         deduped_count += len(ordered) - 1
 
-    rows.sort(key=lambda r: (str(r["session_id"]), str(r["observed_at"]), r["source"]))
-    conflicts.sort(key=lambda r: (str(r["session_id"]), str(r["observed_at"]), r["source"]))
+    rows.sort(key=lambda r: (str(r["session_id"]), str(r["observed_at"]), r.get("source", "auto")))
+    conflicts.sort(key=lambda r: (str(r["session_id"]), str(r["observed_at"]), r.get("source", "auto")))
     return {"rows": rows, "deduped_count": deduped_count, "content_conflict": conflicts}
 
 
@@ -406,6 +425,7 @@ def link_session_identity(
     *,
     hydrated_index: dict[str, dict[str, Any]],
     repo_slug_sha_lookup: dict[tuple[str, str, str], Any],
+    unmatched_identity_less: bool = False,
 ) -> dict[str, dict[str, Any]]:
     """Resolve each imported record to a Hub session identity.
 
@@ -417,6 +437,12 @@ def link_session_identity(
             — the hydrate import-ledger join shape.
         repo_slug_sha_lookup: ``{(repo_slug, base_sha, head_sha): hub_session_id}``
             (a dict with ``"hub_session_id"`` is also accepted).
+        unmatched_identity_less: When ``True`` (the import CLI's wiring over
+            local-only archive roots with an empty hydrated index), an
+            identity-less record — one absent from ``hydrated_index`` and
+            missing the fallback session fields — routes to ``unmatched``
+            instead of raising, so a single repo-less local run cannot abort
+            a whole-archive import.
 
     Returns:
         ``{"linked": {sid: {"hub_session_id", "matched_by"}},
@@ -433,7 +459,8 @@ def link_session_identity(
     Raises:
         ValueError: When a record is unresolvable via the primary rule and is
             missing the session fields required for the fallback — no
-            placeholder linkage is produced.
+            placeholder linkage is produced. (Suppressed in favor of
+            ``unmatched`` only when ``unmatched_identity_less`` is ``True``.)
     """
     linked: dict[str, dict[str, str]] = {}
     unmatched: dict[str, str] = {}
@@ -463,6 +490,9 @@ def link_session_identity(
         base_sha = record.get("base_sha")
         head_sha = record.get("head_sha")
         if not repo_slug or not base_sha or not head_sha:
+            if unmatched_identity_less:
+                unmatched[session_id] = _REASON_UNMATCHED
+                continue
             msg = (
                 f"session {session_id!r} has no Hub index entry and is missing "
                 "the repo_slug/base_sha/head_sha fields required for the "
@@ -668,6 +698,7 @@ def run_pure_import(
     hydrated_index: dict[str, dict[str, Any]],
     repo_slug_sha_lookup: dict[tuple[str, str, str], Any],
     projector_findings: dict[str, list[dict[str, Any]]],
+    unmatched_identity_less: bool = False,
 ) -> dict[str, Any]:
     """Compose the pure import pipeline: dedupe -> link -> run-level -> accounting.
 
@@ -676,6 +707,8 @@ def run_pure_import(
         hydrated_index: See :func:`link_session_identity`.
         repo_slug_sha_lookup: See :func:`link_session_identity`.
         projector_findings: See :func:`classify_run_level`.
+        unmatched_identity_less: Threaded to :func:`link_session_identity`;
+            see its annotation.
 
     Returns:
         ``{"rows", "deduped_count", "content_conflict", "link",
@@ -689,6 +722,7 @@ def run_pure_import(
         merged["rows"],
         hydrated_index=hydrated_index,
         repo_slug_sha_lookup=repo_slug_sha_lookup,
+        unmatched_identity_less=unmatched_identity_less,
     )
     run_level_result = classify_run_level(
         merged["rows"], projector_findings=projector_findings
@@ -768,7 +802,5 @@ def gold_eligible(observation: dict[str, Any]) -> bool:
     for field in ("labeler_version", "labeler_policy_version", "reply_classifier_version"):
         value = observation.get(field)
         if not value or str(value) not in KNOWN_LABELER_VERSIONS:
-            return False
-        if str(value) == STALE_LEGACY:
             return False
     return True

--- a/daydream/archive/importer.py
+++ b/daydream/archive/importer.py
@@ -12,12 +12,110 @@ always accounts for every record.
 
 from __future__ import annotations
 
+import hashlib
+import json
 from typing import Any
 
-__all__ = ["link_session_identity"]
+__all__ = ["canonical_payload_digest", "dedupe_observations", "link_session_identity"]
 
 _REASON_UNMATCHED = "no_hub_entry"
 _REASON_CONFLICT = "derivative_digest_conflict"
+
+# The writer's versioned auto-dedup tuple (daydream/archive/index.py): the
+# evidence identity key. A policy-version bump, reward-version bump, or
+# edited-reply digest change appends a new generation instead of deduping.
+_TUPLE_FIELDS = (
+    "evidence_sha",
+    "labeler_policy_version",
+    "reply_evidence_digest",
+    "labels",
+    "has_posterior",
+    "reward_version",
+)
+
+
+def canonical_payload_digest(row: dict[str, Any], *, include_observed_at: bool) -> str:
+    """Content digest over the canonical-JSON observation payload.
+
+    The bitemporal ``observed_at`` stamp is excluded for auto rows — identical
+    evidence captured by two overlapping backups at different capture times
+    must dedupe regardless of ``observed_at`` (the SQLite PK
+    ``(session_id, observed_at)`` in the target handles identical-timestamp
+    overlap). Human rows include it: they are never auto-deduped by the
+    writer, so only byte-identical human rows collapse.
+    """
+    payload = {k: v for k, v in row.items() if include_observed_at or k != "observed_at"}
+    canonical = json.dumps(payload, sort_keys=True, default=str)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def _dedup_tuple(row: dict[str, Any]) -> tuple[Any, ...]:
+    return (
+        row["source"],
+        *(row.get(field) for field in _TUPLE_FIELDS),
+    )
+
+
+def dedupe_observations(inventories: list[list[dict[str, Any]]]) -> dict[str, Any]:
+    """Merge inventory rows across overlapping backups, deduping by content.
+
+    Args:
+        inventories: One list of ``label_observations`` rows per backup root,
+            each row carrying the table's columns (including ``source``).
+
+    Returns:
+        ``{"rows": [...], "deduped_count": int, "content_conflict": [...]}``
+        where ``rows`` is the deterministic merged row set and
+        ``content_conflict`` holds rows whose dedup tuple matched across
+        inventories but whose immutable payload digests disagreed — ambiguous
+        evidence, reported rather than silently resolved. ``deduped_count``
+        counts dropped duplicate rows (the conflict bucket keeps its rows, so
+        bucket rows + surviving rows always account for every input row).
+
+    Dedupe key: the writer's versioned auto-dedup tuple plus the canonical
+    payload digest. Identical evidence with identical payload dedupes
+    regardless of ``observed_at``; the surviving row keeps the earliest
+    ``observed_at``. Distinct evidence generations are never collapsed —
+    every generation survives (M3, never keep-latest).
+
+    Deterministic: the merged rows are sorted by ``session_id`` then
+    ``observed_at`` (then payload digest), so inventory input order cannot
+    affect the output — byte-identical re-import by construction (M4/AC1).
+    """
+    # Group every input row by dedup tuple, carrying its payload digest.
+    groups: dict[tuple[Any, ...], list[tuple[dict[str, Any], str]]] = {}
+    for inventory in inventories:
+        for row in inventory:
+            human = row["source"] != "auto"
+            key = _dedup_tuple(row)
+            if human:
+                # Human rows are never auto-deduped by the writer: only
+                # byte-identical rows (including observed_at) collapse, and
+                # distinct stamps are legitimate generations — never
+                # content conflicts.
+                key = (*key, canonical_payload_digest(row, include_observed_at=True))
+            groups.setdefault(key, []).append(
+                (row, canonical_payload_digest(row, include_observed_at=human))
+            )
+
+    rows: list[dict[str, Any]] = []
+    conflicts: list[dict[str, Any]] = []
+    deduped_count = 0
+    for group in groups.values():
+        digests = {digest for _, digest in group}
+        if len(digests) > 1:
+            # Same dedup tuple, differing immutable payloads: ambiguous.
+            conflicts.extend(row for row, _ in group)
+            continue
+        # Byte-identical payload: keep one representative with the earliest
+        # observed_at; drop the rest as duplicates.
+        ordered = sorted(group, key=lambda item: (str(item[0]["observed_at"]), item[1]))
+        rows.append(ordered[0][0])
+        deduped_count += len(ordered) - 1
+
+    rows.sort(key=lambda r: (str(r["session_id"]), str(r["observed_at"]), r["source"]))
+    conflicts.sort(key=lambda r: (str(r["session_id"]), str(r["observed_at"]), r["source"]))
+    return {"rows": rows, "deduped_count": deduped_count, "content_conflict": conflicts}
 
 
 def link_session_identity(

--- a/daydream/archive/importer.py
+++ b/daydream/archive/importer.py
@@ -14,8 +14,10 @@ from __future__ import annotations
 
 import hashlib
 import json
+from pathlib import Path
 from typing import Any
 
+from daydream.archive.index import append_label_observation
 from daydream.archive.known_versions import KNOWN_LABELER_VERSIONS, STALE_LEGACY
 
 __all__ = [
@@ -24,7 +26,27 @@ __all__ = [
     "dedupe_observations",
     "gold_eligible",
     "link_session_identity",
+    "merge_imported_observations",
 ]
+
+# Writer columns consumed by append_label_observation; every other key on an
+# import row (legacy, payload_digest, ...) is importer metadata, not payload.
+_WRITER_FIELDS = (
+    "labels",
+    "pr_state",
+    "labeler_version",
+    "evidence_sha",
+    "rubric_json",
+    "valid_at",
+    "reward_version",
+    "reward_json",
+    "composite_reward",
+    "reviewer_logins",
+    "has_posterior",
+    "source",
+    "reply_classifier_version",
+    "reply_evidence_digest",
+)
 
 _REASON_UNMATCHED = "no_hub_entry"
 _REASON_CONFLICT = "derivative_digest_conflict"
@@ -57,6 +79,113 @@ def canonical_payload_digest(row: dict[str, Any], *, include_observed_at: bool) 
     payload = {k: v for k, v in row.items() if include_observed_at or k != "observed_at"}
     canonical = json.dumps(payload, sort_keys=True, default=str)
     return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def _planned_append(row: dict[str, Any]) -> dict[str, Any]:
+    """Shape one import row into append_label_observation keyword arguments."""
+    plan: dict[str, Any] = {
+        "session_id": row["session_id"],
+        "observed_at": row["observed_at"],
+    }
+    for field in _WRITER_FIELDS:
+        value = row.get(field)
+        # Rows read from SQLite carry JSON-encoded list columns; the writer
+        # expects the decoded Python values.
+        if field in ("labels", "reviewer_logins") and isinstance(value, str):
+            try:
+                value = json.loads(value)
+            except ValueError as exc:
+                raise ValueError(
+                    f"imported row for session {row['session_id']!r} at "
+                    f"{row['observed_at']!r} has malformed {field} JSON: {value!r}"
+                ) from exc
+        plan[field] = value
+    plan["has_posterior"] = bool(plan["has_posterior"])
+    return plan
+
+
+def merge_imported_observations(
+    archive_dir: Path,
+    linked_imports: list[dict[str, Any]],
+    *,
+    observations_path: Path | None = None,
+    dry_run: bool = False,
+) -> dict[str, Any]:
+    """Append deduped, identity-linked import rows through the archive writer.
+
+    Every row goes through :func:`append_label_observation` — the single
+    canonical writer — so the versioned auto-dedup tuple, the human-never-dedup
+    rule, and the precedence projection that refreshes the denormalized
+    ``runs.outcome_labels`` cache all apply unchanged. The importer only ever
+    appends: it never overwrites or deletes a newer existing observation (M3),
+    and winners are decided by the writer's projection, not by the import
+    order.
+
+    Args:
+        archive_dir: Target archive root (the Hub-side index being merged into).
+        linked_imports: Deduped inventory rows with ``session_id`` already
+            remapped to the linked Hub session id. Rows may carry a
+            ``payload_digest`` recorded at inventory time.
+        observations_path: Optional JSON file of additional import rows (same
+            shape), loaded and appended to ``linked_imports``.
+        dry_run: When ``True``, return the planned append set without writing
+            any state (S2).
+
+    Returns:
+        ``{"dry_run": bool, "planned": [...], "appended": int, "deduped": int}``
+        where ``planned`` holds one writer-kwarg dict per import row in
+        deterministic ``(session_id, observed_at, source)`` order and
+        ``appended``/``deduped`` count writer outcomes (both 0 on dry run).
+
+    Raises:
+        ValueError: Fail-closed, before any write, when a row's recomputed
+            canonical payload digest disagrees with its inventory-time
+            ``payload_digest`` (evidence drifted between inventory and merge),
+            when a row's JSON list columns are malformed, or when the writer
+            rejects the row (unknown session, non-ISO-8601 ``observed_at``) —
+            each error names the offending row. Never silently defaulted.
+    """
+    imports = list(linked_imports)
+    if observations_path is not None and observations_path.is_file():
+        loaded = json.loads(observations_path.read_text(encoding="utf-8"))
+        if not isinstance(loaded, list):
+            raise ValueError(
+                f"observations file {observations_path} must contain a JSON list of rows"
+            )
+        imports.extend(loaded)
+
+    imports.sort(key=lambda r: (str(r["session_id"]), str(r["observed_at"]), str(r["source"])))
+
+    # Fail-closed drift gate before any write: recompute the same canonical
+    # payload digest the inventory recorded and reject any drifted row
+    # (mirrors run_canonical_harvest's AnnotationDriftError path).
+    for row in imports:
+        if "payload_digest" not in row:
+            continue
+        payload = {k: v for k, v in row.items() if k != "payload_digest"}
+        fresh = canonical_payload_digest(
+            payload, include_observed_at=row["source"] != "auto"
+        )
+        if fresh != row["payload_digest"]:
+            raise ValueError(
+                f"imported observation for session {row['session_id']!r} at "
+                f"{row['observed_at']!r} drifted from its inventory payload digest "
+                f"(expected {row['payload_digest']}, recomputed {fresh}); "
+                f"re-inventory the source before merging"
+            )
+
+    planned = [_planned_append(row) for row in imports]
+    if dry_run:
+        return {"dry_run": True, "planned": planned, "appended": 0, "deduped": 0}
+
+    appended = 0
+    deduped = 0
+    for plan in planned:
+        if append_label_observation(archive_dir, plan.pop("session_id"), **plan):
+            appended += 1
+        else:
+            deduped += 1
+    return {"dry_run": False, "planned": planned, "appended": appended, "deduped": deduped}
 
 
 def _dedup_tuple(row: dict[str, Any]) -> tuple[Any, ...]:

--- a/daydream/archive/importer.py
+++ b/daydream/archive/importer.py
@@ -16,7 +16,14 @@ import hashlib
 import json
 from typing import Any
 
-__all__ = ["canonical_payload_digest", "dedupe_observations", "link_session_identity"]
+from daydream.archive.known_versions import KNOWN_LABELER_VERSIONS, STALE_LEGACY
+
+__all__ = [
+    "canonical_payload_digest",
+    "dedupe_observations",
+    "gold_eligible",
+    "link_session_identity",
+]
 
 _REASON_UNMATCHED = "no_hub_entry"
 _REASON_CONFLICT = "derivative_digest_conflict"
@@ -196,3 +203,21 @@ def link_session_identity(
             }
 
     return {"linked": linked, "unmatched": unmatched, "identity_conflict": identity_conflict}
+
+
+def gold_eligible(observation: dict[str, Any]) -> bool:
+    """Version gate for gold eligibility (M6, KD3).
+
+    Returns True iff every version axis on the observation — labeler
+    (rubric), policy, and classifier versions — is in the known-versions
+    allowlist. A missing/``None`` version field, or the ``"legacy"`` sentinel
+    stamp, makes the row non-gold (safe default: unknown provenance is never
+    decisive). Such rows still import as evidence.
+    """
+    for field in ("labeler_version", "labeler_policy_version", "reply_classifier_version"):
+        value = observation.get(field)
+        if not value or str(value) not in KNOWN_LABELER_VERSIONS:
+            return False
+        if str(value) == STALE_LEGACY:
+            return False
+    return True

--- a/daydream/archive/importer.py
+++ b/daydream/archive/importer.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import re
 from pathlib import Path
 from typing import Any
 
@@ -25,12 +26,17 @@ from daydream.archive.hydrate_rules import (
     REASON_CODE_IMPORT_RUN_LEVEL_ONLY,
     REASON_CODE_IMPORT_STALE_EVIDENCE,
     REASON_CODE_IMPORT_UNMATCHED_SESSION,
+    REASON_CODE_IMPORT_UNREDACTABLE_METADATA,
 )
 from daydream.archive.index import append_label_observation
 from daydream.archive.known_versions import KNOWN_LABELER_VERSIONS, STALE_LEGACY
+from daydream.archive.sanitize import _sanitize_json_value
+from daydream.archive.scan import scan_run_dir
+from daydream.trajectory import redact_value
 
 __all__ = [
     "IMPORT_REASON_CODES",
+    "REDACTED_PATH",
     "accounting",
     "build_import_ledger",
     "canonical_payload_digest",
@@ -52,6 +58,17 @@ IMPORT_REASON_CODES = (
     REASON_CODE_IMPORT_DECISIVE_PER_FINDING,
     REASON_CODE_IMPORT_RUN_LEVEL_ONLY,
 )
+
+# Marker replacing redacted absolute local paths. Carries the ``[REDACTED_``
+# prefix the scanner treats as already-safe output, so redacted payloads do
+# not flag their own markers.
+REDACTED_PATH = "[REDACTED_PATH]"
+
+# Absolute local path embedded inside a larger string. The lookbehind blocks
+# scheme separators (``https://…``) and UNC double slashes, so canonical git
+# URLs survive untouched; standalone path values are caught by the
+# startswith("/") check in :func:`_redact_path_string`.
+_EMBEDDED_ABSOLUTE_PATH_RE = re.compile(r"(?<![:/\w])(/[\w.-]+(?:/[\w.-]+)+)")
 
 # Writer columns consumed by append_label_observation; every other key on an
 # import row (legacy, payload_digest, ...) is importer metadata, not payload.
@@ -103,6 +120,109 @@ def canonical_payload_digest(row: dict[str, Any], *, include_observed_at: bool) 
     payload = {k: v for k, v in row.items() if include_observed_at or k != "observed_at"}
     canonical = json.dumps(payload, sort_keys=True, default=str)
     return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def _redact_path_string(value: str) -> str:
+    """Redact absolute local paths in one string value (never raises)."""
+    if value.startswith("/"):
+        return REDACTED_PATH
+    return _EMBEDDED_ABSOLUTE_PATH_RE.sub(REDACTED_PATH, value)
+
+
+def _redact_json_blob(value: Any, *, field: str, session_id: str) -> Any:
+    """Redact one ``rubric_json``/``reward_json`` payload (URL creds, secrets,
+    absolute local paths).
+
+    Raises:
+        ValueError: When a JSON-encoded string blob is malformed — never
+            silently substituted (fail-closed, names the row + field).
+    """
+    if value is None:
+        return None
+    if isinstance(value, str):
+        was_string = True
+        try:
+            value = json.loads(value)
+        except json.JSONDecodeError as exc:
+            msg = (
+                f"imported row for session {session_id!r} has malformed "
+                f"{field} JSON: {exc}"
+            )
+            raise ValueError(msg) from exc
+    else:
+        was_string = False
+    if not isinstance(value, (dict, list)):
+        return redact_value(_redact_path_string(str(value)))
+
+    def _walk(node: Any) -> Any:
+        if isinstance(node, dict):
+            return {key: _walk(child) for key, child in node.items()}
+        if isinstance(node, list):
+            return [_walk(child) for child in node]
+        if isinstance(node, str):
+            return redact_value(_redact_path_string(_sanitize_json_value(node)))
+        return node
+
+    redacted = _walk(value)
+    if was_string and isinstance(redacted, (dict, list)):
+        # Preserve the column's JSON-encoded string representation.
+        return json.dumps(redacted, sort_keys=True, default=str)
+    return redacted
+
+
+def redact_imported_metadata(rows: list[dict[str, Any]], *, scan_dir: Path) -> dict[str, Any]:
+    """Redact pre-publication metadata and fail closed on uncleanable rows (M9, AC6).
+
+    Every row's ``remote_url`` and ``source_path`` are rewritten through the
+    sanitize module's URL authority plus absolute-path redaction, and the
+    ``rubric_json``/``reward_json`` blobs are walked string-leaf by string-leaf
+    through ``sanitize._sanitize_json_value`` + ``redact_value`` (reuse, not
+    reimplementation). The redacted payload is then serialized to
+    ``scan_dir/payload.json`` and re-scanned with the fail-closed
+    :func:`daydream.archive.scan.scan_run_dir`.
+
+    Returns:
+        ``{"payload": [...], "blocked": bool, "scan_summary": str,
+        "blocked_reasons": [...]}``. ``blocked`` is ``True`` only when the
+        post-redaction scan is dirty — the payload cannot be published; the
+        offending rows are kept in ``payload`` (never dropped silently) and
+        ``blocked_reasons`` carries the stable
+        ``import_unredactable_metadata`` reason code. Redaction runs before
+        ``publish_annotation_state`` (which re-scans and hard-fails on dirty).
+
+    Raises:
+        ValueError: When a ``rubric_json``/``reward_json`` blob is malformed
+            JSON — redaction errors propagate, never placeholder-substituted.
+    """
+    payload: list[dict[str, Any]] = []
+    for row in rows:
+        session_id = str(row.get("session_id", ""))
+        redacted = dict(row)
+        for field in ("remote_url", "source_path"):
+            value = redacted.get(field)
+            if isinstance(value, str):
+                redacted[field] = redact_value(_redact_path_string(_sanitize_json_value(value)))
+        redacted["rubric_json"] = _redact_json_blob(
+            redacted.get("rubric_json"), field="rubric_json", session_id=session_id
+        )
+        redacted["reward_json"] = _redact_json_blob(
+            redacted.get("reward_json"), field="reward_json", session_id=session_id
+        )
+        payload.append(redacted)
+
+    scan_dir.mkdir(parents=True, exist_ok=True)
+    payload_path = scan_dir / "payload.json"
+    payload_path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True, default=str) + "\n", encoding="utf-8"
+    )
+    scan = scan_run_dir(scan_dir)
+    blocked = not scan.clean
+    return {
+        "payload": payload,
+        "blocked": blocked,
+        "scan_summary": scan.summary(),
+        "blocked_reasons": [REASON_CODE_IMPORT_UNREDACTABLE_METADATA] if blocked else [],
+    }
 
 
 def _planned_append(row: dict[str, Any]) -> dict[str, Any]:

--- a/daydream/archive/index.py
+++ b/daydream/archive/index.py
@@ -313,6 +313,7 @@ def append_label_observation(
     source: str = "auto",
     reply_classifier_version: str | None = None,
     reply_evidence_digest: str | None = None,
+    observed_at: str | None = None,
 ) -> bool:
     """Append a row to the immutable ``label_observations`` history.
 
@@ -393,13 +394,35 @@ def append_label_observation(
         (``source != "auto"``) appends are never deduped and always return
         ``True``.
 
+        An explicit ``observed_at`` (aware ISO-8601) is preserved bitemporally
+        as the row's observation time instead of the wall clock; ``None``
+        keeps the existing now() behavior.
+
     Raises:
         ValueError: When ``session_id`` is not present in the ``runs`` table,
-            or when ``valid_at`` is not a parseable aware ISO-8601 timestamp.
+            when ``valid_at`` is not a parseable aware ISO-8601 timestamp, or
+            when ``observed_at`` is set and is not a parseable aware ISO-8601
+            timestamp.
     """
     if valid_at is not None:
         valid_at = canonical_utc_iso(valid_at)
-    observed_dt = datetime.now(timezone.utc)
+    if observed_at is not None:
+        # Bitemporal preservation: an explicit data timestamp (e.g. imported
+        # from a surviving local archive) is stored in place of the wall clock.
+        # Fails closed on non-ISO-8601 or naive input before any write.
+        try:
+            parsed = datetime.fromisoformat(observed_at)
+        except ValueError:
+            raise ValueError(
+                f"observed_at {observed_at!r} is not a parseable ISO-8601 timestamp"
+            ) from None
+        if parsed.tzinfo is None or parsed.utcoffset() is None:
+            raise ValueError(
+                f"observed_at {observed_at!r} is naive: an explicit UTC offset is required"
+            )
+        observed_dt = parsed.astimezone(timezone.utc)
+    else:
+        observed_dt = datetime.now(timezone.utc)
     labels_json = json.dumps(labels)
     reviewer_logins_json = json.dumps(reviewer_logins) if reviewer_logins is not None else None
     has_posterior_int = int(has_posterior)

--- a/daydream/archive/index.py
+++ b/daydream/archive/index.py
@@ -86,6 +86,7 @@ from daydream.archive._schema import (
     _recreate_label_observations_if_stale,
 )
 from daydream.archive.git_safe import normalize_remote_url
+from daydream.archive.known_versions import STALE_LEGACY
 from daydream.archive.manifest import Manifest
 
 # Re-export for callers (including tests) that import these names from this module.
@@ -313,6 +314,8 @@ def append_label_observation(
     source: str = "auto",
     reply_classifier_version: str | None = None,
     reply_evidence_digest: str | None = None,
+    labeler_policy_version: str | None = None,
+    legacy: str = "auto",
     observed_at: str | None = None,
 ) -> bool:
     """Append a row to the immutable ``label_observations`` history.
@@ -371,6 +374,20 @@ def append_label_observation(
         reply_evidence_digest: Stable digest over the combined reply evidence
             (versioned dedup input, M14); persisted and compared in the auto
             dedup key so an edited reply appends a new generation.
+        labeler_policy_version: Versioned policy axis (M13); persisted on the
+            row and part of the auto dedup key so a policy bump appends a new
+            generation. ``None`` (the default, keeping pre-policy callers
+            unchanged) mirrors ``labeler_version`` into the policy column; the
+            ``STALE_LEGACY`` sentinel — the inventory marker for legacy-schema
+            source rows with no policy axis — is stored as SQL ``NULL`` with
+            the ``legacy`` marker stamped, the representation the corpus gold
+            gate (``labeler_policy_version IS NOT NULL``) already treats as
+            non-gold.
+        legacy: Legacy marker for the row — ``"auto"`` (the default) or
+            ``"legacy"`` (a row whose policy axis predates
+            ``label_observations`` versioning; never gold-eligible). Mirrors
+            the schema's legacy stamping so imported legacy rows persist the
+            same representation a migrated in-place row has.
         source: Provenance of this observation — ``"auto"`` (automated rubric
             labeler; the default that keeps existing harvest callers
             unchanged) or ``"human"`` (operator override). Human-sourced rows
@@ -391,8 +408,10 @@ def append_label_observation(
         a fresh generation. A ``None`` digest is not coerced to ``""`` — ``None``
         never equals a present digest, so digest-less legacy callers dedupe on
         the remaining tuple exactly as before (deliberate default). Human
-        (``source != "auto"``) appends are never deduped and always return
-        ``True``.
+        (``source != "auto"``) appends are never deduped by the evidence
+        tuple; only a byte-identical row already occupying the same
+        ``(session_id, observed_at)`` primary key is a no-op re-import (so a
+        re-merged source never grows microsecond-shifted duplicates).
 
         An explicit ``observed_at`` (aware ISO-8601) is preserved bitemporally
         as the row's observation time instead of the wall clock; ``None``
@@ -423,6 +442,19 @@ def append_label_observation(
         observed_dt = parsed.astimezone(timezone.utc)
     else:
         observed_dt = datetime.now(timezone.utc)
+    # Policy axis resolution: versioned callers (the import merge) pass the
+    # source's labeler_policy_version verbatim; callers that predate the axis
+    # leave it None and the free-form labeler_version mirrors into the policy
+    # column (inherited behavior). The STALE_LEGACY sentinel — the inventory-
+    # time marker for a legacy-schema row with no policy axis — is stored as
+    # the canonical legacy representation: NULL policy + legacy='legacy', so
+    # the corpus gold gate (which rejects rows by labeler_policy_version IS
+    # NULL) can never admit a row the importer's version gate excluded.
+    if labeler_policy_version == STALE_LEGACY:
+        labeler_policy_version = None
+        legacy = "legacy"
+    elif labeler_policy_version is None:
+        labeler_policy_version = labeler_version
     labels_json = json.dumps(labels)
     reviewer_logins_json = json.dumps(reviewer_logins) if reviewer_logins is not None else None
     has_posterior_int = int(has_posterior)
@@ -459,7 +491,7 @@ def append_label_observation(
             if (
                 latest_auto is not None
                 and latest_auto["evidence_sha"] == evidence_sha
-                and latest_auto["labeler_policy_version"] == labeler_version
+                and latest_auto["labeler_policy_version"] == labeler_policy_version
                 and latest_auto["reply_evidence_digest"] == reply_evidence_digest
                 and latest_auto["reward_version"] == reward_version
                 and latest_auto["labels"] == labels_json
@@ -479,7 +511,7 @@ def append_label_observation(
                     "(session_id, observed_at, labels, pr_state, labeler_version, evidence_sha, rubric_json, "
                     "valid_at, reward_version, reward_json, composite_reward, reviewer_logins, has_posterior, source, "
                     "labeler_policy_version, reply_classifier_version, reply_evidence_digest, legacy) "
-                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'auto')",
+                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                     (
                         session_id,
                         observed_at,
@@ -495,13 +527,47 @@ def append_label_observation(
                         reviewer_logins_json,
                         has_posterior_int,
                         source,
-                        labeler_version,
+                        labeler_policy_version,
                         reply_classifier_version,
                         reply_evidence_digest,
+                        legacy,
                     ),
                 )
                 break
             except sqlite3.IntegrityError:
+                # Primary-key collision on (session_id, observed_at): a
+                # byte-identical row already occupying this exact stamp is a
+                # no-op re-import — the microsecond bump must never fabricate
+                # a duplicate generation for it (idempotent re-merge of a
+                # surviving source, human or auto). A genuinely distinct
+                # generation at the same stamp keeps the pre-existing bump.
+                existing = conn.execute(
+                    "SELECT labels, pr_state, labeler_version, evidence_sha, rubric_json, "
+                    "valid_at, reward_version, reward_json, composite_reward, reviewer_logins, "
+                    "has_posterior, source, labeler_policy_version, reply_classifier_version, "
+                    "reply_evidence_digest, legacy "
+                    "FROM label_observations WHERE session_id = ? AND observed_at = ?",
+                    (session_id, observed_at),
+                ).fetchone()
+                if existing is not None and tuple(existing) == (
+                    labels_json,
+                    pr_state,
+                    labeler_version,
+                    evidence_sha,
+                    rubric_json,
+                    valid_at_value,
+                    reward_version,
+                    reward_json,
+                    composite_reward,
+                    reviewer_logins_json,
+                    has_posterior_int,
+                    source,
+                    labeler_policy_version,
+                    reply_classifier_version,
+                    reply_evidence_digest,
+                    legacy,
+                ):
+                    return False
                 observed_dt += timedelta(microseconds=1)
         # Recompute the winning observation (human-first, then recency) so the
         # denormalized runs cache mirrors the precedence projection — not

--- a/daydream/archive/known_versions.py
+++ b/daydream/archive/known_versions.py
@@ -1,0 +1,37 @@
+"""Data-driven allowlist of known labeler-version strings.
+
+Seeded from the version axes in ``daydream/training/labeler_versions.py``
+(KD3): a value set that can be extended without touching import logic. This
+module imports nothing beyond the constants module — no cycle into the
+training adjudication package.
+
+Any imported observation whose version axes fall outside this allowlist (or
+stamped ``"legacy"``) still imports as evidence but is never gold-eligible
+(M6): unknown provenance must never be decisive.
+"""
+
+from __future__ import annotations
+
+from daydream.training.labeler_versions import (
+    ADJUDICATION_LABELER_VERSION,
+    HUMAN_LABELER_VERSION,
+    LABELER_POLICY_VERSION,
+    REPLY_CLASSIFIER_VERSION,
+    RUBRIC_SCHEMA_VERSION,
+)
+
+__all__ = ["KNOWN_LABELER_VERSIONS", "STALE_LEGACY"]
+
+# Legacy-schema rows (missing version columns) surface this sentinel string
+# (Assumption 4) and are never gold-eligible.
+STALE_LEGACY = "legacy"
+
+KNOWN_LABELER_VERSIONS: frozenset[str] = frozenset(
+    {
+        RUBRIC_SCHEMA_VERSION,
+        LABELER_POLICY_VERSION,
+        REPLY_CLASSIFIER_VERSION,
+        ADJUDICATION_LABELER_VERSION,
+        HUMAN_LABELER_VERSION,
+    }
+)

--- a/daydream/training/adjudication/cli.py
+++ b/daydream/training/adjudication/cli.py
@@ -362,6 +362,14 @@ def _build_adjudicate_parser() -> argparse.ArgumentParser:
                           help="Print the digest-stable import report as JSON")
     p_import.add_argument("--dry-run", action="store_true",
                           help="Plan the import without writing any state")
+    p_import.add_argument("--publish", action="store_true",
+                          help="Publish the merged state to the private Hub after the import "
+                               "(checkpoint written for fresh-VM resume)")
+    p_import.add_argument("--manifest", type=Path, metavar="PATH",
+                          help="Preview manifest pinning curation_id + snapshot_id "
+                               "(required with --publish)")
+    p_import.add_argument("--hub-repo", type=str, default=_ANNOTATION_HUB_REPO, metavar="REPO",
+                          help=f"Private Hub dataset repo (default: {_ANNOTATION_HUB_REPO})")
 
     return parser
 
@@ -922,7 +930,13 @@ def handle_import_local_observations(argv: list[str]) -> int:
     """
     from daydream.ui import create_console, print_error, print_success
 
-    args = _build_adjudicate_parser().parse_args(["import-local-observations", *argv])
+    parser = _build_adjudicate_parser()
+    args = parser.parse_args(["import-local-observations", *argv])
+    if args.publish:
+        if args.dry_run:
+            parser.error("--publish cannot be combined with --dry-run")
+        if args.manifest is None:
+            parser.error("--publish requires --manifest")
     console = create_console()
     try:
         inventories: list[list[dict[str, Any]]] = []
@@ -1025,6 +1039,22 @@ def handle_import_local_observations(argv: list[str]) -> int:
         }
         report["redaction"] = {"blocked": False, "reasons": []}
 
+    if args.publish:
+        # Compose the existing publication (reuse over rebuild): the private
+        # repo hard-fail and the S1 secret scan are publish_annotation_state's
+        # own fail-closed gates, so a public destination or a credential-shaped
+        # payload is refused before any byte reaches the Hub. The checkpoint is
+        # always written: it is the fresh-VM resume anchor (AC5).
+        try:
+            client = _make_client(args.hub_repo)
+            published = publish_annotation_state(
+                client, args.state_dir, manifest=args.manifest, batch_complete=True,
+            )
+        except (ValueError, HubUnavailableError, HydrationError, PublicDestinationError, FileNotFoundError) as exc:
+            print_error(console, "adjudicate import-local-observations failed", str(exc))
+            return 1
+        report["publish"] = {"prefix": published["prefix"], "uploaded": published["uploaded"]}
+
     if args.json:
         print(json.dumps(report, indent=2, sort_keys=True))
     else:
@@ -1038,7 +1068,8 @@ def handle_import_local_observations(argv: list[str]) -> int:
                 if args.dry_run
                 else f"{report['merge']['appended']} appended, "
                 f"{report['merge']['deduped']} deduped by the writer"
-            ),
+            )
+            + (f"; published to {report['publish']['prefix']}" if args.publish else ""),
         )
 
     if not args.dry_run:

--- a/daydream/training/adjudication/cli.py
+++ b/daydream/training/adjudication/cli.py
@@ -65,6 +65,7 @@ from daydream.archive.importer import (
     canonical_payload_digest,
     merge_imported_observations,
     redact_imported_metadata,
+    redact_metadata_value,
     run_pure_import,
 )
 from daydream.archive.index import _get_connection
@@ -885,9 +886,14 @@ def _inventory_import_root(root: Path) -> dict[str, Any]:
         for column in _IMPORT_VERSION_COLUMNS:
             if column not in row:
                 row[column] = STALE_LEGACY
+        if "source" not in row:
+            # A pre-``source`` legacy label_observations table: default the
+            # precedence marker to the writer's own default ("auto") so no
+            # downstream ``row["source"]`` read raises KeyError on a legacy row.
+            row["source"] = "auto"
         run = runs.get(str(row["session_id"]))
         if run is not None:
-            for field in ("repo_slug", "base_sha", "head_sha"):
+            for field in ("repo_slug", "base_sha", "head_sha", "remote_url", "source_path"):
                 row[field] = run.get(field)
     return {"rows": rows, "source_digest": source_digest, "runs": runs}
 
@@ -895,17 +901,59 @@ def _inventory_import_root(root: Path) -> dict[str, Any]:
 def _seed_target_runs(
     state_dir: Path, sessions: set[str], runs: dict[str, dict[str, Any]]
 ) -> None:
-    """Copy the source runs rows for *sessions* into the state-dir archive.
+    """Materialize the source runs rows for *sessions* into the state-dir archive.
 
     ``append_label_observation`` requires the session to exist in ``runs``;
     importing into the state archive therefore materializes the source run
-    rows first (deterministic: sessions in sorted order). Idempotent via
-    ``INSERT OR REPLACE`` with the full source column set.
+    rows first (deterministic: sessions in sorted order). A session that does
+    not yet exist is inserted with the source row's full column set.
+
+    A session that already exists is **never displaced**: its populated target
+    columns — ``status``/``archived_at``, the ``profile_*`` fields, the cost
+    metrics, and the writer-owned denormalized cache mirrors
+    (``outcome_labels``/``labeled_at``/``rubric_json``/``composite_reward``/
+    ``has_posterior``) — survive an overlapping re-import of an older backup,
+    and only NULL target columns are filled from the source snapshot. The
+    observation merge is append-only/no-displacement, so the run-row seeding
+    follows the same rule: an older overlapping backup must never overwrite
+    newer target state (a deduped no-op append never refreshes the cache, so
+    the target row remains the projection authority).
+    Credential-bearing ``remote_url``/``source_path`` values are redacted
+    fail-closed before insertion (M9/AC6).
     """
     conn = _get_connection(state_dir)
     try:
+        existing = {
+            str(row["session_id"])
+            for row in conn.execute("SELECT session_id FROM runs").fetchall()
+        }
         for session_id in sorted(sessions):
-            run = runs[session_id]
+            run = dict(runs[session_id])
+            # Fail-closed redaction: never persist a credential-bearing URL /
+            # absolute path from the source runs onto the state archive.
+            for field in ("remote_url", "source_path"):
+                if field in run:
+                    run[field] = redact_metadata_value(run[field])
+            if session_id in existing:
+                # No-displacement materialization: fill only the target
+                # columns the source snapshot can add (currently NULL); every
+                # populated target value — including the writer-owned cache
+                # mirrors — wins over the overlapping backup.
+                target = conn.execute(
+                    "SELECT * FROM runs WHERE session_id = ?", (session_id,)
+                ).fetchone()
+                fill = [
+                    (column, run[column])
+                    for column in run
+                    if target[column] is None and run[column] is not None
+                ]
+                if fill:
+                    assignments = ", ".join(f"{column} = ?" for column, _ in fill)
+                    conn.execute(
+                        f"UPDATE runs SET {assignments} WHERE session_id = ?",
+                        [value for _, value in fill] + [session_id],
+                    )
+                continue
             columns = list(run)
             placeholders = ", ".join("?" for _ in columns)
             conn.execute(
@@ -917,70 +965,98 @@ def _seed_target_runs(
         conn.close()
 
 
-def handle_import_local_observations(argv: list[str]) -> int:
-    """Handle ``corpus adjudicate import-local-observations`` (KD6, S1/S2/S3).
+class _ImportBlockedError(Exception):
+    """Fail-closed redaction gate raised by the import merge phase.
 
-    Composes the pure import pipeline (inventory -> linkage -> dedupe ->
-    version gate -> run-level classify -> accounting) over the given archive
-    roots, then — unless ``--dry-run`` — merges the linked rows append-only
-    into the ``--state-dir`` archive and redacts + secret-scans the payload
-    fail-closed. ``--json`` prints the digest-stable report; a real run also
-    writes it to ``--state-dir/import-report.json`` with the ledger in
-    ``--state-dir/import-ledger.json``. Dry-run writes nothing (S2).
+    Raised (instead of merging) when the post-redaction secret scan is dirty:
+    the payload must not be imported. ``message`` carries the composed blocked
+    reason the handler prints verbatim.
     """
-    from daydream.ui import create_console, print_error, print_success
 
-    parser = _build_adjudicate_parser()
-    args = parser.parse_args(["import-local-observations", *argv])
-    if args.publish:
-        if args.dry_run:
-            parser.error("--publish cannot be combined with --dry-run")
-        if args.manifest is None:
-            parser.error("--publish requires --manifest")
-    console = create_console()
-    try:
-        inventories: list[list[dict[str, Any]]] = []
-        sources: list[dict[str, Any]] = []
-        runs_by_session: dict[str, dict[str, Any]] = {}
-        repo_slug_sha_lookup: dict[tuple[str, str, str], Any] = {}
-        for root in args.archive_root:
-            inventory = _inventory_import_root(root)
-            inventories.append(inventory["rows"])
-            sources.append(
-                {
-                    "archive_root": str(root),
-                    "row_count": len(inventory["rows"]),
-                    "source_digest": inventory["source_digest"],
-                }
-            )
-            for session_id, run in inventory["runs"].items():
-                runs_by_session.setdefault(session_id, run)
-                repo_slug, base_sha, head_sha = (
-                    run.get("repo_slug"),
-                    run.get("base_sha"),
-                    run.get("head_sha"),
-                )
-                if repo_slug and base_sha and head_sha:
-                    repo_slug_sha_lookup.setdefault(
-                        (str(repo_slug), str(base_sha), str(head_sha)), session_id
-                    )
-            if not args.json:  # per-root progress (S3)
-                console.print(
-                    f"import: inventoried {len(inventory['rows'])} label_observations(s) "
-                    f"from {root}"
-                )
-        result = run_pure_import(
-            inventories,
-            hydrated_index={},
-            repo_slug_sha_lookup=repo_slug_sha_lookup,
-            projector_findings={},
+    def __init__(self, message: str) -> None:
+        super().__init__(message)
+        self.message = message
+
+
+class _ImportPublishError(Exception):
+    """Fail-closed publish-payload gate raised by the import publish phase.
+
+    Raised when the state archive is missing a publishable adjudication-state
+    file: the import itself only writes ``index.db``, so publishing a fresh
+    state-dir would fail with a bare ``FileNotFoundError``. ``message`` carries
+    the composed prerequisite hint the handler prints verbatim.
+    """
+
+    def __init__(self, message: str) -> None:
+        super().__init__(message)
+        self.message = message
+
+
+def _inventory_import_roots(
+    roots: Sequence[Path], *, console: Any | None = None
+) -> dict[str, Any]:
+    """Read-only inventory of every archive root for the import pipeline.
+
+    Composes the per-root :func:`_inventory_import_root` reads into the
+    pipeline's merge inputs: the dedupe/merge row lists, the per-root source
+    records, and the source-runs maps the merge phase seeds from. Per-root
+    progress is printed on ``console`` when given (the human-readable run;
+    ``--json`` callers pass ``None`` to keep stdout machine-readable).
+
+    Returns:
+        ``{"inventories", "sources", "runs_by_session",
+        "repo_slug_sha_lookup"}``.
+
+    Raises:
+        ValueError/sqlite3.Error/OSError: Any inventory failure (missing
+            ``index.db``, unreadable root) — the caller's fail-closed surface.
+    """
+    inventories: list[list[dict[str, Any]]] = []
+    sources: list[dict[str, Any]] = []
+    runs_by_session: dict[str, dict[str, Any]] = {}
+    repo_slug_sha_lookup: dict[tuple[str, str, str], Any] = {}
+    for root in roots:
+        inventory = _inventory_import_root(root)
+        inventories.append(inventory["rows"])
+        sources.append(
+            {
+                "archive_root": str(root),
+                "row_count": len(inventory["rows"]),
+                "source_digest": inventory["source_digest"],
+            }
         )
-    except ValueError as exc:
-        print_error(create_console(), "adjudicate import-local-observations failed", str(exc))
-        return 1
+        for session_id, run in inventory["runs"].items():
+            runs_by_session.setdefault(session_id, run)
+            repo_slug, base_sha, head_sha = (
+                run.get("repo_slug"),
+                run.get("base_sha"),
+                run.get("head_sha"),
+            )
+            if repo_slug and base_sha and head_sha:
+                repo_slug_sha_lookup.setdefault(
+                    (str(repo_slug), str(base_sha), str(head_sha)), session_id
+                )
+        if console is not None:  # per-root progress (S3)
+            console.print(
+                f"import: inventoried {len(inventory['rows'])} label_observations(s) "
+                f"from {root}"
+            )
+    return {
+        "inventories": inventories,
+        "sources": sources,
+        "runs_by_session": runs_by_session,
+        "repo_slug_sha_lookup": repo_slug_sha_lookup,
+    }
 
-    # Only identity-linked rows can merge: unmatched/conflict rows stay in the
-    # ledger's reason-coded buckets (never silently dropped, never misfiled).
+
+def _link_imported_rows(result: dict[str, Any]) -> list[dict[str, Any]]:
+    """Remap identity-linked import rows onto their Hub session ids.
+
+    Only identity-linked rows can merge: unmatched/conflict rows stay in the
+    ledger's reason-coded buckets (never silently dropped, never misfiled).
+    Each linked row carries an inventory-time payload digest — the merge's
+    fail-closed drift gate recomputes exactly this digest before any write.
+    """
     linked_rows: list[dict[str, Any]] = []
     for row in result["rows"]:
         link = result["link"]["linked"].get(str(row["session_id"]))
@@ -994,66 +1070,201 @@ def handle_import_local_observations(argv: list[str]) -> int:
             merged_row, include_observed_at=merged_row["source"] != "auto"
         )
         linked_rows.append(merged_row)
+    return linked_rows
 
-    if args.dry_run:
-        # Dry-run still exercises the merge's fail-closed drift gate, but the
-        # planned appends are counted, never written (S2).
-        planned_count = len(
-            merge_imported_observations(Path("/nonexistent-import-dry-run"), linked_rows, dry_run=True)[
-                "planned"
-            ]
-        )
-    else:
-        try:
-            _seed_target_runs(
-                args.state_dir,
-                {str(row["session_id"]) for row in linked_rows},
-                runs_by_session,
-            )
-            merged = merge_imported_observations(args.state_dir, linked_rows, dry_run=False)
-            scan = redact_imported_metadata(linked_rows, scan_dir=args.state_dir / "import-scan")
-        except ValueError as exc:
-            print_error(create_console(), "adjudicate import-local-observations failed", str(exc))
-            return 1
-        if scan["blocked"]:
-            print_error(
-                create_console(),
-                "adjudicate import-local-observations blocked by unredactable metadata",
-                "; ".join(scan["blocked_reasons"]) + f" ({scan['scan_summary']})",
-            )
-            return 1
 
+def _write_import_merge(
+    state_dir: Path,
+    linked_rows: list[dict[str, Any]],
+    runs_by_session: dict[str, dict[str, Any]],
+) -> dict[str, Any]:
+    """Redaction-gated merge of the linked rows into the state-dir archive.
+
+    Fail-closed gates first, before any state write (M9/AC6): the redaction +
+    secret scan and the merge's drift / malformed-row gate both run before the
+    seed/merge, so a blocked or drifted import cannot leave partially seeded
+    runs or unredacted observation rows committed in the state archive (and
+    every later run re-blocking on the same dirty payload). ``dry_run=True``
+    never touches the archive, so the gate can run unconditionally.
+
+    Returns:
+        ``{"planned", "appended", "deduped", "scan"}`` — the merge outcome
+        plus the redaction result for the report's ``redaction`` block.
+
+    Raises:
+        _ImportBlockedError: When the post-redaction scan is dirty — the
+            payload cannot be imported.
+        ValueError/sqlite3.Error/OSError: Redaction, drift-gate, seed, or
+            merge failures — the caller's fail-closed surface.
+    """
+    scan = redact_imported_metadata(linked_rows, scan_dir=state_dir / "import-scan")
+    merge_imported_observations(state_dir, linked_rows, dry_run=True)
+    if scan["blocked"]:
+        message = "; ".join(scan["blocked_reasons"]) + f" ({scan['scan_summary']})"
+        raise _ImportBlockedError(message)
+    _seed_target_runs(
+        state_dir,
+        {str(row["session_id"]) for row in linked_rows},
+        runs_by_session,
+    )
+    merged = merge_imported_observations(state_dir, linked_rows, dry_run=False)
+    return {
+        "planned": merged["planned"],
+        "appended": merged["appended"],
+        "deduped": merged["deduped"],
+        "scan": scan,
+    }
+
+
+def _build_import_report(
+    sources: list[dict[str, Any]],
+    result: dict[str, Any],
+    *,
+    dry_run: bool,
+    merge_state: dict[str, Any],
+) -> dict[str, Any]:
+    """Compose the digest-stable import report (S1).
+
+    ``merge_state`` is the merge phase result: the ``merge_imported_observations``
+    shape (``planned``/``appended``/``deduped``) for a dry run, or the
+    :func:`_write_import_merge` shape — the same keys plus the fail-closed
+    ``scan`` — for a real run. Only the real run carries the ``redaction``
+    block; dry runs never write it (S2).
+    """
     report: dict[str, Any] = {
-        "dry_run": bool(args.dry_run),
+        "dry_run": dry_run,
         "sources": sources,
         "deduped_count": result["deduped_count"],
         "accounting": dict(result["accounting"]),
+        "merge": {
+            "planned": len(merge_state["planned"]),
+            "appended": merge_state["appended"],
+            "deduped": merge_state["deduped"],
+        },
     }
-    if args.dry_run:
-        report["merge"] = {"planned": planned_count, "appended": 0, "deduped": 0}
-    else:
-        report["merge"] = {
-            "planned": len(merged["planned"]),
-            "appended": merged["appended"],
-            "deduped": merged["deduped"],
+    if not dry_run:
+        report["redaction"] = {
+            "blocked": bool(merge_state["scan"]["blocked"]),
+            "reasons": list(merge_state["scan"]["blocked_reasons"]),
         }
-        report["redaction"] = {"blocked": False, "reasons": []}
+    return report
 
+
+def _publish_import_state(state_dir: Path, hub_repo: str, manifest: Path) -> dict[str, Any]:
+    """Publish the imported adjudication state additively to the private Hub.
+
+    The publish composition requires the adjudication-state payload
+    (queue.json / observations.jsonl / preview-ledger.json) to exist; the
+    import itself only writes ``index.db``, so fail closed with a prerequisite
+    hint on a fresh state-dir instead of a bare ``FileNotFoundError``. Reuses
+    the existing publication: the private repo hard-fail and the S1 secret
+    scan are ``publish_annotation_state``'s own fail-closed gates, so a public
+    destination or a credential-shaped payload is refused before any byte
+    reaches the Hub. The checkpoint is always written: it is the fresh-VM
+    resume anchor (AC5).
+
+    Returns:
+        ``{"prefix": ..., "uploaded": ...}``.
+
+    Raises:
+        _ImportPublishError: When the state archive is missing a publishable
+            adjudication-state file.
+        ValueError/HubUnavailableError/HydrationError/PublicDestinationError/
+        FileNotFoundError: Propagated from the publication steps.
+    """
+    missing = [
+        name
+        for name in ("queue.json", "observations.jsonl", "preview-ledger.json")
+        if not (state_dir / name).is_file()
+    ]
+    if missing:
+        raise _ImportPublishError(
+            "state archive is missing publishable adjudication-state file(s): "
+            + ", ".join(missing)
+            + "; run `corpus adjudicate build`/`label`/`export` to produce the "
+            "publication payload before --publish"
+        )
+    client = _make_client(hub_repo)
+    published = publish_annotation_state(
+        client, state_dir, manifest=manifest, batch_complete=True,
+    )
+    return {"prefix": published["prefix"], "uploaded": published["uploaded"]}
+
+
+def handle_import_local_observations(argv: list[str]) -> int:
+    """Handle ``corpus adjudicate import-local-observations`` (KD6, S1/S2/S3).
+
+    Thin composition over the independently testable pipeline units: read-only
+    inventory (``_inventory_import_roots``), the pure import pipeline
+    (``run_pure_import``), identity linkage (``_link_imported_rows``), then —
+    unless ``--dry-run`` — the redaction-gated append-only merge
+    (``_write_import_merge``), the digest-stable report
+    (``_build_import_report``), and the optional publish
+    (``_publish_import_state``). This handler owns only arg parsing, the
+    fail-closed error surface, and output; ``--json`` prints the report and a
+    real run writes it to ``--state-dir/import-report.json`` with the ledger
+    in ``--state-dir/import-ledger.json``. Dry-run writes nothing (S2).
+    """
+    from daydream.ui import create_console, print_error, print_success
+
+    parser = _build_adjudicate_parser()
+    args = parser.parse_args(["import-local-observations", *argv])
     if args.publish:
-        # Compose the existing publication (reuse over rebuild): the private
-        # repo hard-fail and the S1 secret scan are publish_annotation_state's
-        # own fail-closed gates, so a public destination or a credential-shaped
-        # payload is refused before any byte reaches the Hub. The checkpoint is
-        # always written: it is the fresh-VM resume anchor (AC5).
-        try:
-            client = _make_client(args.hub_repo)
-            published = publish_annotation_state(
-                client, args.state_dir, manifest=args.manifest, batch_complete=True,
+        if args.dry_run:
+            parser.error("--publish cannot be combined with --dry-run")
+        if args.manifest is None:
+            parser.error("--publish requires --manifest")
+    console = create_console()
+    try:
+        inventory = _inventory_import_roots(
+            args.archive_root, console=None if args.json else console
+        )
+        result = run_pure_import(
+            inventory["inventories"],
+            hydrated_index={},
+            repo_slug_sha_lookup=inventory["repo_slug_sha_lookup"],
+            projector_findings={},
+            unmatched_identity_less=True,
+        )
+        linked_rows = _link_imported_rows(result)
+        # Dry-run still exercises the merge's fail-closed drift gate, but the
+        # planned appends are counted, never written (S2). The real path runs
+        # the redaction + secret scan and the drift / malformed-row gate
+        # before any state write (M9/AC6).
+        merge_state = (
+            merge_imported_observations(args.state_dir, linked_rows, dry_run=True)
+            if args.dry_run
+            else _write_import_merge(
+                args.state_dir, linked_rows, inventory["runs_by_session"]
             )
+        )
+    except _ImportBlockedError as exc:
+        print_error(
+            console,
+            "adjudicate import-local-observations blocked by unredactable metadata",
+            exc.message,
+        )
+        return 1
+    except (ValueError, sqlite3.Error, OSError) as exc:
+        print_error(console, "adjudicate import-local-observations failed", str(exc))
+        return 1
+
+    report = _build_import_report(
+        inventory["sources"], result, dry_run=bool(args.dry_run), merge_state=merge_state
+    )
+    if args.publish:
+        try:
+            report["publish"] = _publish_import_state(
+                args.state_dir, args.hub_repo, args.manifest
+            )
+        except _ImportPublishError as exc:
+            print_error(
+                console, "adjudicate import-local-observations publish failed", exc.message
+            )
+            return 1
         except (ValueError, HubUnavailableError, HydrationError, PublicDestinationError, FileNotFoundError) as exc:
             print_error(console, "adjudicate import-local-observations failed", str(exc))
             return 1
-        report["publish"] = {"prefix": published["prefix"], "uploaded": published["uploaded"]}
 
     if args.json:
         print(json.dumps(report, indent=2, sort_keys=True))
@@ -1062,7 +1273,7 @@ def handle_import_local_observations(argv: list[str]) -> int:
             console,
             f"Import {'planned' if args.dry_run else 'complete'}: "
             f"{sum(report['accounting'].values())} source row(s) across "
-            f"{len(sources)} root(s), {report['deduped_count']} deduped; "
+            f"{len(inventory['sources'])} root(s), {report['deduped_count']} deduped; "
             + (
                 f"{report['merge']['planned']} merge(s) planned; nothing written"
                 if args.dry_run

--- a/daydream/training/adjudication/cli.py
+++ b/daydream/training/adjudication/cli.py
@@ -1081,11 +1081,14 @@ def _write_import_merge(
     """Redaction-gated merge of the linked rows into the state-dir archive.
 
     Fail-closed gates first, before any state write (M9/AC6): the redaction +
-    secret scan and the merge's drift / malformed-row gate both run before the
-    seed/merge, so a blocked or drifted import cannot leave partially seeded
-    runs or unredacted observation rows committed in the state archive (and
-    every later run re-blocking on the same dirty payload). ``dry_run=True``
-    never touches the archive, so the gate can run unconditionally.
+    secret scan and the merge's drift / malformed-row / timestamp gate both
+    run before the seed/merge, so a blocked or drifted import cannot leave
+    partially seeded runs or unredacted observation rows committed in the
+    state archive (and every later run re-blocking on the same dirty payload).
+    The merge commits the scan's **redacted** payload — never the unredacted
+    originals — so credential-bearing metadata cannot reach the archive.
+    ``dry_run=True`` never touches the archive, so the gate can run
+    unconditionally.
 
     Returns:
         ``{"planned", "appended", "deduped", "scan"}`` — the merge outcome
@@ -1098,16 +1101,33 @@ def _write_import_merge(
             merge failures — the caller's fail-closed surface.
     """
     scan = redact_imported_metadata(linked_rows, scan_dir=state_dir / "import-scan")
+    # Pre-write gates over the raw linked rows: drift, malformed-row, and
+    # timestamp validation all run before the seed/merge commits anything.
     merge_imported_observations(state_dir, linked_rows, dry_run=True)
     if scan["blocked"]:
+        # Never leave the dirty scan artifact behind: a later ``scan_run_dir``
+        # pass over the state dir would flag the persisted payload as a
+        # foreign dirty artifact (M9/AC6).
+        (state_dir / "import-scan" / "payload.json").unlink(missing_ok=True)
         message = "; ".join(scan["blocked_reasons"]) + f" ({scan['scan_summary']})"
         raise _ImportBlockedError(message)
+    # The merge commits the scan's *redacted* payload — never the unredacted
+    # originals — so credential-bearing metadata cannot reach the state
+    # archive (M9). Redaction is deterministic over the same in-memory rows
+    # the write-path drift gate re-validates; recompute the payload digests
+    # over the redacted content so that gate stays consistent.
+    redacted_rows = scan["payload"]
+    for row in redacted_rows:
+        row["payload_digest"] = canonical_payload_digest(
+            {k: v for k, v in row.items() if k != "payload_digest"},
+            include_observed_at=row["source"] != "auto",
+        )
     _seed_target_runs(
         state_dir,
-        {str(row["session_id"]) for row in linked_rows},
+        {str(row["session_id"]) for row in redacted_rows},
         runs_by_session,
     )
-    merged = merge_imported_observations(state_dir, linked_rows, dry_run=False)
+    merged = merge_imported_observations(state_dir, redacted_rows, dry_run=False)
     return {
         "planned": merged["planned"],
         "appended": merged["appended"],
@@ -1154,14 +1174,17 @@ def _publish_import_state(state_dir: Path, hub_repo: str, manifest: Path) -> dic
     """Publish the imported adjudication state additively to the private Hub.
 
     The publish composition requires the adjudication-state payload
-    (queue.json / observations.jsonl / preview-ledger.json) to exist; the
-    import itself only writes ``index.db``, so fail closed with a prerequisite
-    hint on a fresh state-dir instead of a bare ``FileNotFoundError``. Reuses
-    the existing publication: the private repo hard-fail and the S1 secret
-    scan are ``publish_annotation_state``'s own fail-closed gates, so a public
-    destination or a credential-shaped payload is refused before any byte
-    reaches the Hub. The checkpoint is always written: it is the fresh-VM
-    resume anchor (AC5).
+    (queue.json / observations.jsonl / preview-ledger.json) and the state
+    archive index (index.db — where the import's appended rows live) to
+    exist; the import itself only writes ``index.db``, so fail closed with a
+    prerequisite hint on a fresh state-dir instead of a bare
+    ``FileNotFoundError``. Reuses the existing publication: the private repo
+    hard-fail and the S1 secret scan are ``publish_annotation_state``'s own
+    fail-closed gates, so a public destination or a credential-shaped payload
+    is refused before any byte reaches the Hub. The published bundle carries
+    ``index.db`` and the checkpoint always records its digest, so a fresh-VM
+    resume restores the imported rows themselves, not just the queue/report
+    (AC5: the VM-local ``--state-dir`` is scratch only).
 
     Returns:
         ``{"prefix": ..., "uploaded": ...}``.
@@ -1174,7 +1197,7 @@ def _publish_import_state(state_dir: Path, hub_repo: str, manifest: Path) -> dic
     """
     missing = [
         name
-        for name in ("queue.json", "observations.jsonl", "preview-ledger.json")
+        for name in ("queue.json", "observations.jsonl", "preview-ledger.json", "index.db")
         if not (state_dir / name).is_file()
     ]
     if missing:
@@ -1272,7 +1295,7 @@ def handle_import_local_observations(argv: list[str]) -> int:
         print_success(
             console,
             f"Import {'planned' if args.dry_run else 'complete'}: "
-            f"{sum(report['accounting'].values())} source row(s) across "
+            f"{sum(report['accounting'].values()) + report['deduped_count']} source row(s) across "
             f"{len(inventory['sources'])} root(s), {report['deduped_count']} deduped; "
             + (
                 f"{report['merge']['planned']} merge(s) planned; nothing written"

--- a/daydream/training/adjudication/cli.py
+++ b/daydream/training/adjudication/cli.py
@@ -31,6 +31,16 @@ deterministic adjudication queue:
   pipeline state (no hand-authored files) and publish it additively to the
   private Hub under ``annotations/<curation-id>/<snapshot-id>/final/``;
   ``--dry-run`` builds and validates the bundle without constructing a client.
+- ``import-local-observations`` — read-only import of surviving local
+  archive/backup roots' immutable ``label_observations`` histories:
+  read-only inventory, identity linkage against the roots' run metadata,
+  content-digest dedupe, version gate, run-level classification,
+  reason-coded accounting (bucket sum == source row count), and — unless
+  ``--dry-run`` — an append-only merge into the ``--state-dir`` archive
+  followed by fail-closed redaction + secret scan. ``--json`` prints the
+  digest-stable import report (also written to
+  ``--state-dir/import-report.json`` on a real run, alongside
+  ``import-ledger.json``). Dry-run writes nothing (S2).
 
 Every handler returns an int exit code (never calls ``sys.exit`` itself);
 argparse converts malformed invocations into ``SystemExit(2)``. Unknown
@@ -41,7 +51,9 @@ offending identifier. No handler mutates anything outside ``--state-dir``.
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
+import sqlite3
 import tempfile
 from collections.abc import Mapping, Sequence
 from datetime import datetime, timezone
@@ -49,6 +61,14 @@ from pathlib import Path
 from typing import Any
 
 from daydream.archive.hydrate import HubUnavailableError, HydrationError, PublicDestinationError, _make_client
+from daydream.archive.importer import (
+    canonical_payload_digest,
+    merge_imported_observations,
+    redact_imported_metadata,
+    run_pure_import,
+)
+from daydream.archive.index import _get_connection
+from daydream.archive.known_versions import STALE_LEGACY
 from daydream.training.adjudication.canonical import run_canonical_harvest
 from daydream.training.adjudication.export import validate_export_rows, write_export_rows
 from daydream.training.adjudication.harvest import build_export_entries
@@ -329,6 +349,19 @@ def _build_adjudicate_parser() -> argparse.ArgumentParser:
                                  help=f"Private Hub dataset repo (default: {_ANNOTATION_HUB_REPO})")
     p_publish_final.add_argument("--dry-run", action="store_true",
                                  help="Build and validate the staging bundle without publishing to the Hub")
+
+    p_import = sub.add_parser(
+        "import-local-observations",
+        help="Import surviving local archive/backup label-observation histories.",
+    )
+    p_import.add_argument("--archive-root", type=Path, action="append", required=True,
+                          metavar="PATH",
+                          help="Source archive/backup root holding index.db (repeatable)")
+    _add_state_dir(p_import)
+    p_import.add_argument("--json", action="store_true",
+                          help="Print the digest-stable import report as JSON")
+    p_import.add_argument("--dry-run", action="store_true",
+                          help="Plan the import without writing any state")
 
     return parser
 
@@ -759,6 +792,266 @@ def handle_harvest_snapshot(argv: list[str]) -> int:
     return 0
 
 
+# Full modern ``label_observations`` column list. Legacy-schema roots are
+# introspected via ``PRAGMA table_info`` and missing version columns are
+# surfaced as the ``"legacy"`` sentinel (never gold-eligible, still imported
+# as evidence).
+_IMPORT_OBSERVATION_COLUMNS = (
+    "session_id",
+    "observed_at",
+    "labels",
+    "pr_state",
+    "labeler_version",
+    "evidence_sha",
+    "rubric_json",
+    "valid_at",
+    "reward_version",
+    "reward_json",
+    "composite_reward",
+    "reviewer_logins",
+    "has_posterior",
+    "source",
+    "labeler_policy_version",
+    "reply_classifier_version",
+    "reply_evidence_digest",
+    "legacy",
+)
+
+_IMPORT_VERSION_COLUMNS = (
+    "labeler_policy_version",
+    "reply_classifier_version",
+    "reply_evidence_digest",
+)
+
+
+def _inventory_import_root(root: Path) -> dict[str, Any]:
+    """Read-only inventory of one archive/backup root (M1, Assumption 4).
+
+    Opens ``root/index.db`` in ``mode=ro`` (the source is never written),
+    reads every ``label_observations`` row ordered by ``observed_at`` ASC,
+    fills version columns missing from a legacy schema with ``"legacy"``, and
+    enriches each row with its run's ``repo_slug``/``base_sha``/``head_sha``
+    so identity linkage can resolve the session.
+
+    Returns:
+        ``{"rows": [...], "source_digest": <sha256 hex of index.db bytes>,
+        "runs": {session_id: full runs row dict}}``.
+
+    Raises:
+        ValueError: When the root has no ``index.db`` or no
+            ``label_observations`` table — always naming the path.
+    """
+    db_path = root / "index.db"
+    if not db_path.is_file():
+        raise ValueError(
+            f"archive root {root} has no index.db; not a daydream archive/backup root"
+        )
+    source_digest = hashlib.sha256(db_path.read_bytes()).hexdigest()
+    conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+    try:
+        conn.row_factory = sqlite3.Row
+        tables = {
+            str(row[0])
+            for row in conn.execute("SELECT name FROM sqlite_master WHERE type = 'table'")
+        }
+        if "label_observations" not in tables:
+            raise ValueError(
+                f"archive root {root} has no label_observations table in index.db"
+            )
+        columns = [str(row[1]) for row in conn.execute("PRAGMA table_info(label_observations)")]
+        selected = [column for column in _IMPORT_OBSERVATION_COLUMNS if column in columns]
+        rows = [
+            dict(row)
+            for row in conn.execute(
+                f"SELECT {', '.join(selected)} FROM label_observations ORDER BY observed_at ASC"
+            )
+        ]
+        runs = (
+            {str(run["session_id"]): dict(run) for run in conn.execute("SELECT * FROM runs")}
+            if "runs" in tables
+            else {}
+        )
+    finally:
+        conn.close()
+    for row in rows:
+        for column in _IMPORT_VERSION_COLUMNS:
+            if column not in row:
+                row[column] = STALE_LEGACY
+        run = runs.get(str(row["session_id"]))
+        if run is not None:
+            for field in ("repo_slug", "base_sha", "head_sha"):
+                row[field] = run.get(field)
+    return {"rows": rows, "source_digest": source_digest, "runs": runs}
+
+
+def _seed_target_runs(
+    state_dir: Path, sessions: set[str], runs: dict[str, dict[str, Any]]
+) -> None:
+    """Copy the source runs rows for *sessions* into the state-dir archive.
+
+    ``append_label_observation`` requires the session to exist in ``runs``;
+    importing into the state archive therefore materializes the source run
+    rows first (deterministic: sessions in sorted order). Idempotent via
+    ``INSERT OR REPLACE`` with the full source column set.
+    """
+    conn = _get_connection(state_dir)
+    try:
+        for session_id in sorted(sessions):
+            run = runs[session_id]
+            columns = list(run)
+            placeholders = ", ".join("?" for _ in columns)
+            conn.execute(
+                f"INSERT OR REPLACE INTO runs ({', '.join(columns)}) VALUES ({placeholders})",
+                [run[column] for column in columns],
+            )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def handle_import_local_observations(argv: list[str]) -> int:
+    """Handle ``corpus adjudicate import-local-observations`` (KD6, S1/S2/S3).
+
+    Composes the pure import pipeline (inventory -> linkage -> dedupe ->
+    version gate -> run-level classify -> accounting) over the given archive
+    roots, then — unless ``--dry-run`` — merges the linked rows append-only
+    into the ``--state-dir`` archive and redacts + secret-scans the payload
+    fail-closed. ``--json`` prints the digest-stable report; a real run also
+    writes it to ``--state-dir/import-report.json`` with the ledger in
+    ``--state-dir/import-ledger.json``. Dry-run writes nothing (S2).
+    """
+    from daydream.ui import create_console, print_error, print_success
+
+    args = _build_adjudicate_parser().parse_args(["import-local-observations", *argv])
+    console = create_console()
+    try:
+        inventories: list[list[dict[str, Any]]] = []
+        sources: list[dict[str, Any]] = []
+        runs_by_session: dict[str, dict[str, Any]] = {}
+        repo_slug_sha_lookup: dict[tuple[str, str, str], Any] = {}
+        for root in args.archive_root:
+            inventory = _inventory_import_root(root)
+            inventories.append(inventory["rows"])
+            sources.append(
+                {
+                    "archive_root": str(root),
+                    "row_count": len(inventory["rows"]),
+                    "source_digest": inventory["source_digest"],
+                }
+            )
+            for session_id, run in inventory["runs"].items():
+                runs_by_session.setdefault(session_id, run)
+                repo_slug, base_sha, head_sha = (
+                    run.get("repo_slug"),
+                    run.get("base_sha"),
+                    run.get("head_sha"),
+                )
+                if repo_slug and base_sha and head_sha:
+                    repo_slug_sha_lookup.setdefault(
+                        (str(repo_slug), str(base_sha), str(head_sha)), session_id
+                    )
+            if not args.json:  # per-root progress (S3)
+                console.print(
+                    f"import: inventoried {len(inventory['rows'])} label_observations(s) "
+                    f"from {root}"
+                )
+        result = run_pure_import(
+            inventories,
+            hydrated_index={},
+            repo_slug_sha_lookup=repo_slug_sha_lookup,
+            projector_findings={},
+        )
+    except ValueError as exc:
+        print_error(create_console(), "adjudicate import-local-observations failed", str(exc))
+        return 1
+
+    # Only identity-linked rows can merge: unmatched/conflict rows stay in the
+    # ledger's reason-coded buckets (never silently dropped, never misfiled).
+    linked_rows: list[dict[str, Any]] = []
+    for row in result["rows"]:
+        link = result["link"]["linked"].get(str(row["session_id"]))
+        if link is None:
+            continue
+        merged_row = dict(row)
+        merged_row["session_id"] = link["hub_session_id"]
+        # Inventory-time payload digest: the merge's fail-closed drift gate
+        # recomputes exactly this digest before any write.
+        merged_row["payload_digest"] = canonical_payload_digest(
+            merged_row, include_observed_at=merged_row["source"] != "auto"
+        )
+        linked_rows.append(merged_row)
+
+    if args.dry_run:
+        # Dry-run still exercises the merge's fail-closed drift gate, but the
+        # planned appends are counted, never written (S2).
+        planned_count = len(
+            merge_imported_observations(Path("/nonexistent-import-dry-run"), linked_rows, dry_run=True)[
+                "planned"
+            ]
+        )
+    else:
+        try:
+            _seed_target_runs(
+                args.state_dir,
+                {str(row["session_id"]) for row in linked_rows},
+                runs_by_session,
+            )
+            merged = merge_imported_observations(args.state_dir, linked_rows, dry_run=False)
+            scan = redact_imported_metadata(linked_rows, scan_dir=args.state_dir / "import-scan")
+        except ValueError as exc:
+            print_error(create_console(), "adjudicate import-local-observations failed", str(exc))
+            return 1
+        if scan["blocked"]:
+            print_error(
+                create_console(),
+                "adjudicate import-local-observations blocked by unredactable metadata",
+                "; ".join(scan["blocked_reasons"]) + f" ({scan['scan_summary']})",
+            )
+            return 1
+
+    report: dict[str, Any] = {
+        "dry_run": bool(args.dry_run),
+        "sources": sources,
+        "deduped_count": result["deduped_count"],
+        "accounting": dict(result["accounting"]),
+    }
+    if args.dry_run:
+        report["merge"] = {"planned": planned_count, "appended": 0, "deduped": 0}
+    else:
+        report["merge"] = {
+            "planned": len(merged["planned"]),
+            "appended": merged["appended"],
+            "deduped": merged["deduped"],
+        }
+        report["redaction"] = {"blocked": False, "reasons": []}
+
+    if args.json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        print_success(
+            console,
+            f"Import {'planned' if args.dry_run else 'complete'}: "
+            f"{sum(report['accounting'].values())} source row(s) across "
+            f"{len(sources)} root(s), {report['deduped_count']} deduped; "
+            + (
+                f"{report['merge']['planned']} merge(s) planned; nothing written"
+                if args.dry_run
+                else f"{report['merge']['appended']} appended, "
+                f"{report['merge']['deduped']} deduped by the writer"
+            ),
+        )
+
+    if not args.dry_run:
+        args.state_dir.mkdir(parents=True, exist_ok=True)
+        (args.state_dir / "import-report.json").write_text(
+            json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+        )
+        (args.state_dir / "import-ledger.json").write_text(
+            json.dumps(result["ledger"], indent=2, sort_keys=True) + "\n", encoding="utf-8"
+        )
+    return 0
+
+
 _HANDLERS = {
     "build": handle_build,
     "show": handle_show,
@@ -770,6 +1063,7 @@ _HANDLERS = {
     "resume-state": handle_resume_state,
     "harvest-snapshot": handle_harvest_snapshot,
     "publish-final": handle_publish_final,
+    "import-local-observations": handle_import_local_observations,
 }
 
 

--- a/daydream/training/adjudication/publish.py
+++ b/daydream/training/adjudication/publish.py
@@ -40,6 +40,10 @@ __all__ = [
 
 # State files published under the snapshot prefix (stable order for digests).
 _STATE_FILES = ("queue.json", "observations.jsonl", "preview-ledger.json")
+# The archive index (imported label_observations rows) is published alongside
+# the state files whenever it exists in the state dir: a fresh-VM resume must
+# restore the import itself, not just the adjudication state.
+_ARCHIVE_INDEX_FILE = "index.db"
 _MANIFEST_FILENAME = "preview-manifest.json"
 _CHECKPOINT_RELPATH = "checkpoints/batch-latest.json"
 _FINAL_SEGMENT = "final"
@@ -79,10 +83,21 @@ def annotation_prefix(manifest: Path | Mapping[str, Any]) -> str:
     return f"annotations/{curation_id}/{snapshot_id}/"
 
 
+# SQLite archives (index.db) are binary, not UTF-8; scan them as latin-1
+# (lossless byte->char mapping, so regex hits still fire on ASCII credentials
+# embedded in the file) instead of rejecting the payload outright.
+_BINARY_STATE_FILES = frozenset({"index.db"})
+
+
 def _scan_for_secrets(name: str, data: bytes) -> None:
     """Fail-closed secret scan (S1): refuse to upload credential-shaped payloads."""
     try:
-        text = data.decode("utf-8")
+        if name in _BINARY_STATE_FILES:
+            # latin-1 maps every byte to a code point losslessly; the ASCII
+            # secret shapes the regex targets are still detectable in SQLite pages.
+            text = data.decode("latin-1")
+        else:
+            text = data.decode("utf-8")
     except UnicodeDecodeError as exc:
         raise PublicDestinationError(f"{name}: payload is not valid UTF-8: {exc}") from exc
     hit = _SECRET_SHAPES.search(text)
@@ -186,6 +201,8 @@ def publish_annotation_state(
         "preview-ledger.json": _read_state_file(state_dir, "preview-ledger.json"),
         _MANIFEST_FILENAME: manifest_bytes,
     }
+    if (state_dir / _ARCHIVE_INDEX_FILE).exists():
+        payloads[_ARCHIVE_INDEX_FILE] = _read_state_file(state_dir, _ARCHIVE_INDEX_FILE)
     for name, data in payloads.items():
         _scan_for_secrets(name, data)
 
@@ -459,7 +476,9 @@ def resume_annotation_state(
 
     stage_dir.mkdir(parents=True, exist_ok=True)
     restored: list[str] = []
-    for name in [*_STATE_FILES, _MANIFEST_FILENAME]:
+    for name in [*_STATE_FILES, _MANIFEST_FILENAME, _ARCHIVE_INDEX_FILE]:
+        if name == _ARCHIVE_INDEX_FILE and name not in digests:
+            continue  # no archive index was published with this checkpoint
         expected = digests.get(name)
         if not isinstance(expected, str):
             raise ValueError(f"{_CHECKPOINT_RELPATH}: checkpoint has no digest for {name!r}")

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -2405,3 +2405,42 @@ def test_migration_marks_legacy_rows(tmp_path: Path) -> None:
     # original labels/observed_at untouched:
     assert rows[0]["observed_at"] == _LEGACY_ROW_OBSERVED_AT_SNAPSHOT
     assert rows[0]["labels"] == '["accepted"]'
+
+
+def test_append_label_observation_preserves_observed_at(tmp_path: Path) -> None:
+    """An explicit ``observed_at`` is preserved bitemporally (M3 of the
+    local-observations import): the stored row carries the original data
+    timestamp verbatim (canonicalized to UTC), not the wall clock."""
+    _seed_one_run(tmp_path, "sess-obs")
+    original = "2025-06-01T12:00:00+00:00"
+    appended = append_label_observation(
+        tmp_path, "sess-obs", labels=["accepted"], pr_state="merged",
+        labeler_version="1055-human-r1", evidence_sha=None, source="human",
+        observed_at=original)
+    assert appended is True
+    row = latest_label_observation(tmp_path, "sess-obs")
+    assert row is not None
+    assert row["observed_at"] == "2025-06-01T12:00:00+00:00"
+
+
+def test_append_label_observation_observed_at_none_uses_wall_clock(tmp_path: Path) -> None:
+    """Default (``observed_at=None``) keeps the existing now() behavior."""
+    _seed_one_run(tmp_path, "sess-now")
+    appended = append_label_observation(
+        tmp_path, "sess-now", labels=["accepted"], pr_state="merged",
+        labeler_version="1055-human-r1", evidence_sha=None, source="human")
+    assert appended is True
+    row = latest_label_observation(tmp_path, "sess-now")
+    assert row is not None
+    assert row["observed_at"].startswith("2")
+
+
+def test_append_label_observation_rejects_non_iso_observed_at(tmp_path: Path) -> None:
+    """A non-ISO-8601 ``observed_at`` fails closed before any write."""
+    _seed_one_run(tmp_path, "sess-bad")
+    with pytest.raises(ValueError, match="observed_at"):
+        append_label_observation(
+            tmp_path, "sess-bad", labels=["accepted"], pr_state="merged",
+            labeler_version="1055-human-r1", evidence_sha=None, source="human",
+            observed_at="not-a-timestamp")
+    assert label_observation_history(tmp_path, "sess-bad") == []

--- a/tests/test_archive_importer.py
+++ b/tests/test_archive_importer.py
@@ -877,6 +877,196 @@ def test_human_source_appended_verbatim(tmp_path: Path) -> None:
     assert hist[0]["observed_at"] == _OBSERVED_B
     assert hist[0]["labels"] == json.dumps(["rejected"])
 
+
+def test_non_iso_observed_at_fails_closed_before_any_write(tmp_path: Path) -> None:
+    """A hand-edited non-ISO observed_at must abort the merge at the pre-write
+    gate, not mid-append: ValueError naming the row and zero rows written
+    (S2/M9)."""
+    target = tmp_path / "target"
+    target.mkdir()
+    _seed_run(target)
+    row: dict[str, Any] = {
+        "session_id": SID,
+        "source": "auto",
+        "observed_at": "not-an-iso-stamp",
+        "labels": ["accepted"],
+        "pr_state": None,
+        "labeler_version": "980-rubric-r2",
+        "evidence_sha": "e" * 64,
+        "rubric_json": None,
+        "valid_at": None,
+        "reward_version": None,
+        "reward_json": None,
+        "composite_reward": None,
+        "reviewer_logins": None,
+        "has_posterior": 0,
+        "labeler_policy_version": "980-policy-r1",
+        "reply_classifier_version": None,
+        "reply_evidence_digest": None,
+    }
+    with pytest.raises(ValueError, match=SID):
+        merge_imported_observations(target, [_row_with_digest(row)])
+    assert label_observation_history(target, SID) == []
+
+
+def test_naive_observed_at_fails_closed_before_any_write(tmp_path: Path) -> None:
+    """A naive observed_at (no UTC offset) is rejected at the pre-write gate
+    exactly like the writer rejects it per row (S2/M9)."""
+    target = tmp_path / "target"
+    target.mkdir()
+    _seed_run(target)
+    row: dict[str, Any] = {
+        "session_id": SID,
+        "source": "auto",
+        "observed_at": "2026-05-01T00:00:00",
+        "labels": ["accepted"],
+        "pr_state": None,
+        "labeler_version": "980-rubric-r2",
+        "evidence_sha": "e" * 64,
+        "rubric_json": None,
+        "valid_at": None,
+        "reward_version": None,
+        "reward_json": None,
+        "composite_reward": None,
+        "reviewer_logins": None,
+        "has_posterior": 0,
+        "labeler_policy_version": "980-policy-r1",
+        "reply_classifier_version": None,
+        "reply_evidence_digest": None,
+    }
+    with pytest.raises(ValueError, match=SID):
+        merge_imported_observations(target, [_row_with_digest(row)])
+    assert label_observation_history(target, SID) == []
+
+
+def test_non_iso_valid_at_fails_closed_before_any_write(tmp_path: Path) -> None:
+    """A non-ISO valid_at is also caught by the pre-write gate, not inside
+    the writer's per-row canonical_utc_iso call (S2/M9)."""
+    target = tmp_path / "target"
+    target.mkdir()
+    _seed_run(target)
+    row: dict[str, Any] = {
+        "session_id": SID,
+        "source": "auto",
+        "observed_at": _OBSERVED_A,
+        "labels": ["accepted"],
+        "pr_state": None,
+        "labeler_version": "980-rubric-r2",
+        "evidence_sha": "e" * 64,
+        "rubric_json": None,
+        "valid_at": "not-a-valid-time",
+        "reward_version": None,
+        "reward_json": None,
+        "composite_reward": None,
+        "reviewer_logins": None,
+        "has_posterior": 0,
+        "labeler_policy_version": "980-policy-r1",
+        "reply_classifier_version": None,
+        "reply_evidence_digest": None,
+    }
+    with pytest.raises(ValueError, match=SID):
+        merge_imported_observations(target, [_row_with_digest(row)])
+    assert label_observation_history(target, SID) == []
+
+
+def test_idempotent_reimport_dedupes_human_rows(tmp_path: Path) -> None:
+    """Human-sourced rows are byte-identical on a re-import, so the PK
+    collision no-op must dedupe them — never a 1-microsecond-shifted
+    duplicate generation (M4)."""
+    source_root = tmp_path / "backup"
+    source_root.mkdir()
+    _seed_run(source_root)
+    append_label_observation(
+        source_root,
+        SID,
+        labels=["rejected"],
+        pr_state=None,
+        labeler_version=HUMAN_LABELER_VERSION,
+        evidence_sha=None,
+        valid_at=_OBSERVED_B,
+        source="human",
+        observed_at=_OBSERVED_B,
+    )
+    imported = [_row_with_digest(r) for r in read_label_rows(source_root)]
+
+    target = tmp_path / "target"
+    target.mkdir()
+    _seed_run(target)
+    merge_imported_observations(target, imported)
+    before = label_observation_history(target, SID)
+
+    merged_again = merge_imported_observations(target, imported)
+    assert merged_again["appended"] == 0
+    assert merged_again["deduped"] == 1
+    assert label_observation_history(target, SID) == before
+
+
+def test_policy_axis_generations_survive_merge(tmp_path: Path) -> None:
+    """A generation pair differing only in labeler_policy_version survives the
+    importer dedupe AND the writer's auto-dedup: distinct policy axes are
+    distinct generations, never collapsed (M3/M14)."""
+    source_root = tmp_path / "backup"
+    source_root.mkdir()
+    _seed_run(source_root)
+    for at, policy in ((_OBSERVED_A, "980-policy-r1"), (_OBSERVED_B, "9999-policy-r2")):
+        append_label_observation(
+            source_root,
+            SID,
+            labels=["accepted"],
+            pr_state=None,
+            labeler_version="980-rubric-r2",
+            evidence_sha="c" * 64,
+            valid_at="2026-04-30T00:00:00+00:00",
+            source="auto",
+            observed_at=at,
+            labeler_policy_version=policy,
+        )
+    imported = [_row_with_digest(r) for r in read_label_rows(source_root)]
+
+    target = tmp_path / "target"
+    target.mkdir()
+    _seed_run(target)
+    merged = merge_imported_observations(target, imported)
+    assert merged["appended"] == 2
+    hist = label_observation_history(target, SID)
+    assert len(hist) == 2
+    assert {r["labeler_policy_version"] for r in hist} == {"980-policy-r1", "9999-policy-r2"}
+
+
+def test_legacy_sentinel_merge_stores_null_policy_and_legacy(tmp_path: Path) -> None:
+    """A legacy-schema source row (labeler_policy_version == STALE_LEGACY)
+    merges as the canonical legacy representation — NULL policy + legacy='legacy'
+    — so the corpus gold gate (labeler_policy_version IS NOT NULL) can never
+    admit a row the importer's version gate excluded (M6)."""
+    target = tmp_path / "target"
+    target.mkdir()
+    _seed_run(target)
+    row: dict[str, Any] = {
+        "session_id": SID,
+        "source": "auto",
+        "observed_at": _OBSERVED_A,
+        "labels": ["accepted"],
+        "pr_state": None,
+        "labeler_version": "980-rubric-r2",
+        "evidence_sha": "e" * 64,
+        "rubric_json": None,
+        "valid_at": None,
+        "reward_version": None,
+        "reward_json": None,
+        "composite_reward": None,
+        "reviewer_logins": None,
+        "has_posterior": 0,
+        "labeler_policy_version": STALE_LEGACY,
+        "reply_classifier_version": None,
+        "reply_evidence_digest": None,
+    }
+    merged = merge_imported_observations(target, [_row_with_digest(row)])
+    assert merged["appended"] == 1
+    hist = label_observation_history(target, SID)
+    assert len(hist) == 1
+    assert hist[0]["labeler_policy_version"] is None
+    assert hist[0]["legacy"] == "legacy"
+
 # ---------------------------------------------------------------------------
 # Task 8: fail-closed secret scan + redaction before publication (M9, AC6)
 # ---------------------------------------------------------------------------

--- a/tests/test_archive_importer.py
+++ b/tests/test_archive_importer.py
@@ -21,12 +21,18 @@ from typing import Any
 import pytest
 
 from daydream.archive.importer import (
+    canonical_payload_digest,
     classify_run_level,
     dedupe_observations,
     gold_eligible,
     link_session_identity,
+    merge_imported_observations,
 )
-from daydream.archive.index import append_label_observation, upsert_run
+from daydream.archive.index import (
+    append_label_observation,
+    label_observation_history,
+    upsert_run,
+)
 from daydream.archive.known_versions import STALE_LEGACY
 from daydream.training.labeler_versions import HUMAN_LABELER_VERSION
 from tests.harness.trajectory import make_manifest
@@ -510,3 +516,205 @@ def test_buckets_account_for_every_row() -> None:
     total = sum(len(v) for v in out["per_finding"].values())
     total += len(out["run_level_only"]) + len(out["ambiguous_run_mapping"])
     assert total == 2
+
+
+# ---------------------------------------------------------------------------
+# Task 6: merge imported observations via the canonical-harvest seam
+# ---------------------------------------------------------------------------
+
+
+def _row_with_digest(row: dict[str, Any]) -> dict[str, Any]:
+    """Attach the inventory-time payload digest a merge validates against."""
+    row = dict(row)
+    row["payload_digest"] = canonical_payload_digest(
+        row, include_observed_at=row["source"] != "auto"
+    )
+    return row
+
+
+def _seed_generation(root: Path, *, observed_at: str, evidence_sha: str, labels: list[str]) -> None:
+    append_label_observation(
+        root,
+        SID,
+        labels=labels,
+        pr_state=None,
+        labeler_version="980-rubric-r2",
+        evidence_sha=evidence_sha,
+        valid_at="2026-04-30T00:00:00+00:00",
+        reply_evidence_digest=None,
+        reward_version=None,
+        has_posterior=False,
+        source="auto",
+        observed_at=observed_at,
+    )
+
+
+def test_bitemporal_history_preserved(tmp_path: Path) -> None:
+    # Three evidence generations A->B->C captured in a surviving backup are
+    # appended into the target archive in order, verbatim (M3).
+    source_root = tmp_path / "backup"
+    source_root.mkdir()
+    _seed_run(source_root)
+    for at, sha, labels in (
+        (_OBSERVED_A, "e" * 64, ["accepted"]),
+        (_OBSERVED_B, "f" * 64, ["rejected"]),
+        ("2026-05-03T00:00:00+00:00", "0" * 64, ["accepted"]),
+    ):
+        _seed_generation(source_root, observed_at=at, evidence_sha=sha, labels=labels)
+    imported = read_label_rows(source_root)
+
+    target = tmp_path / "target"
+    target.mkdir()
+    _seed_run(target)
+    merged = merge_imported_observations(target, [_row_with_digest(r) for r in imported])
+
+    assert merged["appended"] == 3
+    assert merged["deduped"] == 0
+    hist = label_observation_history(target, SID)
+    assert [r["observed_at"] for r in hist] == [
+        _OBSERVED_A,
+        _OBSERVED_B,
+        "2026-05-03T00:00:00+00:00",
+    ]
+    assert hist[0]["labels"] == json.dumps(["accepted"])  # verbatim
+    assert hist[1]["labels"] == json.dumps(["rejected"])
+
+
+def test_newer_existing_observation_never_displaced(tmp_path: Path) -> None:
+    # The target already holds a newer auto observation; importing an older
+    # auto generation appends it but the precedence projection (recency within
+    # source class) keeps the newer row as the winner in the denormalized
+    # runs cache — import must never bypass the projection (M3).
+    target = tmp_path / "target"
+    target.mkdir()
+    _seed_run(target)
+    newer_at = "2026-06-01T00:00:00+00:00"
+    _seed_generation(target, observed_at=newer_at, evidence_sha="f" * 64, labels=["accepted"])
+
+    source_root = tmp_path / "backup"
+    source_root.mkdir()
+    _seed_run(source_root)
+    _seed_generation(source_root, observed_at=_OBSERVED_A, evidence_sha="e" * 64, labels=["rejected"])
+    imported = [_row_with_digest(r) for r in read_label_rows(source_root)]
+
+    merged = merge_imported_observations(target, imported)
+    assert merged["appended"] == 1
+    hist = label_observation_history(target, SID)
+    assert [r["observed_at"] for r in hist] == [_OBSERVED_A, newer_at]  # append-only
+    # runs.outcome_labels cache still reflects the precedence projection:
+    conn = sqlite3.connect(target / "index.db")
+    try:
+        conn.row_factory = sqlite3.Row
+        run = conn.execute("SELECT outcome_labels, labeled_at FROM runs WHERE session_id = ?", (SID,)).fetchone()
+    finally:
+        conn.close()
+    assert run["labeled_at"] == newer_at
+    assert run["outcome_labels"] == json.dumps(["accepted"])
+
+
+def test_idempotent_reimport_dedupes_auto_rows(tmp_path: Path) -> None:
+    # Byte-identical re-import (M4): auto rows already present dedupe via the
+    # existing writer; no new generations appear.
+    source_root = tmp_path / "backup"
+    source_root.mkdir()
+    _seed_run(source_root)
+    _seed_generation(source_root, observed_at=_OBSERVED_A, evidence_sha="e" * 64, labels=["accepted"])
+    imported = [_row_with_digest(r) for r in read_label_rows(source_root)]
+
+    target = tmp_path / "target"
+    target.mkdir()
+    _seed_run(target)
+    merge_imported_observations(target, imported)
+    before = label_observation_history(target, SID)
+
+    merged_again = merge_imported_observations(target, imported)
+    assert merged_again["appended"] == 0
+    assert merged_again["deduped"] == 1
+    assert label_observation_history(target, SID) == before
+
+
+def test_drift_fails_closed_before_any_write(tmp_path: Path) -> None:
+    # A row whose immutable payload changed between inventory and merge is
+    # rejected with a ValueError naming the row; nothing is written (M9
+    # fail-closed, mirroring the canonical-harvest drift gate).
+    target = tmp_path / "target"
+    target.mkdir()
+    _seed_run(target)
+    good = {"session_id": SID, "source": "auto", "observed_at": _OBSERVED_A}
+    row = dict(good)
+    row.update(
+        labels=["accepted"],
+        pr_state=None,
+        labeler_version="980-rubric-r2",
+        evidence_sha="e" * 64,
+        rubric_json=None,
+        valid_at=None,
+        reward_version=None,
+        reward_json=None,
+        composite_reward=None,
+        reviewer_logins=None,
+        has_posterior=0,
+        labeler_policy_version="980-policy-r1",
+        reply_classifier_version=None,
+        reply_evidence_digest=None,
+    )
+    tampered = _row_with_digest(row)
+    tampered["labels"] = ["smuggled"]
+    with pytest.raises(ValueError, match=SID):
+        merge_imported_observations(target, [tampered])
+    assert label_observation_history(target, SID) == []
+
+
+def test_dry_run_plans_without_writing(tmp_path: Path) -> None:
+    source_root = tmp_path / "backup"
+    source_root.mkdir()
+    _seed_run(source_root)
+    _seed_generation(source_root, observed_at=_OBSERVED_A, evidence_sha="e" * 64, labels=["accepted"])
+    imported = [_row_with_digest(r) for r in read_label_rows(source_root)]
+
+    target = tmp_path / "target"
+    target.mkdir()
+    _seed_run(target)
+    merged = merge_imported_observations(target, imported, dry_run=True)
+
+    assert merged["dry_run"] is True
+    assert len(merged["planned"]) == 1
+    assert merged["planned"][0]["session_id"] == SID
+    assert merged["planned"][0]["observed_at"] == _OBSERVED_A
+    assert merged["planned"][0]["source"] == "auto"
+    assert label_observation_history(target, SID) == []
+
+
+def test_human_source_appended_verbatim(tmp_path: Path) -> None:
+    # Human evidence keeps its source class and explicit observed_at: the
+    # writer never dedupes human rows (S0-1) and the bitemporal stamp is
+    # preserved exactly.
+    target = tmp_path / "target"
+    target.mkdir()
+    _seed_run(target)
+    row = {
+        "session_id": SID,
+        "source": "human",
+        "observed_at": _OBSERVED_B,
+        "labels": ["rejected"],
+        "pr_state": None,
+        "labeler_version": HUMAN_LABELER_VERSION,
+        "evidence_sha": None,
+        "rubric_json": None,
+        "valid_at": _OBSERVED_B,
+        "reward_version": None,
+        "reward_json": None,
+        "composite_reward": None,
+        "reviewer_logins": None,
+        "has_posterior": 0,
+        "labeler_policy_version": STALE_LEGACY,
+        "reply_classifier_version": None,
+        "reply_evidence_digest": None,
+    }
+    merged = merge_imported_observations(target, [_row_with_digest(row)])
+    assert merged["appended"] == 1
+    hist = label_observation_history(target, SID)
+    assert len(hist) == 1
+    assert hist[0]["source"] == "human"
+    assert hist[0]["observed_at"] == _OBSERVED_B
+    assert hist[0]["labels"] == json.dumps(["rejected"])

--- a/tests/test_archive_importer.py
+++ b/tests/test_archive_importer.py
@@ -20,7 +20,12 @@ from typing import Any
 
 import pytest
 
-from daydream.archive.importer import dedupe_observations, gold_eligible, link_session_identity
+from daydream.archive.importer import (
+    classify_run_level,
+    dedupe_observations,
+    gold_eligible,
+    link_session_identity,
+)
 from daydream.archive.index import append_label_observation, upsert_run
 from daydream.archive.known_versions import STALE_LEGACY
 from daydream.training.labeler_versions import HUMAN_LABELER_VERSION
@@ -393,3 +398,115 @@ def test_gold_eligibility_three_fixtures() -> None:
     stale = make_observation(ver=STALE_LEGACY)  # non-gold
     unknown = make_observation(ver="9999-future-r9")  # non-gold
     assert [obs for obs in (valid, stale, unknown) if gold_eligible(obs)] == [valid]
+
+
+# --- Task 5: run-level labels stay run-level (M5, AC2) ----------------------
+
+
+def make_session_row(
+    *,
+    session_id: str = SID,
+    evidence_sha: str = "c" * 64,
+    labels: str | list[str] | None = None,
+    record_id: str | None = None,
+) -> dict[str, Any]:
+    """A run-level (session-scoped, no record_id) label observation row."""
+    return {
+        "session_id": session_id,
+        "observed_at": _OBSERVED_A,
+        "record_id": record_id,
+        "evidence_sha": evidence_sha,
+        "labels": json.dumps(labels) if isinstance(labels, list) else (labels or '["finding-accepted"]'),
+        "source": "human",
+    }
+
+
+def test_run_level_label_never_fans_out() -> None:
+    # A run-level label with no projected findings in the session: it is
+    # emitted as run-level evidence only — never copied onto every finding
+    # of the run (AC2) — and lands in the run_level_only bucket.
+    rec = make_session_row()
+    out = classify_run_level([rec], projector_findings={})
+    assert out["per_finding"].get(SID) is None
+    assert SID in out["run_level_only"]
+    assert out["ambiguous_run_mapping"] == {}
+
+
+def test_ambiguous_mapping_routes_to_queue() -> None:
+    # Two candidate findings, neither matching the row's evidence digest:
+    # the run<->finding mapping is ambiguous — the row routes to the
+    # ambiguous_run_mapping bucket (the per-finding adjudication queue),
+    # never a fan-out and never a silent per_finding substitution.
+    rec = make_session_row()
+    ambiguous = {
+        SID: [
+            {"record_id": "r1", "evidence_sha": "z" * 64},
+            {"record_id": "r2", "evidence_sha": "y" * 64},
+        ]
+    }
+    out = classify_run_level([rec], projector_findings=ambiguous)
+    assert SID in out["ambiguous_run_mapping"]
+    assert out["per_finding"].get(SID) is None
+    assert SID not in out["run_level_only"]
+
+
+def test_decisive_identity_and_digest_match_lands_per_finding() -> None:
+    # Exactly one candidate finding matching identity + evidence digest:
+    # the row is per-finding eligible (feeds the _is_admitted_outcome_gold
+    # path through the existing decisive-only semantics).
+    rec = make_session_row(evidence_sha="c" * 64)
+    findings = {SID: [{"record_id": "r1", "evidence_sha": "c" * 64}]}
+    out = classify_run_level([rec], projector_findings=findings)
+    assert out["per_finding"][SID] == [rec]
+    assert out["run_level_only"] == {}
+    assert out["ambiguous_run_mapping"] == {}
+
+
+def test_multiple_candidates_one_digest_match_is_decisive() -> None:
+    # Multiple candidates but exactly one matches the evidence digest: the
+    # identity+digest match is decisive, not ambiguous.
+    rec = make_session_row(evidence_sha="c" * 64)
+    findings = {
+        SID: [
+            {"record_id": "r1", "evidence_sha": "z" * 64},
+            {"record_id": "r2", "evidence_sha": "c" * 64},
+        ]
+    }
+    out = classify_run_level([rec], projector_findings=findings)
+    assert out["per_finding"][SID] == [rec]
+
+
+def test_malformed_labels_json_raises_naming_session() -> None:
+    rec = make_session_row(labels="{not-json")
+    with pytest.raises(ValueError, match=SID):
+        classify_run_level([rec], projector_findings={})
+
+
+def test_referenced_finding_missing_fields_raises() -> None:
+    # A projector_findings entry referenced by the run is malformed (missing
+    # record_id/evidence_sha): raise, never silently substitute.
+    rec = make_session_row(evidence_sha="c" * 64)
+    findings = {SID: [{"record_id": "r1"}]}  # no evidence_sha
+    with pytest.raises(ValueError, match="evidence_sha"):
+        classify_run_level([rec], projector_findings=findings)
+
+
+def test_per_finding_row_is_not_run_level() -> None:
+    # A row that already carries a record_id is per-finding evidence; it is
+    # accounted for in per_finding, never routed through the run-level
+    # buckets (M7: bucket sum == source row count).
+    rec = make_session_row(record_id="r1")
+    out = classify_run_level([rec], projector_findings={})
+    assert out["per_finding"][SID] == [rec]
+    assert out["run_level_only"] == {}
+    assert out["ambiguous_run_mapping"] == {}
+
+
+def test_buckets_account_for_every_row() -> None:
+    # Deterministic partition: every input row lands in exactly one bucket.
+    run_level = make_session_row()
+    per_finding = make_session_row(record_id="r1", evidence_sha="c" * 64)
+    out = classify_run_level([run_level, per_finding], projector_findings={})
+    total = sum(len(v) for v in out["per_finding"].values())
+    total += len(out["run_level_only"]) + len(out["ambiguous_run_mapping"])
+    assert total == 2

--- a/tests/test_archive_importer.py
+++ b/tests/test_archive_importer.py
@@ -20,8 +20,10 @@ from typing import Any
 
 import pytest
 
-from daydream.archive.importer import dedupe_observations, link_session_identity
+from daydream.archive.importer import dedupe_observations, gold_eligible, link_session_identity
 from daydream.archive.index import append_label_observation, upsert_run
+from daydream.archive.known_versions import STALE_LEGACY
+from daydream.training.labeler_versions import HUMAN_LABELER_VERSION
 from tests.harness.trajectory import make_manifest
 
 SID = "sess-abc123"
@@ -368,3 +370,26 @@ def _force_insert_rubric_variant(root: Path, *, observed_at: str) -> None:
 def test_empty_inventories(tmp_path: Path) -> None:
     merged = dedupe_observations([[], []])
     assert merged == {"rows": [], "deduped_count": 0, "content_conflict": []}
+
+
+# --- Task 4: version-gated gold eligibility (M6, KD3) -----------------------
+
+
+def make_observation(ver: str) -> dict[str, Any]:
+    """Minimal observation dict with all version axes set to ``ver``."""
+    return {
+        "session_id": SID,
+        "observed_at": _OBSERVED_A,
+        "labels": ["accepted"],
+        "labeler_version": ver,
+        "labeler_policy_version": ver,
+        "reply_classifier_version": ver,
+        "legacy": "legacy" if ver == STALE_LEGACY else "auto",
+    }
+
+
+def test_gold_eligibility_three_fixtures() -> None:
+    valid = make_observation(ver=HUMAN_LABELER_VERSION)  # gold participates
+    stale = make_observation(ver=STALE_LEGACY)  # non-gold
+    unknown = make_observation(ver="9999-future-r9")  # non-gold
+    assert [obs for obs in (valid, stale, unknown) if gold_eligible(obs)] == [valid]

--- a/tests/test_archive_importer.py
+++ b/tests/test_archive_importer.py
@@ -1,0 +1,87 @@
+"""Tests for the local-observation importer's pure core.
+
+Task 2 covers ``link_session_identity``: Hub session identity linkage with
+session_id primary rule, repo_slug+SHA fallback, and report-don't-drop
+unmatched / identity-conflict buckets (M2, KD1).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from daydream.archive.importer import link_session_identity
+
+SID = "sess-abc123"
+D = "d" * 64
+
+
+def build_hydrated_index_with_session(tmp_path: Path, session_id: str, digest: str) -> dict[str, dict[str, str]]:
+    """Hydrated-index shape follows the hydrate import-ledger join:
+    ``{session_id: {"derivative_digest": ..., "record_id": ...}}``."""
+    return {session_id: {"derivative_digest": digest, "record_id": f"rec-{session_id}"}}
+
+
+def _record(
+    session_id: str,
+    digest: str = D,
+    repo_slug: str | None = "org/repo",
+    base_sha: str | None = "a" * 40,
+    head_sha: str | None = "b" * 40,
+) -> dict[str, str | None]:
+    return {
+        "session_id": session_id,
+        "derivative_digest": digest,
+        "repo_slug": repo_slug,
+        "base_sha": base_sha,
+        "head_sha": head_sha,
+    }
+
+
+def test_link_session_by_session_id(tmp_path: Path) -> None:
+    idx = build_hydrated_index_with_session(tmp_path, SID, digest=D)
+    result = link_session_identity([_record(SID)], hydrated_index=idx, repo_slug_sha_lookup={})
+    entry = result["linked"][SID]
+    assert entry["hub_session_id"] == SID
+    assert entry["matched_by"] == "session_id"
+
+
+def test_link_fallback_repo_slug_sha(tmp_path: Path) -> None:
+    # session_id absent from the hydrated index; repo_slug+SHA fallback matches.
+    lookup = {("org/repo", "a" * 40, "b" * 40): "hub-999"}
+    result = link_session_identity(
+        [_record("s1")], hydrated_index={}, repo_slug_sha_lookup=lookup
+    )
+    entry = result["linked"]["s1"]
+    assert entry["hub_session_id"] == "hub-999"
+    assert entry["matched_by"] == "repo_slug_sha"
+
+
+def test_unmatched_and_conflict_buckets(tmp_path: Path) -> None:
+    idx = build_hydrated_index_with_session(tmp_path, SID, digest=D)
+    records = [
+        _record("no-such-session"),  # no Hub entry, no fallback hit
+        _record(SID, digest="e" * 64),  # conflicting derivative digest
+    ]
+    r = link_session_identity(records, hydrated_index=idx, repo_slug_sha_lookup={})
+    assert "no-such-session" in r["unmatched"]
+    assert SID in r["identity_conflict"]
+
+
+def test_conflicting_digest_never_links(tmp_path: Path) -> None:
+    idx = build_hydrated_index_with_session(tmp_path, SID, digest=D)
+    r = link_session_identity(
+        [_record(SID, digest="e" * 64)], hydrated_index=idx, repo_slug_sha_lookup={}
+    )
+    assert r["linked"] == {}
+    assert SID in r["identity_conflict"]
+
+
+def test_missing_fallback_fields_raises(tmp_path: Path) -> None:
+    # session_id absent from the Hub index and the record lacks the session
+    # fields required for the fallback -> ValueError naming the session_id.
+    record = _record("s-broken", repo_slug=None, base_sha=None, head_sha=None)
+    record.pop("derivative_digest")
+    with pytest.raises(ValueError, match="s-broken"):
+        link_session_identity([record], hydrated_index={}, repo_slug_sha_lookup={})

--- a/tests/test_archive_importer.py
+++ b/tests/test_archive_importer.py
@@ -798,7 +798,7 @@ def test_drift_fails_closed_before_any_write(tmp_path: Path) -> None:
     target = tmp_path / "target"
     target.mkdir()
     _seed_run(target)
-    good = {"session_id": SID, "source": "auto", "observed_at": _OBSERVED_A}
+    good: dict[str, Any] = {"session_id": SID, "source": "auto", "observed_at": _OBSERVED_A}
     row = dict(good)
     row.update(
         labels=["accepted"],
@@ -876,3 +876,105 @@ def test_human_source_appended_verbatim(tmp_path: Path) -> None:
     assert hist[0]["source"] == "human"
     assert hist[0]["observed_at"] == _OBSERVED_B
     assert hist[0]["labels"] == json.dumps(["rejected"])
+
+# ---------------------------------------------------------------------------
+# Task 8: fail-closed secret scan + redaction before publication (M9, AC6)
+# ---------------------------------------------------------------------------
+
+from daydream.archive.hydrate_rules import (  # noqa: E402
+    REASON_CODE_IMPORT_UNREDACTABLE_METADATA,
+)
+from daydream.archive.importer import REDACTED_PATH, redact_imported_metadata  # noqa: E402
+from daydream.archive.scan import scan_run_dir  # noqa: E402
+
+
+def _metadata_row(**overrides: Any) -> dict[str, Any]:
+    row: dict[str, Any] = {
+        "session_id": SID,
+        "observed_at": _OBSERVED_A,
+        "source": "human",
+        "remote_url": "https://github.com/acme/widget.git",
+        "source_path": None,
+        "labels": [],
+        "pr_state": None,
+        "labeler_version": HUMAN_LABELER_VERSION,
+        "evidence_sha": None,
+        "rubric_json": None,
+        "valid_at": _OBSERVED_A,
+        "reward_version": None,
+        "reward_json": None,
+        "composite_reward": None,
+        "reviewer_logins": None,
+        "has_posterior": 0,
+        "labeler_policy_version": STALE_LEGACY,
+        "reply_classifier_version": None,
+        "reply_evidence_digest": None,
+    }
+    row.update(overrides)
+    return row
+
+
+def test_clean_metadata_passes_scan(tmp_path: Path) -> None:
+    scan_dir = tmp_path / "scan"
+    result = redact_imported_metadata([_metadata_row()], scan_dir=scan_dir)
+    assert result["blocked"] is False
+    assert scan_dir.is_dir()
+    assert scan_run_dir(scan_dir).clean
+    # The payload file scanned is the redacted payload itself.
+    payload = json.loads((scan_dir / "payload.json").read_text(encoding="utf-8"))
+    assert payload == result["payload"]
+
+
+def test_absolute_paths_redacted(tmp_path: Path) -> None:
+    row = _metadata_row(
+        remote_url="/Users/k/proj",
+        source_path="/Users/k/proj/inner",
+        rubric_json=json.dumps({"workdir": "/Users/k/proj/build", "note": "ok"}),
+        reward_json=json.dumps([{"home": "/Users/k/proj/out"}]),
+    )
+    result = redact_imported_metadata([row], scan_dir=tmp_path / "scan")
+    assert result["blocked"] is False
+    encoded = json.dumps(result["payload"])
+    assert "/Users/k" not in encoded
+    out_row = result["payload"][0]
+    assert REDACTED_PATH in out_row["remote_url"]
+    assert REDACTED_PATH in out_row["source_path"]
+    rubric = json.loads(out_row["rubric_json"])
+    assert rubric["workdir"] == REDACTED_PATH
+    assert rubric["note"] == "ok"
+    reward = json.loads(out_row["reward_json"])
+    assert reward[0]["home"] == REDACTED_PATH
+
+
+def test_credential_url_redacted(tmp_path: Path) -> None:
+    row = _metadata_row(remote_url="https://user:ghp_secret@github.com/acme/widget.git")
+    result = redact_imported_metadata([row], scan_dir=tmp_path / "scan")
+    assert result["blocked"] is False
+    assert "ghp_secret" not in json.dumps(result["payload"])
+    assert scan_run_dir(tmp_path / "scan").clean
+
+
+def test_dirty_metadata_blocks_publish(tmp_path: Path) -> None:
+    # A credential-shaped string in a free-text field the redaction pass does
+    # not own cannot be made clean: the payload is flagged blocked — never
+    # downgraded to a warning, never dropped silently.
+    dirty = _metadata_row(notes="clone from https://user:secret1@github.com/x/y.git")
+    result = redact_imported_metadata([_metadata_row(), dirty], scan_dir=tmp_path / "scan")
+    assert scan_run_dir(tmp_path / "scan").clean is False
+    assert result["blocked"] is True
+    assert result["blocked_reasons"] == [REASON_CODE_IMPORT_UNREDACTABLE_METADATA]
+
+
+def test_blocked_payload_carries_marker_skipping(tmp_path: Path) -> None:
+    # Already-redacted markers are safe output, not secrets: a payload whose
+    # only "suspicious" text is our own marker scans clean.
+    row = _metadata_row(notes=f"workdir was {REDACTED_PATH}")
+    result = redact_imported_metadata([row], scan_dir=tmp_path / "scan")
+    assert result["blocked"] is False
+    assert len(result["payload"]) == 1
+
+
+def test_malformed_rubric_json_raises(tmp_path: Path) -> None:
+    row = _metadata_row(rubric_json="{not json")
+    with pytest.raises(ValueError, match="rubric_json"):
+        redact_imported_metadata([row], scan_dir=tmp_path / "scan")

--- a/tests/test_archive_importer.py
+++ b/tests/test_archive_importer.py
@@ -20,13 +20,26 @@ from typing import Any
 
 import pytest
 
+from daydream.archive.hydrate_rules import (
+    HYDRATION_INDEX_SCHEMA_VERSION,
+    REASON_CODE_IMPORT_DECISIVE_PER_FINDING,
+    REASON_CODE_IMPORT_IDENTITY_CONFLICT,
+    REASON_CODE_IMPORT_INVALID_VERSION,
+    REASON_CODE_IMPORT_RUN_LEVEL_ONLY,
+    REASON_CODE_IMPORT_STALE_EVIDENCE,
+    REASON_CODE_IMPORT_UNMATCHED_SESSION,
+)
 from daydream.archive.importer import (
+    IMPORT_REASON_CODES,
+    accounting,
+    build_import_ledger,
     canonical_payload_digest,
     classify_run_level,
     dedupe_observations,
     gold_eligible,
     link_session_identity,
     merge_imported_observations,
+    run_pure_import,
 )
 from daydream.archive.index import (
     append_label_observation,
@@ -516,6 +529,151 @@ def test_buckets_account_for_every_row() -> None:
     total = sum(len(v) for v in out["per_finding"].values())
     total += len(out["run_level_only"]) + len(out["ambiguous_run_mapping"])
     assert total == 2
+
+
+# ---------------------------------------------------------------------------
+# Task 7: reason-coded accounting (M7, KD5)
+# ---------------------------------------------------------------------------
+
+SIX_BUCKET_CODES = IMPORT_REASON_CODES
+
+
+def _import_row(
+    session_id: str,
+    *,
+    evidence_sha: str,
+    derivative_digest: str = D,
+    versions: str = "gold",
+) -> dict[str, Any]:
+    """One inventory-shaped observation row with distinct evidence per session.
+
+    ``versions="gold"`` stamps the known-versions allowlist axes;
+    anything else stamps an unknown version (non-gold, M6).
+    """
+    if versions == "gold":
+        labeler, policy, classifier = "980-rubric-r2", "980-policy-r1", "980-classifier-r1"
+    else:
+        labeler = policy = classifier = "9999-future-r9"
+    return {
+        "session_id": session_id,
+        "observed_at": _OBSERVED_A,
+        "labels": '["accepted"]',
+        "pr_state": None,
+        "labeler_version": labeler,
+        "evidence_sha": evidence_sha,
+        "rubric_json": None,
+        "valid_at": None,
+        "reward_version": None,
+        "reward_json": None,
+        "composite_reward": None,
+        "reviewer_logins": None,
+        "has_posterior": 0,
+        "source": "auto",
+        "labeler_policy_version": policy,
+        "reply_classifier_version": classifier,
+        "reply_evidence_digest": None,
+        "derivative_digest": derivative_digest,
+        "repo_slug": "org/repo",
+        "base_sha": "a" * 40,
+        "head_sha": "b" * 40,
+    }
+
+
+def _six_row_fixture() -> tuple[list[dict[str, Any]], dict[str, dict[str, Any]], dict[str, list[dict[str, Any]]]]:
+    """One row per bucket, each session distinct (no dedupe overlap).
+
+    Returns (inventory rows, hydrated_index, projector_findings) covering:
+    unmatched, identity conflict, stale evidence (ambiguous run mapping),
+    invalid version, decisive per-finding, and run-level-only.
+    """
+    rows = [
+        _import_row("s-unmatched", evidence_sha="1" * 64),
+        _import_row("s-conflict", evidence_sha="2" * 64),
+        _import_row("s-stale", evidence_sha="3" * 64),
+        _import_row("s-invalid", evidence_sha="4" * 64, versions="unknown"),
+        _import_row("s-perfinding", evidence_sha="5" * 64),
+        _import_row("s-runlevel", evidence_sha="6" * 64),
+    ]
+    hydrated_index = {
+        "s-conflict": {"derivative_digest": "e" * 64, "record_id": "rec-conflict"},
+        "s-stale": {"derivative_digest": D, "record_id": "rec-stale"},
+        "s-invalid": {"derivative_digest": D, "record_id": "rec-invalid"},
+        "s-perfinding": {"derivative_digest": D, "record_id": "rec-pf"},
+        "s-runlevel": {"derivative_digest": D, "record_id": "rec-rl"},
+    }
+    projector_findings = {
+        "s-stale": [{"record_id": "r1", "evidence_sha": "z" * 64}],  # no digest match
+        "s-perfinding": [{"record_id": "r1", "evidence_sha": "5" * 64}],  # decisive
+    }
+    return rows, hydrated_index, projector_findings
+
+
+def test_reason_codes_sum_to_source_row_count() -> None:
+    rows, hydrated_index, projector_findings = _six_row_fixture()
+    result = run_pure_import(
+        [rows],
+        hydrated_index=hydrated_index,
+        repo_slug_sha_lookup={},
+        projector_findings=projector_findings,
+    )
+    counts = [result["accounting"][code] for code in SIX_BUCKET_CODES]
+    assert set(result["accounting"]) == set(SIX_BUCKET_CODES)
+    assert sum(counts) == len(rows)  # M7: bucket sum == source row count
+
+
+def test_each_bucket_reason_stable() -> None:
+    rows, hydrated_index, projector_findings = _six_row_fixture()
+    result = run_pure_import(
+        [rows],
+        hydrated_index=hydrated_index,
+        repo_slug_sha_lookup={},
+        projector_findings=projector_findings,
+    )
+    acc = result["accounting"]
+    assert acc[REASON_CODE_IMPORT_UNMATCHED_SESSION] == 1
+    assert acc[REASON_CODE_IMPORT_IDENTITY_CONFLICT] == 1
+    assert acc[REASON_CODE_IMPORT_STALE_EVIDENCE] == 1
+    assert acc[REASON_CODE_IMPORT_INVALID_VERSION] == 1
+    assert acc[REASON_CODE_IMPORT_DECISIVE_PER_FINDING] == 1
+    assert acc[REASON_CODE_IMPORT_RUN_LEVEL_ONLY] == 1
+
+
+def test_ledger_mirrors_hydrate_import_ledger_shape() -> None:
+    rows, hydrated_index, projector_findings = _six_row_fixture()
+    result = run_pure_import(
+        [rows],
+        hydrated_index=hydrated_index,
+        repo_slug_sha_lookup={},
+        projector_findings=projector_findings,
+    )
+    ledger = build_import_ledger(result)
+    assert ledger["schema_version"] == HYDRATION_INDEX_SCHEMA_VERSION
+    assert set(ledger["accounting"]) == set(SIX_BUCKET_CODES)
+    assert sum(ledger["accounting"].values()) == len(ledger["observations"])
+    assert len(ledger["observations"]) == len(rows)
+    by_sid = {e["session_id"]: e for e in ledger["observations"]}
+    assert by_sid["s-unmatched"]["reason_code"] == REASON_CODE_IMPORT_UNMATCHED_SESSION
+    assert by_sid["s-conflict"]["reason_code"] == REASON_CODE_IMPORT_IDENTITY_CONFLICT
+    assert by_sid["s-stale"]["reason_code"] == REASON_CODE_IMPORT_STALE_EVIDENCE
+    assert by_sid["s-invalid"]["reason_code"] == REASON_CODE_IMPORT_INVALID_VERSION
+    assert by_sid["s-perfinding"]["reason_code"] == REASON_CODE_IMPORT_DECISIVE_PER_FINDING
+    assert by_sid["s-runlevel"]["reason_code"] == REASON_CODE_IMPORT_RUN_LEVEL_ONLY
+    for entry in ledger["observations"]:
+        assert set(entry) == {"session_id", "observed_at", "source", "reason_code"}
+
+
+def test_unclassifiable_row_raises_naming_it() -> None:
+    # A merged row absent from every link/run-level result and carrying no
+    # dedupe conflict: fail closed with a ValueError naming the row — never
+    # an implicit drop (M7).
+    row = _import_row("s-orphan", evidence_sha="7" * 64)
+    with pytest.raises(ValueError, match="s-orphan"):
+        accounting(
+            [row],
+            content_conflict=[],
+            link_result={"linked": {}, "unmatched": {}, "identity_conflict": {}},
+            run_level_result={"per_finding": {}, "run_level_only": {}, "ambiguous_run_mapping": {}},
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_archive_importer.py
+++ b/tests/test_archive_importer.py
@@ -3,18 +3,53 @@
 Task 2 covers ``link_session_identity``: Hub session identity linkage with
 session_id primary rule, repo_slug+SHA fallback, and report-don't-drop
 unmatched / identity-conflict buckets (M2, KD1).
+
+Task 3 covers ``dedupe_observations``: idempotent, byte-identical dedupe
+across overlapping backups keyed on the writer's versioned auto-dedup tuple
+plus the canonical-JSON payload digest, with content-conflict accounting
+(M4, KD2/Assumption 3).
 """
 
 from __future__ import annotations
 
+import hashlib
+import json
+import sqlite3
 from pathlib import Path
+from typing import Any
 
 import pytest
 
-from daydream.archive.importer import link_session_identity
+from daydream.archive.importer import dedupe_observations, link_session_identity
+from daydream.archive.index import append_label_observation, upsert_run
+from tests.harness.trajectory import make_manifest
 
 SID = "sess-abc123"
 D = "d" * 64
+
+_OBSERVED_A = "2026-05-01T00:00:00+00:00"
+_OBSERVED_B = "2026-05-02T00:00:00+00:00"
+
+_OBSERVATION_COLUMNS = [
+    "session_id",
+    "observed_at",
+    "labels",
+    "pr_state",
+    "labeler_version",
+    "evidence_sha",
+    "rubric_json",
+    "valid_at",
+    "reward_version",
+    "reward_json",
+    "composite_reward",
+    "reviewer_logins",
+    "has_posterior",
+    "source",
+    "labeler_policy_version",
+    "reply_classifier_version",
+    "reply_evidence_digest",
+    "legacy",
+]
 
 
 def build_hydrated_index_with_session(tmp_path: Path, session_id: str, digest: str) -> dict[str, dict[str, str]]:
@@ -85,3 +120,251 @@ def test_missing_fallback_fields_raises(tmp_path: Path) -> None:
     record.pop("derivative_digest")
     with pytest.raises(ValueError, match="s-broken"):
         link_session_identity([record], hydrated_index={}, repo_slug_sha_lookup={})
+
+
+# ---------------------------------------------------------------------------
+# Task 3: dedupe across overlapping backups
+# ---------------------------------------------------------------------------
+
+
+def _seed_run(root: Path) -> None:
+    upsert_run(
+        root,
+        make_manifest(
+            session_id=SID,
+            repo_slug="org/repo",
+            head_sha="b" * 40,
+            base_sha="a" * 40,
+        ),
+    )
+
+
+def _append_observation(root: Path, *, observed_at: str, evidence_sha: str) -> None:
+    append_label_observation(
+        root,
+        SID,
+        labels=["accepted"],
+        pr_state=None,
+        labeler_version="980-rubric-r2",
+        evidence_sha=evidence_sha,
+        # Explicit valid_at: the writer collapses valid_at=None to observed_at,
+        # which would make the two roots' payloads differ by capture stamp.
+        valid_at="2026-04-30T00:00:00+00:00",
+        reply_evidence_digest=None,
+        reward_version=None,
+        has_posterior=False,
+        source="auto",
+        observed_at=observed_at,
+    )
+
+
+def _force_insert_observation(root: Path, *, observed_at: str, evidence_sha: str) -> None:
+    """Insert the exact same evidence payload under a different ``observed_at``.
+
+    Mirrors the real overlap scenario — two independently captured backups of
+    the same archive carry identical rows stamped at their own capture times.
+    """
+    write = sqlite3.connect(root / "index.db")
+    write.execute(
+        "INSERT INTO label_observations (session_id, observed_at, labels, pr_state, labeler_version,"
+        " evidence_sha, rubric_json, valid_at, reward_version, reward_json, composite_reward,"
+        " reviewer_logins, has_posterior, source, labeler_policy_version,"
+        " reply_classifier_version, reply_evidence_digest, legacy) VALUES ("
+        "?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        (
+            SID,
+            observed_at,
+            '["accepted"]',
+            None,
+            "980-rubric-r2",
+            evidence_sha,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            0,
+            "auto",
+            "980-policy-r1",
+            None,
+            None,
+            "auto",
+        ),
+    )
+    write.commit()
+    write.close()
+
+
+def read_label_rows(root: Path) -> list[dict[str, Any]]:
+    """Read-only inventory of one root's ``label_observations`` rows.
+
+    Local test stand-in for the Task 1 inventory: a ``mode=ro`` SQLite read of
+    every column, returned as plain dicts.
+    """
+    conn = sqlite3.connect(f"file:{root / 'index.db'}?mode=ro", uri=True)
+    try:
+        conn.row_factory = sqlite3.Row
+        cols = ", ".join(_OBSERVATION_COLUMNS)
+        rows = conn.execute(f"SELECT {cols} FROM label_observations ORDER BY observed_at").fetchall()
+        return [dict(r) for r in rows]
+    finally:
+        conn.close()
+
+
+def mk_backup_pair(tmp_path: Path, evidence_sha: str) -> tuple[Path, Path]:
+    """Two backup roots holding one shared evidence payload under different
+    ``observed_at`` stamps (root A at ``_OBSERVED_A``, root B at
+    ``_OBSERVED_B``) — the overlapping-backup shape from the plan."""
+    root_a = tmp_path / "backup-a"
+    root_b = tmp_path / "backup-b"
+    for root in (root_a, root_b):
+        root.mkdir()
+        _seed_run(root)
+    _append_observation(root_a, observed_at=_OBSERVED_A, evidence_sha=evidence_sha)
+    _append_observation(root_b, observed_at=_OBSERVED_B, evidence_sha=evidence_sha)
+    # Each root is an independent capture: the writer's within-root auto-dedup
+    # only compares the latest row, so both first-time appends insert — the
+    # shared evidence payload now exists in both roots at different stamps.
+    return root_a, root_b
+
+
+def canonical_digest(rows: list[dict[str, Any]]) -> str:
+    """Content digest over the merged rows — canonical JSON, sorted keys."""
+    payload = json.dumps(rows, sort_keys=True, default=str)
+    return hashlib.sha256(payload.encode()).hexdigest()
+
+
+def test_overlapping_backups_byte_identical(tmp_path: Path) -> None:
+    src_a, src_b = mk_backup_pair(tmp_path, evidence_sha="c" * 64)
+    inv_a = read_label_rows(src_a)
+    inv_b = read_label_rows(src_b)
+    merged = dedupe_observations([inv_a, inv_b])
+
+    canon = canonical_digest(merged["rows"])
+    merged_once = dedupe_observations([inv_a])
+    assert canonical_digest(dedupe_observations([merged_once["rows"], inv_b])["rows"]) == canon
+    # and re-running is a no-op:
+    assert canonical_digest(dedupe_observations([merged["rows"], inv_b])["rows"]) == canon
+    # inventory order must not affect the merged row set:
+    assert canonical_digest(dedupe_observations([inv_b, inv_a])["rows"]) == canon
+
+
+def test_no_duplicate_same_evidence_diff_observed_at(tmp_path: Path) -> None:
+    src_a, src_b = mk_backup_pair(tmp_path, evidence_sha="c" * 64)
+    merged = dedupe_observations([read_label_rows(src_a), read_label_rows(src_b)])
+    keys = {(r["session_id"], r["evidence_sha"], r["labels"]) for r in merged["rows"]}
+    assert len(keys) == len(merged["rows"])  # no dup evidence rows survived
+    # exactly one row was deduped (the second capture of the same evidence)
+    assert merged["deduped_count"] == 1
+    # one surviving row, stamped with the earliest observed_at of the pair
+    assert len(merged["rows"]) == 1
+    assert merged["rows"][0]["observed_at"] == _OBSERVED_A
+
+
+def test_every_generation_kept_never_keep_latest(tmp_path: Path) -> None:
+    # Two *distinct* evidence generations (different policy versions) must both
+    # survive — dedupe collapses identical evidence only, never keeps-latest.
+    src_a, src_b = mk_backup_pair(tmp_path, evidence_sha="c" * 64)
+    _append_observation(src_a, observed_at="2026-05-03T00:00:00+00:00", evidence_sha="e" * 64)
+    inv_a = read_label_rows(src_a)
+    inv_b = read_label_rows(src_b)
+    merged = dedupe_observations([inv_a, inv_b])
+    assert len(merged["rows"]) == 2
+    assert {r["evidence_sha"] for r in merged["rows"]} == {"c" * 64, "e" * 64}
+
+
+def test_human_rows_across_backups_kept(tmp_path: Path) -> None:
+    # Human-sourced rows are never auto-deduped by the writer, so identical
+    # human evidence captured at two different observed_at stamps is preserved
+    # bitemporally; only byte-identical human rows collapse.
+    src_a, src_b = mk_backup_pair(tmp_path, evidence_sha="c" * 64)
+    for root, at in ((src_a, _OBSERVED_A), (src_b, _OBSERVED_B)):
+        append_label_observation(
+            root,
+            SID,
+            labels=["rejected"],
+            pr_state=None,
+            labeler_version="1055-human-r1",
+            evidence_sha="f" * 64,
+            source="human",
+            observed_at=at,
+        )
+    merged = dedupe_observations([read_label_rows(src_a), read_label_rows(src_b)])
+    human = [r for r in merged["rows"] if r["source"] == "human"]
+    # Both human stamps survive (PK collisions in each root bump the stamp by
+    # a microsecond, which does not matter) — they are never collapsed.
+    assert len(human) == 2
+    assert len({r["observed_at"] for r in human}) == 2
+
+
+def test_identical_human_rows_collapse(tmp_path: Path) -> None:
+    src_a, src_b = mk_backup_pair(tmp_path, evidence_sha="c" * 64)
+    for root in (src_a, src_b):
+        append_label_observation(
+            root,
+            SID,
+            labels=["rejected"],
+            pr_state=None,
+            labeler_version="1055-human-r1",
+            evidence_sha="f" * 64,
+            source="human",
+            observed_at="2026-05-04T00:00:00+00:00",
+        )
+    merged = dedupe_observations([read_label_rows(src_a), read_label_rows(src_b)])
+    human = [r for r in merged["rows"] if r["source"] == "human"]
+    assert len(human) == 1
+    # one auto duplicate from the backup pair + one human duplicate
+    assert merged["deduped_count"] == 2
+
+
+def test_same_tuple_diff_payload_routes_to_content_conflict(tmp_path: Path) -> None:
+    # The versioned dedup tuple matches but the immutable payload differs
+    # (different rubric_json) — ambiguous evidence routes to content_conflict,
+    # never silently keeps one.
+    src_a, src_b = mk_backup_pair(tmp_path, evidence_sha="c" * 64)
+    _force_insert_rubric_variant(src_b, observed_at="2026-05-05T00:00:00+00:00")
+    merged = dedupe_observations([read_label_rows(src_a), read_label_rows(src_b)])
+    assert merged["rows"] == []
+    # every row sharing the ambiguous tuple is reported, none silently kept
+    assert len(merged["content_conflict"]) == 3
+    assert merged["deduped_count"] == 0
+
+
+def _force_insert_rubric_variant(root: Path, *, observed_at: str) -> None:
+    """Insert a row matching the tuple but carrying a different rubric_json."""
+    write = sqlite3.connect(root / "index.db")
+    write.execute(
+        "INSERT INTO label_observations (session_id, observed_at, labels, pr_state, labeler_version,"
+        " evidence_sha, rubric_json, valid_at, reward_version, reward_json, composite_reward,"
+        " reviewer_logins, has_posterior, source, labeler_policy_version,"
+        " reply_classifier_version, reply_evidence_digest, legacy) VALUES ("
+        "?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        (
+            SID,
+            observed_at,
+            '["accepted"]',
+            None,
+            "980-rubric-r2",
+            "c" * 64,
+            '{"hash": "variant"}',
+            None,
+            None,
+            None,
+            None,
+            None,
+            0,
+            "auto",
+            "980-rubric-r2",
+            None,
+            None,
+            "auto",
+        ),
+    )
+    write.commit()
+    write.close()
+
+
+def test_empty_inventories(tmp_path: Path) -> None:
+    merged = dedupe_observations([[], []])
+    assert merged == {"rows": [], "deduped_count": 0, "content_conflict": []}

--- a/tests/test_training_adjudication_import_cli.py
+++ b/tests/test_training_adjudication_import_cli.py
@@ -1,0 +1,214 @@
+"""Real-path tests for ``corpus adjudicate import-local-observations`` (KD6).
+
+Every test enters from the production CLI entrypoint
+(``daydream.cli._handle_corpus_command`` / ``handle_adjudicate``) with real
+temp archive roots (real SQLite ``index.db`` files written through the
+production archive writer). No backend or Hub mocking — Task 10 owns the
+publish wiring.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from daydream import cli
+from daydream.archive.index import append_label_observation, upsert_run
+from tests.harness.trajectory import make_manifest
+
+_OBSERVED = "2026-04-30T00:00:00+00:00"
+_VALID_AT = "2026-04-29T00:00:00+00:00"
+
+
+def _seed_session(root: Path, session_id: str, *, evidence_sha: str, labels: list[str]) -> None:
+    """One archived run + one auto label observation, via the real writer.
+
+    The run gets per-session base/head SHAs so the identity fallback lookup
+    (repo_slug, base_sha, head_sha) -> session_id never collides.
+    """
+    head = hashlib.sha256(session_id.encode()).hexdigest()
+    base = hashlib.sha256(("base-" + session_id).encode()).hexdigest()
+    upsert_run(
+        root,
+        make_manifest(
+            session_id=session_id,
+            repo_slug="org/repo",
+            head_sha=head,
+            base_sha=base,
+        ),
+    )
+    append_label_observation(
+        root,
+        session_id,
+        labels=labels,
+        pr_state=None,
+        labeler_version="980-rubric-r2",
+        evidence_sha=evidence_sha,
+        valid_at=_VALID_AT,
+        reply_evidence_digest=None,
+        reward_version=None,
+        has_posterior=False,
+        source="auto",
+        observed_at=_OBSERVED,
+    )
+
+
+def _source_row_count(roots: list[Path]) -> int:
+    total = 0
+    for root in roots:
+        conn = sqlite3.connect(f"file:{root / 'index.db'}?mode=ro", uri=True)
+        try:
+            total += int(conn.execute("SELECT COUNT(*) FROM label_observations").fetchone()[0])
+        finally:
+            conn.close()
+    return total
+
+
+def _digest(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _import_args(*roots: Path, state_dir: Path, extra: list[str]) -> list[str]:
+    argv: list[str] = ["import-local-observations"]
+    for root in roots:
+        argv += ["--archive-root", str(root)]
+    argv += ["--state-dir", str(state_dir), *extra]
+    return argv
+
+
+def test_cli_import_writes_report_dry_run(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    root_a = tmp_path / "src-a"
+    root_b = tmp_path / "src-b"
+    _seed_session(root_a, "sess-a1", evidence_sha="e" * 64, labels=["accepted"])
+    _seed_session(root_a, "sess-a2", evidence_sha="f" * 64, labels=["rejected"])
+    _seed_session(root_b, "sess-b1", evidence_sha="1" * 64, labels=["accepted"])
+    roots = [root_a, root_b]
+    total = _source_row_count(roots)
+    assert total == 3
+
+    state = tmp_path / "state"
+    rc = cli._handle_corpus_command(
+        ["adjudicate", *_import_args(*roots, state_dir=state, extra=["--dry-run", "--json"])]
+    )
+    assert rc == 0
+    report = json.loads(capsys.readouterr().out)
+    assert report["dry_run"] is True
+    # Full reason-coded accounting: every source row lands in exactly one
+    # import bucket (M7).
+    assert sum(report["accounting"].values()) == total
+    assert report["sources"] == [
+        {"archive_root": str(root_a), "row_count": 2, "source_digest": _digest(root_a / "index.db")},
+        {"archive_root": str(root_b), "row_count": 1, "source_digest": _digest(root_b / "index.db")},
+    ]
+    # Dry-run writes no state at all (S2).
+    assert not state.exists()
+
+
+def test_cli_real_path_real_archive(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    src = tmp_path / "src"
+    _seed_session(src, "sess-1", evidence_sha="e" * 64, labels=["accepted"])
+    _seed_session(src, "sess-2", evidence_sha="f" * 64, labels=["rejected"])
+    before = (src / "index.db").read_bytes()
+
+    state = tmp_path / "state"
+    rc = cli._handle_corpus_command(
+        ["adjudicate", *_import_args(src, state_dir=state, extra=[])]
+    )
+    assert rc == 0
+    capsys.readouterr()  # drain the human-readable run before the --json re-run
+    # Read-only sources: byte-identical after a full (non-dry-run) import (M1).
+    assert (src / "index.db").read_bytes() == before
+
+    # Digest-stable report + hydrate-shaped ledger written into --state-dir.
+    report = json.loads((state / "import-report.json").read_text(encoding="utf-8"))
+    assert report["dry_run"] is False
+    assert sum(report["accounting"].values()) == 2
+    ledger = json.loads((state / "import-ledger.json").read_text(encoding="utf-8"))
+    assert ledger["accounting"] == report["accounting"]
+    assert {entry["session_id"] for entry in ledger["observations"]} == {"sess-1", "sess-2"}
+
+    # The merge appended the imported observations into the state archive.
+    conn = sqlite3.connect(f"file:{state / 'index.db'}?mode=ro", uri=True)
+    try:
+        rows = conn.execute(
+            "SELECT session_id, evidence_sha FROM label_observations ORDER BY session_id"
+        ).fetchall()
+    finally:
+        conn.close()
+    assert rows == [("sess-1", "e" * 64), ("sess-2", "f" * 64)]
+
+    # Idempotent re-import (M4): identical sources, nothing new appended,
+    # byte-identical report.
+    rc = cli._handle_corpus_command(
+        ["adjudicate", *_import_args(src, state_dir=state, extra=["--json"])]
+    )
+    assert rc == 0
+    assert json.loads(capsys.readouterr().out)["merge"]["appended"] == 0
+    # Digest-stable (S1): once the state archive has absorbed the import, an
+    # identical re-import produces a byte-identical report.
+    report_bytes = (state / "import-report.json").read_bytes()
+    rc = cli._handle_corpus_command(
+        ["adjudicate", *_import_args(src, state_dir=state, extra=[])]
+    )
+    assert rc == 0
+    assert (state / "import-report.json").read_bytes() == report_bytes
+    assert (src / "index.db").read_bytes() == before
+
+
+def test_cli_overlapping_backups_dedupe_accounting(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    # Two backups of the same archive: the shared rows dedupe, the accounting
+    # still covers every source row across both roots (M4 + M7).
+    root_a = tmp_path / "backup-a"
+    root_b = tmp_path / "backup-b"
+    _seed_session(root_a, "sess-1", evidence_sha="e" * 64, labels=["accepted"])
+    _seed_session(root_a, "sess-2", evidence_sha="f" * 64, labels=["rejected"])
+    for session_id, sha in (("sess-1", "e" * 64), ("sess-2", "f" * 64)):
+        _seed_session(root_b, session_id, evidence_sha=sha, labels=["accepted" if sha[0] == "e" else "rejected"])
+    state = tmp_path / "state"
+    rc = cli._handle_corpus_command(
+        ["adjudicate", *_import_args(root_a, root_b, state_dir=state, extra=["--dry-run", "--json"])]
+    )
+    assert rc == 0
+    report = json.loads(capsys.readouterr().out)
+    assert report["deduped_count"] == 2
+    # Every source row is either accounted in a bucket or dropped as a
+    # byte-identical duplicate (M4 + M7).
+    assert (
+        sum(report["accounting"].values()) + report["deduped_count"]
+        == _source_row_count([root_a, root_b])
+    )
+
+
+def test_cli_missing_archive_root_exits_2() -> None:
+    from daydream.training.adjudication.cli import handle_adjudicate
+
+    with pytest.raises(SystemExit) as exc:
+        handle_adjudicate(["import-local-observations", "--state-dir", "/tmp/x"])
+    assert exc.value.code == 2
+
+
+def test_cli_unknown_subverb_exits_2() -> None:
+    from daydream.training.adjudication.cli import handle_adjudicate
+
+    with pytest.raises(SystemExit) as exc:
+        handle_adjudicate(["import-local-observations-typo", "--archive-root", "/tmp"])
+    assert exc.value.code == 2
+
+
+def test_cli_inventory_failure_exits_1(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    broken = tmp_path / "broken"
+    broken.mkdir()
+    state = tmp_path / "state"
+    rc = cli._handle_corpus_command(
+        ["adjudicate", *_import_args(broken, state_dir=state, extra=[])]
+    )
+    assert rc == 1
+    captured = capsys.readouterr()
+    # The rich panel may elide the long tmp path, but the fail-closed reason
+    # (naming the missing index.db) is always present; no placeholder success.
+    assert "no index.db" in captured.out + captured.err
+    assert not state.exists()  # no placeholder success

--- a/tests/test_training_adjudication_import_cli.py
+++ b/tests/test_training_adjudication_import_cli.py
@@ -183,6 +183,174 @@ def test_cli_overlapping_backups_dedupe_accounting(tmp_path: Path, capsys: pytes
     )
 
 
+def _seed_publishable_state(tmp_path: Path) -> tuple[Path, Path]:
+    """Produce the publishable adjudication state files via the real pipeline.
+
+    ``queue.json`` comes from the real ``build`` verb over an empty hydrated
+    index (empty ``sessions.jsonl`` -> empty queue). ``observations.jsonl``
+    and ``preview-ledger.json`` are the empty-state defaults that publish's
+    fixed payload set requires — their production-by-verb behavior is the
+    publish/label/export verbs' own tested contract, not this test's subject.
+    """
+    index_root = tmp_path / "index-root"
+    index_root.mkdir()
+    (index_root / "sessions.jsonl").write_text("", encoding="utf-8")
+    state = tmp_path / "state"
+    assert cli._handle_corpus_command(
+        ["adjudicate", "build", "--index-root", str(index_root), "--state-dir", str(state)]
+    ) == 0
+    (state / "observations.jsonl").touch()
+    (state / "preview-ledger.json").write_text("{}", encoding="utf-8")
+    return index_root, state
+
+
+def _write_manifest(tmp_path: Path) -> Path:
+    p = tmp_path / "preview-manifest.json"
+    p.write_text(json.dumps({"curation_id": "cur-import", "snapshot_id": "e" * 64}), encoding="utf-8")
+    return p
+
+
+def test_publish_then_resume_reproduces_queue_and_report(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """--publish composes publish_annotation_state after the merge + redaction
+    gate (M8), and a fresh-VM resume from the Hub checkpoint reproduces the
+    identical queue + report (AC5). Only the Hub client is faked."""
+    from daydream.training.adjudication.publish import resume_annotation_state
+    from tests.fixtures.training.build_hub_snapshot import build_annotations_hub
+
+    src = tmp_path / "src"
+    _seed_session(src, "sess-1", evidence_sha="e" * 64, labels=["accepted"])
+    index_root, state = _seed_publishable_state(tmp_path)
+    manifest = _write_manifest(tmp_path)
+
+    hub = build_annotations_hub(curation_id="cur-import", snapshot_id="e" * 64)
+    from daydream.training.adjudication import cli as adjudication_cli
+
+    monkeypatch.setattr(adjudication_cli, "_make_client", lambda repo_id: hub)
+    rc = cli._handle_corpus_command(
+        [
+            "adjudicate",
+            *_import_args(
+                src,
+                state_dir=state,
+                extra=[
+                    "--json",
+                    "--publish",
+                    "--manifest",
+                    str(manifest),
+                    "--hub-repo",
+                    "org/priv-ds",
+                ],
+            ),
+        ]
+    )
+    assert rc == 0
+    capsys.readouterr()
+
+    prefix = f"annotations/cur-import/{'e' * 64}/"
+    # The checkpoint is always written on --publish: it is the fresh-VM
+    # resume anchor (AC5).
+    for name in (
+        "queue.json",
+        "observations.jsonl",
+        "preview-ledger.json",
+        "preview-manifest.json",
+        "checkpoints/batch-latest.json",
+    ):
+        assert prefix + name in hub.files
+
+    # Fresh-VM resume: empty stage dir, restore from the Hub checkpoint.
+    resumed_dir = tmp_path / "resumed"
+    resumed = resume_annotation_state(hub, manifest=manifest, stage_dir=resumed_dir)
+    assert set(resumed["restored"]) == {
+        "queue.json",
+        "observations.jsonl",
+        "preview-ledger.json",
+        "preview-manifest.json",
+    }
+    for name in ("queue.json", "observations.jsonl", "preview-ledger.json"):
+        assert (resumed_dir / name).read_bytes() == (state / name).read_bytes()
+
+    # Identical queue + report (AC5): the report verb over the resumed state
+    # reproduces the pre-publish report byte-for-byte.
+    def _report(state_dir: Path) -> str:
+        assert (
+            cli._handle_corpus_command(
+                ["adjudicate", "report", "--index-root", str(index_root), "--state-dir", str(state_dir)]
+            )
+            == 0
+        )
+        return capsys.readouterr().out
+
+    original_report = _report(state)
+    resumed_report = _report(resumed_dir)
+    assert resumed_report == original_report
+
+
+def test_publish_refuses_non_private_before_any_write(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A non-private destination is refused before any byte is written (M17):
+    exit 1, the refusal named on stderr/stdout, and zero uploads (the hub
+    keeps only its seeded manifest)."""
+    from daydream.archive.hydrate import PublicDestinationError
+    from daydream.training.adjudication.publish import publish_annotation_state
+    from tests.fixtures.training.build_hub_snapshot import build_annotations_hub
+
+    src = tmp_path / "src"
+    _seed_session(src, "sess-1", evidence_sha="e" * 64, labels=["accepted"])
+    _seed_publishable_state(tmp_path)
+    state = tmp_path / "state"
+    manifest = _write_manifest(tmp_path)
+
+    hub = build_annotations_hub(curation_id="cur-import", snapshot_id="e" * 64, private=False)
+    from daydream.training.adjudication import cli as adjudication_cli
+
+    monkeypatch.setattr(adjudication_cli, "_make_client", lambda repo_id: hub)
+    rc = cli._handle_corpus_command(
+        [
+            "adjudicate",
+            *_import_args(
+                src,
+                state_dir=state,
+                extra=["--publish", "--manifest", str(manifest), "--hub-repo", "org/public-ds"],
+            ),
+        ]
+    )
+    assert rc == 1
+    captured = capsys.readouterr()
+    assert "not private" in captured.out + captured.err
+    prefix = f"annotations/cur-import/{'e' * 64}/"
+    assert hub.uploaded_paths == []
+    assert set(hub.files) == {prefix + "preview-manifest.json"}
+
+    # The composition seam itself hard-fails with the typed error, not a
+    # swallowed warning.
+    with pytest.raises(PublicDestinationError):
+        publish_annotation_state(hub, state, manifest=manifest)
+
+
+def test_publish_rejects_dry_run_and_missing_manifest() -> None:
+    from daydream.training.adjudication.cli import handle_adjudicate
+
+    with pytest.raises(SystemExit) as exc:
+        handle_adjudicate(
+            ["import-local-observations", "--archive-root", "/tmp", "--state-dir", "/tmp/s",
+             "--publish", "--dry-run"]
+        )
+    assert exc.value.code == 2
+    with pytest.raises(SystemExit) as exc:
+        handle_adjudicate(
+            ["import-local-observations", "--archive-root", "/tmp", "--state-dir", "/tmp/s", "--publish"]
+        )
+    assert exc.value.code == 2
+
+
 def test_cli_missing_archive_root_exits_2() -> None:
     from daydream.training.adjudication.cli import handle_adjudicate
 

--- a/tests/test_training_adjudication_import_cli.py
+++ b/tests/test_training_adjudication_import_cli.py
@@ -317,12 +317,15 @@ def test_publish_then_resume_reproduces_queue_and_report(
 
     prefix = f"annotations/cur-import/{'e' * 64}/"
     # The checkpoint is always written on --publish: it is the fresh-VM
-    # resume anchor (AC5).
+    # resume anchor (AC5). The archive index (where the import's rows live)
+    # is byte-published with the adjudication payload, so a fresh-VM resume
+    # restores the import itself, not just the queue/report.
     for name in (
         "queue.json",
         "observations.jsonl",
         "preview-ledger.json",
         "preview-manifest.json",
+        "index.db",
         "checkpoints/batch-latest.json",
     ):
         assert prefix + name in hub.files
@@ -335,8 +338,9 @@ def test_publish_then_resume_reproduces_queue_and_report(
         "observations.jsonl",
         "preview-ledger.json",
         "preview-manifest.json",
+        "index.db",
     }
-    for name in ("queue.json", "observations.jsonl", "preview-ledger.json"):
+    for name in ("queue.json", "observations.jsonl", "preview-ledger.json", "index.db"):
         assert (resumed_dir / name).read_bytes() == (state / name).read_bytes()
 
     # Identical queue + report (AC5): the report verb over the resumed state
@@ -416,6 +420,123 @@ def test_publish_rejects_dry_run_and_missing_manifest() -> None:
     assert exc.value.code == 2
 
 
+def test_cli_import_persists_redacted_rows(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """The merge commits the redaction scan's payload, never the unredacted
+    originals: a credential-bearing rubric_json (absolute local path) reaches
+    the state archive only in its redacted form (M9)."""
+    from daydream.archive.importer import REDACTED_PATH
+
+    src = tmp_path / "src"
+    head = hashlib.sha256("sess-1".encode()).hexdigest()
+    base = hashlib.sha256(("base-" + "sess-1").encode()).hexdigest()
+    upsert_run(
+        src,
+        make_manifest(
+            session_id="sess-1",
+            repo_slug="org/repo",
+            head_sha=head,
+            base_sha=base,
+        ),
+    )
+    append_label_observation(
+        src,
+        "sess-1",
+        labels=["accepted"],
+        pr_state=None,
+        labeler_version="980-rubric-r2",
+        evidence_sha="e" * 64,
+        rubric_json=json.dumps({"workdir": "/Users/k/proj/build", "note": "ok"}),
+        valid_at=_VALID_AT,
+        source="auto",
+        observed_at=_OBSERVED,
+    )
+
+    state = tmp_path / "state"
+    rc = cli._handle_corpus_command(
+        ["adjudicate", *_import_args(src, state_dir=state, extra=[])]
+    )
+    assert rc == 0
+    capsys.readouterr()
+    conn = sqlite3.connect(f"file:{state / 'index.db'}?mode=ro", uri=True)
+    try:
+        rows = conn.execute("SELECT rubric_json FROM label_observations").fetchall()
+    finally:
+        conn.close()
+    assert len(rows) == 1
+    assert rows[0][0] is not None
+    assert "/Users/k" not in rows[0][0]
+    rubric = json.loads(rows[0][0])
+    assert rubric["workdir"] == REDACTED_PATH
+    assert rubric["note"] == "ok"
+
+
+def test_cli_import_reports_full_source_inventory(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """The success message reports the full source row inventory (bucketed +
+    deduped), not just the bucket sum (M7)."""
+    root_a = tmp_path / "backup-a"
+    root_b = tmp_path / "backup-b"
+    _seed_session(root_a, "sess-1", evidence_sha="e" * 64, labels=["accepted"])
+    _seed_session(root_b, "sess-1", evidence_sha="e" * 64, labels=["accepted"])
+    state = tmp_path / "state"
+    rc = cli._handle_corpus_command(
+        ["adjudicate", *_import_args(root_a, root_b, state_dir=state, extra=[])]
+    )
+    assert rc == 0
+    captured = capsys.readouterr()
+    report = json.loads((state / "import-report.json").read_text(encoding="utf-8"))
+    total = sum(report["accounting"].values()) + report["deduped_count"]
+    # Collapse Rich's word-wrapping so the message assertion is width-safe.
+    assert f"{total} source row(s)" in " ".join(captured.out.split())
+
+
+def test_cli_import_non_iso_stamp_fails_closed(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """A hand-edited non-ISO observed_at aborts at the pre-write gate: exit 1
+    and no state archive at all (no seeded runs, no partial appends)."""
+    src = tmp_path / "src"
+    head = hashlib.sha256("sess-1".encode()).hexdigest()
+    base = hashlib.sha256(("base-" + "sess-1").encode()).hexdigest()
+    upsert_run(
+        src,
+        make_manifest(
+            session_id="sess-1",
+            repo_slug="org/repo",
+            head_sha=head,
+            base_sha=base,
+        ),
+    )
+    append_label_observation(
+        src,
+        "sess-1",
+        labels=["accepted"],
+        pr_state=None,
+        labeler_version="980-rubric-r2",
+        evidence_sha="e" * 64,
+        valid_at=_VALID_AT,
+        source="auto",
+        observed_at=_OBSERVED,
+    )
+    # Corrupt the stamp in place (the trigger requires a hand-edited/corrupt
+    # source db; writer-produced values are always ISO-8601).
+    write = sqlite3.connect(src / "index.db")
+    write.execute(
+        "UPDATE label_observations SET observed_at = ? WHERE session_id = 'sess-1'",
+        ("2026-04-30 00:00:00",),
+    )
+    write.commit()
+    write.close()
+
+    state = tmp_path / "state"
+    rc = cli._handle_corpus_command(
+        ["adjudicate", *_import_args(src, state_dir=state, extra=[])]
+    )
+    assert rc == 1
+    captured = capsys.readouterr()
+    assert "observed_at" in captured.out + captured.err
+    # Fail-closed before any state write: no archive, no seeded runs, no
+    # partial appends, no placeholder success report.
+    assert (state / "index.db").exists() is False
+
+
 def test_cli_missing_archive_root_exits_2() -> None:
     from daydream.training.adjudication.cli import handle_adjudicate
 
@@ -443,5 +564,7 @@ def test_cli_inventory_failure_exits_1(tmp_path: Path, capsys: pytest.CaptureFix
     captured = capsys.readouterr()
     # The rich panel may elide the long tmp path, but the fail-closed reason
     # (naming the missing index.db) is always present; no placeholder success.
-    assert "no index.db" in captured.out + captured.err
+    # Assert the single token so Rich's fold (word-boundary wrapping) cannot
+    # split the reason on an 80-col non-TTY console.
+    assert "index.db" in captured.out + captured.err
     assert not state.exists()  # no placeholder success

--- a/tests/test_training_adjudication_import_cli.py
+++ b/tests/test_training_adjudication_import_cli.py
@@ -159,6 +159,71 @@ def test_cli_real_path_real_archive(tmp_path: Path, capsys: pytest.CaptureFixtur
     assert (src / "index.db").read_bytes() == before
 
 
+def test_cli_reimport_does_not_displace_newer_target_runs_state(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """An overlapping re-import of an older backup must not displace newer
+    target runs state (status/archived_at/profile_*/cost metrics, plus the
+    writer-owned cache mirrors): the run-row seeding is no-displacement like
+    the observation merge, so append-only holds for both tables (M3)."""
+    src = tmp_path / "src"
+    _seed_session(src, "sess-1", evidence_sha="e" * 64, labels=["accepted"])
+    state = tmp_path / "state"
+    assert cli._handle_corpus_command(
+        ["adjudicate", *_import_args(src, state_dir=state, extra=[])]
+    ) == 0
+
+    # Newer target state: a later archive refresh rewrites the same session
+    # with a newer timestamp, evolved profile, and updated cost metrics.
+    head = hashlib.sha256("sess-1".encode()).hexdigest()
+    base = hashlib.sha256(("base-" + "sess-1").encode()).hexdigest()
+    upsert_run(
+        state,
+        make_manifest(
+            session_id="sess-1",
+            repo_slug="org/repo",
+            head_sha=head,
+            base_sha=base,
+            archived_at="2026-05-01T00:00:00+00:00",
+            status="partial",
+            profile_name="profile-v2",
+            total_cost_usd=99.5,
+        ),
+    )
+    conn = sqlite3.connect(f"file:{state / 'index.db'}?mode=ro", uri=True)
+    conn.row_factory = sqlite3.Row
+    try:
+        newer = dict(
+            conn.execute(
+                "SELECT archived_at, status, profile_name, total_cost_usd, "
+                "outcome_labels, labeled_at FROM runs WHERE session_id = 'sess-1'"
+            ).fetchone()
+        )
+    finally:
+        conn.close()
+
+    # Re-import the (older) source backup overlapping the same session: every
+    # populated target column must survive untouched (only NULL columns may be
+    # filled from the source snapshot).
+    assert cli._handle_corpus_command(
+        ["adjudicate", *_import_args(src, state_dir=state, extra=["--json"])]
+    ) == 0
+    capsys.readouterr()
+    conn = sqlite3.connect(f"file:{state / 'index.db'}?mode=ro", uri=True)
+    conn.row_factory = sqlite3.Row
+    try:
+        after = dict(
+            conn.execute(
+                "SELECT archived_at, status, profile_name, total_cost_usd, "
+                "outcome_labels, labeled_at FROM runs WHERE session_id = 'sess-1'"
+            ).fetchone()
+        )
+    finally:
+        conn.close()
+    populated = {key: value for key, value in newer.items() if value is not None}
+    assert {key: after[key] for key in populated} == populated
+
+
 def test_cli_overlapping_backups_dedupe_accounting(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
     # Two backups of the same archive: the shared rows dedupe, the accounting
     # still covers every source row across both roots (M4 + M7).

--- a/tests/test_training_adjudication_publish.py
+++ b/tests/test_training_adjudication_publish.py
@@ -68,6 +68,14 @@ def _state(tmp_path: Path) -> Path:
         encoding="utf-8",
     )
     (state / "preview-ledger.json").write_text("{}", encoding="utf-8")
+    # index.db is part of the published state (the import's label_observations
+    # rows live there); a byte-identical SQLite file is enough for the digest
+    # round-trip the resume test asserts.
+    import sqlite3 as _sq
+    conn = _sq.connect(state / "index.db")
+    conn.execute("CREATE TABLE IF NOT EXISTS label_observations (id INTEGER PRIMARY KEY)")
+    conn.commit()
+    conn.close()
     return state
 
 


### PR DESCRIPTION
Closes #1082

## Summary
- New `import-local-observations` CLI subcommand to import observations from archive backups
- Fail-closed secret scan + redaction before importer publish; content-digest dedupe for overlapping backups
- Known-versions allowlist gates gold eligibility; run-level labels imported as run-level evidence only
- Merge imported observations via the canonical harvest seam; reason-code ledger accounting
- Hub session identity linkage; `observed_at` preserved on label observation append
- Imported observations published to private Hub with fail-closed, no-displacement import merge + resume
- Checkpoint payloads now include `index.db` (when present) so fresh-VM resume restores archive state; SQLite payloads secret-scanned losslessly via latin-1

## Test Plan
- Full suite green: 5176 passed, 21 skipped
- Two sequential daydream deep-precision review rounds completed (round-2 trajectory uploaded to HF)