### PR TITLE
training: enforce corpus-v2 stack, repository, and profile output-share caps

### DIFF
--- a/daydream/cli.py
+++ b/daydream/cli.py
@@ -626,8 +626,23 @@ def _build_build_corpus_v2_parser() -> argparse.ArgumentParser:
         type=float,
         default=None,
         dest="max_stack_share",
-        help="Not supported by build-v2: the v2 projection applies per-tier caps "
-        "(BuildCorpusV2Config.caps), so passing this flag is refused",
+        help="Maximum projected share of any single detected stack, in (0, 1]",
+    )
+
+    parser.add_argument(
+        "--max-repo-share",
+        type=float,
+        default=None,
+        dest="max_repo_share",
+        help="Maximum projected share of any single repository slug, in (0, 1]",
+    )
+
+    parser.add_argument(
+        "--max-profile-share",
+        type=float,
+        default=None,
+        dest="max_profile_share",
+        help="Maximum projected share of any single native profile, in (0, 1]",
     )
 
     parser.add_argument(
@@ -669,17 +684,14 @@ def _handle_build_corpus_v2_command(argv: list[str]) -> int:
     parser = _build_build_corpus_v2_parser()
     args = parser.parse_args(argv)
 
-    if args.max_stack_share is not None:
-        if not (0.0 < args.max_stack_share <= 1.0):
-            print_error(create_console(), "Invalid --max-stack-share", "Must be in (0, 1].")
+    for flag, value in (
+        ("--max-stack-share", args.max_stack_share),
+        ("--max-repo-share", args.max_repo_share),
+        ("--max-profile-share", args.max_profile_share),
+    ):
+        if value is not None and not (0.0 < value <= 1.0):
+            print_error(create_console(), f"Invalid {flag}", "Must be in (0, 1].")
             return 1
-        print_error(
-            create_console(),
-            "Unsupported --max-stack-share",
-            "corpus build-v2 applies per-tier caps (BuildCorpusV2Config.caps); "
-            "per-stack share caps are not part of the v2 projection.",
-        )
-        return 1
 
     if args.annotations_snapshot is not None:
         print_error(
@@ -741,6 +753,9 @@ def _handle_build_corpus_v2_command(argv: list[str]) -> int:
             license_policy_path=args.license_policy,
             allow_copyleft=frozenset(s.casefold() for s in args.allow_copyleft),
             as_of=args.as_of,
+            max_stack_share=args.max_stack_share,
+            max_repo_share=args.max_repo_share,
+            max_profile_share=args.max_profile_share,
         )
     except ValueError as exc:
         print_error(create_console(), "Invalid --as-of", str(exc))

--- a/daydream/training/corpus_v2/projector.py
+++ b/daydream/training/corpus_v2/projector.py
@@ -618,6 +618,57 @@ def _apply_share_caps(
     return population, exclusions
 
 
+def _share_caps_report(
+    records: list[Record],
+    exclusions: dict[str, int],
+    *,
+    max_stack_share: float | None,
+    max_repo_share: float | None,
+    max_profile_share: float | None,
+) -> dict[str, Any]:
+    """Shared summary/lineage ``share_caps`` block (one builder, two consumers
+    — they cannot drift). ``configured`` lists the non-None share limits keyed
+    stack/repo/profile; ``applied`` reports final per-value counts + shares
+    against the final emitted population per dimension; ``exclusions`` lists
+    the merged ``share-cap:<dimension>:<value>`` exclusion counts."""
+    configured = {
+        key: value
+        for key, value in (
+            ("stack", max_stack_share),
+            ("repo", max_repo_share),
+            ("profile", max_profile_share),
+        )
+        if value is not None
+    }
+    getters: dict[str, Callable[[Record], Any]] = {
+        "stack": lambda r: r.get("stack"),
+        "repository": lambda r: cast(dict[str, Any], r.get("lineage") or {}).get("repo_slug"),
+        "profile": lambda r: cast(dict[str, Any], r.get("profile") or {}).get("profile_name"),
+    }
+    applied: dict[str, dict[str, dict[str, float]]] = {}
+    total = len(records)
+    for key, getter in getters.items():
+        counts: dict[Any, int] = {}
+        for rec in records:
+            value = getter(rec)
+            counts[value] = counts.get(value, 0) + 1
+        applied[key] = {
+            str(value) if value is not None else "(none)": {
+                "count": count,
+                "share": (count / total) if total else 0.0,
+            }
+            for value, count in sorted(
+                counts.items(), key=lambda kv: (kv[0] is None, str(kv[0]))
+            )
+        }
+    return {
+        "version": 1,
+        "configured": configured,
+        "applied": applied,
+        "exclusions": dict(sorted(exclusions.items())),
+    }
+
+
 def _caps_applied(records: list[Record], caps: dict[str, int]) -> dict[str, int]:
     """Final per-tier population (what the caps resolved to), deterministic."""
     return _count_by(records, lambda r: str(r["tier"])) if caps else {}
@@ -646,7 +697,9 @@ def run_build_corpus_v2(config: BuildCorpusV2Config) -> dict[str, Any]:
     report only.
 
     Returns a summary dict with ``total``/``emitted``, per-type/per-tier/
-    per-split counts, the ``caps`` block (configured vs applied), and
+    per-split counts, the ``caps`` block (configured vs applied), the
+    ``share_caps`` block (only when at least one output-share cap is
+    configured — shared with lineage.json so the two cannot drift), and
     ``exclusions_by_reason`` — all derived from the final population in
     deterministic order. Non-decisive findings land in the human
     ``adjudication-report.json`` with their evidence (D8: report output, not
@@ -845,6 +898,35 @@ def run_build_corpus_v2(config: BuildCorpusV2Config) -> dict[str, Any]:
             kept.append(rec)
         records = kept
 
+    # Output-share caps (issue #1079): true share of the final emitted
+    # population, enforced per dimension (stack → repository → profile)
+    # sequentially over the post-tier-cap population. Only runs when at least
+    # one share is configured, so tier-cap-only builds stay byte-identical
+    # and neither the summary nor lineage gains a ``share_caps`` block.
+    share_caps_report: dict[str, Any] | None = None
+    if (
+        config.max_stack_share is not None
+        or config.max_repo_share is not None
+        or config.max_profile_share is not None
+    ):
+        records, share_exclusions = _apply_share_caps(
+            records,
+            max_stack_share=config.max_stack_share,
+            max_repo_share=config.max_repo_share,
+            max_profile_share=config.max_profile_share,
+        )
+        for excl_key, excl_count in share_exclusions.items():
+            exclusions_by_reason[f"share-cap:{excl_key}"] = (
+                exclusions_by_reason.get(f"share-cap:{excl_key}", 0) + excl_count
+            )
+        share_caps_report = _share_caps_report(
+            records,
+            share_exclusions,
+            max_stack_share=config.max_stack_share,
+            max_repo_share=config.max_repo_share,
+            max_profile_share=config.max_profile_share,
+        )
+
     canonical = _dump_jsonl(records)
     _atomic_write(config.out_dir / "corpus.jsonl", canonical)
     # Versioned twin of the canonical corpus (same bytes, atomic, pre-_SUCCESS).
@@ -907,6 +989,11 @@ def run_build_corpus_v2(config: BuildCorpusV2Config) -> dict[str, Any]:
         "exclusions_by_reason": dict(sorted(exclusions_by_reason.items())),
         "caps": {"configured": dict(sorted(config.caps.items())),
                  "applied": _caps_applied(records, config.caps)},
+        **(
+            {"share_caps": share_caps_report}
+            if share_caps_report is not None
+            else {}
+        ),
         "adjudication_count": len(adjudication),
         # License identity pin (M7/AC4, issue #1080): the digest-pinned policy
         # the re-evaluation consumed, the C5 exclusion list the C5 gate
@@ -964,6 +1051,11 @@ def run_build_corpus_v2(config: BuildCorpusV2Config) -> dict[str, Any]:
         "records_by_split": dict(split_counts),
         "caps": {"configured": dict(sorted(config.caps.items())),
                  "applied": _caps_applied(records, config.caps)},
+        **(
+            {"share_caps": share_caps_report}
+            if share_caps_report is not None
+            else {}
+        ),
         "exclusions_by_reason": dict(sorted(exclusions_by_reason.items())),
         "license_distribution": _license_decision_distribution(decisions),
     }

--- a/daydream/training/corpus_v2/projector.py
+++ b/daydream/training/corpus_v2/projector.py
@@ -87,6 +87,11 @@ class BuildCorpusV2Config:
     val_rate: float = 0.1
     salt: str = "daydream-corpus-v2"
     caps: dict[str, int] = field(default_factory=dict)
+    # Output-share caps (issue #1079): true share of the final emitted
+    # population, enforced per dimension over the post-tier-cap population.
+    max_stack_share: float | None = None
+    max_repo_share: float | None = None
+    max_profile_share: float | None = None
     labeler_policy_version: str = "1"
     reply_classifier_version: str = "1"
     rubric_schema_version: str = "per-finding-resolutions-v1"
@@ -112,6 +117,10 @@ class BuildCorpusV2Config:
                 "pinned license policy is a configuration error"
             )
         object.__setattr__(self, "license_policy_path", Path(self.license_policy_path))
+        for field_name in ("max_stack_share", "max_repo_share", "max_profile_share"):
+            share = getattr(self, field_name)
+            if share is not None and not (0.0 < share <= 1.0):
+                raise ValueError(f"{field_name} must be in (0.0, 1.0], got {share}")
         if self.as_of is not None:
             object.__setattr__(self, "as_of", normalize_as_of(self.as_of))
 

--- a/daydream/training/corpus_v2/projector.py
+++ b/daydream/training/corpus_v2/projector.py
@@ -15,8 +15,10 @@ atomically with a lineage pin.
 
 import hashlib
 import json
+import math
 import os
 import tempfile
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
@@ -487,6 +489,133 @@ def _license_decision_distribution(
         )
         distribution[key] = distribution.get(key, 0) + 1
     return dict(sorted(distribution.items()))
+
+
+def _apply_share_caps(
+    records: list[Record],
+    *,
+    max_stack_share: float | None,
+    max_repo_share: float | None,
+    max_profile_share: float | None,
+) -> tuple[list[Record], dict[str, int]]:
+    """Pure share-cap selection over the post-tier-cap population.
+
+    Applies the three dimensions sequentially (stack → repository → profile).
+    Within a dimension, iterates until every value's share of the current
+    population is within its configured limit (strict output-share semantics:
+    ``count / total <= limit`` over the final emitted population), keeping the
+    lowest ``record_id`` records of any over-share group. Returns the kept list
+    (sorted by ``record_id``) and exclusion counts keyed
+    ``"<dimension>:<value>"`` (``None`` values form their own bucket spelled
+    ``(none)``).
+
+    Fails closed with ``ValueError`` if enforcing a cap would leave a total
+    population of zero (the cap cannot keep a single record of the population
+    it is asked to cap). A dimension value dropping out entirely is fine —
+    only total-population-zero is fatal; once iteration has reduced a
+    dimension's population, a sole remaining value that can no longer be
+    trimmed without emptying the population is left intact rather than
+    destroyed. Never samples; input order does not affect the result.
+    """
+    dimensions: list[tuple[str, str, Callable[[Record], Any], float | None]] = [
+        (
+            "stack",
+            "max_stack_share",
+            lambda r: r.get("stack"),
+            max_stack_share,
+        ),
+        (
+            "repository",
+            "max_repo_share",
+            lambda r: cast(dict[str, Any], r.get("lineage") or {}).get("repo_slug"),
+            max_repo_share,
+        ),
+        (
+            "profile",
+            "max_profile_share",
+            lambda r: cast(dict[str, Any], r.get("profile") or {}).get("profile_name"),
+            max_profile_share,
+        ),
+    ]
+    exclusions: dict[str, int] = {}
+    population = sorted(records, key=lambda r: str(r["record_id"]))
+    original = list(population)
+    for dimension, flag, getter, limit in dimensions:
+        if limit is None:
+            continue
+        if not population:
+            raise ValueError(
+                f"{flag}={limit} configured but the population is already empty "
+                "— fail-closed"
+            )
+        # Fail-closed degeneracy check against the original input population:
+        # a cap that cannot keep a single record of an over-share group
+        # covering the whole input would collapse it to zero — refuse before
+        # doing any work. (Populations reduced by earlier dimensions or by
+        # this dimension's own iteration are handled by the no-progress break
+        # in the loop below instead.)
+        entry_total = len(original)
+        entry_counts: dict[Any, int] = {}
+        for rec in original:
+            value = getter(rec)
+            entry_counts[value] = entry_counts.get(value, 0) + 1
+        for value, count in entry_counts.items():
+            if count / entry_total > limit and count == entry_total:
+                allowed = math.floor(limit * entry_total)
+                while (allowed + 1) / entry_total <= limit:
+                    allowed += 1
+                while allowed > 0 and allowed / entry_total > limit:
+                    allowed -= 1
+                if allowed == 0:
+                    raise ValueError(
+                        f"{flag}={limit} for {dimension}={value!r} would reduce the "
+                        f"total population to zero (population {entry_total}) — fail-closed"
+                    )
+        while True:
+            total = len(population)
+            counts: dict[Any, int] = {}
+            for rec in population:
+                value = getter(rec)
+                counts[value] = counts.get(value, 0) + 1
+            over: dict[Any, int] = {}
+            blocked = False
+            for value, count in counts.items():
+                if count / total > limit:
+                    # Largest keep-count whose share of the current population
+                    # is still <= limit (float-safety guards around the floor;
+                    # the same arithmetic runs on every pass, so the result is
+                    # deterministic and order-invariant).
+                    allowed = math.floor(limit * total)
+                    while (allowed + 1) / total <= limit:
+                        allowed += 1
+                    while allowed > 0 and allowed / total > limit:
+                        allowed -= 1
+                    if allowed == 0 and count == total:
+                        # Sole remaining value after earlier reductions or
+                        # exclusions: trimming it further would empty the
+                        # population entirely.
+                        blocked = True
+                        break
+                    over[value] = allowed
+            if blocked or not over:
+                break
+            kept: list[Record] = []
+            taken: dict[Any, int] = {}
+            for rec in population:
+                value = getter(rec)
+                if value in over and taken.get(value, 0) >= over[value]:
+                    key = f"{dimension}:{str(value) if value is not None else '(none)'}"
+                    exclusions[key] = exclusions.get(key, 0) + 1
+                    continue
+                taken[value] = taken.get(value, 0) + 1
+                kept.append(rec)
+            if not kept:
+                raise ValueError(
+                    f"{flag}={limit} would reduce the total population to zero across "
+                    f"{dimension} values {sorted(str(v) for v in over)} — fail-closed"
+                )
+            population = kept
+    return population, exclusions
 
 
 def _caps_applied(records: list[Record], caps: dict[str, int]) -> dict[str, int]:

--- a/daydream/training/corpus_v2/projector.py
+++ b/daydream/training/corpus_v2/projector.py
@@ -22,7 +22,7 @@ from collections.abc import Callable
 from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Literal, Mapping, cast, overload
+from typing import Any, Literal, Mapping, NoReturn, cast, overload
 
 from daydream.archive.index import normalize_as_of
 from daydream.archive.sanitize import _derivative_digest
@@ -523,6 +523,34 @@ def _max_keep_count(total: int, limit: float) -> int:
     return allowed
 
 
+def _raise_share_caps_fail_closed(
+    *,
+    flag: str,
+    limit: float,
+    dimension: str,
+    population: int | None = None,
+    value: Any | None = None,
+    values: list[Any] | None = None,
+) -> NoReturn:
+    """Single home for the fail-closed ``ValueError`` terminal state of the
+    share-cap stage (the contract documented in ``_apply_share_caps``): every
+    total-population-zero path — the entry degeneracy pre-check, a sole
+    remaining value that can no longer be trimmed without emptying the
+    population, and a trim round that would empty the whole population —
+    funnels through this one raise so the message shape cannot drift between
+    sites. ``value`` names the single over-share value (first two paths);
+    ``values`` spells out the over-share value list (third path)."""
+    if values is not None:
+        raise ValueError(
+            f"{flag}={limit} would reduce the total population to zero across "
+            f"{dimension} values {sorted(str(v) for v in values)} — fail-closed"
+        )
+    raise ValueError(
+        f"{flag}={limit} for {dimension}={value!r} would reduce the total population "
+        f"to zero (population {population}) — fail-closed"
+    )
+
+
 def _apply_share_caps(
     records: list[Record],
     *,
@@ -591,9 +619,12 @@ def _apply_share_caps(
         for value, count in entry_counts.items():
             if count / entry_total > limit and count == entry_total:
                 if _max_keep_count(entry_total, limit) == 0:
-                    raise ValueError(
-                        f"{flag}={limit} for {dimension}={value!r} would reduce the "
-                        f"total population to zero (population {entry_total}) — fail-closed"
+                    _raise_share_caps_fail_closed(
+                        flag=flag,
+                        limit=limit,
+                        dimension=dimension,
+                        population=entry_total,
+                        value=value,
                     )
     # Fixed-point loop (issue #1079, F1): a later dimension's trimming can
     # remove records of one value and push an earlier dimension's value back
@@ -623,10 +654,12 @@ def _apply_share_caps(
                             # population entirely — the same terminal state as
                             # the entry degeneracy pre-check above, so fail
                             # closed (never emit a lone value above its cap).
-                            raise ValueError(
-                                f"{flag}={limit} for {dimension}={value!r} would reduce "
-                                f"the total population to zero (population {total}) — "
-                                "fail-closed"
+                            _raise_share_caps_fail_closed(
+                                flag=flag,
+                                limit=limit,
+                                dimension=dimension,
+                                population=total,
+                                value=value,
                             )
                         over[value] = allowed
                 if not over:
@@ -644,9 +677,11 @@ def _apply_share_caps(
                     taken[value] = taken.get(value, 0) + 1
                     kept.append(rec)
                 if not kept:
-                    raise ValueError(
-                        f"{flag}={limit} would reduce the total population to zero across "
-                        f"{dimension} values {sorted(str(v) for v in over)} — fail-closed"
+                    _raise_share_caps_fail_closed(
+                        flag=flag,
+                        limit=limit,
+                        dimension=dimension,
+                        values=list(over),
                     )
                 population = kept
                 pass_exclusions += round_exclusions

--- a/daydream/training/corpus_v2/projector.py
+++ b/daydream/training/corpus_v2/projector.py
@@ -491,6 +491,38 @@ def _license_decision_distribution(
     return dict(sorted(distribution.items()))
 
 
+_SHARE_DIMENSIONS: tuple[tuple[str, str, Callable[[Record], Any]], ...] = (
+    # One dimension table consumed by both the share-cap selection stage and
+    # the report builder, so the three vocabulary uses (configured keys,
+    # applied keys, exclusion-key prefixes) can never drift apart: every
+    # consumer spells the repository dimension ``repo``, matching the
+    # ``max_repo_share`` flag.
+    ("stack", "max_stack_share", lambda r: r.get("stack")),
+    (
+        "repo",
+        "max_repo_share",
+        lambda r: cast(dict[str, Any], r.get("lineage") or {}).get("repo_slug"),
+    ),
+    (
+        "profile",
+        "max_profile_share",
+        lambda r: cast(dict[str, Any], r.get("profile") or {}).get("profile_name"),
+    ),
+)
+
+
+def _max_keep_count(total: int, limit: float) -> int:
+    """Largest ``allowed`` with ``allowed / total <= limit`` (float-safety
+    guards around the floor; the same arithmetic runs on every pass, so the
+    result is deterministic and order-invariant)."""
+    allowed = math.floor(limit * total)
+    while (allowed + 1) / total <= limit:
+        allowed += 1
+    while allowed > 0 and allowed / total > limit:
+        allowed -= 1
+    return allowed
+
+
 def _apply_share_caps(
     records: list[Record],
     *,
@@ -500,121 +532,126 @@ def _apply_share_caps(
 ) -> tuple[list[Record], dict[str, int]]:
     """Pure share-cap selection over the post-tier-cap population.
 
-    Applies the three dimensions sequentially (stack → repository → profile).
     Within a dimension, iterates until every value's share of the current
     population is within its configured limit (strict output-share semantics:
     ``count / total <= limit`` over the final emitted population), keeping the
-    lowest ``record_id`` records of any over-share group. Returns the kept list
-    (sorted by ``record_id``) and exclusion counts keyed
-    ``"<dimension>:<value>"`` (``None`` values form their own bucket spelled
-    ``(none)``).
+    lowest ``record_id`` records of any over-share group. The three dimensions
+    (stack → repo → profile) are applied sequentially and the whole sequence
+    is re-run to a fixed point: a later dimension's exclusions re-shape the
+    population and can push an earlier dimension's value back over its limit
+    (sequential drift on correlated dimensions — e.g. multi-stack repos,
+    per-repo profiles), so every dimension must be re-enforced until a
+    complete pass excludes nothing and every configured share is within its
+    limit of the final population. Returns the kept list (sorted by
+    ``record_id``) and exclusion counts keyed ``"<dimension>:<value>"``
+    (``None`` values form their own bucket spelled ``(none)``).
 
     Fails closed with ``ValueError`` if enforcing a cap would leave a total
     population of zero (the cap cannot keep a single record of the population
-    it is asked to cap). A dimension value dropping out entirely is fine —
-    only total-population-zero is fatal; once iteration has reduced a
-    dimension's population, a sole remaining value that can no longer be
-    trimmed without emptying the population is left intact rather than
-    destroyed. Never samples; input order does not affect the result.
+    it is asked to cap). An already-empty population (no decisive findings, or
+    tier caps that trimmed everything) is returned unchanged — configured caps
+    exclude nothing from an empty corpus. A dimension value dropping out
+    entirely is fine — only total-population-zero is fatal; a sole remaining
+    value that can no longer be trimmed without emptying the population hits
+    the same fail-closed terminal state as the entry degeneracy pre-check and
+    raises rather than emitting a lone value at 100% share over its cap.
+    Never samples; input order does not affect the result.
     """
-    dimensions: list[tuple[str, str, Callable[[Record], Any], float | None]] = [
-        (
-            "stack",
-            "max_stack_share",
-            lambda r: r.get("stack"),
-            max_stack_share,
-        ),
-        (
-            "repository",
-            "max_repo_share",
-            lambda r: cast(dict[str, Any], r.get("lineage") or {}).get("repo_slug"),
-            max_repo_share,
-        ),
-        (
-            "profile",
-            "max_profile_share",
-            lambda r: cast(dict[str, Any], r.get("profile") or {}).get("profile_name"),
-            max_profile_share,
-        ),
-    ]
+    limits = {
+        "stack": max_stack_share,
+        "repo": max_repo_share,
+        "profile": max_profile_share,
+    }
+    dimensions: list[tuple[str, str, Callable[[Record], Any], float]] = []
+    for name, flag, getter in _SHARE_DIMENSIONS:
+        limit = limits[name]
+        if limit is not None:
+            dimensions.append((name, flag, getter, limit))
     exclusions: dict[str, int] = {}
     population = sorted(records, key=lambda r: str(r["record_id"]))
+    if not population:
+        # Empty population (no decisive findings, or tier caps trimmed
+        # everything): configured caps exclude nothing — a previously
+        # completing zero-record build stays completing.
+        return population, exclusions
     original = list(population)
+    # Fail-closed degeneracy pre-check against the original input population:
+    # a cap that cannot keep a single record of an over-share group covering
+    # the whole input would collapse it to zero — refuse before doing any work.
+    # (Populations reduced by earlier dimensions or by a fixed-point re-pass
+    # are handled by the fail-closed sole-value check in the trim loop below,
+    # so this check is invariant and runs once per configured dimension on the
+    # entry population.)
+    entry_total = len(original)
     for dimension, flag, getter, limit in dimensions:
-        if limit is None:
-            continue
-        if not population:
-            raise ValueError(
-                f"{flag}={limit} configured but the population is already empty "
-                "— fail-closed"
-            )
-        # Fail-closed degeneracy check against the original input population:
-        # a cap that cannot keep a single record of an over-share group
-        # covering the whole input would collapse it to zero — refuse before
-        # doing any work. (Populations reduced by earlier dimensions or by
-        # this dimension's own iteration are handled by the no-progress break
-        # in the loop below instead.)
-        entry_total = len(original)
         entry_counts: dict[Any, int] = {}
         for rec in original:
             value = getter(rec)
             entry_counts[value] = entry_counts.get(value, 0) + 1
         for value, count in entry_counts.items():
             if count / entry_total > limit and count == entry_total:
-                allowed = math.floor(limit * entry_total)
-                while (allowed + 1) / entry_total <= limit:
-                    allowed += 1
-                while allowed > 0 and allowed / entry_total > limit:
-                    allowed -= 1
-                if allowed == 0:
+                if _max_keep_count(entry_total, limit) == 0:
                     raise ValueError(
                         f"{flag}={limit} for {dimension}={value!r} would reduce the "
                         f"total population to zero (population {entry_total}) — fail-closed"
                     )
-        while True:
-            total = len(population)
-            counts: dict[Any, int] = {}
-            for rec in population:
-                value = getter(rec)
-                counts[value] = counts.get(value, 0) + 1
-            over: dict[Any, int] = {}
-            blocked = False
-            for value, count in counts.items():
-                if count / total > limit:
-                    # Largest keep-count whose share of the current population
-                    # is still <= limit (float-safety guards around the floor;
-                    # the same arithmetic runs on every pass, so the result is
-                    # deterministic and order-invariant).
-                    allowed = math.floor(limit * total)
-                    while (allowed + 1) / total <= limit:
-                        allowed += 1
-                    while allowed > 0 and allowed / total > limit:
-                        allowed -= 1
-                    if allowed == 0 and count == total:
-                        # Sole remaining value after earlier reductions or
-                        # exclusions: trimming it further would empty the
-                        # population entirely.
-                        blocked = True
-                        break
-                    over[value] = allowed
-            if blocked or not over:
-                break
-            kept: list[Record] = []
-            taken: dict[Any, int] = {}
-            for rec in population:
-                value = getter(rec)
-                if value in over and taken.get(value, 0) >= over[value]:
-                    key = f"{dimension}:{str(value) if value is not None else '(none)'}"
-                    exclusions[key] = exclusions.get(key, 0) + 1
-                    continue
-                taken[value] = taken.get(value, 0) + 1
-                kept.append(rec)
-            if not kept:
-                raise ValueError(
-                    f"{flag}={limit} would reduce the total population to zero across "
-                    f"{dimension} values {sorted(str(v) for v in over)} — fail-closed"
-                )
-            population = kept
+    # Fixed-point loop (issue #1079, F1): a later dimension's trimming can
+    # remove records of one value and push an earlier dimension's value back
+    # over its limit, so a single sequential pass does not guarantee the M4
+    # contract. Re-run the full dimension sequence until a complete pass
+    # excludes nothing — each pass that excludes reduces the population, so
+    # the loop provably terminates, and every configured dimension is then
+    # within its limit of the final emitted population.
+    while True:
+        pass_exclusions = 0
+        for dimension, flag, getter, limit in dimensions:
+            while True:
+                total = len(population)
+                counts: dict[Any, int] = {}
+                for rec in population:
+                    value = getter(rec)
+                    counts[value] = counts.get(value, 0) + 1
+                over: dict[Any, int] = {}
+                for value, count in counts.items():
+                    if count / total > limit:
+                        # Largest keep-count whose share of the current
+                        # population is still <= limit.
+                        allowed = _max_keep_count(total, limit)
+                        if allowed == 0 and count == total:
+                            # Sole remaining value after earlier reductions or
+                            # exclusions: trimming it further would empty the
+                            # population entirely — the same terminal state as
+                            # the entry degeneracy pre-check above, so fail
+                            # closed (never emit a lone value above its cap).
+                            raise ValueError(
+                                f"{flag}={limit} for {dimension}={value!r} would reduce "
+                                f"the total population to zero (population {total}) — "
+                                "fail-closed"
+                            )
+                        over[value] = allowed
+                if not over:
+                    break
+                kept: list[Record] = []
+                taken: dict[Any, int] = {}
+                round_exclusions = 0
+                for rec in population:
+                    value = getter(rec)
+                    if value in over and taken.get(value, 0) >= over[value]:
+                        key = f"{dimension}:{str(value) if value is not None else '(none)'}"
+                        exclusions[key] = exclusions.get(key, 0) + 1
+                        round_exclusions += 1
+                        continue
+                    taken[value] = taken.get(value, 0) + 1
+                    kept.append(rec)
+                if not kept:
+                    raise ValueError(
+                        f"{flag}={limit} would reduce the total population to zero across "
+                        f"{dimension} values {sorted(str(v) for v in over)} — fail-closed"
+                    )
+                population = kept
+                pass_exclusions += round_exclusions
+        if pass_exclusions == 0:
+            break
     return population, exclusions
 
 
@@ -630,29 +667,27 @@ def _share_caps_report(
     — they cannot drift). ``configured`` lists the non-None share limits keyed
     stack/repo/profile; ``applied`` reports final per-value counts + shares
     against the final emitted population per dimension; ``exclusions`` lists
-    the merged ``share-cap:<dimension>:<value>`` exclusion counts."""
-    configured = {
-        key: value
-        for key, value in (
-            ("stack", max_stack_share),
-            ("repo", max_repo_share),
-            ("profile", max_profile_share),
-        )
-        if value is not None
+    the merged ``share-cap:<dimension>:<value>`` exclusion counts. Both draw
+    dimension names and value getters from the single ``_SHARE_DIMENSIONS``
+    table, so configured/applied/exclusion vocabulary stays one spelling."""
+    limits = {
+        "stack": max_stack_share,
+        "repo": max_repo_share,
+        "profile": max_profile_share,
     }
-    getters: dict[str, Callable[[Record], Any]] = {
-        "stack": lambda r: r.get("stack"),
-        "repository": lambda r: cast(dict[str, Any], r.get("lineage") or {}).get("repo_slug"),
-        "profile": lambda r: cast(dict[str, Any], r.get("profile") or {}).get("profile_name"),
+    configured = {
+        name: limits[name]
+        for name, _flag, _getter in _SHARE_DIMENSIONS
+        if limits[name] is not None
     }
     applied: dict[str, dict[str, dict[str, float]]] = {}
     total = len(records)
-    for key, getter in getters.items():
+    for name, _flag, getter in _SHARE_DIMENSIONS:
         counts: dict[Any, int] = {}
         for rec in records:
             value = getter(rec)
             counts[value] = counts.get(value, 0) + 1
-        applied[key] = {
+        applied[name] = {
             str(value) if value is not None else "(none)": {
                 "count": count,
                 "share": (count / total) if total else 0.0,
@@ -899,10 +934,13 @@ def run_build_corpus_v2(config: BuildCorpusV2Config) -> dict[str, Any]:
         records = kept
 
     # Output-share caps (issue #1079): true share of the final emitted
-    # population, enforced per dimension (stack → repository → profile)
-    # sequentially over the post-tier-cap population. Only runs when at least
-    # one share is configured, so tier-cap-only builds stay byte-identical
-    # and neither the summary nor lineage gains a ``share_caps`` block.
+    # population, enforced per dimension (stack → repo → profile) over
+    # the post-tier-cap population. The dimension sequence is re-run to a
+    # fixed point so a later pass can never leave an earlier dimension back
+    # over its cap (F1: a single sequential pass drifts on correlated
+    # dimensions). Only runs when at least one share is configured, so
+    # tier-cap-only builds stay byte-identical and neither the summary nor
+    # lineage gains a ``share_caps`` block.
     share_caps_report: dict[str, Any] | None = None
     if (
         config.max_stack_share is not None
@@ -926,6 +964,21 @@ def run_build_corpus_v2(config: BuildCorpusV2Config) -> dict[str, Any]:
             max_repo_share=config.max_repo_share,
             max_profile_share=config.max_profile_share,
         )
+
+    # Re-pin lineage valid_at over the final emitted population (post tier-cap
+    # and share-cap exclusions): the in-loop pin above is computed before
+    # either caps stage drops records, so it could name a cap-excluded record's
+    # evidence — contradicting the "emitted records' evidence only" contract
+    # above. Recomputing over the post-cap records keeps the pin reachable;
+    # uncapped builds re-pin to the identical value (max is order-independent).
+    valid_at = config.as_of
+    for rec in records:
+        rec_valid_at = cast(dict[str, Any], rec["lineage"]).get("valid_at")
+        if rec_valid_at is not None and (
+            valid_at is None
+            or datetime.fromisoformat(str(rec_valid_at)) > datetime.fromisoformat(valid_at)
+        ):
+            valid_at = str(rec_valid_at)
 
     canonical = _dump_jsonl(records)
     _atomic_write(config.out_dir / "corpus.jsonl", canonical)

--- a/tests/test_corpus_v2.py
+++ b/tests/test_corpus_v2.py
@@ -113,6 +113,7 @@ def _write_annotations_snapshot(
     valid_at: str = "2026-01-01T00:00:00+00:00",
     session_id: str = "sess-a",
     dispositions: list[str] | None = None,
+    stack: str = "python",
     n_siblings: int = 1,
 ) -> Path:
     """Two-bundle shape: a self-verified annotation bundle (its own
@@ -139,8 +140,21 @@ def _write_annotations_snapshot(
 
     ann_dir = bundle_dir.parent / f"{bundle_dir.name}-annotations"
     ann_dir.mkdir(parents=True, exist_ok=True)
-    fps = ["a1" * 32, "b2" * 32, "c3" * 32]
-    rows = []
+    # Merge with any rows a previous call wrote (per-session helper called
+    # multiple times over one bundle): the snapshot is one annotations.jsonl
+    # for all sessions, and a stale SHA256SUMS listing must not be hashed
+    # into itself.
+    prior = [
+        json.loads(line) for line in
+        (ann_dir / "annotations.jsonl").read_text().splitlines() if line
+    ] if (ann_dir / "annotations.jsonl").exists() else []
+    (ann_dir / "SHA256SUMS").unlink(missing_ok=True)
+    # Session-scoped fingerprints when merging (second session's rows must
+    # not collide with the first's, since the snapshot is keyed by
+    # fingerprint globally); a lone call keeps the canonical fingerprints.
+    sess_prefix = hashlib.sha256(session_id.encode()).hexdigest()[:2] if prior else ""
+    fps = [sess_prefix + fp for fp in ("a1" * 32, "b2" * 32, "c3" * 32)]
+    rows = list(prior)
     for i, disposition in enumerate(dispositions or ["accepted", "rejected", "ambiguous"]):
         evidence = (
             [{"comment_id": i + 1, "created_at": "2026-02-01T00:00:00+00:00",
@@ -159,7 +173,7 @@ def _write_annotations_snapshot(
             # must surface both at the two-bundle projection boundary.
             "profile": {"profile_schema_version": 2, "profile_name": "deep-review",
                         "profile_source_kind": "builtin", "profile_digest": "d" * 64},
-            "stack": "python",
+            "stack": stack,
         })
     (ann_dir / "annotations.jsonl").write_text(
         "".join(json.dumps(r, sort_keys=True) + "\n" for r in rows))

--- a/tests/test_corpus_v2.py
+++ b/tests/test_corpus_v2.py
@@ -149,32 +149,36 @@ def _write_annotations_snapshot(
         (ann_dir / "annotations.jsonl").read_text().splitlines() if line
     ] if (ann_dir / "annotations.jsonl").exists() else []
     (ann_dir / "SHA256SUMS").unlink(missing_ok=True)
-    # Session-scoped fingerprints when merging (second session's rows must
-    # not collide with the first's, since the snapshot is keyed by
-    # fingerprint globally); a lone call keeps the canonical fingerprints.
-    sess_prefix = hashlib.sha256(session_id.encode()).hexdigest()[:2] if prior else ""
-    fps = [sess_prefix + fp for fp in ("a1" * 32, "b2" * 32, "c3" * 32)]
     rows = list(prior)
-    for i, disposition in enumerate(dispositions or ["accepted", "rejected", "ambiguous"]):
-        evidence = (
-            [{"comment_id": i + 1, "created_at": "2026-02-01T00:00:00+00:00",
-              "classifier_label": disposition, "valid_at": valid_at}]
-            if disposition in ("accepted", "rejected")
-            else []
-        )
-        fingerprint = fps[i % len(fps)]
-        rows.append({
-            "record_id": _record_id(session_id, f"{session_id}:root", "seg-0", fingerprint),
-            "session_id": session_id, "fingerprint": fingerprint,
-            "disposition": disposition, "evidence": evidence,
-            # Real canonical-record shape (adjudication/snapshot.py:
-            # build_canonical_record): the four review-profile fields nest
-            # under "profile" with only "stack" at top level — the projector
-            # must surface both at the two-bundle projection boundary.
-            "profile": {"profile_schema_version": 2, "profile_name": "deep-review",
-                        "profile_source_kind": "builtin", "profile_digest": "d" * 64},
-            "stack": stack,
-        })
+    # Session-scoped fingerprints when merging (a second, distinct session's
+    # rows must not collide with the first's, since the snapshot is keyed by
+    # fingerprint globally); a lone call keeps the canonical fingerprints.
+    # A session already in the snapshot is an idempotent no-op: re-appending
+    # with a fresh session prefix would fabricate distinct prefixed
+    # duplicates of the same findings (same session, different fingerprints).
+    if session_id not in {row.get("session_id") for row in rows}:
+        sess_prefix = hashlib.sha256(session_id.encode()).hexdigest()[:2] if prior else ""
+        fps = [sess_prefix + fp for fp in ("a1" * 32, "b2" * 32, "c3" * 32)]
+        for i, disposition in enumerate(dispositions or ["accepted", "rejected", "ambiguous"]):
+            evidence = (
+                [{"comment_id": i + 1, "created_at": "2026-02-01T00:00:00+00:00",
+                  "classifier_label": disposition, "valid_at": valid_at}]
+                if disposition in ("accepted", "rejected")
+                else []
+            )
+            fingerprint = fps[i % len(fps)]
+            rows.append({
+                "record_id": _record_id(session_id, f"{session_id}:root", "seg-0", fingerprint),
+                "session_id": session_id, "fingerprint": fingerprint,
+                "disposition": disposition, "evidence": evidence,
+                # Real canonical-record shape (adjudication/snapshot.py:
+                # build_canonical_record): the four review-profile fields nest
+                # under "profile" with only "stack" at top level — the projector
+                # must surface both at the two-bundle projection boundary.
+                "profile": {"profile_schema_version": 2, "profile_name": "deep-review",
+                            "profile_source_kind": "builtin", "profile_digest": "d" * 64},
+                "stack": stack,
+            })
     (ann_dir / "annotations.jsonl").write_text(
         "".join(json.dumps(r, sort_keys=True) + "\n" for r in rows))
     _write_sumsums(bundle_dir)  # the trajectory joins the curation digest pin
@@ -237,6 +241,34 @@ def test_load_bundle_admission_gate_passes_wellformed_bundle(tmp_path: Path) -> 
     bundle_dir = _write_bundle(tmp_path, repo_slugs={"sess-a": "owner/repo-a"})
     loaded = load_curated_bundle(bundle_dir)  # no raise
     assert all(b.repo_slug for b in loaded.admitted)
+
+
+def test_repeated_annotation_snapshot_session_does_not_fabricate_duplicates(tmp_path: Path) -> None:
+    # The merge path prefixes a NEW session's fingerprints so distinct
+    # sessions don't collide (the snapshot is keyed by fingerprint globally),
+    # but the prefix used to toggle on file-emptiness — so re-calling the
+    # helper with the SAME session_id re-appended the same findings under a
+    # fresh session prefix: same session, different fingerprint, and
+    # _load_snapshot only rejects duplicates within a single read, so both
+    # rows projected as distinct records. A repeated session must be an
+    # idempotent no-op instead.
+    bundle_dir = _write_bundle(tmp_path)
+    _write_annotations_snapshot(bundle_dir, session_id="sess-a",
+                                dispositions=["accepted", "rejected"])
+    snap = _write_annotations_snapshot(bundle_dir, session_id="sess-a",
+                                       dispositions=["accepted", "rejected"])
+    rows = [json.loads(line) for line in snap.read_text().splitlines() if line.strip()]
+    assert len(rows) == 2  # one per finding, not a prefixed duplicate pair
+    assert [r["session_id"] for r in rows] == ["sess-a", "sess-a"]
+    assert {r["fingerprint"] for r in rows} == {"a1" * 32, "b2" * 32}
+    assert len({r["record_id"] for r in rows}) == 2
+    out = tmp_path / "proj"
+    run_build_corpus_v2(_cfg(out, bundle_dir, snap))
+    records = [
+        json.loads(line)
+        for line in (out / "corpus.jsonl").read_text().splitlines() if line.strip()
+    ]
+    assert len(records) == 2
 
 
 @pytest.fixture

--- a/tests/test_corpus_v2_reproducibility.py
+++ b/tests/test_corpus_v2_reproducibility.py
@@ -85,6 +85,31 @@ def test_split_membership_recorded_in_record_lineage(tmp_path: Path) -> None:
         assert record["lineage"]["split"] in {"train", "validation", "holdout"}
 
 
+def test_share_capped_replay_is_byte_identical_and_splits_disjoint(tmp_path: Path) -> None:
+    from tests.test_corpus_v2 import _write_bundle
+
+    bundle_dir = _write_bundle(tmp_path)
+    snap = _write_annotations_snapshot(
+        bundle_dir, session_id="sess-a", n_siblings=4,
+        dispositions=["accepted", "accepted", "accepted"],
+    )
+    for out in (tmp_path / "a", tmp_path / "b"):
+        run_build_corpus_v2(
+            _cfg(out, bundle_dir, snap, max_stack_share=0.5, max_repo_share=0.6,
+                 max_profile_share=0.7)
+        )
+    for name in ("corpus.jsonl", "corpus-v2.jsonl", "lineage.json",
+                 "train.jsonl", "validation.jsonl", "holdout.jsonl"):
+        assert (tmp_path / "b" / name).read_bytes() == (tmp_path / "a" / name).read_bytes()
+    train, val, hold = _read_split_memberships(tmp_path / "a")
+    assert not (set(train) & set(val))
+    assert not (set(train) & set(hold))
+    assert not (set(val) & set(hold))
+    # share caps present in the lineage of a capped build
+    lineage = json.loads((tmp_path / "a" / "lineage.json").read_text())
+    assert lineage["share_caps"]["version"] == 1
+
+
 def test_v1_and_v2_projection_paths_are_independent(tmp_path: Path, archive_dir: Any) -> None:
     """Run BOTH projectors over the same pinned inputs; assert (a) v1 bytes
     are identical before/after any v2 build, and (b) v2 reprojection is

--- a/tests/test_corpus_v2_reproducibility.py
+++ b/tests/test_corpus_v2_reproducibility.py
@@ -86,13 +86,41 @@ def test_split_membership_recorded_in_record_lineage(tmp_path: Path) -> None:
 
 
 def test_share_capped_replay_is_byte_identical_and_splits_disjoint(tmp_path: Path) -> None:
-    from tests.test_corpus_v2 import _write_bundle
+    import hashlib
+
+    from tests.test_corpus_v2 import (
+        _admit_second_batch,
+        _write_annotations_snapshot,
+        _write_bundle,
+    )
 
     bundle_dir = _write_bundle(tmp_path)
     snap = _write_annotations_snapshot(
         bundle_dir, session_id="sess-a", n_siblings=4,
         dispositions=["accepted", "accepted", "accepted"],
     )
+    # A second admitted session with a distinct stack/repo so every configured
+    # share cap is satisfiable (a lone value is 100% of the population and can
+    # never satisfy a <1.0 cap); re-profile only the last row to a second
+    # profile value so the profile trim branch executes without ever leaving a
+    # lone survivor, then refresh the annotation bundle's SHA256SUMS (same
+    # mechanics as the build-wiring fixtures).
+    _admit_second_batch(bundle_dir, "owner/repo-b", spdx_id="MIT")
+    snap = _write_annotations_snapshot(
+        bundle_dir, session_id="sess-b", n_siblings=2,
+        dispositions=["accepted", "accepted"], stack="rust",
+    )
+    rows = [json.loads(line) for line in snap.read_text().splitlines() if line]
+    rows[-1]["profile"]["profile_name"] = "quick-review"
+    snap.write_text("".join(json.dumps(r, sort_keys=True) + "\n" for r in rows))
+    ann_dir = snap.parent
+    rel = sorted(
+        p.relative_to(ann_dir).as_posix() for p in ann_dir.rglob("*")
+        if p.is_file() and p.name != "SHA256SUMS"
+    )
+    (ann_dir / "SHA256SUMS").write_text("".join(
+        f"{hashlib.sha256((ann_dir / p).read_bytes()).hexdigest()}  {p}\n" for p in rel
+    ))
     for out in (tmp_path / "a", tmp_path / "b"):
         run_build_corpus_v2(
             _cfg(out, bundle_dir, snap, max_stack_share=0.5, max_repo_share=0.6,

--- a/tests/test_corpus_v2_share_caps.py
+++ b/tests/test_corpus_v2_share_caps.py
@@ -1,6 +1,6 @@
-"""Tests for the pure share-cap selection stage (_apply_share_caps)."""
-
+"""Tests for the corpus-v2 share-cap stage and its build wiring."""
 from collections.abc import Callable
+from pathlib import Path
 from typing import Any
 
 import pytest
@@ -113,3 +113,92 @@ class TestApplyShareCaps:
             _apply_share_caps(
                 records, max_stack_share=0.2, max_repo_share=None, max_profile_share=None
             )
+
+
+class TestBuildWiring:
+    def _share_cfg(self, out: Path, bundle: Path, snap: Path, **share: Any) -> Any:
+        from tests.test_corpus_v2 import _cfg
+
+        return _cfg(out, bundle, snap, **share)
+
+    def _build(self, tmp_path: Path, **share: Any) -> tuple[Path, dict[str, Any]]:
+        from daydream.training.corpus_v2.projector import run_build_corpus_v2
+        from tests.test_corpus_v2 import (
+            _admit_second_batch,
+            _write_annotations_snapshot,
+            _write_bundle,
+        )
+
+        bundle = _write_bundle(tmp_path)
+        # 3 accepted findings on sess-a (same stack/repo/profile) → over any
+        # small share cap once a second dimension value exists; the 2-record
+        # fixture is exercised for *reporting* here, M4's strict share math
+        # is covered by TestApplyShareCaps.
+        snap = _write_annotations_snapshot(
+            bundle, session_id="sess-a",
+            dispositions=["accepted", "accepted", "rejected"],
+        )
+        # Two admitted sessions so the emitted population has a second
+        # stack/repo/profile value and the share cap is actually satisfiable
+        # (the flip needs the annotation lineage to exist first).
+        _admit_second_batch(bundle, "owner/repo-b", spdx_id="MIT")
+        _write_annotations_snapshot(
+            bundle, session_id="sess-b", dispositions=["accepted", "accepted"], stack="rust",
+        )
+        out = tmp_path / "out"
+        summary = run_build_corpus_v2(
+            self._share_cfg(out, bundle, snap, **share)
+        )
+        return out, summary
+
+    def test_share_caps_exceed_and_exclusions_recorded(self, tmp_path: Path) -> None:
+        import json
+
+        out, summary = self._build(tmp_path, max_stack_share=0.5)
+        emitted = [
+            json.loads(line)
+            for line in (out / "corpus.jsonl").read_text().splitlines() if line
+        ]
+        assert emitted, "cap stage must never silently empty the corpus"
+        stack_counts: dict[str, int] = {}
+        for r in emitted:
+            stack_counts[str(r["stack"])] = stack_counts.get(str(r["stack"]), 0) + 1
+        total = len(emitted)
+        for value, count in stack_counts.items():
+            assert count / total <= 0.5 + 1e-9, f"stack {value} exceeded cap"
+        assert summary["share_caps"]["configured"]["stack"] == 0.5
+        assert summary["share_caps"]["version"] == 1
+        assert summary["exclusions_by_reason"]  # tier/np keys present
+
+    def test_lineage_and_summary_share_caps_cannot_drift(self, tmp_path: Path) -> None:
+        import json
+
+        out, summary = self._build(tmp_path, max_repo_share=0.5)
+        lineage = json.loads((out / "lineage.json").read_text())
+        assert lineage["share_caps"] == summary["share_caps"]
+        assert lineage["share_caps"]["version"] == 1
+        assert lineage["share_caps"]["configured"]["repo"] == 0.5
+        # final per-value counts + shares are reported against the final population
+        assert "applied" in lineage["share_caps"] and "exclusions" in lineage["share_caps"]
+
+    def test_no_caps_configured_report_block_absent(self, tmp_path: Path) -> None:
+        import json
+
+        out, summary = self._build(tmp_path)
+        lineage = json.loads((out / "lineage.json").read_text())
+        assert "share_caps" not in lineage
+        assert "share_caps" not in summary
+
+    def test_zero_population_cap_fails_closed(self, tmp_path: Path) -> None:
+        from daydream.training.corpus_v2.projector import run_build_corpus_v2
+        from tests.test_corpus_v2 import _write_annotations_snapshot, _write_bundle
+
+        bundle = _write_bundle(tmp_path)
+        snap = _write_annotations_snapshot(bundle, session_id="sess-a",
+                                           dispositions=["accepted", "accepted", "accepted"])
+        with pytest.raises(ValueError, match="max_profile_share"):
+            run_build_corpus_v2(
+                self._share_cfg(tmp_path / "out2", bundle, snap, max_profile_share=0.1)
+            )
+        # fail-closed: nothing written
+        assert not (tmp_path / "out2" / "_SUCCESS").exists()

--- a/tests/test_corpus_v2_share_caps.py
+++ b/tests/test_corpus_v2_share_caps.py
@@ -1,48 +1,115 @@
-"""Output-share caps for corpus v2 (issue #1079, M1-M11)."""
+"""Tests for the pure share-cap selection stage (_apply_share_caps)."""
 
-from pathlib import Path
+from collections.abc import Callable
 from typing import Any
 
 import pytest
 
 
-def _share_cfg(out_dir: Path, bundle_dir: Path, snapshot: Path, **kw: Any) -> Any:
-    from tests.test_corpus_v2 import _cfg
+def _mk_record(rid: str, stack: str | None, repo: str, profile: str | None) -> dict[str, Any]:
+    return {
+        "record_id": rid,
+        "tier": "silver",
+        "stack": stack,
+        "profile": {"profile_name": profile},
+        "lineage": {"repo_slug": repo, "split": "train"},
+    }
 
-    return _cfg(out_dir, bundle_dir, snapshot, **kw)
 
+class TestApplyShareCaps:
+    def test_over_share_group_is_capped_to_limit(self) -> None:
+        from daydream.training.corpus_v2.projector import _apply_share_caps
 
-class TestShareCapValidation:
-    def test_share_below_or_equal_zero_refuses(self, tmp_path: Path) -> None:
-        from tests.test_corpus_v2 import _write_annotations_snapshot, _write_bundle
+        records = [_mk_record(f"r{i:03d}", "python", "owner/repo-a", "deep") for i in range(10)]
+        records.append(_mk_record("r900", "rust", "owner/repo-b", "deep"))
+        kept, exclusions = _apply_share_caps(
+            records, max_stack_share=0.5, max_repo_share=None, max_profile_share=None
+        )
+        # Strict output-share semantics: iterate until python's share of the
+        # final population is <= 0.5. With one rust record anchoring the
+        # population, python converges to 1 kept (1/2) — 9 excluded, lowest
+        # record_id kept.
+        assert len(kept) == 2
+        py = [r for r in kept if r["stack"] == "python"]
+        assert [r["record_id"] for r in py] == ["r000"]
+        assert [r["record_id"] for r in kept if r["stack"] == "rust"] == ["r900"]
+        assert exclusions == {"stack:python": 9}
 
-        bundle = _write_bundle(tmp_path)
-        snap = _write_annotations_snapshot(bundle)
+    def test_final_shares_respect_limits_after_sequential_passes(self) -> None:
+        from daydream.training.corpus_v2.projector import _apply_share_caps
+
+        # Profiles must vary (a single profile value is trivially 100% of any
+        # positive population and could never satisfy a <1.0 cap); the contract
+        # under test is that every final share <= its limit over the final
+        # population after the sequential stack → repository → profile passes.
+        records = [
+            _mk_record(
+                f"r{i:03d}",
+                "python" if i < 9 else "rust",
+                "owner/repo-a" if i < 9 else "owner/repo-b",
+                "deep" if i % 2 else "quick",
+            )
+            for i in range(10)
+        ]
+        kept, _ = _apply_share_caps(
+            records, max_stack_share=0.6, max_repo_share=None, max_profile_share=0.5
+        )
+        total = len(kept)
+        assert total > 0
+        checks: list[tuple[str, float, Callable[[dict[str, Any]], str]]] = [
+            ("stack", 0.6, lambda r: str(r["stack"])),
+            ("profile", 0.5, lambda r: str(r["profile"]["profile_name"])),
+        ]
+        for key, limit, getter in checks:
+            counts: dict[str, int] = {}
+            for r in kept:
+                counts[getter(r)] = counts.get(getter(r), 0) + 1
+            for value, count in counts.items():
+                assert count / total <= limit + 1e-9, f"{key}={value} share {count}/{total}"
+
+    def test_order_invariance_identical_kept_population(self) -> None:
+        from daydream.training.corpus_v2.projector import _apply_share_caps
+
+        records = [
+            _mk_record(
+                f"r{i:03d}",
+                "python" if i % 3 else "rust",
+                "owner/repo-a",
+                "deep" if i % 2 else "quick",
+            )
+            for i in range(12)
+        ]
+        a_kept, a_excl = _apply_share_caps(
+            list(records), max_stack_share=0.5, max_repo_share=0.9, max_profile_share=0.6
+        )
+        shuffled = list(reversed(records))
+        b_kept, b_excl = _apply_share_caps(
+            shuffled, max_stack_share=0.5, max_repo_share=0.9, max_profile_share=0.6
+        )
+        assert [r["record_id"] for r in a_kept] == [r["record_id"] for r in b_kept]
+        assert a_excl == b_excl
+
+    def test_none_dimension_value_is_its_own_bucket_and_cappable(self) -> None:
+        from daydream.training.corpus_v2.projector import _apply_share_caps
+
+        records = [_mk_record(f"r{i:03d}", None, "owner/repo-a", None) for i in range(8)]
+        records.append(_mk_record("r800", "rust", "owner/repo-b", "deep"))
+        kept, exclusions = _apply_share_caps(
+            records, max_stack_share=0.5, max_repo_share=None, max_profile_share=None
+        )
+        # None bucket capped like any value: final pop 5, at most 2-3 None-stack kept.
+        none_kept = [r for r in kept if r["stack"] is None]
+        total = len(kept)
+        assert total > 0
+        assert len(none_kept) / total <= 0.5 + 1e-9
+        assert "stack:(none)" in exclusions
+
+    def test_degenerate_cap_that_empties_population_fails_closed(self) -> None:
+        from daydream.training.corpus_v2.projector import _apply_share_caps
+
+        records = [_mk_record(f"r{i:03d}", "python", "owner/repo-a", "deep") for i in range(4)]
         with pytest.raises(ValueError, match="max_stack_share"):
-            _share_cfg(tmp_path / "out", bundle, snap, max_stack_share=0.0)
-
-    def test_share_above_one_refuses(self, tmp_path: Path) -> None:
-        from tests.test_corpus_v2 import _write_annotations_snapshot, _write_bundle
-
-        bundle = _write_bundle(tmp_path)
-        snap = _write_annotations_snapshot(bundle)
-        with pytest.raises(ValueError, match="max_repo_share"):
-            _share_cfg(tmp_path / "out", bundle, snap, max_repo_share=1.5)
-
-    def test_share_of_one_is_allowed(self, tmp_path: Path) -> None:
-        from tests.test_corpus_v2 import _write_annotations_snapshot, _write_bundle
-
-        bundle = _write_bundle(tmp_path)
-        snap = _write_annotations_snapshot(bundle)
-        config = _share_cfg(tmp_path / "out", bundle, snap, max_profile_share=1.0)
-        assert config.max_profile_share == 1.0
-
-    def test_unset_shares_default_to_none(self, tmp_path: Path) -> None:
-        from tests.test_corpus_v2 import _write_annotations_snapshot, _write_bundle
-
-        bundle = _write_bundle(tmp_path)
-        snap = _write_annotations_snapshot(bundle)
-        config = _share_cfg(tmp_path / "out", bundle, snap)
-        assert config.max_stack_share is None
-        assert config.max_repo_share is None
-        assert config.max_profile_share is None
+            # 0.2 * 4 = 0.8 → keep 0 → population would collapse to zero.
+            _apply_share_caps(
+                records, max_stack_share=0.2, max_repo_share=None, max_profile_share=None
+            )

--- a/tests/test_corpus_v2_share_caps.py
+++ b/tests/test_corpus_v2_share_caps.py
@@ -1,4 +1,5 @@
 """Tests for the corpus-v2 share-cap stage and its build wiring."""
+import hashlib
 import json
 from collections.abc import Callable
 from pathlib import Path
@@ -68,6 +69,53 @@ class TestApplyShareCaps:
             for value, count in counts.items():
                 assert count / total <= limit + 1e-9, f"{key}={value} share {count}/{total}"
 
+    def test_sequential_passes_reconverge_correlated_dimensions(self) -> None:
+        from daydream.training.corpus_v2.projector import _apply_share_caps
+
+        # F1-shaped correlated fixture: python is concentrated in repo-a while
+        # rust is split repo-a x2 + repo-b x3, and python sits exactly at the
+        # 0.5 stack cap on entry (5/10). The repository pass (a later
+        # dimension) then trims repo-a by lowest record_id — removing rust
+        # records and pushing python back over its stack cap (4/7 = 0.571). A
+        # single sequential pass would leave that drift in the output (it
+        # breaks the M4 contract); the cap stage must re-run the dimension
+        # sequence to a fixed point and reconverge every dimension within its
+        # limit of the final population.
+        records = [
+            _mk_record(f"r{i:03d}", "python", "owner/repo-a", "deep") for i in range(5)
+        ]
+        records += [
+            _mk_record("r005", "rust", "owner/repo-a", "deep"),
+            _mk_record("r006", "rust", "owner/repo-a", "deep"),
+            _mk_record("r007", "rust", "owner/repo-b", "quick"),
+            _mk_record("r008", "rust", "owner/repo-b", "quick"),
+            _mk_record("r009", "rust", "owner/repo-b", "quick"),
+        ]
+        kept, exclusions = _apply_share_caps(
+            records, max_stack_share=0.5, max_repo_share=0.6, max_profile_share=None
+        )
+        # The fixed point rebuilds a population where every dimension is back
+        # within its limit — three python + three rust across both repos, all
+        # shares 0.5. The drift (python at 0.571 after the repo pass) is
+        # repaired by re-running the stack pass after the repository pass's
+        # exclusions.
+        assert [r["record_id"] for r in kept] == [
+            "r000", "r001", "r002", "r007", "r008", "r009",
+        ]
+        total = len(kept)
+        stack: dict[str, int] = {}
+        repo: dict[str, int] = {}
+        for r in kept:
+            stack[str(r["stack"])] = stack.get(str(r["stack"]), 0) + 1
+            repo[str(r["lineage"]["repo_slug"])] = repo.get(str(r["lineage"]["repo_slug"]), 0) + 1
+        for value, count in stack.items():
+            assert count / total <= 0.5 + 1e-9, f"stack={value} share {count}/{total}"
+        for value, count in repo.items():
+            assert count / total <= 0.6 + 1e-9, f"repo={value} share {count}/{total}"
+        # The repository pass excluded 3; a later fixed-point pass re-ran the
+        # stack pass (1 further exclusion) to repair the drift.
+        assert exclusions == {"repo:owner/repo-a": 3, "stack:python": 1}
+
     def test_order_invariance_identical_kept_population(self) -> None:
         from daydream.training.corpus_v2.projector import _apply_share_caps
 
@@ -75,7 +123,7 @@ class TestApplyShareCaps:
             _mk_record(
                 f"r{i:03d}",
                 "python" if i % 3 else "rust",
-                "owner/repo-a",
+                "owner/repo-a" if i % 2 else "owner/repo-b",
                 "deep" if i % 2 else "quick",
             )
             for i in range(12)
@@ -113,6 +161,62 @@ class TestApplyShareCaps:
             # 0.2 * 4 = 0.8 → keep 0 → population would collapse to zero.
             _apply_share_caps(
                 records, max_stack_share=0.2, max_repo_share=None, max_profile_share=None
+            )
+
+    def test_sole_remaining_value_above_cap_fails_closed(self) -> None:
+        from daydream.training.corpus_v2.projector import _apply_share_caps
+
+        # Mono-value boundary consistency (issues #5/#7): a cap that floors to
+        # zero on the entry population raises fail-closed, and the identical
+        # terminal state via iteration (one over-share value left, trimming it
+        # would empty the population) must raise too — never emit a single
+        # record at 100% share over its cap with exit 0.
+        for cap in (0.2, 0.4):
+            records = [
+                _mk_record(f"r{i:03d}", "python", "owner/repo-a", "deep") for i in range(4)
+            ]
+            with pytest.raises(ValueError, match="max_stack_share"):
+                # 0.4 * 4 = 1.6 → keep 1 → the sole survivor is then 100%
+                # of a 1-record population and can no longer be trimmed.
+                _apply_share_caps(
+                    records, max_stack_share=cap, max_repo_share=None, max_profile_share=None
+                )
+
+    def test_empty_population_with_configured_caps_stays_empty(self) -> None:
+        from daydream.training.corpus_v2.projector import _apply_share_caps
+
+        # Issue #6: a zero-record build (no decisive findings, or tier caps
+        # that trimmed everything) previously completed with an empty corpus;
+        # configuring a share cap must not turn it into a hard failure.
+        kept, exclusions = _apply_share_caps(
+            [], max_stack_share=0.5, max_repo_share=0.5, max_profile_share=0.5
+        )
+        assert kept == []
+        assert exclusions == {}
+
+    def test_fixed_point_fails_closed_when_caps_conflict(self) -> None:
+        from daydream.training.corpus_v2.projector import _apply_share_caps
+
+        # Finding-1 counterexample: the repo pass re-trims by lowest record_id
+        # and would push stack A to 100% under single sequential passes. The
+        # fixed point re-runs the stack pass, but the greedy lowest-id policy
+        # cannot satisfy both caps here — it must fail closed rather than emit
+        # a population that silently violates an earlier dimension's cap.
+        records = [
+            _mk_record("r001", "A", "owner/r1", "deep"),
+            _mk_record("r002", "A", "owner/r1", "deep"),
+            _mk_record("r003", "A", "owner/r1", "deep"),
+            _mk_record("r004", "B", "owner/r1", "deep"),
+            _mk_record("r005", "B", "owner/r1", "deep"),
+            _mk_record("r006", "B", "owner/r1", "deep"),
+            _mk_record("r007", "B", "owner/r1", "deep"),
+            _mk_record("r008", "B", "owner/r1", "deep"),
+            _mk_record("r009", "A", "owner/r2", "deep"),
+            _mk_record("r010", "A", "owner/r2", "deep"),
+        ]
+        with pytest.raises(ValueError, match="max_stack_share"):
+            _apply_share_caps(
+                records, max_stack_share=0.5, max_repo_share=0.5, max_profile_share=None
             )
 
 
@@ -174,13 +278,17 @@ class TestBuildWiring:
     def test_sequential_passes_converge_all_final_shares_within_limits(
         self, tmp_path: Path
     ) -> None:
-        # Real build over a many-record fixture with ALL THREE caps set tight;
-        # assert every final per-value share in the emitted corpus is <= its
-        # limit — the M4 contract — and that the build did not fail. The
-        # fixture needs variety in all three dimensions (a lone value is 100%
-        # of the population and can never satisfy a <1.0 cap): two admitted
-        # sessions give distinct stacks/repos, and the annotation rows are
-        # re-profiled to give two profile values.
+        # Real build with ALL THREE caps set tight (0.6) over a correlated
+        # 5-record fixture (python/repo-a vs rust/repo-b) that exercises the
+        # exclusion path: re-profiling every python row plus the first rust
+        # row to deep-review puts four of the five records on one profile
+        # value (4/5 = 0.8 > 0.6), so the profile pass must trim at entry — a
+        # fixture landing every dimension exactly on the cap would never run
+        # the trim branch and could not catch drift from a later pass. Assert
+        # every final per-value share in the emitted corpus is <= its limit
+        # (the M4 contract) against the post-trim final population, and that
+        # the cap stage actually excluded records (its report names them
+        # under ``exclusions_by_reason`` as ``share-cap:*``).
         import hashlib
 
         from daydream.training.corpus_v2.projector import run_build_corpus_v2
@@ -200,11 +308,11 @@ class TestBuildWiring:
             bundle, session_id="sess-b", n_siblings=4,
             dispositions=["accepted", "accepted"], stack="rust",
         )
-        # Re-profile three of the five accepted rows so both profile values
-        # sit under the 0.6 cap on the emitted population.
+        # Re-profile only the last accepted row to quick-review so deep-review
+        # holds 4/5 of the emitted population (0.8 > 0.6) and the trim branch
+        # executes.
         rows = [json.loads(line) for line in snap.read_text().splitlines() if line]
-        for row in rows[2:]:
-            row["profile"]["profile_name"] = "quick-review"
+        rows[-1]["profile"]["profile_name"] = "quick-review"
         snap.write_text("".join(json.dumps(r, sort_keys=True) + "\n" for r in rows))
         ann_dir = snap.parent
         rel = sorted(
@@ -216,7 +324,7 @@ class TestBuildWiring:
         ))
 
         out = tmp_path / "out"
-        run_build_corpus_v2(self._share_cfg(
+        summary = run_build_corpus_v2(self._share_cfg(
             out, bundle, snap,
             max_stack_share=0.6, max_repo_share=0.6, max_profile_share=0.6,
         ))
@@ -237,6 +345,11 @@ class TestBuildWiring:
                 counts[getter(r)] = counts.get(getter(r), 0) + 1
             for value, count in counts.items():
                 assert count / total <= limit + 1e-9, f"{key}={value}: {count}/{total} > {limit}"
+        # The exclusion path executed: the over-share profile value was
+        # trimmed at entry and reported as a share-cap exclusion.
+        assert any(
+            key.startswith("share-cap:") for key in summary["exclusions_by_reason"]
+        ), summary["exclusions_by_reason"]
 
     def test_lineage_and_summary_share_caps_cannot_drift(self, tmp_path: Path) -> None:
         import json
@@ -246,6 +359,12 @@ class TestBuildWiring:
         assert lineage["share_caps"] == summary["share_caps"]
         assert lineage["share_caps"]["version"] == 1
         assert lineage["share_caps"]["configured"]["repo"] == 0.5
+        # one shared spelling across configured/applied/exclusion keys
+        assert "repo" in lineage["share_caps"]["applied"]
+        assert "repository" not in lineage["share_caps"]["applied"]
+        assert any(
+            key.startswith("share-cap:repo:") for key in lineage["exclusions_by_reason"]
+        )
         # final per-value counts + shares are reported against the final population
         assert "applied" in lineage["share_caps"] and "exclusions" in lineage["share_caps"]
 
@@ -284,6 +403,7 @@ class TestCliShareFlags:
 
     def _base_argv(self, tmp_path: Path) -> list[str]:
         from tests.test_corpus_v2 import (
+            _admit_second_batch,
             _policy_file,
             _write_annotations_snapshot,
             _write_bundle,
@@ -291,6 +411,29 @@ class TestCliShareFlags:
 
         bundle_dir = _write_bundle(tmp_path)
         snap = _write_annotations_snapshot(bundle_dir)
+        # A second admitted session with a distinct stack/repo so every
+        # configured share cap is satisfiable (a lone value is 100% of the
+        # population and can never satisfy a <1.0 cap); re-profile the tail
+        # rows to a second profile value so the profile dimension has variety
+        # too. The annotation bundle's SHA256SUMS must be refreshed after the
+        # re-profile (same mechanics as the build-wiring fixtures).
+        _admit_second_batch(bundle_dir, "owner/repo-b", spdx_id="MIT")
+        snap = _write_annotations_snapshot(
+            bundle_dir, session_id="sess-b", dispositions=["accepted", "accepted"],
+            stack="rust",
+        )
+        rows = [json.loads(line) for line in snap.read_text().splitlines() if line]
+        for row in rows[2:]:
+            row["profile"]["profile_name"] = "quick-review"
+        snap.write_text("".join(json.dumps(r, sort_keys=True) + "\n" for r in rows))
+        ann_dir = snap.parent
+        rel = sorted(
+            p.relative_to(ann_dir).as_posix() for p in ann_dir.rglob("*")
+            if p.is_file() and p.name != "SHA256SUMS"
+        )
+        (ann_dir / "SHA256SUMS").write_text("".join(
+            f"{hashlib.sha256((ann_dir / p).read_bytes()).hexdigest()}  {p}\n" for p in rel
+        ))
         return [
             "--bundle-root", str(bundle_dir),
             "--annotation-bundle-root", str(snap.parent),

--- a/tests/test_corpus_v2_share_caps.py
+++ b/tests/test_corpus_v2_share_caps.py
@@ -1,0 +1,48 @@
+"""Output-share caps for corpus v2 (issue #1079, M1-M11)."""
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+
+def _share_cfg(out_dir: Path, bundle_dir: Path, snapshot: Path, **kw: Any) -> Any:
+    from tests.test_corpus_v2 import _cfg
+
+    return _cfg(out_dir, bundle_dir, snapshot, **kw)
+
+
+class TestShareCapValidation:
+    def test_share_below_or_equal_zero_refuses(self, tmp_path: Path) -> None:
+        from tests.test_corpus_v2 import _write_annotations_snapshot, _write_bundle
+
+        bundle = _write_bundle(tmp_path)
+        snap = _write_annotations_snapshot(bundle)
+        with pytest.raises(ValueError, match="max_stack_share"):
+            _share_cfg(tmp_path / "out", bundle, snap, max_stack_share=0.0)
+
+    def test_share_above_one_refuses(self, tmp_path: Path) -> None:
+        from tests.test_corpus_v2 import _write_annotations_snapshot, _write_bundle
+
+        bundle = _write_bundle(tmp_path)
+        snap = _write_annotations_snapshot(bundle)
+        with pytest.raises(ValueError, match="max_repo_share"):
+            _share_cfg(tmp_path / "out", bundle, snap, max_repo_share=1.5)
+
+    def test_share_of_one_is_allowed(self, tmp_path: Path) -> None:
+        from tests.test_corpus_v2 import _write_annotations_snapshot, _write_bundle
+
+        bundle = _write_bundle(tmp_path)
+        snap = _write_annotations_snapshot(bundle)
+        config = _share_cfg(tmp_path / "out", bundle, snap, max_profile_share=1.0)
+        assert config.max_profile_share == 1.0
+
+    def test_unset_shares_default_to_none(self, tmp_path: Path) -> None:
+        from tests.test_corpus_v2 import _write_annotations_snapshot, _write_bundle
+
+        bundle = _write_bundle(tmp_path)
+        snap = _write_annotations_snapshot(bundle)
+        config = _share_cfg(tmp_path / "out", bundle, snap)
+        assert config.max_stack_share is None
+        assert config.max_repo_share is None
+        assert config.max_profile_share is None

--- a/tests/test_corpus_v2_share_caps.py
+++ b/tests/test_corpus_v2_share_caps.py
@@ -171,6 +171,73 @@ class TestBuildWiring:
         assert summary["share_caps"]["version"] == 1
         assert summary["exclusions_by_reason"]  # tier/np keys present
 
+    def test_sequential_passes_converge_all_final_shares_within_limits(
+        self, tmp_path: Path
+    ) -> None:
+        # Real build over a many-record fixture with ALL THREE caps set tight;
+        # assert every final per-value share in the emitted corpus is <= its
+        # limit — the M4 contract — and that the build did not fail. The
+        # fixture needs variety in all three dimensions (a lone value is 100%
+        # of the population and can never satisfy a <1.0 cap): two admitted
+        # sessions give distinct stacks/repos, and the annotation rows are
+        # re-profiled to give two profile values.
+        import hashlib
+
+        from daydream.training.corpus_v2.projector import run_build_corpus_v2
+        from tests.test_corpus_v2 import (
+            _admit_second_batch,
+            _write_annotations_snapshot,
+            _write_bundle,
+        )
+
+        bundle = _write_bundle(tmp_path)
+        snap = _write_annotations_snapshot(
+            bundle, session_id="sess-a", n_siblings=6,
+            dispositions=["accepted", "accepted", "accepted"], stack="python",
+        )
+        _admit_second_batch(bundle, "owner/repo-b", spdx_id="MIT")
+        _write_annotations_snapshot(
+            bundle, session_id="sess-b", n_siblings=4,
+            dispositions=["accepted", "accepted"], stack="rust",
+        )
+        # Re-profile three of the five accepted rows so both profile values
+        # sit under the 0.6 cap on the emitted population.
+        rows = [json.loads(line) for line in snap.read_text().splitlines() if line]
+        for row in rows[2:]:
+            row["profile"]["profile_name"] = "quick-review"
+        snap.write_text("".join(json.dumps(r, sort_keys=True) + "\n" for r in rows))
+        ann_dir = snap.parent
+        rel = sorted(
+            p.relative_to(ann_dir).as_posix() for p in ann_dir.rglob("*")
+            if p.is_file() and p.name != "SHA256SUMS"
+        )
+        (ann_dir / "SHA256SUMS").write_text("".join(
+            f"{hashlib.sha256((ann_dir / p).read_bytes()).hexdigest()}  {p}\n" for p in rel
+        ))
+
+        out = tmp_path / "out"
+        run_build_corpus_v2(self._share_cfg(
+            out, bundle, snap,
+            max_stack_share=0.6, max_repo_share=0.6, max_profile_share=0.6,
+        ))
+        emitted = [
+            json.loads(line)
+            for line in (out / "corpus.jsonl").read_text().splitlines() if line
+        ]
+        total = len(emitted)
+        assert total > 0
+        dims: list[tuple[str, Callable[[dict[str, Any]], str], float]] = [
+            ("stack", lambda r: str(r["stack"]), 0.6),
+            ("repo", lambda r: str(r["lineage"]["repo_slug"]), 0.6),
+            ("profile", lambda r: str(r["profile"]["profile_name"]), 0.6),
+        ]
+        for key, getter, limit in dims:
+            counts: dict[str, int] = {}
+            for r in emitted:
+                counts[getter(r)] = counts.get(getter(r), 0) + 1
+            for value, count in counts.items():
+                assert count / total <= limit + 1e-9, f"{key}={value}: {count}/{total} > {limit}"
+
     def test_lineage_and_summary_share_caps_cannot_drift(self, tmp_path: Path) -> None:
         import json
 

--- a/tests/test_corpus_v2_share_caps.py
+++ b/tests/test_corpus_v2_share_caps.py
@@ -1,4 +1,5 @@
 """Tests for the corpus-v2 share-cap stage and its build wiring."""
+import json
 from collections.abc import Callable
 from pathlib import Path
 from typing import Any
@@ -202,3 +203,115 @@ class TestBuildWiring:
             )
         # fail-closed: nothing written
         assert not (tmp_path / "out2" / "_SUCCESS").exists()
+
+
+# ---------------------------------------------------------------------------
+# Task 5: CLI wiring — build-v2 accepts share-cap flags (M2, M9)
+# ---------------------------------------------------------------------------
+
+
+class TestCliShareFlags:
+    """CLI-level share-cap wiring: parser acceptance, fail-closed range
+    validation before any build work, and dry-run parity over the real
+    projection path."""
+
+    def _base_argv(self, tmp_path: Path) -> list[str]:
+        from tests.test_corpus_v2 import (
+            _policy_file,
+            _write_annotations_snapshot,
+            _write_bundle,
+        )
+
+        bundle_dir = _write_bundle(tmp_path)
+        snap = _write_annotations_snapshot(bundle_dir)
+        return [
+            "--bundle-root", str(bundle_dir),
+            "--annotation-bundle-root", str(snap.parent),
+            "--license-policy", str(_policy_file(tmp_path)),
+            "--out", str(tmp_path / "out" / "corpus.jsonl"),
+        ]
+
+    def test_share_flags_accepted_by_parser(self) -> None:
+        from daydream.cli import _build_build_corpus_v2_parser
+
+        args = _build_build_corpus_v2_parser().parse_args(
+            ["--bundle-root", "/b", "--annotation-bundle-root", "/a",
+             "--license-policy", "/l", "--out", "/o/corpus.jsonl",
+             "--max-stack-share", "0.5", "--max-repo-share", "0.6",
+             "--max-profile-share", "0.7"]
+        )
+        assert args.max_stack_share == 0.5
+        assert args.max_repo_share == 0.6
+        assert args.max_profile_share == 0.7
+
+    @pytest.mark.parametrize(
+        ("flag", "value"),
+        [("--max-stack-share", "1.5"), ("--max-stack-share", "0"),
+         ("--max-repo-share", "1.5"), ("--max-repo-share", "-0.1"),
+         ("--max-profile-share", "1.5"), ("--max-profile-share", "0")],
+    )
+    def test_share_out_of_range_refuses_before_build(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str], flag: str, value: str
+    ) -> None:
+        from daydream.cli import _handle_build_corpus_v2_command
+
+        rc = _handle_build_corpus_v2_command(self._base_argv(tmp_path) + [flag, value])
+        assert rc == 1
+        assert f"Invalid {flag}" in capsys.readouterr().out
+        # refused before any build work: no output written
+        assert not (tmp_path / "out" / "_SUCCESS").exists()
+
+    def test_dry_run_writes_nothing_but_reports_capped_population(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        from daydream.cli import _handle_build_corpus_v2_command
+        from daydream.training.corpus_v2 import BuildCorpusV2Config, run_build_corpus_v2
+        from tests.test_corpus_v2 import _policy_file
+
+        argv = self._base_argv(tmp_path) + [
+            "--dry-run", "--max-stack-share", "0.5", "--max-repo-share", "0.6",
+            "--max-profile-share", "0.7",
+        ]
+        rc = _handle_build_corpus_v2_command(argv)
+        assert rc == 0
+        # dry run writes nothing into the real output directory
+        assert not (tmp_path / "out").exists() or not any((tmp_path / "out").iterdir())
+        out_text = capsys.readouterr().out
+
+        # the printed count names the projected (share-capped) population:
+        # run the same projection directly and compare the emitted counts.
+        bundle_dir = tmp_path / "curated" / "cur-0123456789abcdef"
+        snap = bundle_dir.parent / (bundle_dir.name + "-annotations")
+        direct = run_build_corpus_v2(BuildCorpusV2Config(
+            out_dir=tmp_path / "direct",
+            bundle_dir=bundle_dir,
+            annotation_bundle_dir=snap,
+            license_policy_path=_policy_file(tmp_path),
+            max_stack_share=0.5, max_repo_share=0.6, max_profile_share=0.7,
+        ))
+        assert str(direct["emitted"]) in out_text
+
+    def test_dry_run_parity_for_capped_build(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        from daydream.cli import _handle_build_corpus_v2_command
+        from tests.test_corpus_v2 import _policy_file
+
+        argv = self._base_argv(tmp_path) + ["--dry-run", "--max-stack-share", "0.5"]
+        rc = _handle_build_corpus_v2_command(argv)
+        assert rc == 0
+        capsys.readouterr()
+        # the real build with the same caps succeeds over the same inputs
+        bundle_dir = tmp_path / "curated" / "cur-0123456789abcdef"
+        snap = bundle_dir.parent / (bundle_dir.name + "-annotations")
+        rc2 = _handle_build_corpus_v2_command([
+            "--bundle-root", str(bundle_dir),
+            "--annotation-bundle-root", str(snap),
+            "--license-policy", str(_policy_file(tmp_path)),
+            "--out", str(tmp_path / "real" / "corpus.jsonl"),
+            "--max-stack-share", "0.5",
+        ])
+        assert rc2 == 0
+        assert (tmp_path / "real" / "_SUCCESS").is_file()
+        lineage = json.loads((tmp_path / "real" / "lineage.json").read_text())
+        assert lineage["share_caps"]["configured"] == {"stack": 0.5}

--- a/tests/test_corpus_v2_share_caps.py
+++ b/tests/test_corpus_v2_share_caps.py
@@ -3,7 +3,7 @@ import hashlib
 import json
 from collections.abc import Callable
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 import pytest
 
@@ -105,7 +105,8 @@ class TestApplyShareCaps:
         total = len(kept)
         stack: dict[str, int] = {}
         repo: dict[str, int] = {}
-        for r in kept:
+        for raw in kept:
+            r = cast(dict[str, Any], raw)
             stack[str(r["stack"])] = stack.get(str(r["stack"]), 0) + 1
             repo[str(r["lineage"]["repo_slug"])] = repo.get(str(r["lineage"]["repo_slug"]), 0) + 1
         for value, count in stack.items():


### PR DESCRIPTION
## Summary
- Implements output-share caps for corpus-v2 builds: stack share, repository share, and profile share caps enforced as a fixed point so sequential splitting cannot drift.
- build-v2 accepts --max-stack-share and repo/profile share flags.
- Repeated annotation snapshot sessions are treated as idempotent.

## Test Plan
- [x] All three share caps hold simultaneously on a real build
- [x] Share-capped builds replay byte-identically with disjoint splits
- [x] Full suite: 5263 passed, 21 skipped (review round 2 gate)

Closes #1079