### PR TITLE
training: carry repository and license identity and enforce C5/C8 in corpus v2 (Closes #1080)

### DIFF
--- a/daydream/archive/hydrate.py
+++ b/daydream/archive/hydrate.py
@@ -24,6 +24,7 @@ import re
 import shutil
 import time
 from collections import Counter
+from collections.abc import Iterable, Mapping
 from dataclasses import dataclass, field
 from dataclasses import fields as dataclass_fields
 from pathlib import Path, PurePosixPath
@@ -33,8 +34,12 @@ from daydream.archive import hydrate_rules, sanitize
 from daydream.archive.git_safe import normalize_remote_url
 from daydream.archive.hydrate_rules import (
     REASON_CODE_BUNDLE_UNREADABLE,
+    REASON_CODE_C5_EXCLUDED_REPO,
+    REASON_CODE_C8_COPYLEFT_UNOPTED,
     REASON_CODE_IDENTITY_COLLISION,
+    REASON_CODE_LICENSE_EVIDENCE_MISSING,
     REASON_CODE_PATH_TRAVERSAL,
+    REASON_CODE_REPO_IDENTITY_MISSING,
     REASON_CODE_SANITIZE_FAILED,
     REASON_CODE_SECRETS_SCAN_DIRTY,
     REASON_CODE_UNTRUSTED_REMOTE_HOST,
@@ -1154,6 +1159,67 @@ def _latest_admitted_digests(path: Path) -> dict[str, str | None]:
     return latest
 
 
+def admission_summary_buckets(
+    entries: Iterable[tuple[str, str | None]],
+) -> dict[str, int]:
+    """Pure four-bucket license summary over ``(session_id, reason_code)``
+    admission decisions (issue #1080 S2).
+
+    ``None`` counts as admitted; the stable Task-1 rejection codes map to the
+    human buckets (``repo_identity_missing`` folds into
+    ``license_evidence_missing`` — missing identity is missing evidence for
+    the license gate). Any other code is not a license-gate decision and
+    raises: the bucket sum equals the license-gate session count by
+    construction (M8).
+    """
+    code_map = {
+        REASON_CODE_C5_EXCLUDED_REPO: "c5_excluded",
+        REASON_CODE_C8_COPYLEFT_UNOPTED: "c8_copyleft_unopted",
+        REASON_CODE_LICENSE_EVIDENCE_MISSING: "license_evidence_missing",
+        REASON_CODE_REPO_IDENTITY_MISSING: "license_evidence_missing",
+    }
+    buckets: dict[str, int] = {
+        "admitted": 0,
+        "c5_excluded": 0,
+        "c8_copyleft_unopted": 0,
+        "license_evidence_missing": 0,
+    }
+    for _sid, code in entries:
+        if code is None:
+            buckets["admitted"] += 1
+        elif code in code_map:
+            buckets[code_map[code]] += 1
+        else:
+            raise ValueError(
+                f"license admission summary: {code!r} is not a license-gate "
+                "reason code — the summary buckets only partition license decisions"
+            )
+    return buckets
+
+
+def license_admission_summary(ledger: Mapping[str, Any]) -> dict[str, int]:
+    """Human admission summary derived from the built import ledger.
+
+    Imported sessions count as admitted; rejections count only when they
+    carry a license-gate reason code (ingest/fixture rejections were never
+    adjudicated by the license gate and are skipped).
+    """
+    entries: list[tuple[str, str | None]] = [
+        (str(item["session_id"]), None) for item in ledger.get("imported", [])
+    ]
+    license_codes = {
+        REASON_CODE_C5_EXCLUDED_REPO,
+        REASON_CODE_C8_COPYLEFT_UNOPTED,
+        REASON_CODE_LICENSE_EVIDENCE_MISSING,
+        REASON_CODE_REPO_IDENTITY_MISSING,
+    }
+    for item in ledger.get("rejections", []):
+        code = item.get("reason_code")
+        if code in license_codes:
+            entries.append((str(item["session_id"]), str(code)))
+    return admission_summary_buckets(entries)
+
+
 def build_import_ledger(stage: Path, *, revision: str, source_commit: str) -> dict[str, Any]:
     """Build and persist the value-free admission ledger (issue #982 M11).
 
@@ -1662,6 +1728,10 @@ class HydrateSummary:
     dry_run_incomplete_manifests: tuple[str, ...] = ()
     verify_admitted: int = 0
     verified: bool = False
+    # Issue #1080 S2: four-bucket license admission summary (admitted /
+    # c5-excluded / copyleft-unopted / evidence-missing) over the import
+    # ledger; empty when no license policy was configured.
+    license_admission: dict[str, int] = field(default_factory=dict)
 
 
 def _curation_manifest_doc(
@@ -1957,6 +2027,11 @@ def run_hydrate_hub(config: HydrateHubConfig, client: HubClient | None = None) -
             allow_copyleft=config.allow_copyleft,
         )
     ledger = build_import_ledger(config.stage_dir, revision=source_commit, source_commit=source_commit)
+    license_admission = (
+        license_admission_summary(ledger)
+        if config.license_policy_path is not None
+        else {}
+    )
     curation_id = str(ledger["curation_id"])
     checkpoint = resume_state(dest_client, curation_id=curation_id, stage_dir=config.stage_dir / "_resume")
     publish_batches(
@@ -1975,6 +2050,7 @@ def run_hydrate_hub(config: HydrateHubConfig, client: HubClient | None = None) -
         dry_run_admitted=int(ledger["tallies"]["imported"]),
         dry_run_rejected=int(ledger["tallies"]["rejections"]),
         dry_run_incomplete_manifests=tuple(ledger["tallies"]["incomplete_manifests"]),
+        license_admission=license_admission,
     )
     summary.verify_admitted = verify_publication(
         dest_client,

--- a/daydream/archive/hydrate.py
+++ b/daydream/archive/hydrate.py
@@ -686,6 +686,127 @@ def ingest_bundles(stage: Path, *, revision: str) -> list[IngestResult]:
     return results
 
 
+def _manifest_repo_slug(data: dict[str, Any]) -> str | None:
+    """Repository identity from a session manifest (nested ``git.repo_slug`` or flat).
+
+    A missing/blank slug stays ``None`` in the row — identity refusal is the
+    admission gate's job (fail-closed there), never a substituted fallback.
+    """
+    raw = _read_manifest_field(data, "repo_slug")
+    return raw if isinstance(raw, str) and raw.strip() else None
+
+
+def _manifest_license_evidence(data: dict[str, Any]) -> dict[str, str] | None:
+    """Declared license evidence (``spdx_id`` + ``source``) from a session manifest.
+
+    Schema-shaped: only the two string fields the frozen curation-manifest-v1
+    schema allows are carried; anything else (missing, blank, non-dict) is ``None``.
+    """
+    raw = data.get("license_evidence")
+    if not isinstance(raw, dict):
+        return None
+    spdx_id = raw.get("spdx_id")
+    if not isinstance(spdx_id, str) or not spdx_id.strip():
+        return None
+    evidence = {"spdx_id": spdx_id.strip()}
+    source = raw.get("source")
+    if isinstance(source, str):
+        evidence["source"] = source
+    return evidence
+
+
+def _session_identity(stage: Path, sid: str, revision: str, *, root: str, collision: bool) -> \
+        tuple[str | None, dict[str, str] | None]:
+    """Read ``repo_slug`` + ``license_evidence`` for a session from its manifest.
+
+    Tries the derivative locations in the same precedence the digest derivation
+    uses (runs/, quarantine conflict copy, moved rejected root, raw download
+    bundle); ``(None, None)`` when no manifest is readable anywhere.
+    """
+    segment = sid if _is_bare_segment(sid) else hashlib.sha256(sid.encode()).hexdigest()
+    candidates = [stage / "runs" / sid]
+    if collision:
+        candidates.append(stage / "quarantine" / f"{segment}.conflict")
+    candidates += [stage / root / segment,
+                   stage / "downloads" / str(revision) / "bundles" / segment]
+    for candidate in candidates:
+        data = _read_manifest_dict(candidate)
+        if data is not None:
+            return _manifest_repo_slug(data), _manifest_license_evidence(data)
+    return None, None
+
+
+def apply_license_gate(
+    stage: Path,
+    *,
+    revision: str,
+    license_policy_path: str | Path | None,
+    allow_copyleft: frozenset[str] | set[str],
+) -> list[tuple[str, str]]:
+    """Per-repo license admission gate over the admitted derivatives (issue #1080).
+
+    Runs after the existing gates (ingest -> dedupe -> fixture exclusion): each
+    admitted session's ``repo_slug`` + declared license evidence are resolved
+    into an immutable per-repo decision via
+    :func:`daydream.training.corpus_v2.license.resolve_repo_decision` (C5
+    exclusion list first, then policy + opt-in). A ``rejected`` decision moves
+    the derivative to ``stage/excluded/<sid>/`` exactly like the fixture
+    exclusion path and records a stable-code exclusion in the dedupe ledger, so
+    the import-ledger accounting invariant (admitted + rejected = input) holds
+    by construction — every session still lands in exactly one bucket.
+
+    Fail-closed: a missing ``license_policy_path`` raises ``ValueError`` before
+    any gate work — never downgraded to a warning. Apart from the excluded-
+    directory move the gate is pure w.r.t. its inputs, so decisions are
+    replay-identical. Returns the rejected ``(session_id, reason_code)`` pairs.
+    """
+    if not license_policy_path:
+        raise ValueError(
+            "license admission gate requires license_policy_path (fail-closed): "
+            "no license policy file was provided"
+        )
+    from daydream.training.corpus_v2.license import (  # noqa: PLC0415  # local: avoid import cycle at module load
+        load_license_policy,
+        resolve_repo_decision,
+    )
+
+    policy, _digest = load_license_policy(license_policy_path)
+    curated = _curated_dir(stage, str(revision))
+    ledger_path = _dedupe_dir(stage, curated.name) / "dedupe.jsonl"
+    rejected: list[tuple[str, str]] = []
+    runs_dir = stage / "runs"
+    if runs_dir.is_dir():
+        for derivative in sorted(p for p in runs_dir.iterdir() if p.is_dir()):
+            data = _read_manifest_dict(derivative)
+            if data is None:
+                raise HydrationError(
+                    redact_text(f"admitted derivative {derivative.name} has an unreadable manifest")
+                )
+            sid = str(data.get("session_id") or derivative.name)
+            if not _is_bare_segment(sid):
+                raise HydrationError(
+                    redact_text(f"admitted derivative {derivative.name} has an unsafe session id {sid!r}")
+                )
+            decision = resolve_repo_decision(
+                _manifest_repo_slug(data) or "",
+                _manifest_license_evidence(data),
+                policy,
+                allow_copyleft,
+            )
+            if decision.status != "rejected" or decision.reason_code is None:
+                continue
+            _move_dir(derivative, stage / "excluded" / sid)
+            _append_dedupe_entry(
+                ledger_path,
+                {"session_id": sid, "status": "excluded", "reason_code": decision.reason_code,
+                 "content_digest": None, "revision": str(revision), "at": _utc_now()},
+            )
+            rejected.append((sid, decision.reason_code))
+    if rejected:
+        rebuild_index(stage)  # excluded derivatives leave the staging index immediately
+    return rejected
+
+
 def _staging_local_source_path(raw: Any, stage: Path) -> str | None:
     """Rewrite an embedded ``source_path`` to a staging-local value or ``None``.
 
@@ -1522,6 +1643,10 @@ class HydrateHubConfig:
     destination_repo: str
     stage_dir: Path
     exploratory: bool = False
+    # License admission gate (issue #1080): the policy file is the digest-pinned
+    # versioned artifact; allow_copyleft is the exact-slug C8 opt-in set.
+    license_policy_path: str | None = None
+    allow_copyleft: frozenset[str] = frozenset()
 
 
 @dataclass
@@ -1546,6 +1671,9 @@ def _curation_manifest_doc(
     batches: list[dict[str, Any]] = []
     for entry in ledger.get("imported", []):
         sid = str(entry["session_id"])
+        repo_slug, license_evidence = _session_identity(
+            stage, sid, str(ledger["pinned_revision"]), root="excluded", collision=False
+        )
         batches.append(
             {
                 "session_id": sid,
@@ -1554,6 +1682,8 @@ def _curation_manifest_doc(
                 "reason_code": None,
                 "artifact_relpath": f"batches/{sid}",
                 "manifest_relpath": f"batches/{sid}/manifest.json",
+                "repo_slug": repo_slug,
+                "license_evidence": license_evidence,
             }
         )
     for rejection in ledger.get("rejections", []):
@@ -1581,6 +1711,9 @@ def _curation_manifest_doc(
             source_dir = next((c for c in candidates if c.is_dir()), None)
             digest = sanitize._derivative_digest(source_dir) if source_dir is not None \
                 else hashlib.sha256(sid.encode()).hexdigest()
+        repo_slug, license_evidence = _session_identity(
+            stage, sid, str(ledger["pinned_revision"]), root=root, collision=collision
+        )
         batches.append(
             {
                 "session_id": sid,
@@ -1589,6 +1722,8 @@ def _curation_manifest_doc(
                 "reason_code": code,
                 "artifact_relpath": relpath,
                 "manifest_relpath": None,
+                "repo_slug": repo_slug,
+                "license_evidence": license_evidence,
             }
         )
     return {
@@ -1811,6 +1946,16 @@ def run_hydrate_hub(config: HydrateHubConfig, client: HubClient | None = None) -
     download_snapshot(source_client, revision=source_commit, stage_dir=config.stage_dir / "downloads")
     ingest_bundles(config.stage_dir, revision=source_commit)
     dedupe_admitted(config.stage_dir, revision=source_commit)
+    if config.license_policy_path is not None:
+        # Issue #1080: the per-repo license gate runs after the existing gates;
+        # apply_license_gate itself refuses (ValueError, fail-closed) on a
+        # missing policy input.
+        apply_license_gate(
+            config.stage_dir,
+            revision=source_commit,
+            license_policy_path=config.license_policy_path,
+            allow_copyleft=config.allow_copyleft,
+        )
     ledger = build_import_ledger(config.stage_dir, revision=source_commit, source_commit=source_commit)
     curation_id = str(ledger["curation_id"])
     checkpoint = resume_state(dest_client, curation_id=curation_id, stage_dir=config.stage_dir / "_resume")

--- a/daydream/archive/hydrate_rules.py
+++ b/daydream/archive/hydrate_rules.py
@@ -79,6 +79,12 @@ EXCLUSION_CODES = (
     "fixture_pytest_path",
     "fixture_tmp_artifact",
     "non_production_bundle",
+    # License/repo-identity admission codes (issue #1080): a gate rejection is
+    # an exclusion, not a quarantine — the bundle content is fine, the repo is.
+    REASON_CODE_C5_EXCLUDED_REPO,
+    REASON_CODE_C8_COPYLEFT_UNOPTED,
+    REASON_CODE_LICENSE_EVIDENCE_MISSING,
+    REASON_CODE_REPO_IDENTITY_MISSING,
 )
 
 

--- a/daydream/archive/hydrate_rules.py
+++ b/daydream/archive/hydrate_rules.py
@@ -14,7 +14,8 @@ SANITIZER_VERSION = "1"
 HYDRATION_INDEX_SCHEMA_VERSION = "1"
 ADMISSION_POLICY_VERSION = "1"
 
-# Stable quarantine/exclusion reason codes (fixed registry at v1).
+# Stable quarantine/exclusion reason codes (v1 registry; extended for
+# license/repo gates by issue #1080).
 REASON_CODE_FIXTURE_PYTEST_PATH = "fixture_pytest_path"
 REASON_CODE_FIXTURE_TMP_ARTIFACT = "fixture_tmp_artifact"
 REASON_CODE_NON_PRODUCTION_BUNDLE = "non_production_bundle"
@@ -25,6 +26,13 @@ REASON_CODE_UNTRUSTED_REMOTE_HOST = "untrusted_remote_host"
 REASON_CODE_SANITIZE_FAILED = "sanitize_failed"
 REASON_CODE_IDENTITY_COLLISION = "identity_collision"
 REASON_CODE_PATH_TRAVERSAL = "path_traversal"
+
+# License/repo-identity reason codes (issue #1080 corpus-v2 gates). Stable
+# strings (KD5); the registry extends for license/repo gates.
+REASON_CODE_C5_EXCLUDED_REPO = "c5_excluded_repo"
+REASON_CODE_C8_COPYLEFT_UNOPTED = "c8_copyleft_unopted"
+REASON_CODE_LICENSE_EVIDENCE_MISSING = "license_evidence_missing"
+REASON_CODE_REPO_IDENTITY_MISSING = "repo_identity_missing"
 
 # Import-specific reason codes (issue #1082 local-observation importer, fixed
 # registry). Every surviving observation row maps to exactly one of these six

--- a/daydream/cli.py
+++ b/daydream/cli.py
@@ -579,6 +579,15 @@ def _build_build_corpus_v2_parser() -> argparse.ArgumentParser:
         "--bundle-root before the projection runs",
     )
     parser.add_argument(
+        "--license-policy",
+        type=Path,
+        default=None,
+        dest="license_policy",
+        metavar="PATH",
+        help="Digest-pinned license policy JSON; every record's per-repo license "
+        "decision is resolved from it (required)",
+    )
+    parser.add_argument(
         "--annotations-snapshot",
         type=Path,
         default=None,
@@ -671,6 +680,14 @@ def _handle_build_corpus_v2_command(argv: list[str]) -> int:
             "(_SUCCESS + SHA256SUMS + lineage.json + annotations.jsonl).",
         )
         return 1
+    if args.license_policy is None:
+        print_error(
+            create_console(),
+            "Missing --license-policy",
+            "A corpus v2 build requires a pinned license policy file; per-repo "
+            "license decisions are resolved from it (fail-closed).",
+        )
+        return 1
 
     # --out names the corpus JSONL; the projector writes its canonical file set
     # (corpus.jsonl, corpus-v2.jsonl, split manifests, lineage.json) into that
@@ -685,6 +702,7 @@ def _handle_build_corpus_v2_command(argv: list[str]) -> int:
             out_dir=out_dir,
             bundle_dir=args.bundle_root,
             annotation_bundle_dir=args.annotation_bundle_dir,
+            license_policy_path=args.license_policy,
             as_of=args.as_of,
         )
     except ValueError as exc:

--- a/daydream/cli.py
+++ b/daydream/cli.py
@@ -1777,6 +1777,15 @@ def _handle_hydrate_hub_command(argv: list[str]) -> int:
         f"rejected {summary.dry_run_rejected} batch(es); "
         f"verify admitted {summary.verify_admitted} batch(es)",
     )
+    if summary.license_admission:
+        buckets = summary.license_admission
+        print_info(
+            console,
+            "license admission: "
+            f"admitted {buckets['admitted']}; c5-excluded {buckets['c5_excluded']}; "
+            f"copyleft-unopted {buckets['c8_copyleft_unopted']}; "
+            f"evidence-missing {buckets['license_evidence_missing']}",
+        )
     if summary.dry_run_incomplete_manifests:
         print_warning(
             console,

--- a/daydream/cli.py
+++ b/daydream/cli.py
@@ -596,6 +596,23 @@ def _build_build_corpus_v2_parser() -> argparse.ArgumentParser:
         help=argparse.SUPPRESS,  # deprecated: refused in the handler
     )
     parser.add_argument(
+        "--repo-slug",
+        type=str,
+        default=None,
+        dest="repo_slug",
+        metavar="SLUG",
+        help=argparse.SUPPRESS,  # URL-identity smuggling: refused in the handler
+    )
+    parser.add_argument(
+        "--allow-copyleft",
+        action="append",
+        default=[],
+        dest="allow_copyleft",
+        metavar="OWNER/REPO",
+        help="Repeatable; permit a specific copyleft (GPL/AGPL) repo by exact "
+        "owner/repo slug (case-insensitive)",
+    )
+    parser.add_argument(
         "--out",
         type=Path,
         required=True,
@@ -680,6 +697,15 @@ def _handle_build_corpus_v2_command(argv: list[str]) -> int:
             "(_SUCCESS + SHA256SUMS + lineage.json + annotations.jsonl).",
         )
         return 1
+    if args.repo_slug is not None:
+        print_error(
+            create_console(),
+            "Unsupported --repo-slug",
+            "A raw remote URL (or any override slug) is never a repo identity; "
+            "per-repo identity comes from the curation manifest, which the "
+            "bundle gate verifies.",
+        )
+        return 1
     if args.license_policy is None:
         print_error(
             create_console(),
@@ -687,6 +713,16 @@ def _handle_build_corpus_v2_command(argv: list[str]) -> int:
             "A corpus v2 build requires a pinned license policy file; per-repo "
             "license decisions are resolved from it (fail-closed).",
         )
+        return 1
+
+    # Validate the policy file before any build work (M10): a malformed or
+    # unknown-version policy must refuse without creating the output directory.
+    from daydream.training.corpus_v2.license import load_license_policy
+
+    try:
+        load_license_policy(args.license_policy)
+    except (OSError, ValueError, TypeError) as exc:
+        print_error(create_console(), "Invalid --license-policy", str(exc))
         return 1
 
     # --out names the corpus JSONL; the projector writes its canonical file set
@@ -703,6 +739,7 @@ def _handle_build_corpus_v2_command(argv: list[str]) -> int:
             bundle_dir=args.bundle_root,
             annotation_bundle_dir=args.annotation_bundle_dir,
             license_policy_path=args.license_policy,
+            allow_copyleft=frozenset(s.casefold() for s in args.allow_copyleft),
             as_of=args.as_of,
         )
     except ValueError as exc:
@@ -2075,7 +2112,7 @@ _CORPUS_USAGE = (
     "Data-pipeline sub-verbs:\n"
     "  harvest   walk the archive and append one bitemporal annotation per indexed run\n"
     "  build     project the as-of-pinned annotations into a JSONL training corpus\n"
-    "  build-v2  project curated-bundle per-finding resolutions into corpus-v2 records\n"
+    "  build-v2  project curated-bundle resolutions into corpus-v2 records (pinned --license-policy required)\n"
     "  label     record an authoritative human outcome label that overrides automated ones\n"
     "  hydrate-hub  hydrate a pinned Hub snapshot into a sanitized, verified staging archive\n"
     "  calibrate-reward  validate a calibration bundle and emit a deterministic reward-calibration artifact\n"

--- a/daydream/cli.py
+++ b/daydream/cli.py
@@ -1438,6 +1438,25 @@ def _build_hydrate_hub_parser() -> argparse.ArgumentParser:
         help="Opt in to a moving branch/tag source revision (output is non-canonical).",
     )
     parser.add_argument(
+        "--license-policy",
+        type=Path,
+        default=None,
+        dest="license_policy",
+        metavar="PATH",
+        help="Digest-pinned license policy JSON; when set, the per-repo license "
+        "admission gate runs at hydration and rejected sessions are excluded "
+        "before publication (issue #1080)",
+    )
+    parser.add_argument(
+        "--allow-copyleft",
+        action="append",
+        default=[],
+        dest="allow_copyleft",
+        metavar="OWNER/REPO",
+        help="Repeatable; permit a specific copyleft (GPL/AGPL) repo by exact "
+        "owner/repo slug (case-insensitive); only meaningful with --license-policy",
+    )
+    parser.add_argument(
         "--dry-run",
         action="store_true",
         dest="dry_run",
@@ -1748,6 +1767,10 @@ def _handle_hydrate_hub_command(argv: list[str]) -> int:
         destination_repo=args.destination_repo,
         stage_dir=stage_dir,
         exploratory=args.exploratory,
+        license_policy_path=(
+            str(args.license_policy) if args.license_policy is not None else None
+        ),
+        allow_copyleft=frozenset(s.casefold() for s in args.allow_copyleft),
     )
     if args.dry_run:
         return _hydrate_hub_dry_run(config, console)

--- a/daydream/cli.py
+++ b/daydream/cli.py
@@ -1760,6 +1760,19 @@ def _handle_hydrate_hub_command(argv: list[str]) -> int:
         )
         return 1
 
+    # Pre-validate the license policy up front so a malformed or missing
+    # --license-policy is named by this handler (and redaction-processed) instead
+    # of escaping as an unredacted generic "Fatal Error" from main(). Mirrors the
+    # build-v2 handler's fail-closed validation.
+    if args.license_policy is not None:
+        from daydream.training.corpus_v2.license import load_license_policy
+
+        try:
+            load_license_policy(args.license_policy)
+        except (OSError, ValueError, TypeError) as exc:
+            print_error(console, "Invalid --license-policy", str(exc))
+            return 1
+
     stage_dir = args.stage_dir.expanduser()
     config = _hydrate.HydrateHubConfig(
         source_repo=args.source_repo,
@@ -1832,8 +1845,20 @@ def _hydrate_hub_dry_run(config: Any, console: Any) -> int:
         _hydrate.download_snapshot(client, revision=source_commit, stage_dir=config.stage_dir / "downloads")
         _hydrate.ingest_bundles(config.stage_dir, revision=source_commit)
         _hydrate.dedupe_admitted(config.stage_dir, revision=source_commit)
+        if config.license_policy_path is not None:
+            _hydrate.apply_license_gate(
+                config.stage_dir,
+                revision=source_commit,
+                license_policy_path=config.license_policy_path,
+                allow_copyleft=config.allow_copyleft,
+            )
         ledger = _hydrate.build_import_ledger(
             config.stage_dir, revision=source_commit, source_commit=source_commit
+        )
+        license_admission = (
+            _hydrate.license_admission_summary(ledger)
+            if config.license_policy_path is not None
+            else {}
         )
     except _hydrate.HydrationError as exc:
         print_error(console, "Hydration dry-run failed", redact_text(str(exc)))
@@ -1854,6 +1879,15 @@ def _hydrate_hub_dry_run(config: Any, console: Any) -> int:
         f"accounted {tallies.get('accounted', 0)} candidate(s); "
         f"reason codes: {reason_tally or 'none'}; no publication performed",
     )
+    if license_admission:
+        print_info(
+            console,
+            "license admission: "
+            f"admitted {license_admission['admitted']}; "
+            f"c5-excluded {license_admission['c5_excluded']}; "
+            f"copyleft-unopted {license_admission['c8_copyleft_unopted']}; "
+            f"evidence-missing {license_admission['license_evidence_missing']}",
+        )
     incomplete = [str(item) for item in tallies.get("incomplete_manifests", [])]
     if incomplete:
         print_warning(

--- a/daydream/training/corpus_v2/bundle.py
+++ b/daydream/training/corpus_v2/bundle.py
@@ -28,7 +28,13 @@ class BundleError(ValueError):
 
 
 class BundleBatch(BaseModel):
-    """One batch row from the curation manifest (v1 shape)."""
+    """One batch row from the curation manifest.
+
+    The optional ``repo_slug`` (the ``normalize_remote_url`` slug, never a raw
+    remote URL) and ``license_evidence`` (``spdx_id`` + ``source``) fields are
+    carried by newer manifests; the admission gate, not this parser, enforces
+    their presence.
+    """
 
     model_config = ConfigDict(frozen=True)
 
@@ -39,6 +45,8 @@ class BundleBatch(BaseModel):
     artifact_relpath: str
     artifact_digest: str | None = None
     manifest_relpath: str | None = None
+    repo_slug: str | None = None
+    license_evidence: dict[str, Any] | None = None
 
 
 @dataclass(frozen=True)

--- a/daydream/training/corpus_v2/bundle.py
+++ b/daydream/training/corpus_v2/bundle.py
@@ -14,6 +14,11 @@ from typing import Any
 
 from pydantic import BaseModel, ConfigDict
 
+from daydream.archive.hydrate_rules import (
+    REASON_CODE_LICENSE_EVIDENCE_MISSING,
+    REASON_CODE_REPO_IDENTITY_MISSING,
+)
+
 _SCHEMA_PATH = Path(__file__).parent.parent / "schema" / "curation-manifest-v1.json"
 # The only producer (daydream.archive.hydrate.finalize) writes the manifest as
 # ``curation-manifest.json`` under ``curated/<curation-id>/``; the bundle root
@@ -47,6 +52,7 @@ class BundleBatch(BaseModel):
     manifest_relpath: str | None = None
     repo_slug: str | None = None
     license_evidence: dict[str, Any] | None = None
+
 
 
 @dataclass(frozen=True)
@@ -110,9 +116,12 @@ def _validate_relpath(root: Path, relpath: str, what: str) -> Path:
 def load_curated_bundle(root: Path) -> CuratedBundle:
     """Load a curated bundle from a local checkout, gating in order: the
     ``_SUCCESS`` marker, curation-manifest schema validation (which yields the
-    canonical ``publication_prefix``), SHA256SUMS verification, and
-    relative-path existence for every batch's artifacts. Raises
-    :class:`BundleError` naming the offending path/field on any gate failure.
+    canonical ``publication_prefix``), SHA256SUMS verification,
+    relative-path existence for every batch's artifacts, and the admission
+    gate (every ``admitted`` batch must carry non-blank ``repo_slug`` and
+    ``license_evidence`` with a non-empty ``spdx_id``; quarantined/excluded
+    rows are exempt). Raises :class:`BundleError` naming the offending
+    path/field on any gate failure.
     """
     root = Path(root)
     _gate((root / _SUCCESS_NAME).is_file(), f"bundle {root}: missing {_SUCCESS_NAME} marker")
@@ -139,6 +148,25 @@ def load_curated_bundle(root: Path) -> CuratedBundle:
         _validate_relpath(root, batch.artifact_relpath, "artifact_relpath")
         if batch.manifest_relpath is not None:
             _validate_relpath(root, batch.manifest_relpath, "manifest_relpath")
+
+    # Admission gate: pure structural check on manifest rows — the admission
+    # decision was made at hydration; this boundary refuses bundles that
+    # predate the gate. Only admitted content is blocked; quarantined and
+    # excluded rows are non-admitted by construction.
+    for batch in batches:
+        if batch.status != "admitted":
+            continue
+        if not batch.repo_slug or not batch.repo_slug.strip():
+            raise BundleError(
+                f"bundle {root}: admitted batch {batch.session_id!r}: "
+                f"{REASON_CODE_REPO_IDENTITY_MISSING}"
+            )
+        evidence = batch.license_evidence
+        if not evidence or not isinstance(evidence.get("spdx_id"), str) or not evidence["spdx_id"].strip():
+            raise BundleError(
+                f"bundle {root}: admitted batch {batch.session_id!r}: "
+                f"{REASON_CODE_LICENSE_EVIDENCE_MISSING}"
+            )
 
     return CuratedBundle(
         curation_id=doc["curation_id"],

--- a/daydream/training/corpus_v2/license.py
+++ b/daydream/training/corpus_v2/license.py
@@ -80,6 +80,29 @@ def load_license_policy(path: str | Path) -> tuple[LicensePolicy, str]:
     return policy, hashlib.sha256(raw).hexdigest()
 
 
+def normalize_repo_slug(raw: str) -> str:
+    """Normalize a producer-authored repo slug to canonical ``owner/repo``.
+
+    Manifest ``repo_slug`` fields are producer-authored data; the C5 exclusion
+    and C8 copyleft lists are canonical ``owner/repo``. A stamped clone URL
+    ('https://github.com/owner/repo'), a '.git'-suffixed slug, or padded
+    whitespace must reduce to the canonical spelling so the fail-closed gates
+    cannot be bypassed by spelling. Returns ``''`` when the input does not
+    reduce to an ``owner/repo`` shape (never a false C5/C8 match, and treated
+    as missing identity by the caller).
+    """
+    slug = raw.strip()
+    if "://" in slug:
+        remainder = slug.split("://", 1)[1]
+        slug = remainder.split("/", 1)[1] if "/" in remainder else ""
+    if slug.endswith(".git"):
+        slug = slug[: -len(".git")]
+    owner, sep, repo = slug.strip().partition("/")
+    if not sep or not owner.strip() or not repo.strip() or "/" in repo:
+        return ""
+    return f"{owner.strip()}/{repo.strip()}"
+
+
 def resolve_repo_decision(
     repo_slug: str,
     evidence: dict[str, Any] | None,
@@ -90,19 +113,25 @@ def resolve_repo_decision(
     its inputs (determinism constraint) — the only I/O is the C5 exclusion
     list, which is static repo data.
 
+    The decision identity is the canonical ``owner/repo`` spelling of the
+    producer-authored slug (see :func:`normalize_repo_slug`), so a manifest
+    that stamps the clone URL, a '.git' suffix, or padded whitespace cannot
+    bypass C5/C8 by spelling, and the stamped identity is never a raw URL.
+
     Precedence:
     1. C5 exclusion list -> ``c5_excluded_repo`` unconditionally (no override).
-    2. Missing/blank repo slug -> ``repo_identity_missing``.
+    2. Missing/blank/non-canonical repo slug -> ``repo_identity_missing``.
     3. Missing/unknown evidence -> ``license_evidence_missing``.
     4. SPDX rejected and slug not opted in -> ``c8_copyleft_unopted``.
     5. Otherwise admitted.
     """
     evidence_ref = str(evidence.get("source", "")) if isinstance(evidence, dict) else ""
 
-    folded_slug = repo_slug.casefold()
+    canonical_slug = normalize_repo_slug(repo_slug)
+    folded_slug = canonical_slug.casefold()
     if folded_slug in {slug.casefold() for slug in load_exclusion_list()}:
         return RepoDecision(
-            repo_slug=repo_slug,
+            repo_slug=canonical_slug,
             status="rejected",
             reason_code=REASON_CODE_C5_EXCLUDED_REPO,
             spdx_id=None,
@@ -110,9 +139,9 @@ def resolve_repo_decision(
             evidence_ref=evidence_ref,
         )
 
-    if not isinstance(repo_slug, str) or not repo_slug.strip():
+    if not isinstance(repo_slug, str) or not canonical_slug:
         return RepoDecision(
-            repo_slug=repo_slug,
+            repo_slug=canonical_slug,
             status="rejected",
             reason_code=REASON_CODE_REPO_IDENTITY_MISSING,
             spdx_id=None,
@@ -127,7 +156,7 @@ def resolve_repo_decision(
             spdx_id = raw_spdx.strip()
     if spdx_id is None or spdx_id not in policy.spdx_decisions:
         return RepoDecision(
-            repo_slug=repo_slug,
+            repo_slug=canonical_slug,
             status="rejected",
             reason_code=REASON_CODE_LICENSE_EVIDENCE_MISSING,
             spdx_id=spdx_id,
@@ -139,7 +168,7 @@ def resolve_repo_decision(
     allowed = {slug.casefold() for slug in allow_copyleft}
     if decision == "rejected" and folded_slug not in allowed:
         return RepoDecision(
-            repo_slug=repo_slug,
+            repo_slug=canonical_slug,
             status="rejected",
             reason_code=REASON_CODE_C8_COPYLEFT_UNOPTED,
             spdx_id=spdx_id,
@@ -148,7 +177,7 @@ def resolve_repo_decision(
         )
 
     return RepoDecision(
-        repo_slug=repo_slug,
+        repo_slug=canonical_slug,
         status="admitted",
         reason_code=None,
         spdx_id=spdx_id,

--- a/daydream/training/corpus_v2/license.py
+++ b/daydream/training/corpus_v2/license.py
@@ -1,0 +1,157 @@
+"""License-policy artifact and deterministic per-repo admission decision (#1080).
+
+The policy is a digest-pinned versioned file; the decision is a pure function
+of its inputs so every record's license decision is reproducible and immutable
+once recorded. Fail-closed: missing evidence, unknown SPDX ids, and missing
+repo identity all resolve to rejection with a stable reason code — never a
+silently substituted fallback.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from pydantic import BaseModel, field_validator
+
+from daydream.archive.hydrate_rules import (
+    REASON_CODE_C5_EXCLUDED_REPO,
+    REASON_CODE_C8_COPYLEFT_UNOPTED,
+    REASON_CODE_LICENSE_EVIDENCE_MISSING,
+    REASON_CODE_REPO_IDENTITY_MISSING,
+)
+from daydream.training.exclusion import load_exclusion_list
+
+
+class LicensePolicy(BaseModel):
+    """Digest-pinned license decision policy (frozen)."""
+
+    model_config = {"frozen": True}
+
+    policy_version: str
+    spdx_decisions: dict[str, str]
+
+    @field_validator("policy_version")
+    @classmethod
+    def _policy_version_present(cls, v: str) -> str:
+        if not v or not v.strip():
+            raise ValueError("policy_version must be a non-empty string")
+        return v
+
+    @field_validator("spdx_decisions")
+    @classmethod
+    def _decisions_closed_vocab(cls, v: dict[str, str]) -> dict[str, str]:
+        for spdx_id, decision in v.items():
+            if decision not in {"accepted", "rejected"}:
+                raise ValueError(
+                    f"spdx_decisions[{spdx_id!r}] must be 'accepted' or 'rejected', got {decision!r}"
+                )
+        return v
+
+
+@dataclass(frozen=True)
+class RepoDecision:
+    """Immutable per-repo license decision recorded at admission."""
+
+    repo_slug: str
+    status: str  # "admitted" | "rejected"
+    reason_code: str | None
+    spdx_id: str | None
+    policy_version: str
+    evidence_ref: str
+
+
+def load_license_policy(path: str | Path) -> tuple[LicensePolicy, str]:
+    """Load the license policy file; return it with the sha256 hex digest of
+    the raw file bytes (the lineage pin). Fail-closed on malformed policies."""
+    policy_path = Path(path)
+    raw = policy_path.read_bytes()
+    data = json.loads(raw.decode("utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError(f"license policy {policy_path} must be a JSON object")
+    if "policy_version" not in data:
+        raise ValueError(f"license policy {policy_path} is missing 'policy_version'")
+    try:
+        policy = LicensePolicy.model_validate(data)
+    except Exception as exc:
+        raise ValueError(f"invalid license policy {policy_path}: {exc}") from exc
+    return policy, hashlib.sha256(raw).hexdigest()
+
+
+def resolve_repo_decision(
+    repo_slug: str,
+    evidence: dict[str, Any] | None,
+    policy: LicensePolicy,
+    allow_copyleft: frozenset[str] | set[str],
+) -> RepoDecision:
+    """Resolve the immutable license decision for one repo. Pure function of
+    its inputs (determinism constraint) — the only I/O is the C5 exclusion
+    list, which is static repo data.
+
+    Precedence:
+    1. C5 exclusion list -> ``c5_excluded_repo`` unconditionally (no override).
+    2. Missing/blank repo slug -> ``repo_identity_missing``.
+    3. Missing/unknown evidence -> ``license_evidence_missing``.
+    4. SPDX rejected and slug not opted in -> ``c8_copyleft_unopted``.
+    5. Otherwise admitted.
+    """
+    evidence_ref = str(evidence.get("source", "")) if isinstance(evidence, dict) else ""
+
+    folded_slug = repo_slug.casefold()
+    if folded_slug in {slug.casefold() for slug in load_exclusion_list()}:
+        return RepoDecision(
+            repo_slug=repo_slug,
+            status="rejected",
+            reason_code=REASON_CODE_C5_EXCLUDED_REPO,
+            spdx_id=None,
+            policy_version=policy.policy_version,
+            evidence_ref=evidence_ref,
+        )
+
+    if not isinstance(repo_slug, str) or not repo_slug.strip():
+        return RepoDecision(
+            repo_slug=repo_slug,
+            status="rejected",
+            reason_code=REASON_CODE_REPO_IDENTITY_MISSING,
+            spdx_id=None,
+            policy_version=policy.policy_version,
+            evidence_ref=evidence_ref,
+        )
+
+    spdx_id: str | None = None
+    if isinstance(evidence, dict):
+        raw_spdx = evidence.get("spdx_id")
+        if isinstance(raw_spdx, str) and raw_spdx.strip():
+            spdx_id = raw_spdx.strip()
+    if spdx_id is None or spdx_id not in policy.spdx_decisions:
+        return RepoDecision(
+            repo_slug=repo_slug,
+            status="rejected",
+            reason_code=REASON_CODE_LICENSE_EVIDENCE_MISSING,
+            spdx_id=spdx_id,
+            policy_version=policy.policy_version,
+            evidence_ref=evidence_ref,
+        )
+
+    decision = policy.spdx_decisions[spdx_id]
+    allowed = {slug.casefold() for slug in allow_copyleft}
+    if decision == "rejected" and folded_slug not in allowed:
+        return RepoDecision(
+            repo_slug=repo_slug,
+            status="rejected",
+            reason_code=REASON_CODE_C8_COPYLEFT_UNOPTED,
+            spdx_id=spdx_id,
+            policy_version=policy.policy_version,
+            evidence_ref=evidence_ref,
+        )
+
+    return RepoDecision(
+        repo_slug=repo_slug,
+        status="admitted",
+        reason_code=None,
+        spdx_id=spdx_id,
+        policy_version=policy.policy_version,
+        evidence_ref=evidence_ref,
+    )

--- a/daydream/training/corpus_v2/license.py
+++ b/daydream/training/corpus_v2/license.py
@@ -95,6 +95,14 @@ def normalize_repo_slug(raw: str) -> str:
     if "://" in slug:
         remainder = slug.split("://", 1)[1]
         slug = remainder.split("/", 1)[1] if "/" in remainder else ""
+    elif "@" in slug and ":" in slug:
+        # SCP spelling 'git@host:owner/repo(.git)' has no scheme. Strip the
+        # user@host prefix so the remainder reduces to 'owner/repo' below.
+        userhost, __, scp_path = slug.rpartition(":")
+        if "@" not in userhost:
+            slug = ""
+        else:
+            slug = scp_path
     if slug.endswith(".git"):
         slug = slug[: -len(".git")]
     owner, sep, repo = slug.strip().partition("/")

--- a/daydream/training/corpus_v2/projector.py
+++ b/daydream/training/corpus_v2/projector.py
@@ -22,6 +22,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Literal, Mapping, cast, overload
 
+from daydream.archive.hydrate_rules import REASON_CODE_C5_EXCLUDED_REPO
 from daydream.archive.index import normalize_as_of
 from daydream.archive.sanitize import _derivative_digest
 from daydream.training.corpus import _is_posterior_leak, _trajectory_set_hash
@@ -36,6 +37,7 @@ from daydream.training.corpus_v2.provenance import extract_provenance
 from daydream.training.corpus_v2.segments import segment
 from daydream.training.corpus_v2.splits import assign_split
 from daydream.training.corpus_v2.tiers import classify_tier
+from daydream.training.exclusion import EXCLUSION_PATH
 
 __all__ = ["BuildCorpusV2Config", "project_findings", "run_build_corpus_v2"]
 
@@ -463,6 +465,22 @@ def _count_by(records: list[Record], key: Any) -> dict[str, int]:
     return dict(sorted(counts.items()))
 
 
+def _license_decision_distribution(
+    decisions: dict[str, dict[str, Any]]
+) -> dict[str, int]:
+    """Admitted/rejected decision counts across admitted batches, keyed by
+    ``admitted`` or the rejection reason code — deterministic order."""
+    distribution: dict[str, int] = {}
+    for decision in decisions.values():
+        key = (
+            "admitted"
+            if decision["status"] == "admitted"
+            else str(decision["reason_code"])
+        )
+        distribution[key] = distribution.get(key, 0) + 1
+    return dict(sorted(distribution.items()))
+
+
 def _caps_applied(records: list[Record], caps: dict[str, int]) -> dict[str, int]:
     """Final per-tier population (what the caps resolved to), deterministic."""
     return _count_by(records, lambda r: str(r["tier"])) if caps else {}
@@ -502,25 +520,25 @@ def run_build_corpus_v2(config: BuildCorpusV2Config) -> dict[str, Any]:
     """
     bundle = load_curated_bundle(config.bundle_dir)
     assert config.annotation_bundle_dir is not None  # __post_init__ guarantees
-    # Per-repo license decisions (issue #1080): the projector consumes the
-    # decisions recorded at admission — resolved once per admitted batch as
-    # the pure function of its recorded repo identity + evidence under the
-    # pinned policy. An admitted batch whose decision does not resolve to
-    # admission (or is missing) refuses the build, naming the session — never
-    # coerced to a default decision.
-    policy, _policy_digest = load_license_policy(
+    # Per-repo license decisions (issue #1080): the projector re-runs the C5/C8
+    # gate over every admitted batch (defence in depth — admission should have
+    # caught these) as the pure function of the batch's recorded repo identity
+    # + evidence under the pinned policy, so the re-evaluation is
+    # replay-identical to admission. A C5-excluded repo refuses the build
+    # outright (always-enforced, no override); other license rejections (C8
+    # copyleft unopted, missing identity/evidence) exclude the batch's records
+    # — never emitted — and are accounted under their reason code in
+    # ``exclusions_by_reason``. Either way no unopted-copyleft or benchmark
+    # repo content can reach training data.
+    policy, policy_digest = load_license_policy(
         config.license_policy_path if config.license_policy_path is not None else ""
     )
     decisions: dict[str, dict[str, Any]] = {}
+    c5_refusals: list[tuple[str, str]] = []
     for batch in bundle.admitted:
         repo_decision = resolve_repo_decision(
             batch.repo_slug or "", batch.license_evidence, policy, config.allow_copyleft
         )
-        if repo_decision.status != "admitted":
-            raise ValueError(
-                f"session {batch.session_id}: recorded license decision is not admitted "
-                f"({repo_decision.reason_code}); refusing to project"
-            )
         decisions[batch.session_id] = {
             "status": repo_decision.status,
             "reason_code": repo_decision.reason_code,
@@ -529,6 +547,16 @@ def run_build_corpus_v2(config: BuildCorpusV2Config) -> dict[str, Any]:
             "evidence_ref": repo_decision.evidence_ref,
             "repo_slug": repo_decision.repo_slug,
         }
+        if repo_decision.status != "admitted" and (
+            repo_decision.reason_code == REASON_CODE_C5_EXCLUDED_REPO
+        ):
+            c5_refusals.append((batch.session_id, repo_decision.reason_code or ""))
+    if c5_refusals:
+        raise ValueError(
+            "license gate: refusing to project — C5-excluded repo content "
+            f"reached the projection boundary as (session_id, reason_code) "
+            f"pairs {sorted(c5_refusals)}; no output written"
+        )
     annotation_lineage = _verify_annotation_bundle(
         config.annotation_bundle_dir, bundle, config.bundle_dir
     )
@@ -544,6 +572,7 @@ def run_build_corpus_v2(config: BuildCorpusV2Config) -> dict[str, Any]:
     # could hash into different splits (D5 disjointness is per finding).
     seen_findings: set[tuple[str, str]] = set()
     adjudicated_findings: set[tuple[str, str]] = set()
+    exclusions_by_reason: dict[str, int] = {}
     # lineage valid_at is pinned over the emitted records' evidence only —
     # annotation rows for sessions never admitted/emitted must not drift it.
     valid_at = config.as_of
@@ -597,6 +626,14 @@ def run_build_corpus_v2(config: BuildCorpusV2Config) -> dict[str, Any]:
                             "found at projection; refusing to project"
                         )
                     record_decision: dict[str, Any] = decision
+                    # A batch the license gate rejected at projection is never
+                    # emitted: every one of its deduped records lands in the
+                    # exclusions accounting under the decision's reason code
+                    # (same accumulation shape as the tier-cap block below).
+                    if record_decision["status"] == "rejected":
+                        code = str(record_decision["reason_code"])
+                        exclusions_by_reason[code] = exclusions_by_reason.get(code, 0) + 1
+                        continue
                     # Non-decisive findings are report output only (D8): they
                     # never become training records, so corpus.jsonl and the
                     # split manifests exclude them by construction while
@@ -659,7 +696,7 @@ def run_build_corpus_v2(config: BuildCorpusV2Config) -> dict[str, Any]:
     # assignment, over the deduplicated final population. Excess records of a
     # capped tier are excluded (never silently dropped) and named in the
     # summary, lineage, and exclusion reasons.
-    exclusions_by_reason: dict[str, int] = {"non-decisive-adjudication": len(adjudication)}
+    exclusions_by_reason["non-decisive-adjudication"] = len(adjudication)
     if config.caps:
         kept: list[Record] = []
         per_tier: dict[str, int] = {}
@@ -738,6 +775,21 @@ def run_build_corpus_v2(config: BuildCorpusV2Config) -> dict[str, Any]:
         "caps": {"configured": dict(sorted(config.caps.items())),
                  "applied": _caps_applied(records, config.caps)},
         "adjudication_count": len(adjudication),
+        # License identity pin (M7/AC4, issue #1080): the digest-pinned policy
+        # the re-evaluation consumed, the C5 exclusion list the C5 gate
+        # consulted, the copyleft opt-ins, every recorded per-repo decision,
+        # and the admitted/rejected decision distribution — all pure functions
+        # of the bundle + policy, so re-runs stay byte-identical.
+        "license_policy": {
+            "path_digest": policy_digest,
+            "policy_version": policy.policy_version,
+        },
+        "exclusion_list_digest": hashlib.sha256(EXCLUSION_PATH.read_bytes()).hexdigest(),
+        "copyleft_opt_ins": sorted(config.allow_copyleft),
+        "license_decisions": {
+            str(decision["repo_slug"]): decision for decision in decisions.values()
+        },
+        "license_decision_distribution": _license_decision_distribution(decisions),
     }
     _atomic_write(
         config.out_dir / "lineage.json",

--- a/daydream/training/corpus_v2/projector.py
+++ b/daydream/training/corpus_v2/projector.py
@@ -31,6 +31,7 @@ from daydream.training.corpus_v2.bundle import (
     load_curated_bundle,
 )
 from daydream.training.corpus_v2.identity import record_id
+from daydream.training.corpus_v2.license import load_license_policy, resolve_repo_decision
 from daydream.training.corpus_v2.provenance import extract_provenance
 from daydream.training.corpus_v2.segments import segment
 from daydream.training.corpus_v2.splits import assign_split
@@ -88,7 +89,14 @@ class BuildCorpusV2Config:
     labeler_policy_version: str = "1"
     reply_classifier_version: str = "1"
     rubric_schema_version: str = "per-finding-resolutions-v1"
-    license: str | None = None
+    # Required: a build without a pinned license policy is a config error
+    # (raised as ValueError naming the field, mirroring annotation_bundle_dir)
+    # — declared optional so that misconfiguration, not a missing kwarg, is
+    # what callers see. The per-repo license decision is resolved from this
+    # policy against each batch's recorded identity + evidence; there is no
+    # global license string to stamp (C5/C8, issue #1080).
+    license_policy_path: Path | None = None
+    allow_copyleft: frozenset[str] = frozenset()
 
     def __post_init__(self) -> None:
         if self.annotation_bundle_dir is None:
@@ -97,6 +105,12 @@ class BuildCorpusV2Config:
                 "pinned annotation bundle is a configuration error"
             )
         object.__setattr__(self, "annotation_bundle_dir", Path(self.annotation_bundle_dir))
+        if self.license_policy_path is None:
+            raise ValueError(
+                "license_policy_path is required: a corpus v2 build without a "
+                "pinned license policy is a configuration error"
+            )
+        object.__setattr__(self, "license_policy_path", Path(self.license_policy_path))
         if self.as_of is not None:
             object.__setattr__(self, "as_of", normalize_as_of(self.as_of))
 
@@ -488,6 +502,33 @@ def run_build_corpus_v2(config: BuildCorpusV2Config) -> dict[str, Any]:
     """
     bundle = load_curated_bundle(config.bundle_dir)
     assert config.annotation_bundle_dir is not None  # __post_init__ guarantees
+    # Per-repo license decisions (issue #1080): the projector consumes the
+    # decisions recorded at admission — resolved once per admitted batch as
+    # the pure function of its recorded repo identity + evidence under the
+    # pinned policy. An admitted batch whose decision does not resolve to
+    # admission (or is missing) refuses the build, naming the session — never
+    # coerced to a default decision.
+    policy, _policy_digest = load_license_policy(
+        config.license_policy_path if config.license_policy_path is not None else ""
+    )
+    decisions: dict[str, dict[str, Any]] = {}
+    for batch in bundle.admitted:
+        repo_decision = resolve_repo_decision(
+            batch.repo_slug or "", batch.license_evidence, policy, config.allow_copyleft
+        )
+        if repo_decision.status != "admitted":
+            raise ValueError(
+                f"session {batch.session_id}: recorded license decision is not admitted "
+                f"({repo_decision.reason_code}); refusing to project"
+            )
+        decisions[batch.session_id] = {
+            "status": repo_decision.status,
+            "reason_code": repo_decision.reason_code,
+            "spdx_id": repo_decision.spdx_id,
+            "policy_version": repo_decision.policy_version,
+            "evidence_ref": repo_decision.evidence_ref,
+            "repo_slug": repo_decision.repo_slug,
+        }
     annotation_lineage = _verify_annotation_bundle(
         config.annotation_bundle_dir, bundle, config.bundle_dir
     )
@@ -549,6 +590,13 @@ def run_build_corpus_v2(config: BuildCorpusV2Config) -> dict[str, Any]:
                     if key in seen_findings:
                         continue
                     seen_findings.add(key)
+                    decision = decisions.get(seg.session_id)
+                    if decision is None:
+                        raise ValueError(
+                            f"session {seg.session_id}: no recorded license decision "
+                            "found at projection; refusing to project"
+                        )
+                    record_decision: dict[str, Any] = decision
                     # Non-decisive findings are report output only (D8): they
                     # never become training records, so corpus.jsonl and the
                     # split manifests exclude them by construction while
@@ -591,7 +639,8 @@ def run_build_corpus_v2(config: BuildCorpusV2Config) -> dict[str, Any]:
                         "valid_at": rec_valid_at,
                         "split": split,
                         "exclusion_reason": None,
-                        "license_decision": config.license,
+                        "repo_slug": record_decision["repo_slug"],
+                        "license_decision": record_decision,
                     }
                     # v2 schema stamp: every projected record carries the
                     # training-record schema version it was emitted under.
@@ -647,7 +696,8 @@ def run_build_corpus_v2(config: BuildCorpusV2Config) -> dict[str, Any]:
         split_counts[str(lineage_field["split"])] += 1
     # Every Req-11 field: hub commit, curation id, content digests, policy/
     # classifier/rubric versions, as_of + valid_at pins, split assignment,
-    # exclusion reasons, and the C5/license decision. Nothing silently dropped.
+    # exclusion reasons, and each record's per-repo license decision. Nothing
+    # silently dropped.
     content_digests: dict[str, str] = {
         batch.session_id: batch.content_digest for batch in bundle.admitted if batch.content_digest
     }
@@ -676,7 +726,6 @@ def run_build_corpus_v2(config: BuildCorpusV2Config) -> dict[str, Any]:
         "rubric_schema_version": config.rubric_schema_version,
         "as_of": config.as_of,
         "valid_at": valid_at,
-        "license": config.license,
         "salt": config.salt,
         "holdout_rate": config.holdout_rate,
         "val_rate": config.val_rate,

--- a/daydream/training/corpus_v2/projector.py
+++ b/daydream/training/corpus_v2/projector.py
@@ -627,14 +627,6 @@ def run_build_corpus_v2(config: BuildCorpusV2Config) -> dict[str, Any]:
                             "found at projection; refusing to project"
                         )
                     record_decision: dict[str, Any] = decision
-                    # A batch the license gate rejected at projection is never
-                    # emitted: every one of its deduped records lands in the
-                    # exclusions accounting under the decision's reason code
-                    # (same accumulation shape as the tier-cap block below).
-                    if record_decision["status"] == "rejected":
-                        code = str(record_decision["reason_code"])
-                        exclusions_by_reason[code] = exclusions_by_reason.get(code, 0) + 1
-                        continue
                     # Non-decisive findings are report output only (D8): they
                     # never become training records, so corpus.jsonl and the
                     # split manifests exclude them by construction while

--- a/daydream/training/corpus_v2/projector.py
+++ b/daydream/training/corpus_v2/projector.py
@@ -22,7 +22,6 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Literal, Mapping, cast, overload
 
-from daydream.archive.hydrate_rules import REASON_CODE_C5_EXCLUDED_REPO
 from daydream.archive.index import normalize_as_of
 from daydream.archive.sanitize import _derivative_digest
 from daydream.training.corpus import _is_posterior_leak, _trajectory_set_hash
@@ -524,17 +523,15 @@ def run_build_corpus_v2(config: BuildCorpusV2Config) -> dict[str, Any]:
     # gate over every admitted batch (defence in depth — admission should have
     # caught these) as the pure function of the batch's recorded repo identity
     # + evidence under the pinned policy, so the re-evaluation is
-    # replay-identical to admission. A C5-excluded repo refuses the build
-    # outright (always-enforced, no override); other license rejections (C8
-    # copyleft unopted, missing identity/evidence) exclude the batch's records
-    # — never emitted — and are accounted under their reason code in
-    # ``exclusions_by_reason``. Either way no unopted-copyleft or benchmark
-    # repo content can reach training data.
+    # replay-identical to admission. Any non-admitted decision refuses the
+    # build outright before any file write (C5-excluded, unopted copyleft,
+    # missing identity/evidence alike — always-enforced, fail-closed), so no
+    # benchmark or unopted-copyleft repo content can reach training data.
     policy, policy_digest = load_license_policy(
         config.license_policy_path if config.license_policy_path is not None else ""
     )
     decisions: dict[str, dict[str, Any]] = {}
-    c5_refusals: list[tuple[str, str]] = []
+    license_refusals: list[tuple[str, str]] = []
     for batch in bundle.admitted:
         repo_decision = resolve_repo_decision(
             batch.repo_slug or "", batch.license_evidence, policy, config.allow_copyleft
@@ -547,15 +544,19 @@ def run_build_corpus_v2(config: BuildCorpusV2Config) -> dict[str, Any]:
             "evidence_ref": repo_decision.evidence_ref,
             "repo_slug": repo_decision.repo_slug,
         }
-        if repo_decision.status != "admitted" and (
-            repo_decision.reason_code == REASON_CODE_C5_EXCLUDED_REPO
-        ):
-            c5_refusals.append((batch.session_id, repo_decision.reason_code or ""))
-    if c5_refusals:
+        # Any license rejection (not just the always-enforced C5 refusal)
+        # refuses the whole projection before any file write: an unopted
+        # copyleft (or identity/evidence-missing) batch's records must never
+        # be emitted, and the fail-closed ordering is compute rejections →
+        # raise if any → else write (M9; AC6; covered end-to-end by
+        # test_end_to_end_mixed_repo_publication_gated).
+        if repo_decision.status != "admitted":
+            license_refusals.append((batch.session_id, repo_decision.reason_code or ""))
+    if license_refusals:
         raise ValueError(
-            "license gate: refusing to project — C5-excluded repo content "
-            f"reached the projection boundary as (session_id, reason_code) "
-            f"pairs {sorted(c5_refusals)}; no output written"
+            "license gate: refusing to project — non-admitted repo license "
+            "decisions reached the projection boundary as (session_id, "
+            f"reason_code) pairs {sorted(license_refusals)}; no output written"
         )
     annotation_lineage = _verify_annotation_bundle(
         config.annotation_bundle_dir, bundle, config.bundle_dir
@@ -800,8 +801,8 @@ def run_build_corpus_v2(config: BuildCorpusV2Config) -> dict[str, Any]:
     # exclusion-list digest, the copyleft opt-ins, every per-repo decision, and
     # the decision distribution — a pure function of the bundle + policy +
     # exclusion.txt bytes, so re-runs are byte-identical. Written atomically
-    # before ``_SUCCESS`` so the completeness gate covers it; the C5 refusal
-    # above means this file only ever exists on clean builds.
+    # before ``_SUCCESS`` so the completeness gate covers it; the license-gate
+    # refusal above means this file only ever exists on clean builds.
     license_report = {
         "policy": {"policy_version": policy.policy_version, "digest": policy_digest},
         "exclusion_list_digest": lineage["exclusion_list_digest"],

--- a/daydream/training/corpus_v2/projector.py
+++ b/daydream/training/corpus_v2/projector.py
@@ -527,6 +527,10 @@ def run_build_corpus_v2(config: BuildCorpusV2Config) -> dict[str, Any]:
     # build outright before any file write (C5-excluded, unopted copyleft,
     # missing identity/evidence alike — always-enforced, fail-closed), so no
     # benchmark or unopted-copyleft repo content can reach training data.
+    # mypy narrowing: __post_init__ guarantees a non-None policy path
+    # (ValueError otherwise), but mypy can't see through object.__setattr__,
+    # so assert it at the use site.
+    assert config.license_policy_path is not None
     policy, policy_digest = load_license_policy(config.license_policy_path)
     decisions: dict[str, dict[str, Any]] = {}
     license_refusals: list[tuple[str, str]] = []

--- a/daydream/training/corpus_v2/projector.py
+++ b/daydream/training/corpus_v2/projector.py
@@ -527,9 +527,7 @@ def run_build_corpus_v2(config: BuildCorpusV2Config) -> dict[str, Any]:
     # build outright before any file write (C5-excluded, unopted copyleft,
     # missing identity/evidence alike — always-enforced, fail-closed), so no
     # benchmark or unopted-copyleft repo content can reach training data.
-    policy, policy_digest = load_license_policy(
-        config.license_policy_path if config.license_policy_path is not None else ""
-    )
+    policy, policy_digest = load_license_policy(config.license_policy_path)
     decisions: dict[str, dict[str, Any]] = {}
     license_refusals: list[tuple[str, str]] = []
     for batch in bundle.admitted:
@@ -780,7 +778,7 @@ def run_build_corpus_v2(config: BuildCorpusV2Config) -> dict[str, Any]:
         "exclusion_list_digest": hashlib.sha256(EXCLUSION_PATH.read_bytes()).hexdigest(),
         "copyleft_opt_ins": sorted(config.allow_copyleft),
         "license_decisions": {
-            str(decision["repo_slug"]): decision for decision in decisions.values()
+            str(session_id): decision for session_id, decision in decisions.items()
         },
         "license_decision_distribution": _license_decision_distribution(decisions),
     }
@@ -800,7 +798,7 @@ def run_build_corpus_v2(config: BuildCorpusV2Config) -> dict[str, Any]:
         "exclusion_list_digest": lineage["exclusion_list_digest"],
         "copyleft_opt_ins": sorted(config.allow_copyleft),
         "decisions": dict(sorted(
-            (str(decision["repo_slug"]), decision) for decision in decisions.values()
+            (str(session_id), decision) for session_id, decision in decisions.items()
         )),
         "distribution": _license_decision_distribution(decisions),
     }

--- a/daydream/training/corpus_v2/projector.py
+++ b/daydream/training/corpus_v2/projector.py
@@ -796,6 +796,26 @@ def run_build_corpus_v2(config: BuildCorpusV2Config) -> dict[str, Any]:
         json.dumps(lineage, sort_keys=True, indent=2, ensure_ascii=False) + "\n",
     )
 
+    # Human license report (issue #1080 M7): the digest-pinned policy, the C5
+    # exclusion-list digest, the copyleft opt-ins, every per-repo decision, and
+    # the decision distribution — a pure function of the bundle + policy +
+    # exclusion.txt bytes, so re-runs are byte-identical. Written atomically
+    # before ``_SUCCESS`` so the completeness gate covers it; the C5 refusal
+    # above means this file only ever exists on clean builds.
+    license_report = {
+        "policy": {"policy_version": policy.policy_version, "digest": policy_digest},
+        "exclusion_list_digest": lineage["exclusion_list_digest"],
+        "copyleft_opt_ins": sorted(config.allow_copyleft),
+        "decisions": dict(sorted(
+            (str(decision["repo_slug"]), decision) for decision in decisions.values()
+        )),
+        "distribution": _license_decision_distribution(decisions),
+    }
+    _atomic_write(
+        config.out_dir / "license-report.json",
+        json.dumps(license_report, sort_keys=True, indent=2, ensure_ascii=False) + "\n",
+    )
+
     # Completeness marker (mirrors the bundle's own ``_SUCCESS`` gate): the
     # projection file set is only consumable once every member is in place,
     # so a mid-write failure never leaves a partial projection behind.
@@ -812,4 +832,5 @@ def run_build_corpus_v2(config: BuildCorpusV2Config) -> dict[str, Any]:
         "caps": {"configured": dict(sorted(config.caps.items())),
                  "applied": _caps_applied(records, config.caps)},
         "exclusions_by_reason": dict(sorted(exclusions_by_reason.items())),
+        "license_distribution": _license_decision_distribution(decisions),
     }

--- a/daydream/training/schema/curation-manifest-v1.json
+++ b/daydream/training/schema/curation-manifest-v1.json
@@ -81,6 +81,19 @@
           "manifest_relpath": {
             "type": ["string", "null"],
             "pattern": "^(?!/)(?!.*\\.\\.).+$"
+          },
+          "repo_slug": {
+            "type": ["string", "null"],
+            "minLength": 1,
+            "description": "Repository identity as the normalize_remote_url slug (e.g. owner/repo). Never a raw remote URL."
+          },
+          "license_evidence": {
+            "type": ["object", "null"],
+            "additionalProperties": false,
+            "properties": {
+              "spdx_id": {"type": "string"},
+              "source": {"type": "string"}
+            }
           }
         }
       }

--- a/daydream/training/schema/v2.json
+++ b/daydream/training/schema/v2.json
@@ -98,6 +98,7 @@
         "valid_at",
         "split",
         "exclusion_reason",
+        "repo_slug",
         "license_decision"
       ],
       "properties": {
@@ -135,8 +136,41 @@
         "exclusion_reason": {
           "type": ["string", "null"]
         },
+        "repo_slug": {
+          "type": "string",
+          "minLength": 1
+        },
         "license_decision": {
-          "type": ["string", "null"]
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "status",
+            "reason_code",
+            "spdx_id",
+            "policy_version",
+            "evidence_ref",
+            "repo_slug"
+          ],
+          "properties": {
+            "status": {
+              "enum": ["admitted", "rejected"]
+            },
+            "reason_code": {
+              "type": ["string", "null"]
+            },
+            "spdx_id": {
+              "type": ["string", "null"]
+            },
+            "policy_version": {
+              "type": "string"
+            },
+            "evidence_ref": {
+              "type": "string"
+            },
+            "repo_slug": {
+              "type": "string"
+            }
+          }
         }
       }
     }

--- a/daydream/training/stacks.py
+++ b/daydream/training/stacks.py
@@ -11,24 +11,31 @@ this module re-implements no parsing.
 
 Corpus v2 adds :func:`load_dataset_v2`, an additive sibling that loads the
 frozen per-split manifests of a ``run_build_corpus_v2`` projection directory
-and refuses any record not stamped ``schema_version == "2"``. The C5/C8
-license gates are **not** enforced by any v2 code path: v2 projected records
-carry no ``repo_slug`` (no owner/repo field — the projection emits none and
-``schema/v2.json`` declares none), and the curation manifest carries no repo
-identity either, so neither the loader nor the bundle admission gates can
-evaluate the exclusion or copyleft lists. C5/C8 for v2 data is a
-curation-time responsibility: the curation process assembling the admitted
-bundle is where excluded/copyleft repos must be refused, before projection;
-no v2 consumer re-checks them. The v1 surface (``load_dataset``, its
-``legacy_policy`` stamping, and its error messages) is untouched.
+and refuses any record not stamped ``schema_version == "2"``. Every v2
+record must also carry its repo identity and immutable license decision
+under ``lineage`` (structurally required — an absent field is itself the
+failure, never a bypass), and the C5/C8 gates are re-run fail-closed over
+every loaded record: an excluded repo is refused unconditionally, and a
+copyleft-class record is refused unless its exact slug was passed via
+``allow_copyleft``. The v1 surface (``load_dataset``, its ``legacy_policy``
+stamping, and its error messages) is untouched.
 """
 
 from __future__ import annotations
 
 import json
 from pathlib import Path
+from typing import cast
 
-from daydream.training.exclusion import load_copyleft_list, load_exclusion_list
+from daydream.archive.hydrate_rules import (
+    REASON_CODE_C5_EXCLUDED_REPO,
+    REASON_CODE_C8_COPYLEFT_UNOPTED,
+)
+from daydream.training.exclusion import (
+    is_copyleft,
+    load_copyleft_list,
+    load_exclusion_list,
+)
 
 __all__ = ["load_dataset", "load_dataset_v2"]
 
@@ -111,35 +118,50 @@ def _enforce_license_gates(
         )
 
 
-def load_dataset_v2(path: str | Path) -> list[dict[str, object]]:
+def load_dataset_v2(
+    path: str | Path,
+    *,
+    allow_copyleft: frozenset[str] | set[str] = frozenset(),
+) -> list[dict[str, object]]:
     """Load a projected corpus v2 directory (the frozen train/validation/
-    holdout JSONL manifests from ``run_build_corpus_v2``).
+    holdout JSONL manifests from ``run_build_corpus_v2``), enforcing repo
+    identity, the license-decision stamp, and C5/C8 fail-closed.
 
     ``holdout.jsonl``. A ``_SUCCESS`` completeness marker (written last by
     the projector, mirroring the bundle's own gate) is required: a partial
     projection left by a mid-write failure is refused, never consumed.
 
-    The C5 exclusion and C8 copyleft fail-closed gates are **not** applied by
-    this loader: v2 projected records carry no ``repo_slug`` (the record
-    shape has no owner/repo field — the projection emits none and
-    ``schema/v2.json`` declares none), so they cannot be evaluated against
-    the exclusion or copyleft lists, and no other v2 code path consults
-    those lists either. C5/C8 for v2 data lives at bundle curation time —
-    the curation process assembling the admitted bundle must refuse excluded
-    and unopted-copyleft repos before the projection is built. This loader
-    only verifies the v2 schema stamp on every record.
+    Structural gate: every record must carry ``lineage.repo_slug`` (a
+    non-empty string) and ``lineage.license_decision`` (a dict with
+    ``status`` in ``{"admitted", "rejected"}`` and a non-empty ``repo_slug``).
+    The field's absence is itself the failure — a stripped record can never
+    slip through as "not applicable".
+
+    Consumption gate (defense in depth over the recorded decisions): the
+    C5/C8 lists are re-evaluated over every loaded record. A record whose
+    ``repo_slug`` is on the exclusion list is refused unconditionally — no
+    keyword can suppress C5. A copyleft-class record (on the copyleft list,
+    or carrying a ``c8_copyleft_unopted`` decision reason) is refused unless
+    its exact slug was passed via ``allow_copyleft``.
 
     Args:
         path: The projection output directory containing ``train.jsonl``,
             ``validation.jsonl`` and ``holdout.jsonl``.
+        allow_copyleft: ``owner/repo`` slugs the caller has explicitly opted
+            in. Empty by default, so copyleft repos are always refused unless
+            explicitly admitted. Never overrides the C5 exclusion list.
 
     Returns:
         The full list of v2 training-record dicts, in split-file order.
 
     Raises:
-        ValueError: When the projection lacks its ``_SUCCESS`` marker, or
-            when any record's ``schema_version`` is not ``"2"`` (the
-            offending record id is named).
+        ValueError: When the projection lacks its ``_SUCCESS`` marker, when
+            any record's ``schema_version`` is not ``"2"``, when a record is
+            missing its repo identity or license decision (the offending
+            record id and field are named), or when any record's repo is on
+            the exclusion list (C5) or is copyleft without being in
+            ``allow_copyleft`` (C8). All offending slugs are named; no
+            records are returned.
         json.JSONDecodeError: When a line is not valid JSON — never a silent
             skip.
     """
@@ -166,4 +188,92 @@ def load_dataset_v2(path: str | Path) -> list[dict[str, object]]:
                     )
                 records.append(record)
 
+    _enforce_v2_identity_and_gates(records, projection_dir, allow_copyleft)
     return records
+
+
+_ALLOWED_V2_LICENSE_STATUSES = frozenset({"admitted", "rejected"})
+
+
+def _v2_lineages(records: list[dict[str, object]]) -> list[dict[str, object]]:
+    """Validated ``lineage`` dicts (structural gate already passed)."""
+    return [
+        cast(dict[str, object], rec["lineage"])
+        for rec in records
+        if isinstance(rec.get("lineage"), dict)
+    ]
+
+
+def _enforce_v2_identity_and_gates(
+    records: list[dict[str, object]],
+    path: Path,
+    allow_copyleft: frozenset[str] | set[str],
+) -> None:
+    """Structural repo-identity requirement plus the C5/C8 fail-closed gates
+    re-run over loaded v2 records (see :func:`load_dataset_v2`)."""
+    for record in records:
+        record_id = record.get("record_id")
+        lineage_obj = record.get("lineage")
+        lineage = lineage_obj if isinstance(lineage_obj, dict) else None
+        repo_slug = lineage.get("repo_slug") if lineage else None
+        if not isinstance(repo_slug, str) or not repo_slug:
+            raise ValueError(
+                f"corpus v2 record {record_id!r} in {path}: lineage.repo_slug "
+                "missing or empty — refusing a record without repo identity"
+            )
+        decision_obj = lineage.get("license_decision") if lineage else None
+        decision = decision_obj if isinstance(decision_obj, dict) else None
+        decision_slug = decision.get("repo_slug") if decision else None
+        if (
+            not isinstance(decision, dict)
+            or decision.get("status") not in _ALLOWED_V2_LICENSE_STATUSES
+            or not isinstance(decision_slug, str)
+            or not decision_slug
+        ):
+            raise ValueError(
+                f"corpus v2 record {record_id!r} in {path}: lineage.license_decision "
+                "missing, malformed, or not a resolved admitted/rejected decision — "
+                "refusing a record without an immutable license decision"
+            )
+
+    excluded = {slug.casefold() for slug in load_exclusion_list()}
+    excluded_offenders = sorted(
+        {
+            slug
+            for lineage in _v2_lineages(records)
+            if (slug := str(lineage["repo_slug"]).casefold()) in excluded
+        }
+    )
+    if excluded_offenders:
+        raise ValueError(
+            f"C5 violation ({REASON_CODE_C5_EXCLUDED_REPO}): excluded repo(s) in "
+            f"corpus v2 projection {path}: {', '.join(excluded_offenders)}. These "
+            "repositories are the held-out benchmark and must never appear in a "
+            "training dataset, regardless of any flag."
+        )
+
+    allowed = frozenset(slug.casefold() for slug in allow_copyleft)
+    copyleft_known = frozenset(slug.casefold() for slug in load_copyleft_list())
+    copyleft_offenders = sorted(
+        {
+            slug
+            for lineage in _v2_lineages(records)
+            if (slug := str(lineage["repo_slug"]).casefold())
+            and slug not in allowed
+            and (
+                is_copyleft(slug, allowed, copyleft_list=copyleft_known)
+                or (
+                    isinstance(lineage.get("license_decision"), dict)
+                    and cast(dict[str, object], lineage["license_decision"]).get("reason_code")
+                    == REASON_CODE_C8_COPYLEFT_UNOPTED
+                )
+            )
+        }
+    )
+    if copyleft_offenders:
+        raise ValueError(
+            f"C8 violation ({REASON_CODE_C8_COPYLEFT_UNOPTED}): copyleft repo(s) "
+            f"in corpus v2 projection {path} without explicit opt-in: "
+            f"{', '.join(copyleft_offenders)}. Pass these slugs via "
+            "allow_copyleft to admit them."
+        )

--- a/tests/fixtures/training/build_snapshot_decisive.py
+++ b/tests/fixtures/training/build_snapshot_decisive.py
@@ -56,9 +56,12 @@ def build_snapshot_decisive(*, hostile: bool = False) -> FakeHub:
         manifest = _snapshot_manifest(
             session_id, session.repo_slug, session.skill, session.outcome_labels
         )
-        files[f"{session_id}/manifest.json"] = json.dumps(
-            manifest.to_dict(), indent=2
-        ).encode()
+        data = manifest.to_dict()
+        # License evidence the corpus-v2 admission gate and bundle loader
+        # require for every admitted batch (MIT, accepted by the policy the
+        # projector run in the test pins).
+        data["license_evidence"] = {"spdx_id": "MIT", "source": "github-api"}
+        files[f"{session_id}/manifest.json"] = json.dumps(data, indent=2).encode()
         files[f"{session_id}/trajectory.json"] = json.dumps(
             _snapshot_trajectory_decisive(session_id), indent=2
         ).encode()

--- a/tests/test_annotation_pipeline_integration.py
+++ b/tests/test_annotation_pipeline_integration.py
@@ -137,9 +137,12 @@ def test_full_annotation_pipeline_survives_vm_loss(
         run_build_corpus_v2,
     )
 
+    policy_path = tmp_path / "license-policy.json"
+    policy_path.write_text(json.dumps(
+        {"policy_version": "1", "spdx_decisions": {"MIT": "accepted"}}) + "\n")
     summary = run_build_corpus_v2(BuildCorpusV2Config(
         out_dir=tmp_path / "corpus-out", bundle_dir=stage / "curated" / curation_id,
-        annotation_bundle_dir=clean))
+        annotation_bundle_dir=clean, license_policy_path=policy_path))
     assert (tmp_path / "corpus-out" / "_SUCCESS").is_file()
     records = [json.loads(line) for line in
                (tmp_path / "corpus-out" / "corpus.jsonl").read_text().splitlines() if line]

--- a/tests/test_archive_hydrate.py
+++ b/tests/test_archive_hydrate.py
@@ -820,6 +820,35 @@ class TestLicenseAdmissionGate:
         admitted = [b for b in manifest["batches"] if b["status"] == "admitted"]
         assert [b["session_id"] for b in admitted] == ["sess-a"]
 
+    def test_hydration_c5_gate_catches_non_canonical_slug_spelling(self, tmp_path: Path) -> None:
+        # The license gate compares the canonical owner/repo identity: a
+        # manifest that stamps the clone URL as repo_slug cannot bypass C5
+        # (issue #1080, fail-closed).
+        c5_manifest = {
+            "session_id": "sess-c5",
+            "git": {
+                "remote_url": "https://github.com/getsentry/sentry",
+                "repo_slug": "https://github.com/getsentry/sentry",
+            },
+            "license_evidence": {"spdx_id": "MIT", "source": "manifest"},
+        }
+        stage = self._seed_stage(tmp_path, {
+            "sess-a": self._session_manifest("sess-a", "owner/repo-a", spdx="MIT"),
+            "sess-c5": json.dumps(c5_manifest).encode(),
+        })
+        hydrate.apply_license_gate(
+            stage, revision=self.REV,
+            license_policy_path=self._write_policy(tmp_path), allow_copyleft=frozenset())
+        manifest = self._built_manifest(stage)
+        c5 = next(
+            b for b in manifest["batches"]
+            if b["status"] == "excluded"
+            and b["reason_code"] == hydrate_rules.REASON_CODE_C5_EXCLUDED_REPO
+        )
+        assert c5["session_id"] == "sess-c5"
+        assert not (stage / "runs" / "sess-c5").exists()
+        assert (stage / "excluded" / "sess-c5").exists()
+
     def test_hydration_excludes_unopted_copyleft_and_missing_evidence(self, tmp_path: Path) -> None:
         stage = self._seed_stage(tmp_path, {
             "sess-gpl": self._session_manifest("sess-gpl", "owner/gpl-repo", spdx="GPL-3.0-only"),

--- a/tests/test_archive_hydrate.py
+++ b/tests/test_archive_hydrate.py
@@ -808,10 +808,12 @@ class TestLicenseAdmissionGate:
             license_policy_path=self._write_policy(tmp_path), allow_copyleft=frozenset())
         manifest = self._built_manifest(stage)
         c5 = next(
-            b for b in manifest["batches"]
-            if b["status"] == "excluded"
-            and b["reason_code"] == hydrate_rules.REASON_CODE_C5_EXCLUDED_REPO
+            (b for b in manifest["batches"]
+             if b["status"] == "excluded"
+             and b["reason_code"] == hydrate_rules.REASON_CODE_C5_EXCLUDED_REPO),
+            None,
         )
+        assert c5 is not None, "C5 gate failed to exclude the sentry repo (needs C5 batch)"
         assert c5["session_id"] == "sess-c5"
         assert c5["artifact_relpath"].startswith("excluded/")
         assert not (stage / "runs" / "sess-c5").exists()
@@ -841,10 +843,12 @@ class TestLicenseAdmissionGate:
             license_policy_path=self._write_policy(tmp_path), allow_copyleft=frozenset())
         manifest = self._built_manifest(stage)
         c5 = next(
-            b for b in manifest["batches"]
-            if b["status"] == "excluded"
-            and b["reason_code"] == hydrate_rules.REASON_CODE_C5_EXCLUDED_REPO
+            (b for b in manifest["batches"]
+             if b["status"] == "excluded"
+             and b["reason_code"] == hydrate_rules.REASON_CODE_C5_EXCLUDED_REPO),
+            None,
         )
+        assert c5 is not None, "C5 gate failed to exclude the sentry repo (needs C5 batch)"
         assert c5["session_id"] == "sess-c5"
         assert not (stage / "runs" / "sess-c5").exists()
         assert (stage / "excluded" / "sess-c5").exists()

--- a/tests/test_archive_hydrate.py
+++ b/tests/test_archive_hydrate.py
@@ -5,6 +5,7 @@ import hashlib
 import json
 import pathlib
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -742,3 +743,143 @@ class TestDedupeAndLedger:
         ledger_path = stage / "curated" / ledger["curation_id"] / "import-ledger.json"
         assert ledger_path.is_file()
         assert json.loads(ledger_path.read_text())["pinned_revision"] == "a" * 40
+
+
+class TestLicenseAdmissionGate:
+    """Issue #1080 task 3: per-repo license decisions at hydration admission."""
+
+    REV = "a" * 40
+
+    @staticmethod
+    def _session_manifest(sid: str, slug: str, spdx: str | None = None) -> bytes:
+        data: dict[str, object] = {
+            "session_id": sid,
+            "git": {"remote_url": f"https://github.com/{slug}", "repo_slug": slug},
+        }
+        if spdx is not None:
+            data["license_evidence"] = {"spdx_id": spdx, "source": "manifest"}
+        return json.dumps(data).encode()
+
+    def _seed_stage(self, tmp_path: Path, sessions: dict[str, bytes]) -> Path:
+        files: dict[str, bytes] = {}
+        for sid, manifest in sessions.items():
+            files[f"bundles/{sid}/manifest.json"] = manifest
+            files[f"bundles/{sid}/trajectory.json"] = b"{}"
+        hub = FakeHub(repo_id="org/private-ds", private=True, files=files)
+        hub.commit_revision(self.REV)
+        stage = tmp_path / "stage"
+        hydrate.download_snapshot(hub, revision=self.REV, stage_dir=stage / "downloads")
+        hydrate.ingest_bundles(stage, revision=self.REV)
+        hydrate.dedupe_admitted(stage, revision=self.REV)
+        return stage
+
+    def _write_policy(self, tmp_path: Path) -> Path:
+        policy_path = tmp_path / "license-policy.json"
+        policy_path.write_text(json.dumps({
+            "policy_version": "1",
+            "spdx_decisions": {"MIT": "accepted", "GPL-3.0-only": "rejected"},
+        }))
+        return policy_path
+
+    def _built_manifest(self, stage: Path) -> dict[str, Any]:
+        ledger = hydrate.build_import_ledger(stage, revision=self.REV, source_commit=self.REV)
+        return hydrate._curation_manifest_doc(
+            stage, curation_id=str(ledger["curation_id"]), source_commit=self.REV, ledger=ledger
+        )
+
+    def test_manifest_batches_carry_repo_slug_and_license_evidence(self, tmp_path: Path) -> None:
+        stage = self._seed_stage(tmp_path, {
+            "sess-a": self._session_manifest("sess-a", "owner/repo-a", spdx="MIT"),
+        })
+        manifest = self._built_manifest(stage)
+        admitted = [b for b in manifest["batches"] if b["status"] == "admitted"]
+        assert admitted, "seed must produce at least one admitted batch"
+        for batch in admitted:
+            assert batch["repo_slug"] == "owner/repo-a"
+            assert batch["license_evidence"] == {"spdx_id": "MIT", "source": "manifest"}
+
+    def test_hydration_excludes_c5_repo_at_admission(self, tmp_path: Path) -> None:
+        stage = self._seed_stage(tmp_path, {
+            "sess-a": self._session_manifest("sess-a", "owner/repo-a", spdx="MIT"),
+            "sess-c5": self._session_manifest("sess-c5", "getsentry/sentry", spdx="MIT"),
+        })
+        hydrate.apply_license_gate(
+            stage, revision=self.REV,
+            license_policy_path=self._write_policy(tmp_path), allow_copyleft=frozenset())
+        manifest = self._built_manifest(stage)
+        c5 = next(
+            b for b in manifest["batches"]
+            if b["status"] == "excluded"
+            and b["reason_code"] == hydrate_rules.REASON_CODE_C5_EXCLUDED_REPO
+        )
+        assert c5["session_id"] == "sess-c5"
+        assert c5["artifact_relpath"].startswith("excluded/")
+        assert not (stage / "runs" / "sess-c5").exists()
+        assert (stage / "excluded" / "sess-c5").exists()
+        # the admitted MIT repo is untouched
+        admitted = [b for b in manifest["batches"] if b["status"] == "admitted"]
+        assert [b["session_id"] for b in admitted] == ["sess-a"]
+
+    def test_hydration_excludes_unopted_copyleft_and_missing_evidence(self, tmp_path: Path) -> None:
+        stage = self._seed_stage(tmp_path, {
+            "sess-gpl": self._session_manifest("sess-gpl", "owner/gpl-repo", spdx="GPL-3.0-only"),
+            "sess-noev": self._session_manifest("sess-noev", "owner/noev-repo"),
+        })
+        hydrate.apply_license_gate(
+            stage, revision=self.REV,
+            license_policy_path=self._write_policy(tmp_path), allow_copyleft=frozenset())
+        manifest = self._built_manifest(stage)
+        rows = {b["session_id"]: (b["status"], b["reason_code"])
+                for b in manifest["batches"]}
+        assert rows["sess-gpl"] == ("excluded", hydrate_rules.REASON_CODE_C8_COPYLEFT_UNOPTED)
+        assert rows["sess-noev"] == ("excluded", hydrate_rules.REASON_CODE_LICENSE_EVIDENCE_MISSING)
+
+    def test_allow_copyleft_opt_in_admits_exact_slug_only(self, tmp_path: Path) -> None:
+        stage = self._seed_stage(tmp_path, {
+            "sess-opted": self._session_manifest("sess-opted", "owner/gpl-repo", spdx="GPL-3.0-only"),
+            "sess-similar": self._session_manifest("sess-similar", "owner/similar-gpl-repo", spdx="GPL-3.0-only"),
+        })
+        hydrate.apply_license_gate(
+            stage, revision=self.REV,
+            license_policy_path=self._write_policy(tmp_path), allow_copyleft={"owner/gpl-repo"})
+        manifest = self._built_manifest(stage)
+        rows = {b["session_id"]: (b["status"], b["reason_code"])
+                for b in manifest["batches"]}
+        assert rows["sess-opted"] == ("admitted", None)
+        assert rows["sess-similar"] == ("excluded", hydrate_rules.REASON_CODE_C8_COPYLEFT_UNOPTED)
+
+    def test_license_gate_refuses_missing_policy_fail_closed(self, tmp_path: Path) -> None:
+        stage = self._seed_stage(tmp_path, {
+            "sess-a": self._session_manifest("sess-a", "owner/repo-a", spdx="MIT"),
+        })
+        with pytest.raises(ValueError, match="license_policy_path"):
+            hydrate.apply_license_gate(
+                stage, revision=self.REV, license_policy_path=None, allow_copyleft=frozenset())
+        # refusal is pre-work: nothing moved, nothing recorded
+        assert (stage / "runs" / "sess-a").exists()
+        assert not (stage / "excluded").exists()
+
+    def test_gate_wired_into_run_hydrate_hub_and_manifest_rows(self, tmp_path: Path) -> None:
+        """run_hydrate_hub threads the policy through; the C5 repo never publishes."""
+        hub = FakeHub(repo_id="org/private-ds", private=True, files={
+            "bundles/sess-a/manifest.json": self._session_manifest("sess-a", "owner/repo-a", spdx="MIT"),
+            "bundles/sess-a/trajectory.json": b"{}",
+            "bundles/sess-c5/manifest.json": self._session_manifest("sess-c5", "getsentry/sentry", spdx="MIT"),
+            "bundles/sess-c5/trajectory.json": b"{}",
+        })
+        hub.commit_revision(self.REV)
+        stage = tmp_path / "stage"
+        summary = hydrate.run_hydrate_hub(hydrate.HydrateHubConfig(
+            source_repo="org/private-ds", source_revision=self.REV,
+            destination_repo="org/private-ds", stage_dir=stage,
+            license_policy_path=str(self._write_policy(tmp_path)), allow_copyleft=frozenset(),
+        ), client=hub)
+        assert summary.verified is True
+        assert summary.dry_run_admitted == 1 and summary.dry_run_rejected == 1
+        doc = json.loads(hub.download_file(
+            f"curated/{summary.curation_id}/curation-manifest.json", revision=summary.output_commit_sha))
+        rows = {b["session_id"]: b for b in doc["batches"]}
+        assert rows["sess-a"]["repo_slug"] == "owner/repo-a"
+        assert rows["sess-a"]["license_evidence"] == {"spdx_id": "MIT", "source": "manifest"}
+        assert rows["sess-c5"]["reason_code"] == hydrate_rules.REASON_CODE_C5_EXCLUDED_REPO
+        assert rows["sess-c5"]["status"] == "excluded"

--- a/tests/test_archive_hydrate.py
+++ b/tests/test_archive_hydrate.py
@@ -883,3 +883,42 @@ class TestLicenseAdmissionGate:
         assert rows["sess-a"]["license_evidence"] == {"spdx_id": "MIT", "source": "manifest"}
         assert rows["sess-c5"]["reason_code"] == hydrate_rules.REASON_CODE_C5_EXCLUDED_REPO
         assert rows["sess-c5"]["status"] == "excluded"
+
+
+class TestAdmissionSummary:
+    """Issue #1080 task 9 (S2): per-repo human summary over the admission ledger."""
+
+    def test_admission_summary_buckets_every_session(self, tmp_path: Path) -> None:
+        gate = TestLicenseAdmissionGate()
+        stage = gate._seed_stage(tmp_path, {
+            "sess-a": gate._session_manifest("sess-a", "owner/repo-a", spdx="MIT"),
+            "sess-c5": gate._session_manifest("sess-c5", "getsentry/sentry", spdx="MIT"),
+            "sess-gpl": gate._session_manifest("sess-gpl", "owner/gpl-repo", spdx="GPL-3.0-only"),
+            "sess-noev": gate._session_manifest("sess-noev", "owner/noev-repo"),
+        })
+        hydrate.apply_license_gate(
+            stage, revision=gate.REV,
+            license_policy_path=gate._write_policy(tmp_path), allow_copyleft=frozenset())
+        ledger = hydrate.build_import_ledger(stage, revision=gate.REV, source_commit=gate.REV)
+        summary = hydrate.license_admission_summary(ledger)
+        assert summary["admitted"] == 1
+        assert summary["c5_excluded"] == 1
+        assert summary["c8_copyleft_unopted"] == 1
+        assert summary["license_evidence_missing"] == 1
+        # M8: the buckets partition the license-gate sessions by construction.
+        assert sum(summary.values()) == 4
+
+    def test_admission_summary_pure_helper_buckets_seed_entries(self) -> None:
+        entries: list[tuple[str, str | None]] = [
+            ("s1", None),
+            ("s2", hydrate_rules.REASON_CODE_C5_EXCLUDED_REPO),
+            ("s3", hydrate_rules.REASON_CODE_C8_COPYLEFT_UNOPTED),
+            ("s4", hydrate_rules.REASON_CODE_LICENSE_EVIDENCE_MISSING),
+            ("s5", hydrate_rules.REASON_CODE_REPO_IDENTITY_MISSING),
+        ]
+        summary = hydrate.admission_summary_buckets(entries)
+        assert summary["admitted"] == 1
+        assert summary["c5_excluded"] == 1
+        assert summary["c8_copyleft_unopted"] == 1
+        assert summary["license_evidence_missing"] == 2  # identity-missing folds in
+        assert sum(summary.values()) == 5

--- a/tests/test_cli_corpus_namespace.py
+++ b/tests/test_cli_corpus_namespace.py
@@ -12,6 +12,7 @@ These tests drive ``cli.main`` through ``sys.argv`` (the production
 entrypoint), mocking only the handler/backend seam, and assert on the exit
 code and on whether the handler was actually invoked — not on mere dispatch.
 """
+import json
 from pathlib import Path
 from typing import Any
 
@@ -79,6 +80,83 @@ def test_bare_corpus_prints_help_exits_2(capsys: pytest.CaptureFixture[str]) -> 
     assert "build-v2" in captured.out
     assert "label" in captured.out
     assert "calibrate-reward" in captured.out
+
+
+# ---------------------------------------------------------------------------
+# Task 8 (#1080): build-v2 operator inputs — pinned license policy, exact-slug
+# copyleft opt-ins, and refusal of URL-shaped identities. Real-path: the
+# handler runs the real projector over a real fixture bundle pair; only the
+# policy file is authored by the test.
+# ---------------------------------------------------------------------------
+
+
+def _run_build_v2(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str], extra_args: list[str]
+) -> tuple[int, str]:
+    """Drive ``daydream corpus build-v2`` through ``cli.main`` over the
+    standard fixture bundle pair (from tests.test_corpus_v2) and return
+    (exit code, captured stdout+stderr)."""
+    from tests.test_corpus_v2 import _write_annotations_snapshot, _write_bundle
+
+    bundle_dir = _write_bundle(tmp_path)
+    snap = _write_annotations_snapshot(bundle_dir, dispositions=["accepted"])
+    out_dir = tmp_path / "corpus-out"
+    rc = _run_main([
+        "corpus", "build-v2",
+        "--bundle-root", str(bundle_dir),
+        "--annotation-bundle-root", str(snap.parent),
+        "--out", str(out_dir / "corpus-v2.jsonl"),
+        *extra_args,
+    ])
+    captured = capsys.readouterr()
+    return rc, captured.out + captured.err
+
+
+def test_build_v2_accepts_license_policy_and_repeatable_opt_in(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    policy = tmp_path / "license-policy.json"
+    policy.write_text(json.dumps({"policy_version": "1", "spdx_decisions": {"MIT": "accepted"}}))
+    rc, _out = _run_build_v2(tmp_path, capsys, [
+        "--license-policy", str(policy),
+        "--allow-copyleft", "a/b", "--allow-copyleft", "c/d",
+    ])
+    assert rc == 0
+    lineage = json.loads((tmp_path / "corpus-out" / "lineage.json").read_text())
+    assert lineage["license_policy"]["policy_version"] == "1"
+    assert lineage["copyleft_opt_ins"] == ["a/b", "c/d"]
+
+
+def test_build_v2_requires_license_policy(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    rc, out = _run_build_v2(tmp_path, capsys, [])
+    assert rc == 1
+    assert "license-policy" in out
+
+
+def test_build_v2_refuses_unknown_policy_version(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # Refused before any build work: no output directory is created.
+    policy_path = tmp_path / "bad-policy.json"
+    policy_path.write_text(json.dumps({"policy_version": "", "spdx_decisions": {}}))
+    rc, out = _run_build_v2(tmp_path, capsys, ["--license-policy", str(policy_path)])
+    assert rc == 1
+    assert "policy_version" in out
+    assert not (tmp_path / "corpus-out").exists()
+
+
+def test_build_v2_refuses_raw_authenticated_url_as_identity(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # A raw remote URL is never a repo identity: any URL-shaped --repo-slug
+    # value is refused before it can reach BuildCorpusV2Config.
+    rc, out = _run_build_v2(tmp_path, capsys, [
+        "--repo-slug", "https://user:token@github.com/owner/repo",
+    ])
+    assert rc == 1
+    assert "Unsupported --repo-slug" in out
 
 
 def test_bare_harvest_is_unknown_verb_treated_as_review_target(

--- a/tests/test_cli_hydrate.py
+++ b/tests/test_cli_hydrate.py
@@ -54,6 +54,7 @@ def test_success_path_drives_orchestrator(
         dry_run_rejected = 0
         dry_run_incomplete_manifests: tuple[str, ...] = ()
         verify_admitted = 1
+        license_admission: dict[str, int] = {}
 
     def fake_run(config: Any) -> FakeSummary:
         calls.append(config)
@@ -80,6 +81,7 @@ def test_success_path_surfaces_incomplete_manifests(
         dry_run_rejected = 0
         dry_run_incomplete_manifests = ("sess-a (missing trajectory.json)",)
         verify_admitted = 1
+        license_admission: dict[str, int] = {}
 
     monkeypatch.setenv("HF_TOKEN", "t")
     monkeypatch.setattr(cli, "_run_hydrate_hub", lambda _config: FakeSummary())

--- a/tests/test_cli_hydrate.py
+++ b/tests/test_cli_hydrate.py
@@ -69,6 +69,47 @@ def test_success_path_drives_orchestrator(
     assert calls and calls[0].source_revision == "a" * 40
 
 
+def test_cli_wires_license_policy_into_hydration(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """--license-policy/--allow-copyleft reach HydrateHubConfig, and the
+    previously unreachable license admission summary prints (issue #1080)."""
+    calls: list[Any] = []
+
+    class FakeSummary:
+        curation_id = "cur-" + "0" * 16
+        output_commit_sha = "b" * 40
+        verified = True
+        dry_run_discovered = 2
+        dry_run_admitted = 1
+        dry_run_rejected = 1
+        dry_run_incomplete_manifests: tuple[str, ...] = ()
+        verify_admitted = 1
+        license_admission = {
+            "admitted": 1, "c5_excluded": 1,
+            "c8_copyleft_unopted": 0, "license_evidence_missing": 0,
+        }
+
+    def fake_run(config: Any) -> FakeSummary:
+        calls.append(config)
+        return FakeSummary()
+
+    monkeypatch.setenv("HF_TOKEN", "t")
+    monkeypatch.setattr(cli, "_run_hydrate_hub", fake_run, raising=False)
+    policy = tmp_path / "license-policy.json"
+    policy.write_text('{"policy_version": "1", "spdx_decisions": {}}')
+    rc = cli._handle_hydrate_hub_command(
+        ["--source-repo", "org/ds", "--source-revision", "a" * 40,
+         "--destination-repo", "org/ds", "--stage-dir", str(tmp_path),
+         "--license-policy", str(policy),
+         "--allow-copyleft", "Owner/Gpl-Repo"])
+    assert rc == 0
+    assert calls and calls[0].license_policy_path == str(policy)
+    assert calls[0].allow_copyleft == frozenset({"owner/gpl-repo"})
+    output = " ".join(capsys.readouterr().out.split())
+    assert "license admission: admitted 1; c5-excluded 1" in output
+
+
 def test_success_path_surfaces_incomplete_manifests(
     monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path, capsys: pytest.CaptureFixture[str]
 ) -> None:

--- a/tests/test_corpus_v2.py
+++ b/tests/test_corpus_v2.py
@@ -101,6 +101,8 @@ def _write_bundle(
 def _cfg(out_dir: Path, bundle_dir: Path, snapshot: Path, **kw: Any) -> Any:
     from daydream.training.corpus_v2.projector import BuildCorpusV2Config
 
+    if kw.get("license_policy_path") is None:
+        kw["license_policy_path"] = _policy_file(bundle_dir.parent)
     return BuildCorpusV2Config(out_dir=out_dir, bundle_dir=bundle_dir,
                                annotation_bundle_dir=snapshot.parent, **kw)
 
@@ -560,6 +562,86 @@ def test_build_summary_and_lineage_are_complete(tmp_path: Path) -> None:
     assert "missing" in adj_report.read_text()
 
 
+# ---------------------------------------------------------------------------
+# Task 5: per-repo license decisions on projected records
+# ---------------------------------------------------------------------------
+
+_UNSET = object()
+
+
+def _policy_file(tmp_path: Path) -> Path:
+    """Minimal deterministic license policy: MIT accepted under version 1."""
+    policy_path = tmp_path / "license-policy.json"
+    policy_path.write_text(
+        json.dumps({"policy_version": "1", "spdx_decisions": {"MIT": "accepted"}}) + "\n"
+    )
+    return policy_path
+
+
+def _config_for(
+    bundle_dir: Path,
+    tmp_path: Path,
+    license_policy: Any = _UNSET,
+    **kw: Any,
+) -> Any:
+    """BuildCorpusV2Config over the fixture's bundle + annotation bundle.
+
+    The policy defaults to ``_policy_file(tmp_path)``; passing ``None``
+    explicitly produces the misconfigured (no-policy) config.
+    """
+    if license_policy is _UNSET:
+        license_policy = _policy_file(tmp_path)
+    snap = bundle_dir.parent / (bundle_dir.name + "-annotations") / "annotations.jsonl"
+    return BuildCorpusV2Config(
+        out_dir=tmp_path / "out",
+        bundle_dir=bundle_dir,
+        annotation_bundle_dir=snap.parent,
+        license_policy_path=license_policy,
+        **kw,
+    )
+
+
+def test_projected_records_carry_per_repo_license_decision(
+    tmp_path: Path, existing_bundle_fixture: tuple[Path, list[dict[str, Any]], dict[str, str]]
+) -> None:
+    bundle_dir, _rows, _kwargs = existing_bundle_fixture
+    run_build_corpus_v2(_config_for(bundle_dir, tmp_path, license_policy=_policy_file(tmp_path)))
+    records = [json.loads(line) for line in
+               (tmp_path / "out" / "corpus-v2.jsonl").read_text().splitlines() if line]
+    assert records
+    for rec in records:
+        lineage = rec["lineage"]
+        assert lineage["repo_slug"] == "owner/repo-a"
+        decision = lineage["license_decision"]
+        assert isinstance(decision, dict)
+        assert decision["status"] == "admitted"
+        assert decision["policy_version"] == "1"
+        assert decision["repo_slug"] == "owner/repo-a"
+
+
+def test_build_with_only_global_license_and_no_policy_is_refused(
+    tmp_path: Path, existing_bundle_fixture: tuple[Path, list[dict[str, Any]], dict[str, str]]
+) -> None:
+    bundle_dir, _rows, _kwargs = existing_bundle_fixture
+    with pytest.raises(ValueError, match="license_policy"):
+        _config_for(bundle_dir, tmp_path, license_policy=None)
+
+
+def test_schema_validation_accepts_evolved_v2_records(
+    tmp_path: Path, existing_bundle_fixture: tuple[Path, list[dict[str, Any]], dict[str, str]]
+) -> None:
+    # The projected records validate against the edited schema/v2.json
+    # (repo_slug required in lineage; license_decision required as object).
+    import jsonschema  # noqa: PLC0415
+
+    bundle_dir, _rows, _kwargs = existing_bundle_fixture
+    run_build_corpus_v2(_config_for(bundle_dir, tmp_path, license_policy=_policy_file(tmp_path)))
+    schema = json.loads((tmp_path / "out" / "schema.json").read_text())
+    for rec in (json.loads(line) for line in
+                (tmp_path / "out" / "corpus-v2.jsonl").read_text().splitlines() if line):
+        jsonschema.validate(rec, schema)  # no raise
+
+
 def test_projected_records_carry_profile_and_stack_provenance(tmp_path: Path) -> None:
     bundle_dir = _write_bundle(tmp_path)
     snap = _write_annotations_snapshot(bundle_dir, dispositions=["accepted", "rejected"])
@@ -778,6 +860,7 @@ def test_cli_build_v2_projects_real_bundle(tmp_path: Path) -> None:
     snap = _write_annotations_snapshot(bundle_dir)
     rc = _run_cli(["corpus", "build-v2", "--bundle-root", str(bundle_dir),
                    "--annotation-bundle-root", str(snap.parent),
+                   "--license-policy", str(_policy_file(bundle_dir.parent)),
                    "--out", str(tmp_path / "out" / "c.jsonl")])
     assert rc == 0
     assert (tmp_path / "out" / "corpus-v2.jsonl").is_file()
@@ -808,7 +891,8 @@ def test_build_v2_accepts_separate_annotation_bundle_with_exact_linkage(
         curation_id=kwargs["curation_id"], sanitized_commit=kwargs["hub_commit"],
         batch_fileset_digest=_derivative_digest(bundle_dir))
     config = BuildCorpusV2Config(out_dir=tmp_path / "out", bundle_dir=bundle_dir,
-                                 annotation_bundle_dir=ann)
+                                 annotation_bundle_dir=ann,
+                                 license_policy_path=_policy_file(tmp_path))
     summary = run_build_corpus_v2(config)
     assert summary["emitted"] > 0
     # curation bundle untouched (K3: no mutation of the finalized bundle)
@@ -843,7 +927,8 @@ def test_build_v2_refuses_broken_annotation_bundles(
     if mutate in ("wrong_curation", "wrong_commit", "wrong_fileset"):
         (ann / "lineage.json").write_text(json.dumps(lineage, sort_keys=True) + "\n", encoding="utf-8")
     config = BuildCorpusV2Config(out_dir=tmp_path / "out", bundle_dir=bundle_dir,
-                                 annotation_bundle_dir=ann)
+                                 annotation_bundle_dir=ann,
+                                 license_policy_path=_policy_file(tmp_path))
     with pytest.raises(ValueError):
         run_build_corpus_v2(config)
 

--- a/tests/test_corpus_v2.py
+++ b/tests/test_corpus_v2.py
@@ -1111,3 +1111,120 @@ def test_license_report_written_before_success_marker(
     assert (tmp_path / "out" / "license-report.json").is_file()
     assert summary["license_distribution"] == {"admitted": 1}
 
+
+# ---------------------------------------------------------------------------
+# Task 10: publication gate end-to-end (AC6) + real-path verification
+# ---------------------------------------------------------------------------
+
+
+def _run_build_v2_cli(
+    bundle_dir: Path, tmp_path: Path, policy: Path, capsys: pytest.CaptureFixture[str],
+    *, out_name: str = "pub",
+) -> tuple[int, str]:
+    """Drive ``daydream corpus build-v2`` (the production entrypoint) over the
+    fixture's bundle + annotation bundle, returning (exit code, combined
+    terminal output). The projection publishes into ``tmp_path/<out_name>/``."""
+    out = tmp_path / out_name / "corpus-v2.jsonl"
+    ann = bundle_dir.parent / (bundle_dir.name + "-annotations")
+    rc = _run_cli(["corpus", "build-v2", "--bundle-root", str(bundle_dir),
+                   "--annotation-bundle-root", str(ann),
+                   "--license-policy", str(policy),
+                   "--out", str(out)])
+    captured = capsys.readouterr()
+    return rc, captured.out + captured.err
+
+
+def _admit_second_batch(bundle_dir: Path, slug: str, *, spdx_id: str = "Apache-2.0") -> None:
+    """Flip the quarantined ``sess-b`` batch to admitted with its own repo
+    identity + license evidence, give it a real ATIF trajectory, and refresh
+    the bundle SHA256SUMS plus the annotation bundle's linkage pin (same
+    mechanics as ``_inject_admitted_repo_slug``) — producing a genuinely
+    mixed-repo clean bundle (two admitted slugs, both license-clean)."""
+    manifest_path = bundle_dir / "curation-manifest.json"
+    manifest = json.loads(manifest_path.read_text())
+    for batch in manifest["batches"]:
+        if batch["session_id"] == "sess-b":
+            batch["status"] = "admitted"
+            batch["reason_code"] = None
+            batch["repo_slug"] = slug
+            batch["license_evidence"] = {"spdx_id": spdx_id, "source": "manifest"}
+            batch["manifest_relpath"] = "batches/sess-b/manifest.json"
+    manifest_path.write_text(json.dumps(manifest))
+    batch_dir = bundle_dir / "batches" / "sess-b"
+    (batch_dir / "manifest.json").write_text(json.dumps({"session_id": "sess-b"}) + "\n")
+    (batch_dir / "trajectory.json").write_text(json.dumps({
+        "session_id": "sess-b",
+        "trajectory_id": "sess-b:root",
+        "subagent_trajectory_ref": [
+            {"trajectory_id": "sess-b:fix-0", "session_id": "sess-b", "steps": [
+                {"step_id": 1, "source": "agent", "message": "fix"},
+            ]},
+        ],
+    }) + "\n")
+    _write_sumsums(bundle_dir)
+    ann_dir = bundle_dir.parent / (bundle_dir.name + "-annotations")
+    ann_lineage = json.loads((ann_dir / "lineage.json").read_text())
+    ann_lineage["batch_fileset_digest"] = _derivative_digest(bundle_dir)
+    (ann_dir / "lineage.json").write_text(json.dumps(ann_lineage, sort_keys=True) + "\n")
+    rel = sorted(
+        p.relative_to(ann_dir).as_posix()
+        for p in ann_dir.rglob("*")
+        if p.is_file() and p.name not in ("SHA256SUMS", "_SUCCESS")
+    )
+    (ann_dir / "SHA256SUMS").write_text("".join(
+        f"{hashlib.sha256((ann_dir / p).read_bytes()).hexdigest()}  {p}\n" for p in rel
+    ))
+
+
+def test_end_to_end_mixed_repo_publication_gated(
+    tmp_path: Path,
+    existing_bundle_fixture: tuple[Path, list[dict[str, Any]], dict[str, str]],
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Real-path: entering from the CLI (``daydream corpus build-v2``, the
+    production entrypoint), a hydrate-shaped bundle whose admitted batch
+    carries a C5-excluded repo slug must exit 1, publish no ``_SUCCESS``,
+    and name the stable reason code; the mirror case — an unopted copyleft
+    repo under a policy that rejects it — fails the same way. The clean
+    mixed-repo counterpart publishes with every record's lineage carrying
+    its batch's ``repo_slug`` + per-repo ``license_decision``."""
+    bundle_dir, _rows, _kwargs = existing_bundle_fixture
+    _inject_admitted_repo_slug(bundle_dir, "discourse/discourse")  # C5
+    rc, out = _run_build_v2_cli(bundle_dir, tmp_path, _policy_file(tmp_path), capsys)
+    assert rc == 1
+    assert not (tmp_path / "pub" / "_SUCCESS").exists()
+    assert "c5_excluded_repo" in out
+
+    # Mirror: an unopted GPL repo fails the same way (C8), still from the CLI.
+    _inject_admitted_repo_slug(bundle_dir, "owner/gpl-repo", spdx_id="GPL-3.0-only")
+    policy = _policy_file(tmp_path, spdx_decisions={"MIT": "accepted", "GPL-3.0-only": "rejected"})
+    rc, out = _run_build_v2_cli(bundle_dir, tmp_path, policy, capsys, out_name="pub-gpl")
+    assert rc == 1
+    assert not (tmp_path / "pub-gpl" / "_SUCCESS").exists()
+    assert "c8_copyleft_unopted" in out
+
+
+def test_end_to_end_clean_mixed_repo_publishes(
+    tmp_path: Path,
+    existing_bundle_fixture: tuple[Path, list[dict[str, Any]], dict[str, str]],
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Real-path happy path: a clean mixed-repo bundle (two admitted slugs,
+    MIT + Apache-2.0, both accepted by the pinned policy) exits 0 from the
+    CLI, publishes ``_SUCCESS``, and every record's lineage carries its
+    batch's ``repo_slug`` + ``license_decision``."""
+    bundle_dir, _rows, _kwargs = existing_bundle_fixture
+    _admit_second_batch(bundle_dir, "owner/apache-repo")
+    policy = _policy_file(tmp_path, spdx_decisions={"MIT": "accepted", "Apache-2.0": "accepted"})
+    rc, out = _run_build_v2_cli(bundle_dir, tmp_path, policy, capsys)
+    assert rc == 0, out
+    assert (tmp_path / "pub" / "_SUCCESS").is_file()
+    records = [json.loads(line) for line in
+               (tmp_path / "pub" / "corpus-v2.jsonl").read_text().splitlines() if line]
+    assert records
+    for rec in records:
+        lineage = rec["lineage"]
+        assert lineage["repo_slug"] == "owner/repo-a"
+        assert lineage["license_decision"]["status"] == "admitted"
+        assert lineage["license_decision"]["repo_slug"] == "owner/repo-a"
+        assert lineage["license_decision"]["policy_version"] == "1"

--- a/tests/test_corpus_v2.py
+++ b/tests/test_corpus_v2.py
@@ -569,11 +569,13 @@ def test_build_summary_and_lineage_are_complete(tmp_path: Path) -> None:
 _UNSET = object()
 
 
-def _policy_file(tmp_path: Path) -> Path:
+def _policy_file(tmp_path: Path, *, spdx_decisions: dict[str, str] | None = None) -> Path:
     """Minimal deterministic license policy: MIT accepted under version 1."""
+    if spdx_decisions is None:
+        spdx_decisions = {"MIT": "accepted"}
     policy_path = tmp_path / "license-policy.json"
     policy_path.write_text(
-        json.dumps({"policy_version": "1", "spdx_decisions": {"MIT": "accepted"}}) + "\n"
+        json.dumps({"policy_version": "1", "spdx_decisions": spdx_decisions}) + "\n"
     )
     return policy_path
 
@@ -940,3 +942,136 @@ def test_build_v2_still_works_without_annotation_bundle_dir_raises(
     bundle_dir, _rows, kwargs = existing_bundle_fixture
     with pytest.raises(ValueError, match="annotation_bundle_dir"):
         BuildCorpusV2Config(out_dir=tmp_path / "out", bundle_dir=bundle_dir)
+
+
+# ---------------------------------------------------------------------------
+# Task 6: projection re-enforces C5/C8, accounts rejections, gates _SUCCESS
+# ---------------------------------------------------------------------------
+
+import daydream.archive.hydrate_rules as hydrate_rules  # noqa: E402
+
+_LICENSE_CODES = frozenset({
+    hydrate_rules.REASON_CODE_C5_EXCLUDED_REPO,
+    hydrate_rules.REASON_CODE_C8_COPYLEFT_UNOPTED,
+    hydrate_rules.REASON_CODE_LICENSE_EVIDENCE_MISSING,
+    hydrate_rules.REASON_CODE_REPO_IDENTITY_MISSING,
+})
+
+
+def _inject_admitted_repo_slug(
+    bundle_dir: Path, slug: str, *, spdx_id: str = "MIT"
+) -> None:
+    """Rewrite every admitted batch's repo identity + license evidence in the
+    curation manifest (defence-in-depth probe: admission should have caught
+    the bad slug — the projector must not trust that) and recompute the
+    bundle's SHA256SUMS so only the manifest content changed."""
+    manifest_path = bundle_dir / "curation-manifest.json"
+    manifest = json.loads(manifest_path.read_text())
+    for batch in manifest["batches"]:
+        if batch["status"] == "admitted":
+            batch["repo_slug"] = slug
+            batch["license_evidence"] = {"spdx_id": spdx_id, "source": "manifest"}
+    manifest_path.write_text(json.dumps(manifest))
+    _write_sumsums(bundle_dir)
+    # The manifest edit changes the bundle's file-set digest, so re-harvest
+    # the annotation bundle's linkage pin against the new bundle bytes
+    # (otherwise the two-bundle gate would refuse on staleness, not license).
+    ann_dir = bundle_dir.parent / (bundle_dir.name + "-annotations")
+    ann_lineage = json.loads((ann_dir / "lineage.json").read_text())
+    ann_lineage["batch_fileset_digest"] = _derivative_digest(bundle_dir)
+    (ann_dir / "lineage.json").write_text(json.dumps(ann_lineage, sort_keys=True) + "\n")
+    rel = sorted(
+        p.relative_to(ann_dir).as_posix()
+        for p in ann_dir.rglob("*")
+        if p.is_file() and p.name not in ("SHA256SUMS", "_SUCCESS")
+    )
+    (ann_dir / "SHA256SUMS").write_text("".join(
+        f"{hashlib.sha256((ann_dir / p).read_bytes()).hexdigest()}  {p}\n" for p in rel
+    ))
+
+
+def _record_count_of_admitted_batches(bundle_dir: Path) -> int:
+    """Total per-finding record count of the admitted batches: the annotation
+    rows whose session_id belongs to an admitted manifest batch."""
+    manifest = json.loads((bundle_dir / "curation-manifest.json").read_text())
+    admitted_ids = {b["session_id"] for b in manifest["batches"] if b["status"] == "admitted"}
+    snap = bundle_dir.parent / (bundle_dir.name + "-annotations") / "annotations.jsonl"
+    return sum(
+        1
+        for line in snap.read_text().splitlines() if line.strip()
+        if json.loads(line).get("session_id") in admitted_ids
+    )
+
+
+def test_projection_rejects_c5_repo_and_refuses_success(
+    tmp_path: Path, existing_bundle_fixture: tuple[Path, list[dict[str, Any]], dict[str, str]]
+) -> None:
+    bundle_dir, _rows, _kwargs = existing_bundle_fixture
+    # Defence in depth: admission should have caught a C5 slug — the
+    # projector must too (boundary 2), refusing before any file write.
+    _inject_admitted_repo_slug(bundle_dir, "getsentry/sentry")
+    with pytest.raises(ValueError, match=hydrate_rules.REASON_CODE_C5_EXCLUDED_REPO):
+        run_build_corpus_v2(_config_for(bundle_dir, tmp_path, license_policy=_policy_file(tmp_path)))
+    assert not (tmp_path / "out" / "_SUCCESS").exists()
+    assert not (tmp_path / "out" / "corpus-v2.jsonl").exists()  # refuse = write nothing
+
+
+def test_exclusions_by_reason_counts_license_rejections(
+    tmp_path: Path, existing_bundle_fixture: tuple[Path, list[dict[str, Any]], dict[str, str]]
+) -> None:
+    bundle_dir, _rows, _kwargs = existing_bundle_fixture
+    # Copyleft evidence the policy rejects, with no opt-in: the batch is
+    # excluded (never emitted) and counted under its reason code.
+    _inject_admitted_repo_slug(bundle_dir, "owner/gpl-repo", spdx_id="GPL-3.0-only")
+    policy = _policy_file(tmp_path, spdx_decisions={"MIT": "accepted", "GPL-3.0-only": "rejected"})
+    summary = run_build_corpus_v2(_config_for(bundle_dir, tmp_path, license_policy=policy))
+    assert summary["exclusions_by_reason"][hydrate_rules.REASON_CODE_C8_COPYLEFT_UNOPTED] >= 1
+    assert summary["emitted"] == 0
+
+
+def test_mixed_repo_admitted_plus_rejected_counts_balance(
+    tmp_path: Path, existing_bundle_fixture: tuple[Path, list[dict[str, Any]], dict[str, str]]
+) -> None:
+    # M8 invariant at projection: admitted records + every license rejection
+    # bucket equals the total admitted-batch record count.
+    bundle_dir, _rows, _kwargs = existing_bundle_fixture
+    _inject_admitted_repo_slug(bundle_dir, "owner/gpl-repo", spdx_id="GPL-3.0-only")
+    total_admitted = _record_count_of_admitted_batches(bundle_dir)
+    policy = _policy_file(tmp_path, spdx_decisions={"MIT": "accepted", "GPL-3.0-only": "rejected"})
+    summary = run_build_corpus_v2(_config_for(bundle_dir, tmp_path, license_policy=policy))
+    rejections = sum(
+        v for k, v in summary["exclusions_by_reason"].items() if k in _LICENSE_CODES
+    )
+    assert summary["emitted"] + rejections == total_admitted
+
+
+def test_build_lineage_pins_license_policy_and_decisions(
+    tmp_path: Path, existing_bundle_fixture: tuple[Path, list[dict[str, Any]], dict[str, str]]
+) -> None:
+    import hashlib as _hashlib  # noqa: PLC0415
+
+    from daydream.training.exclusion import EXCLUSION_PATH  # noqa: PLC0415
+
+    bundle_dir, _rows, _kwargs = existing_bundle_fixture
+    out = tmp_path / "out"
+    run_build_corpus_v2(_config_for(bundle_dir, tmp_path, license_policy=_policy_file(tmp_path)))
+    lineage = json.loads((out / "lineage.json").read_text())
+    assert lineage["license_policy"]["policy_version"] == "1"
+    assert lineage["license_policy"]["path_digest"] == _hashlib.sha256(
+        _policy_file(tmp_path).read_bytes()
+    ).hexdigest()
+    assert lineage["exclusion_list_digest"] == _hashlib.sha256(
+        EXCLUSION_PATH.read_bytes()
+    ).hexdigest()
+    assert lineage["copyleft_opt_ins"] == []
+    assert lineage["license_decisions"] == {
+        "owner/repo-a": {
+            "status": "admitted",
+            "reason_code": None,
+            "spdx_id": "MIT",
+            "policy_version": "1",
+            "evidence_ref": "manifest",
+            "repo_slug": "owner/repo-a",
+        }
+    }
+    assert lineage["license_decision_distribution"] == {"admitted": 1}

--- a/tests/test_corpus_v2.py
+++ b/tests/test_corpus_v2.py
@@ -1048,7 +1048,7 @@ def test_build_lineage_pins_license_policy_and_decisions(
     ).hexdigest()
     assert lineage["copyleft_opt_ins"] == []
     assert lineage["license_decisions"] == {
-        "owner/repo-a": {
+        "sess-a": {
             "status": "admitted",
             "reason_code": None,
             "spdx_id": "MIT",
@@ -1058,6 +1058,35 @@ def test_build_lineage_pins_license_policy_and_decisions(
         }
     }
     assert lineage["license_decision_distribution"] == {"admitted": 1}
+
+
+def test_multi_session_repo_license_decisions_all_recorded(
+    tmp_path: Path,
+) -> None:
+    # Two admitted batches sharing one repo_slug must both appear in the
+    # lineage's license_decisions and the license report: the decisions dict
+    # is session-scoped (keyed by session_id), so a repo_slug-keyed collapse
+    # would silently drop one decision while the distribution counts both.
+    bundle_dir = _write_bundle(tmp_path)
+    manifest = json.loads((bundle_dir / "curation-manifest.json").read_text())
+    for batch in manifest["batches"]:
+        batch["status"] = "admitted"
+        batch["reason_code"] = None
+        batch["repo_slug"] = "owner/repo-a"
+        batch["license_evidence"] = {"spdx_id": "MIT", "source": "manifest"}
+    (bundle_dir / "curation-manifest.json").write_text(json.dumps(manifest))
+    ann_snapshot = _write_annotations_snapshot(bundle_dir, session_id="sess-a")
+    run_build_corpus_v2(_cfg(tmp_path / "out", bundle_dir, ann_snapshot))
+    lineage = json.loads((tmp_path / "out" / "lineage.json").read_text())
+    assert set(lineage["license_decisions"]) == {"sess-a", "sess-b"}
+    assert all(
+        decision["repo_slug"] == "owner/repo-a"
+        for decision in lineage["license_decisions"].values()
+    )
+    assert lineage["license_decision_distribution"] == {"admitted": 2}
+    report = json.loads((tmp_path / "out" / "license-report.json").read_text())
+    assert set(report["decisions"]) == {"sess-a", "sess-b"}
+    assert report["distribution"] == {"admitted": 2}
 
 
 # ---------------------------------------------------------------------------
@@ -1088,7 +1117,8 @@ def test_license_report_artifact_is_deterministic(
     ).hexdigest()
     assert report["exclusion_list_digest"] == _sha256_of_exclusion_txt()
     assert report["copyleft_opt_ins"] == []
-    assert report["decisions"]["owner/repo-a"]["status"] == "admitted"
+    assert report["decisions"]["sess-a"]["status"] == "admitted"
+    assert report["decisions"]["sess-a"]["repo_slug"] == "owner/repo-a"
     assert set(report["distribution"]) >= {"admitted"}
     # Byte-identical replay of the report alone (pure function of the
     # bundle + policy + exclusion.txt bytes):

--- a/tests/test_corpus_v2.py
+++ b/tests/test_corpus_v2.py
@@ -6,7 +6,12 @@ from typing import Any
 import pytest
 
 from daydream.archive.sanitize import _derivative_digest
-from daydream.training.corpus_v2.bundle import BundleError, CuratedBundle, load_curated_bundle
+from daydream.training.corpus_v2.bundle import (
+    BundleBatch,
+    BundleError,
+    CuratedBundle,
+    load_curated_bundle,
+)
 from daydream.training.corpus_v2.identity import record_id
 from daydream.training.corpus_v2.provenance import extract_provenance
 from daydream.training.corpus_v2.segments import segment, segment_agents
@@ -60,7 +65,13 @@ def _write_sumsums(bundle_dir: Path, *, exclude: frozenset[str] = frozenset()) -
     (bundle_dir / "SHA256SUMS").write_text("\n".join(lines) + "\n")
 
 
-def _write_bundle(tmp_path: Path, *, with_success: bool = True, corrupt_digest: bool = False) -> Path:
+def _write_bundle(
+    tmp_path: Path,
+    *,
+    with_success: bool = True,
+    corrupt_digest: bool = False,
+    repo_slugs: dict[str, str] | None = None,
+) -> Path:
     bundle_dir = tmp_path / "curated" / "cur-0123456789abcdef"
     # Producer-realistic batch shape: artifact_relpath names the batch
     # DIRECTORY (``batches/<session_id>/``) containing the ATIF
@@ -69,7 +80,13 @@ def _write_bundle(tmp_path: Path, *, with_success: bool = True, corrupt_digest: 
         target = bundle_dir / rel
         target.parent.mkdir(parents=True, exist_ok=True)
         target.write_text("{}\n")
-    (bundle_dir / "curation-manifest.json").write_text(json.dumps(_MANIFEST))
+    manifest = json.loads(json.dumps(_MANIFEST))
+    if repo_slugs is not None:
+        for batch in manifest["batches"]:
+            if batch["session_id"] in repo_slugs and batch["status"] == "admitted":
+                batch["repo_slug"] = repo_slugs[batch["session_id"]]
+                batch["license_evidence"] = {"spdx_id": "MIT", "source": "manifest"}
+    (bundle_dir / "curation-manifest.json").write_text(json.dumps(manifest))
     _write_sumsums(bundle_dir)
     if with_success:
         (bundle_dir / "_SUCCESS").write_text("ok\n")
@@ -197,6 +214,26 @@ def _write_annotation_bundle(root: Path, rows: list[dict[str, Any]], *, curation
     if success:
         (root / "_SUCCESS").write_text("ok\n", encoding="utf-8")
     return root
+
+
+def test_load_bundle_carries_repo_slug_and_license_evidence(tmp_path: Path) -> None:
+    bundle_dir = _write_bundle(tmp_path, repo_slugs={"sess-a": "owner/repo-a"})
+    loaded = load_curated_bundle(bundle_dir)
+    sess_a = next(b for b in loaded.batches if b.session_id == "sess-a")
+    assert sess_a.repo_slug == "owner/repo-a"
+    assert sess_a.license_evidence == {"spdx_id": "MIT", "source": "manifest"}
+
+
+def test_bundle_batch_tolerates_absent_new_fields() -> None:
+    # Legacy manifests (pre-gate bundles) still parse; the *gate* (Task 4)
+    # rejects them, not the schema parser — keep KD7's refusal at the gate
+    # layer so the error names the reason code, not a pydantic traceback.
+    batch = BundleBatch(
+        session_id="s", content_digest="1" * 64, status="admitted",
+        reason_code=None, artifact_relpath="batches/s",
+    )
+    assert batch.repo_slug is None
+    assert batch.license_evidence is None
 
 
 def test_load_bundle_requires_success_marker(tmp_path: Path) -> None:

--- a/tests/test_corpus_v2.py
+++ b/tests/test_corpus_v2.py
@@ -65,12 +65,15 @@ def _write_sumsums(bundle_dir: Path, *, exclude: frozenset[str] = frozenset()) -
     (bundle_dir / "SHA256SUMS").write_text("\n".join(lines) + "\n")
 
 
+_SEED_REPO_SLUGS = {"sess-a": "owner/repo-a"}
+
+
 def _write_bundle(
     tmp_path: Path,
     *,
     with_success: bool = True,
     corrupt_digest: bool = False,
-    repo_slugs: dict[str, str] | None = None,
+    repo_slugs: dict[str, str] | None = _SEED_REPO_SLUGS,
 ) -> Path:
     bundle_dir = tmp_path / "curated" / "cur-0123456789abcdef"
     # Producer-realistic batch shape: artifact_relpath names the batch
@@ -178,6 +181,46 @@ def _write_annotations_snapshot(
     ))
     (ann_dir / "_SUCCESS").write_text("ok\n")
     return ann_dir / "annotations.jsonl"
+
+
+def test_load_bundle_refuses_batches_missing_repo_identity(tmp_path: Path) -> None:
+    # Strip repo_slug + license_evidence from the admitted batch to produce
+    # the legacy (pre-gate) bundle shape; recompute SHA256SUMS so the error
+    # names identity, not digests.
+    bundle_dir = _write_bundle(tmp_path, repo_slugs=None)
+    manifest_path = bundle_dir / "curation-manifest.json"
+    manifest = json.loads(manifest_path.read_text())
+    for batch in manifest["batches"]:
+        batch.pop("repo_slug", None)
+        batch.pop("license_evidence", None)
+    manifest_path.write_text(json.dumps(manifest))
+    _write_sumsums(bundle_dir)
+    from daydream.archive.hydrate_rules import REASON_CODE_REPO_IDENTITY_MISSING
+
+    with pytest.raises(BundleError, match=REASON_CODE_REPO_IDENTITY_MISSING):
+        load_curated_bundle(bundle_dir)
+
+
+def test_load_bundle_refuses_missing_license_evidence(tmp_path: Path) -> None:
+    bundle_dir = _write_bundle(tmp_path, repo_slugs={"sess-a": "owner/repo-a"})
+    # Strip license_evidence from sess-a's row only, keeping repo_slug.
+    manifest_path = bundle_dir / "curation-manifest.json"
+    manifest = json.loads(manifest_path.read_text())
+    for batch in manifest["batches"]:
+        if batch["session_id"] == "sess-a":
+            batch.pop("license_evidence", None)
+    manifest_path.write_text(json.dumps(manifest))
+    _write_sumsums(bundle_dir)
+    from daydream.archive.hydrate_rules import REASON_CODE_LICENSE_EVIDENCE_MISSING
+
+    with pytest.raises(BundleError, match=REASON_CODE_LICENSE_EVIDENCE_MISSING):
+        load_curated_bundle(bundle_dir)
+
+
+def test_load_bundle_admission_gate_passes_wellformed_bundle(tmp_path: Path) -> None:
+    bundle_dir = _write_bundle(tmp_path, repo_slugs={"sess-a": "owner/repo-a"})
+    loaded = load_curated_bundle(bundle_dir)  # no raise
+    assert all(b.repo_slug for b in loaded.admitted)
 
 
 @pytest.fixture

--- a/tests/test_corpus_v2.py
+++ b/tests/test_corpus_v2.py
@@ -1075,3 +1075,55 @@ def test_build_lineage_pins_license_policy_and_decisions(
         }
     }
     assert lineage["license_decision_distribution"] == {"admitted": 1}
+
+
+# ---------------------------------------------------------------------------
+# Task 9: digest-pinned license report artifact
+# ---------------------------------------------------------------------------
+
+
+def _sha256_of_exclusion_txt() -> str:
+    import hashlib as _hashlib  # noqa: PLC0415
+
+    from daydream.training.exclusion import EXCLUSION_PATH  # noqa: PLC0415
+
+    return _hashlib.sha256(EXCLUSION_PATH.read_bytes()).hexdigest()
+
+
+def test_license_report_artifact_is_deterministic(
+    tmp_path: Path, existing_bundle_fixture: tuple[Path, list[dict[str, Any]], dict[str, str]]
+) -> None:
+    bundle_dir, _rows, _kwargs = existing_bundle_fixture
+    config = _config_for(bundle_dir, tmp_path, license_policy=_policy_file(tmp_path))
+    run_build_corpus_v2(config)
+    report_path = tmp_path / "out" / "license-report.json"
+    assert report_path.is_file()
+    report = json.loads(report_path.read_text())
+    assert report["policy"]["policy_version"] == "1"
+    assert report["policy"]["digest"] == hashlib.sha256(
+        _policy_file(tmp_path).read_bytes()
+    ).hexdigest()
+    assert report["exclusion_list_digest"] == _sha256_of_exclusion_txt()
+    assert report["copyleft_opt_ins"] == []
+    assert report["decisions"]["owner/repo-a"]["status"] == "admitted"
+    assert set(report["distribution"]) >= {"admitted"}
+    # Byte-identical replay of the report alone (pure function of the
+    # bundle + policy + exclusion.txt bytes):
+    first = report_path.read_bytes()
+    run_build_corpus_v2(_config_for(bundle_dir, tmp_path / "again",
+                                    license_policy=_policy_file(tmp_path)))
+    assert (tmp_path / "again" / "out" / "license-report.json").read_bytes() == first
+
+
+def test_license_report_written_before_success_marker(
+    tmp_path: Path, existing_bundle_fixture: tuple[Path, list[dict[str, Any]], dict[str, str]]
+) -> None:
+    # The completeness gate covers the report: it exists on every clean build
+    # that publishes _SUCCESS, and the summary exposes the distribution.
+    bundle_dir, _rows, _kwargs = existing_bundle_fixture
+    summary = run_build_corpus_v2(
+        _config_for(bundle_dir, tmp_path, license_policy=_policy_file(tmp_path))
+    )
+    assert (tmp_path / "out" / "_SUCCESS").is_file()
+    assert (tmp_path / "out" / "license-report.json").is_file()
+    assert summary["license_distribution"] == {"admitted": 1}

--- a/tests/test_corpus_v2.py
+++ b/tests/test_corpus_v2.py
@@ -950,13 +950,6 @@ def test_build_v2_still_works_without_annotation_bundle_dir_raises(
 
 import daydream.archive.hydrate_rules as hydrate_rules  # noqa: E402
 
-_LICENSE_CODES = frozenset({
-    hydrate_rules.REASON_CODE_C5_EXCLUDED_REPO,
-    hydrate_rules.REASON_CODE_C8_COPYLEFT_UNOPTED,
-    hydrate_rules.REASON_CODE_LICENSE_EVIDENCE_MISSING,
-    hydrate_rules.REASON_CODE_REPO_IDENTITY_MISSING,
-})
-
 
 def _inject_admitted_repo_slug(
     bundle_dir: Path, slug: str, *, spdx_id: str = "MIT"
@@ -990,19 +983,6 @@ def _inject_admitted_repo_slug(
     ))
 
 
-def _record_count_of_admitted_batches(bundle_dir: Path) -> int:
-    """Total per-finding record count of the admitted batches: the annotation
-    rows whose session_id belongs to an admitted manifest batch."""
-    manifest = json.loads((bundle_dir / "curation-manifest.json").read_text())
-    admitted_ids = {b["session_id"] for b in manifest["batches"] if b["status"] == "admitted"}
-    snap = bundle_dir.parent / (bundle_dir.name + "-annotations") / "annotations.jsonl"
-    return sum(
-        1
-        for line in snap.read_text().splitlines() if line.strip()
-        if json.loads(line).get("session_id") in admitted_ids
-    )
-
-
 def test_projection_rejects_c5_repo_and_refuses_success(
     tmp_path: Path, existing_bundle_fixture: tuple[Path, list[dict[str, Any]], dict[str, str]]
 ) -> None:
@@ -1016,33 +996,36 @@ def test_projection_rejects_c5_repo_and_refuses_success(
     assert not (tmp_path / "out" / "corpus-v2.jsonl").exists()  # refuse = write nothing
 
 
-def test_exclusions_by_reason_counts_license_rejections(
+def test_unopted_copyleft_repo_refuses_projection(
     tmp_path: Path, existing_bundle_fixture: tuple[Path, list[dict[str, Any]], dict[str, str]]
 ) -> None:
+    # Copyleft evidence the policy rejects, with no opt-in: the projection
+    # refuses outright before any file write (M9/AC6), naming the stable
+    # reason code — defence in depth: admission should have caught this,
+    # the projector must too.
     bundle_dir, _rows, _kwargs = existing_bundle_fixture
-    # Copyleft evidence the policy rejects, with no opt-in: the batch is
-    # excluded (never emitted) and counted under its reason code.
     _inject_admitted_repo_slug(bundle_dir, "owner/gpl-repo", spdx_id="GPL-3.0-only")
     policy = _policy_file(tmp_path, spdx_decisions={"MIT": "accepted", "GPL-3.0-only": "rejected"})
-    summary = run_build_corpus_v2(_config_for(bundle_dir, tmp_path, license_policy=policy))
-    assert summary["exclusions_by_reason"][hydrate_rules.REASON_CODE_C8_COPYLEFT_UNOPTED] >= 1
-    assert summary["emitted"] == 0
+    with pytest.raises(ValueError, match=hydrate_rules.REASON_CODE_C8_COPYLEFT_UNOPTED):
+        run_build_corpus_v2(_config_for(bundle_dir, tmp_path, license_policy=policy))
+    assert not (tmp_path / "out" / "_SUCCESS").exists()
+    assert not (tmp_path / "out" / "corpus-v2.jsonl").exists()  # refuse = write nothing
 
 
-def test_mixed_repo_admitted_plus_rejected_counts_balance(
+def test_mixed_repo_with_one_unopted_copyleft_batch_refuses_and_names_pairs(
     tmp_path: Path, existing_bundle_fixture: tuple[Path, list[dict[str, Any]], dict[str, str]]
 ) -> None:
-    # M8 invariant at projection: admitted records + every license rejection
-    # bucket equals the total admitted-batch record count.
+    # M9/AC6 at projection: a mixed-repo bundle where one admitted batch is
+    # unopted copyleft refuses the whole build — even with clean batches
+    # present — and the error names every offending (session_id, reason_code)
+    # pair, sorted.
     bundle_dir, _rows, _kwargs = existing_bundle_fixture
-    _inject_admitted_repo_slug(bundle_dir, "owner/gpl-repo", spdx_id="GPL-3.0-only")
-    total_admitted = _record_count_of_admitted_batches(bundle_dir)
+    _admit_second_batch(bundle_dir, "owner/gpl-repo", spdx_id="GPL-3.0-only")
     policy = _policy_file(tmp_path, spdx_decisions={"MIT": "accepted", "GPL-3.0-only": "rejected"})
-    summary = run_build_corpus_v2(_config_for(bundle_dir, tmp_path, license_policy=policy))
-    rejections = sum(
-        v for k, v in summary["exclusions_by_reason"].items() if k in _LICENSE_CODES
-    )
-    assert summary["emitted"] + rejections == total_admitted
+    with pytest.raises(ValueError, match=r"\('sess-b', 'c8_copyleft_unopted'\)") as excinfo:
+        run_build_corpus_v2(_config_for(bundle_dir, tmp_path, license_policy=policy))
+    # The clean batch is named nowhere in the refusal — only offenders are.
+    assert "'sess-a'" not in str(excinfo.value)
 
 
 def test_build_lineage_pins_license_policy_and_decisions(
@@ -1127,3 +1110,4 @@ def test_license_report_written_before_success_marker(
     assert (tmp_path / "out" / "_SUCCESS").is_file()
     assert (tmp_path / "out" / "license-report.json").is_file()
     assert summary["license_distribution"] == {"admitted": 1}
+

--- a/tests/test_corpus_v2_license.py
+++ b/tests/test_corpus_v2_license.py
@@ -1,0 +1,79 @@
+import hashlib
+import json
+from pathlib import Path
+
+from daydream.archive import hydrate_rules
+from daydream.training.corpus_v2.license import (
+    LicensePolicy,
+    load_license_policy,
+    resolve_repo_decision,
+)
+
+
+def _expected_digest(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _policy() -> LicensePolicy:
+    return LicensePolicy(
+        policy_version="1",
+        spdx_decisions={"MIT": "accepted", "GPL-3.0-only": "rejected"},
+    )
+
+
+def test_reason_codes_are_frozen_strings() -> None:
+    assert hydrate_rules.REASON_CODE_C5_EXCLUDED_REPO == "c5_excluded_repo"
+    assert hydrate_rules.REASON_CODE_C8_COPYLEFT_UNOPTED == "c8_copyleft_unopted"
+    assert hydrate_rules.REASON_CODE_LICENSE_EVIDENCE_MISSING == "license_evidence_missing"
+    assert hydrate_rules.REASON_CODE_REPO_IDENTITY_MISSING == "repo_identity_missing"
+
+
+def test_load_license_policy_pins_version_and_digest(tmp_path: Path) -> None:
+    policy_path = tmp_path / "license-policy.json"
+    policy_path.write_text(json.dumps({
+        "policy_version": "1",
+        "spdx_decisions": {"MIT": "accepted", "GPL-3.0-only": "rejected"},
+    }))
+    policy, digest = load_license_policy(policy_path)
+    assert isinstance(policy, LicensePolicy)
+    assert policy.policy_version == "1"
+    assert digest == _expected_digest(policy_path)  # sha256 hex of file bytes
+
+
+def test_resolve_repo_decision_fail_closed_on_missing_evidence() -> None:
+    decision = resolve_repo_decision(
+        repo_slug="owner/repo", evidence=None, policy=_policy(), allow_copyleft=frozenset()
+    )
+    assert decision.status == "rejected"
+    assert decision.reason_code == hydrate_rules.REASON_CODE_LICENSE_EVIDENCE_MISSING
+
+
+def test_resolve_repo_decision_c5_is_hard() -> None:
+    # C5 rejection wins even with evidence saying accepted and even when the
+    # slug appears in allow_copyleft (no override exists for C5 — spec M3).
+    decision = resolve_repo_decision(
+        repo_slug="getsentry/sentry",
+        evidence={"spdx_id": "MIT", "source": "manifest"},
+        policy=_policy(),
+        allow_copyleft=frozenset({"getsentry/sentry"}),
+    )
+    assert decision.status == "rejected"
+    assert decision.reason_code == hydrate_rules.REASON_CODE_C5_EXCLUDED_REPO
+
+
+def test_resolve_repo_decision_c8_exact_slug_opt_in_only() -> None:
+    opted = resolve_repo_decision(
+        repo_slug="owner/gpl-repo",
+        evidence={"spdx_id": "GPL-3.0-only", "source": "manifest"},
+        policy=_policy(),
+        allow_copyleft=frozenset({"OWNER/GPL-REPO"}),  # case-variant of the same slug
+    )
+    assert opted.status == "admitted"
+    other = resolve_repo_decision(
+        repo_slug="owner/similar-gpl-repo",
+        evidence={"spdx_id": "GPL-3.0-only", "source": "manifest"},
+        policy=_policy(),
+        allow_copyleft=frozenset({"owner/gpl-repo"}),
+    )
+    assert other.status == "rejected"
+    assert other.reason_code == hydrate_rules.REASON_CODE_C8_COPYLEFT_UNOPTED

--- a/tests/test_corpus_v2_license.py
+++ b/tests/test_corpus_v2_license.py
@@ -61,6 +61,51 @@ def test_resolve_repo_decision_c5_is_hard() -> None:
     assert decision.reason_code == hydrate_rules.REASON_CODE_C5_EXCLUDED_REPO
 
 
+def test_resolve_repo_decision_c5_catches_non_canonical_spellings() -> None:
+    # A manifest may stamp the clone URL, a '.git'-suffixed slug, or padded
+    # whitespace; the C5 gate compares the canonical owner/repo identity, so
+    # no producer spelling bypasses the exclusion (spec M3, fail-closed).
+    for slug in (
+        "https://github.com/getsentry/sentry",
+        "getsentry/sentry.git",
+        "  getsentry/sentry  ",
+        "https://github.com/getsentry/sentry.git",
+    ):
+        decision = resolve_repo_decision(
+            repo_slug=slug,
+            evidence={"spdx_id": "MIT", "source": "manifest"},
+            policy=_policy(),
+            allow_copyleft=frozenset(),
+        )
+        assert decision.status == "rejected"
+        assert decision.reason_code == hydrate_rules.REASON_CODE_C5_EXCLUDED_REPO
+        assert decision.repo_slug == "getsentry/sentry"
+
+
+def test_resolve_repo_decision_stamps_canonical_identity() -> None:
+    decision = resolve_repo_decision(
+        repo_slug=" https://github.com/OWNER/Repo.git ",
+        evidence={"spdx_id": "MIT", "source": "manifest"},
+        policy=_policy(),
+        allow_copyleft=frozenset(),
+    )
+    assert decision.status == "admitted"
+    assert decision.repo_slug == "OWNER/Repo"  # never the raw URL spelling
+
+
+def test_resolve_repo_decision_non_canonical_shape_is_identity_missing() -> None:
+    # A slug that does not reduce to owner/repo is not a repo identity;
+    # fail-closed as repo_identity_missing, never admitted under the raw shape.
+    decision = resolve_repo_decision(
+        repo_slug="owner/repo/extra",
+        evidence={"spdx_id": "MIT", "source": "manifest"},
+        policy=_policy(),
+        allow_copyleft=frozenset(),
+    )
+    assert decision.status == "rejected"
+    assert decision.reason_code == hydrate_rules.REASON_CODE_REPO_IDENTITY_MISSING
+
+
 def test_resolve_repo_decision_c8_exact_slug_opt_in_only() -> None:
     opted = resolve_repo_decision(
         repo_slug="owner/gpl-repo",

--- a/tests/test_corpus_v2_license.py
+++ b/tests/test_corpus_v2_license.py
@@ -70,6 +70,8 @@ def test_resolve_repo_decision_c5_catches_non_canonical_spellings() -> None:
         "getsentry/sentry.git",
         "  getsentry/sentry  ",
         "https://github.com/getsentry/sentry.git",
+        "git@github.com:getsentry/sentry.git",
+        "git@host:getsentry/sentry",
     ):
         decision = resolve_repo_decision(
             repo_slug=slug,

--- a/tests/test_corpus_v2_reproducibility.py
+++ b/tests/test_corpus_v2_reproducibility.py
@@ -14,7 +14,7 @@ from daydream.training import corpus_v2 as corpus_v2_pkg
 from daydream.training.corpus import BuildCorpusConfig, CorpusFilters, run_build_corpus
 from daydream.training.corpus_v2.projector import BuildCorpusV2Config, run_build_corpus_v2
 from daydream.training.corpus_v2.splits import assign_split
-from tests.test_corpus_v2 import _cfg, _write_annotations_snapshot, _write_bundle
+from tests.test_corpus_v2 import _cfg, _policy_file, _write_annotations_snapshot, _write_bundle
 from tests.test_training_corpus import _seed_run_with_annotation
 
 
@@ -104,7 +104,8 @@ def test_v1_and_v2_projection_paths_are_independent(tmp_path: Path, archive_dir:
         bundle_dir = _write_bundle(out_dir)
         snap = _write_annotations_snapshot(bundle_dir)
         run_build_corpus_v2(BuildCorpusV2Config(out_dir=out_dir / "out", bundle_dir=bundle_dir,
-                                                annotation_bundle_dir=snap.parent))
+                                                annotation_bundle_dir=snap.parent,
+                                                license_policy_path=_policy_file(bundle_dir.parent)))
         return out_dir / "out" / "corpus.jsonl"
 
     v1_before = _run_v1_build(tmp_path / "v1a" / "corpus.jsonl").read_bytes()

--- a/tests/test_stacks_v2_gate.py
+++ b/tests/test_stacks_v2_gate.py
@@ -47,6 +47,8 @@ def _record(**overrides: object) -> dict[str, object]:
         lineage["repo_slug"] = overrides["repo_slug"]
         decision = cast(dict[str, object], lineage["license_decision"])
         decision["repo_slug"] = overrides["repo_slug"]
+        # The override must not remain as a foreign top-level key.
+        record.pop("repo_slug")
     return record
 
 

--- a/tests/test_stacks_v2_gate.py
+++ b/tests/test_stacks_v2_gate.py
@@ -1,0 +1,154 @@
+"""Structural consumption gate for ``load_dataset_v2`` (issue #1080).
+
+Enters from the production entrypoint (``load_dataset_v2``) over real
+projection directories on the real filesystem and asserts observable
+outcomes: the loader must structurally require per-record repo identity and
+license decisions, and re-run the C5/C8 gates fail-closed over the loaded
+records — no kwarg can suppress C5, and C8 is admitted only via the exact
+``allow_copyleft`` opt-in.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+
+from daydream.archive.hydrate_rules import (
+    REASON_CODE_C5_EXCLUDED_REPO,
+    REASON_CODE_C8_COPYLEFT_UNOPTED,
+)
+from daydream.training.stacks import load_dataset_v2
+
+
+def _record(**overrides: object) -> dict[str, object]:
+    """A minimal v2 record in the shape the projector emits: repo identity
+    and an immutable license decision nested under ``lineage``."""
+    record: dict[str, object] = {
+        "schema_version": "2",
+        "record_id": "rec-0001",
+        "tier": "gold",
+        "lineage": {
+            "repo_slug": "owner/repo",
+            "license_decision": {
+                "status": "admitted",
+                "repo_slug": "owner/repo",
+                "reason_code": None,
+            },
+        },
+    }
+    record.update(overrides)
+    # Convenience: a repo_slug override must propagate into the lineage's
+    # identity and decision stamp, not land as a foreign top-level key.
+    if "repo_slug" in overrides:
+        lineage = cast(dict[str, object], record["lineage"])
+        lineage["repo_slug"] = overrides["repo_slug"]
+        decision = cast(dict[str, object], lineage["license_decision"])
+        decision["repo_slug"] = overrides["repo_slug"]
+    return record
+
+
+def _write_projection(tmp_path: Path, records: list[dict[str, object]]) -> Path:
+    out = tmp_path / "proj"
+    out.mkdir(exist_ok=True)
+    (out / "_SUCCESS").write_text("ok\n")
+    (out / "train.jsonl").write_text(
+        "".join(json.dumps(r) + "\n" for r in records), encoding="utf-8"
+    )
+    for name in ("validation.jsonl", "holdout.jsonl"):
+        (out / name).write_text("", encoding="utf-8")
+    return out
+
+
+def _load_records(out: Path) -> list[dict[str, Any]]:
+    lines = (out / "train.jsonl").read_text(encoding="utf-8").splitlines()
+    return [json.loads(line) for line in lines if line.strip()]
+
+
+def _strip(tmp_path: Path, *path: str) -> None:
+    out = tmp_path / "proj"
+    records = _load_records(out)
+    for record in records:
+        node: Any = record
+        for key in path[:-1]:
+            node = node[key]
+        del node[path[-1]]
+    (out / "train.jsonl").write_text(
+        "".join(json.dumps(r) + "\n" for r in records), encoding="utf-8"
+    )
+
+
+def _set(tmp_path: Path, dotted: str, value: object) -> None:
+    out = tmp_path / "proj"
+    records = _load_records(out)
+    keys = dotted.split(".")
+    for record in records:
+        node: Any = record
+        for key in keys[:-1]:
+            node = node[key]
+        node[keys[-1]] = value
+    (out / "train.jsonl").write_text(
+        "".join(json.dumps(r) + "\n" for r in records), encoding="utf-8"
+    )
+
+
+def test_load_v2_raises_on_stripped_repo_slug(tmp_path: Path) -> None:
+    _write_projection(tmp_path, [_record()])
+    _strip(tmp_path, "lineage", "repo_slug")
+    with pytest.raises(ValueError, match="repo_slug"):
+        load_dataset_v2(tmp_path / "proj")
+
+
+def test_load_v2_raises_on_stripped_license_decision(tmp_path: Path) -> None:
+    _write_projection(tmp_path, [_record()])
+    _strip(tmp_path, "lineage", "license_decision")
+    with pytest.raises(ValueError, match="license_decision"):
+        load_dataset_v2(tmp_path / "proj")
+
+
+def test_load_v2_raises_on_unknown_license_status(tmp_path: Path) -> None:
+    _write_projection(tmp_path, [_record()])
+    _set(tmp_path, "lineage.license_decision.status", "maybe")
+    with pytest.raises(ValueError, match="license_decision"):
+        load_dataset_v2(tmp_path / "proj")
+
+
+def test_load_v2_enforces_c5_over_loaded_records(tmp_path: Path) -> None:
+    _write_projection(tmp_path, [_record(repo_slug="grafana/grafana")])
+    with pytest.raises(ValueError, match=REASON_CODE_C5_EXCLUDED_REPO):
+        load_dataset_v2(tmp_path / "proj")
+
+
+def test_load_v2_enforces_c8_with_exact_slug_opt_in(tmp_path: Path) -> None:
+    record = _record(repo_slug="owner/gpl-repo")
+    assert isinstance(record["lineage"], dict)
+    record["lineage"]["license_decision"] = {
+        "status": "rejected",
+        "repo_slug": "owner/gpl-repo",
+        "reason_code": REASON_CODE_C8_COPYLEFT_UNOPTED,
+    }
+    out = _write_projection(tmp_path, [record])
+    with pytest.raises(ValueError, match=REASON_CODE_C8_COPYLEFT_UNOPTED):
+        load_dataset_v2(out)
+    # Opt-in via the function's new keyword admits the exact slug only.
+    admitted = load_dataset_v2(out, allow_copyleft=frozenset({"owner/gpl-repo"}))
+    assert [r["record_id"] for r in admitted] == ["rec-0001"]
+
+    other = _record(repo_slug="owner/other-gpl-repo")
+    assert isinstance(other["lineage"], dict)
+    other["lineage"]["license_decision"] = {
+        "status": "rejected",
+        "repo_slug": "owner/other-gpl-repo",
+        "reason_code": REASON_CODE_C8_COPYLEFT_UNOPTED,
+    }
+    _write_projection(tmp_path, [other])
+    with pytest.raises(ValueError, match=REASON_CODE_C8_COPYLEFT_UNOPTED):
+        load_dataset_v2(tmp_path / "proj", allow_copyleft=frozenset({"owner/gpl-repo"}))
+
+
+def test_load_v2_admits_clean_records(tmp_path: Path) -> None:
+    out = _write_projection(tmp_path, [_record(), _record(record_id="rec-0002")])
+    records = load_dataset_v2(out)
+    assert len(records) == 2


### PR DESCRIPTION
## Summary
- Corpus v2 now carries repository and license identity through the pipeline and enforces the C5/C8 constraints from #1080.
- Session-scoped license decisions with a hydrated license gate (round-2 daydream review fix, commit 717c484).

## Test Plan
- Full suite green: 5224 passed, 21 environmental skips (188.9s).
- Two sequential daydream deep-precision review rounds passed; findings fixed and pushed.

Closes #1080