### PR TITLE
training: make frozen corpus v2 directly consumable by Stage 0, SFT, and RFT (Closes #1081)

### DIFF
--- a/daydream/cli.py
+++ b/daydream/cli.py
@@ -44,7 +44,7 @@ import signal
 import sys
 from collections.abc import Callable
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, NoReturn
 
 import anyio
 from rich.console import Console
@@ -2071,25 +2071,46 @@ def _handle_label_command(argv: list[str]) -> int:
     return 0
 
 
+class _TrainParser(argparse.ArgumentParser):
+    """Train parser that maps usage errors to exit code 1.
+
+    The train verb reports refusals (including conflicting inputs) as a
+    validation failure with exit 1 rather than argparse's default 2, so
+    harnesses see one failure code for "the run was refused".
+    """
+
+    def error(self, message: str) -> NoReturn:
+        self.print_usage(sys.stderr)
+        self.exit(1, f"{self.prog}: error: {message}\n")
+
+
 def _build_train_parser() -> argparse.ArgumentParser:
     """Build the parser for ``daydream train --corpus <path> --out <dir> [...]``.
 
     Dispatched manually from ``main()`` (verb-first) so its flags don't
     collide with the top-level ``TARGET`` positional.
     """
-    parser = argparse.ArgumentParser(
+    parser = _TrainParser(
         prog="daydream train",
         description=(
             "Run the four-stage training pipeline (stage0 gate → stage1 SFT → "
             "stage2 RFT → stage3 adapter) and write a stage manifest."
         ),
     )
-    parser.add_argument(
+    corpus_group = parser.add_mutually_exclusive_group(required=True)
+    corpus_group.add_argument(
         "--corpus",
         type=Path,
-        required=True,
         metavar="PATH",
         help="Input JSONL training corpus (one record per line; C5/C8 fail-closed)",
+    )
+    corpus_group.add_argument(
+        "--corpus-v2",
+        type=Path,
+        dest="corpus_v2",
+        metavar="DIR",
+        help="Frozen corpus-v2 projection directory; verifies _SUCCESS/lineage/"
+             "split digests and re-applies C5/C8",
     )
     parser.add_argument(
         "--out",
@@ -2147,6 +2168,7 @@ def _handle_train_command(argv: list[str]) -> int:
 
     config = PipelineConfig(
         corpus=args.corpus,
+        corpus_v2=args.corpus_v2,
         out_dir=args.out,
         stages=tuple(args.stages) if args.stages else ("stage0", "stage1", "stage2", "stage3"),
         base_model=args.base_model,

--- a/daydream/training/coordinator.py
+++ b/daydream/training/coordinator.py
@@ -42,9 +42,10 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import re
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 from daydream.archive import get_archive_dir
 from daydream.training import gate as gate_mod
@@ -53,6 +54,7 @@ from daydream.training.gate import FrozenSplit, GateConfig, GateReport, freeze_s
 from daydream.training.lineage import ResumeAborted, RunIdentity, stage_digests, validate_resume
 from daydream.training.reward import DEFAULT_WEIGHTS, REWARD_VERSION
 from daydream.training.reward_model import OutcomeModel, train_outcome_model
+from daydream.training.stacks_v2 import V2Projection, load_v2_projection, recompute_split_from_record_id
 
 __all__ = ["PipelineConfig", "run_pipeline"]
 
@@ -69,7 +71,13 @@ class PipelineConfig:
     changes the run's identity and invalidates a resume (M18).
 
     Attributes:
-        corpus: Path to the JSONL training corpus (one record per line).
+        corpus: Path to the JSONL training corpus (one record per line) — the
+            v1 input. Exactly one of ``corpus`` and ``corpus_v2`` must be set;
+            they are mutually exclusive.
+        corpus_v2: Path to a frozen corpus-v2 projection directory (the
+            ``run_build_corpus_v2`` output). When set, the pipeline loads the
+            projection via :func:`daydream.training.stacks_v2.load_v2_projection`
+            and Stage 0 consumes the projector's frozen split.
         out_dir: Root directory for stage outputs and ``manifest.json``.
         stages: Ordered stage names to run.
         base_model: HuggingFace model id the LoRA adapter trains against.
@@ -87,8 +95,9 @@ class PipelineConfig:
         stack_pins: Exact dependency pins carried in the run identity.
     """
 
-    corpus: Path
     out_dir: Path
+    corpus: Path | None = None
+    corpus_v2: Path | None = None
     stages: tuple[str, ...] = STAGES
     base_model: str = "Qwen/Qwen3-8B"
     tokenizer_renderer: str = "default"
@@ -114,6 +123,13 @@ class PipelineConfig:
             raise ValueError(
                 f"held_out_fraction must be in (0, 1) exclusive (got {self.held_out_fraction!r})"
             )
+        if self.corpus is not None and self.corpus_v2 is not None:
+            raise ValueError(
+                "corpus and corpus_v2 are mutually exclusive: a run consumes either "
+                "the v1 JSONL corpus or a frozen corpus-v2 projection directory, never both"
+            )
+        if self.corpus is None and self.corpus_v2 is None:
+            raise ValueError("exactly one of corpus or corpus_v2 must be set")
 
 
 def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
@@ -129,28 +145,52 @@ def _file_digest(path: Path) -> str:
     return hashlib.sha256(path.read_bytes()).hexdigest()
 
 
-def _outcome_rows(records: list[dict[str, Any]]) -> list[dict[str, Any]]:
-    """Extract gold outcome rows for the Stage-0 labels file from either shape.
+def _outcome_rows(
+    records: list[dict[str, Any]], *, require_finding_text: bool = False
+) -> list[dict[str, Any]]:
+    """Extract gold outcome rows for the Stage-0 labels file from any shape.
 
-    Accepts both the committed fixture shape (``comment_id``/``text``/``label``)
-    and production ``run_build_corpus`` exports (``session_id``/
-    ``review_output``/``outcome_label``). Gold-gate evidence fields
-    (``has_posterior``, ``labeler_policy_version``, ``decisive_mix``,
+    Accepts the committed fixture shape (``comment_id``/``text``/``label``),
+    production ``run_build_corpus`` exports (``session_id``/
+    ``review_output``/``outcome_label``), and corpus-v2 records
+    (``session_id``/``finding_text``/``outcome_label``). Gold-gate evidence
+    fields (``has_posterior``, ``labeler_policy_version``, ``decisive_mix``,
     ``decisive_only``) are carried through when the record provides them; an
     absent ``labeler_policy_version`` is left absent so the admission guard in
     :mod:`daydream.training.reward_model` refuses the legacy row rather than
-    silently admitting it.
+    silently admitting it. On v2 records the policy version lives under
+    ``lineage`` and is promoted from there when the record carries no
+    top-level value.
+
+    Args:
+        records: Corpus records in any of the accepted shapes.
+        require_finding_text: When True (the corpus-v2 path), a gold-labeled
+            record with no readable text raises instead of being silently
+            skipped — a v2 gold record without its localized finding text is
+            a broken projection, never an empty-row row.
+
+    Raises:
+        RuntimeError: When ``require_finding_text`` is set and a gold-labeled
+            record carries no ``finding_text``/``text``/``review_output``.
     """
     rows: list[dict[str, Any]] = []
     for rec in records:
         comment_id = rec.get("comment_id") or rec.get("session_id")
-        text = rec.get("text") or rec.get("review_output")
+        text = rec.get("finding_text") or rec.get("text") or rec.get("review_output")
         label = rec.get("label") or rec.get("outcome_label")
         # Only the two gold outcome classes feed the Stage-0 model; contested/
         # null-label rows are not gold outcome rows and are excluded here.
         if label not in ("accepted", "rejected"):
             continue
         if not (comment_id and text):
+            if require_finding_text:
+                raise RuntimeError(
+                    f"stage0 refused: corpus-v2 gold record "
+                    f"{rec.get('record_id') or comment_id!r} has outcome_label "
+                    f"{label!r} but no finding_text/text/review_output — a gold "
+                    "record without its localized finding text is a broken "
+                    "projection, not an empty row"
+                )
             continue
         row: dict[str, Any] = {
             "comment_id": comment_id,
@@ -160,6 +200,10 @@ def _outcome_rows(records: list[dict[str, Any]]) -> list[dict[str, Any]]:
         for key in ("has_posterior", "labeler_policy_version", "decisive_mix", "decisive_only"):
             if key in rec:
                 row[key] = rec[key]
+        if "labeler_policy_version" not in row:
+            lineage_obj = rec.get("lineage")
+            if isinstance(lineage_obj, dict) and lineage_obj.get("labeler_policy_version") is not None:
+                row["labeler_policy_version"] = lineage_obj["labeler_policy_version"]
         rows.append(row)
     return rows
 
@@ -172,7 +216,10 @@ def _sft_rows(records: list[dict[str, Any]]) -> tuple[list[dict[str, Any]], dict
     on rejected or silver traces. Rows are prompt/completion JSONL — the shape
     the prime-rl ``sft`` loader accepts (``messages`` column or both
     ``prompt``/``completion``). Gold vs silver counts are reported separately
-    (M9), matching the recipe's tier accounting.
+    (M9), matching the recipe's tier accounting. On corpus-v2 records the
+    completion is the localized ``finding_text`` of the gold-accepted
+    finding; the completion field chain is
+    ``completion`` → ``finding_text`` → ``text`` → ``review_output``.
 
     Current-policy SFT prefers native-profile traces (M23): accepted rows are
     partitioned by the ``legacy_policy`` tag ``stacks.load_dataset`` stamps
@@ -192,7 +239,12 @@ def _sft_rows(records: list[dict[str, Any]]) -> tuple[list[dict[str, Any]], dict
     legacy: list[dict[str, Any]] = []
     for rec in records:
         label = rec.get("label") or rec.get("outcome_label")
-        completion = rec.get("completion") or rec.get("text") or rec.get("review_output")
+        completion = (
+            rec.get("completion")
+            or rec.get("finding_text")
+            or rec.get("text")
+            or rec.get("review_output")
+        )
         if not isinstance(completion, str) or not completion:
             continue
         if label == "accepted":
@@ -263,6 +315,13 @@ def _materialize_diff(rec: dict[str, Any]) -> str | None:
         return None
 
 
+def _is_full_sha(value: object) -> bool:
+    """Whether a value is a full-length hex SHA — at least a full 40-char git
+    commit SHA (longer sha256-style content-address stamps are tolerated).
+    Truncated or non-hex values are rejected."""
+    return bool(re.fullmatch(r"[0-9a-f]{40,}", str(value)))
+
+
 def _rft_rows(records: list[dict[str, Any]]) -> list[dict[str, Any]]:
     """Materialize Stage-2 RFT replay inputs from corpus records (M16).
 
@@ -271,7 +330,10 @@ def _rft_rows(records: list[dict[str, Any]]) -> list[dict[str, Any]]:
     intrinsic signals ``reward.score_trajectory`` consumes. Identity is
     validated fail-closed, matching ``run_rft``: a record missing
     base/head/diff raises naming it, so Stage 2 is never recorded complete
-    over unrunnable inputs.
+    over unrunnable inputs. base/head are read v2-first from
+    ``task_identity`` with the v1 ``code_context`` fallback (Pattern A), and
+    must be full-length hex SHAs — a truncated SHA is refused like a missing
+    one.
 
     ``diff`` falls back to :func:`_materialize_diff` when the record carries
     no raw ``diff`` body: production ``run_build_corpus`` exports (schema v1,
@@ -281,7 +343,8 @@ def _rft_rows(records: list[dict[str, Any]]) -> list[dict[str, Any]]:
 
     Raises:
         RuntimeError: When any record lacks ``base_sha``/``head_sha``/``diff``
-            identity (never written, never skipped silently).
+            identity or carries a truncated/non-hex SHA (never written, never
+            skipped silently).
     """
     rows: list[dict[str, Any]] = []
     for rec in records:
@@ -289,9 +352,11 @@ def _rft_rows(records: list[dict[str, Any]]) -> list[dict[str, Any]]:
         raw_ctx = rec.get("code_context")
         if isinstance(raw_ctx, dict):
             code_ctx = raw_ctx
+        task_identity = rec.get("task_identity")
+        identity = task_identity if isinstance(task_identity, dict) else {}
         rid = str(rec.get("comment_id") or rec.get("session_id") or "")
-        base_sha = rec.get("base_sha") or code_ctx.get("base_sha")
-        head_sha = rec.get("head_sha") or code_ctx.get("head_sha")
+        base_sha = identity.get("base_sha") or rec.get("base_sha") or code_ctx.get("base_sha")
+        head_sha = identity.get("head_sha") or rec.get("head_sha") or code_ctx.get("head_sha")
         diff = rec.get("diff")
         if not diff:
             diff = _materialize_diff(rec)
@@ -306,9 +371,19 @@ def _rft_rows(records: list[dict[str, Any]]) -> list[dict[str, Any]]:
                 "RFT rebuilds every task from base/head/diff identity (M16) and never skips a "
                 "record silently"
             )
+        for name, value in (("base_sha", base_sha), ("head_sha", head_sha)):
+            if not _is_full_sha(value):
+                raise RuntimeError(
+                    f"stage2 refused: record {rid!r} carries a truncated or non-hex "
+                    f"{name} {value!r}; RFT rebuilds every task from full-length "
+                    "commit SHAs and never replays against a shortened identity"
+
+                )
         length = rec.get("length")
         if length is None:
-            length = len(str(rec.get("text") or rec.get("review_output") or ""))
+            length = len(
+                str(rec.get("text") or rec.get("review_output") or rec.get("finding_text") or "")
+            )
         rows.append(
             {
                 "id": rid,
@@ -326,15 +401,96 @@ def _rft_rows(records: list[dict[str, Any]]) -> list[dict[str, Any]]:
     return rows
 
 
+def _frozen_split_from_projection(
+    projection: V2Projection, labels_path: Path, *, held_out_fraction: float, seed: int
+) -> FrozenSplit:
+    """Build the Stage-0 :class:`FrozenSplit` from the projector's frozen
+    boundary instead of re-freezing at runtime.
+
+    The corpus-v2 projection was split deterministically at build time
+    (``lineage.split`` per record, drift-gated by the loader). Stage 0 maps
+    that three-way boundary onto its two-way partition — train+validation
+    rows train, holdout rows evaluate — and verifies the boundary fail-closed:
+    every gold record's recorded ``lineage.split`` must match the split
+    recomputed from its record id under the lineage's pinned salt/rates, the
+    same recompute comparison the loader enforces.
+
+    The split digest is the same content address :func:`freeze_split` emits
+    (SHA-256 over the sorted held-out comment ids plus the seed), so the
+    resume guard and stage manifest consume it unchanged.
+
+    Raises:
+        RuntimeError: On boundary drift (recorded vs recomputed split) or a
+            holdout side with no gold outcome rows.
+    """
+    train = _outcome_rows(
+        [*projection.by_split["train"], *projection.by_split["validation"]],
+        require_finding_text=True,
+    )
+    held_out = _outcome_rows(projection.by_split["holdout"], require_finding_text=True)
+    if not held_out:
+        raise RuntimeError(
+            "stage0 refused: the corpus-v2 frozen split has no gold outcome rows in "
+            "its holdout split; the gate would evaluate against nothing and refuses closed"
+        )
+    salt = str(projection.lineage["salt"])
+    holdout_rate = float(cast(float, projection.lineage["holdout_rate"]))
+    val_rate = float(cast(float, projection.lineage["val_rate"]))
+    for rec in projection.records:
+        lineage_obj = rec.get("lineage")
+        recorded = lineage_obj.get("split") if isinstance(lineage_obj, dict) else None
+        recomputed = recompute_split_from_record_id(
+            str(rec.get("record_id", "")),
+            salt=salt,
+            holdout_rate=holdout_rate,
+            val_rate=val_rate,
+        )
+        if recorded != recomputed:
+            raise RuntimeError(
+                f"stage0 refused: corpus-v2 record {rec.get('record_id')!r} boundary "
+                f"drift — recorded split {recorded!r} != recomputed {recomputed!r}; "
+                "the frozen split is not trusted over recomputation"
+            )
+    held_out_ids = [str(r["comment_id"]) for r in held_out]
+    digest = gate_mod._split_digest(held_out_ids, seed)
+    digest_path = labels_path.name + ".gate-split.json"
+    sidecar = {
+        "digest": digest,
+        "seed": seed,
+        "held_out_fraction": held_out_fraction,
+        "held_out_ids": sorted(held_out_ids),
+        "train_ids": sorted(str(r["comment_id"]) for r in train),
+    }
+    sidecar_path = labels_path.parent / digest_path
+    tmp = sidecar_path.with_name(sidecar_path.name + ".tmp")
+    tmp.write_text(json.dumps(sidecar, indent=2, sort_keys=True))
+    os.replace(tmp, sidecar_path)
+    return FrozenSplit(
+        digest=digest,
+        fingerprint=digest[:8],
+        digest_path=digest_path,
+        train_rows=train,
+        held_out_rows=held_out,
+        seed=seed,
+        held_out_fraction=held_out_fraction,
+    )
+
+
 def _run_stage0(
-    config: PipelineConfig, records: list[dict[str, Any]], stage_dir: Path
+    config: PipelineConfig,
+    records: list[dict[str, Any]],
+    stage_dir: Path,
+    *,
+    projection: V2Projection | None = None,
 ) -> tuple[dict[str, Any], GateReport, FrozenSplit]:
     """Stage 0: freeze split, train the outcome model, evaluate the gate.
 
     All CPU-bound; runs identically on the dry path (the gate evaluates on
     cached model state — the small classifier is trained in-process, no GPU).
+    On corpus-v2 input the split is not re-frozen: the projector's frozen
+    boundary is consumed via :func:`_frozen_split_from_projection`.
     """
-    rows = _outcome_rows(records)
+    rows = _outcome_rows(records, require_finding_text=projection is not None)
     if not rows:
         raise RuntimeError(
             "stage0 gate evidence missing: corpus carries no gold outcome rows "
@@ -344,9 +500,17 @@ def _run_stage0(
     labels_path = stage_dir / "labels.jsonl"
     labels_path.write_text("\n".join(json.dumps(r, sort_keys=True) for r in rows))
 
-    split = freeze_split(
-        labels_path, held_out_fraction=config.held_out_fraction, seed=config.seed
-    )
+    if projection is not None:
+        split = _frozen_split_from_projection(
+            projection,
+            labels_path,
+            held_out_fraction=config.held_out_fraction,
+            seed=config.seed,
+        )
+    else:
+        split = freeze_split(
+            labels_path, held_out_fraction=config.held_out_fraction, seed=config.seed
+        )
     model: OutcomeModel = train_outcome_model(
         labels_path,
         split=split,
@@ -462,7 +626,8 @@ def run_pipeline(config: PipelineConfig, *, dry_run: bool) -> dict[str, Any]:
     """Run the configured stages in order and write the stage manifest.
 
     Args:
-        config: The pipeline configuration (corpus, output root, stages).
+        config: The pipeline configuration (corpus or corpus_v2 input, output
+            root, stages).
         dry_run: When true, execute only what needs no GPU (corpus load,
             Stage-0 gate, validation, manifest) and mark the GPU stages
             ``skipped_dry`` — the CI path.
@@ -477,9 +642,22 @@ def run_pipeline(config: PipelineConfig, *, dry_run: bool) -> dict[str, Any]:
         RuntimeError: When Stage 3 is requested without a passed Stage-0 gate,
             or the corpus carries no gold outcome rows for Stage 0.
     """
-    corpus_path = Path(config.corpus)
-    records = stacks.load_dataset(corpus_path, allow_copyleft=config.allow_copyleft)
-    corpus_digest = _file_digest(corpus_path)
+    projection: V2Projection | None = None
+    if config.corpus_v2 is not None:
+        # Frozen corpus-v2 directory: the v2 loader re-applies the C5/C8 and
+        # split-drift gates, and the directory-level digest replaces the
+        # single-file corpus digest in the run identity.
+        v2_path = config.corpus_v2
+        corpus_path = Path(v2_path)
+        projection = load_v2_projection(v2_path, allow_copyleft=config.allow_copyleft)
+        records = list(projection.records)
+        corpus_digest = projection.digest
+    else:
+        v1_path = config.corpus
+        assert v1_path is not None  # PipelineConfig.__post_init__ enforces exactly-one
+        corpus_path = Path(v1_path)
+        records = stacks.load_dataset(corpus_path, allow_copyleft=config.allow_copyleft)
+        corpus_digest = _file_digest(corpus_path)
 
     out_dir = Path(config.out_dir)
     stage_entries: dict[str, dict[str, Any]] = {}
@@ -507,7 +685,9 @@ def run_pipeline(config: PipelineConfig, *, dry_run: bool) -> dict[str, Any]:
     for stage in config.stages:
         stage_dir = out_dir / stage
         if stage == "stage0":
-            entry, gate_report, frozen_split = _run_stage0(config, records, stage_dir)
+            entry, gate_report, frozen_split = _run_stage0(
+                config, records, stage_dir, projection=projection
+            )
             stage_entries[stage] = entry
             stage_records[stage] = {"records": records}
             split_digest = frozen_split.digest

--- a/daydream/training/coordinator.py
+++ b/daydream/training/coordinator.py
@@ -328,7 +328,10 @@ def _rft_rows(records: list[dict[str, Any]]) -> list[dict[str, Any]]:
     must be full-length hex SHAs — validated through the shared
     :func:`daydream.training.rft.validate_full_sha`, so Stage 2 and
     ``run_rft`` enforce the identical full 40-hex contract; a truncated or
-    non-hex SHA is refused like a missing one.
+    non-hex SHA is refused like a missing one. ``repo_slug`` is likewise read
+    v2-first (``task_identity``, then ``lineage``) with the v1 top-level
+    fallback, so a v2 row never carries a null repo_slug that the replay's
+    ``_reconstruct_task`` would refuse.
 
     ``diff`` falls back to :func:`_materialize_diff` when the record carries
     no raw ``diff`` body: production ``run_build_corpus`` exports (schema v1,
@@ -349,6 +352,8 @@ def _rft_rows(records: list[dict[str, Any]]) -> list[dict[str, Any]]:
             code_ctx = raw_ctx
         task_identity = rec.get("task_identity")
         identity = task_identity if isinstance(task_identity, dict) else {}
+        raw_lineage = rec.get("lineage")
+        lineage_obj = raw_lineage if isinstance(raw_lineage, dict) else {}
         rid = str(rec.get("comment_id") or rec.get("session_id") or "")
         base_sha = identity.get("base_sha") or rec.get("base_sha") or code_ctx.get("base_sha")
         head_sha = identity.get("head_sha") or rec.get("head_sha") or code_ctx.get("head_sha")
@@ -379,7 +384,12 @@ def _rft_rows(records: list[dict[str, Any]]) -> list[dict[str, Any]]:
         rows.append(
             {
                 "id": rid,
-                "repo_slug": rec.get("repo_slug"),
+                # repo_slug is read v2-first (task_identity, then lineage) with
+                # the v1 top-level fallback, so a v2 record never emits a null
+                # repo_slug that run_rft's replay would refuse.
+                "repo_slug": identity.get("repo_slug")
+                or lineage_obj.get("repo_slug")
+                or rec.get("repo_slug"),
                 "base_sha": base_sha,
                 "head_sha": head_sha,
                 "diff": diff,
@@ -408,8 +418,11 @@ def _frozen_split_from_projection(
     same recompute comparison the loader enforces.
 
     The split digest is the same content address :func:`freeze_split` emits
-    (SHA-256 over the sorted held-out comment ids plus the seed), so the
-    resume guard and stage manifest consume it unchanged.
+    (SHA-256 over the sorted held-out comment ids plus the seed), and the
+    digest sidecar (``<labels>.gate-split.json``) is written by the shared
+    :func:`daydream.training.gate.write_split_sidecar`, so the resume guard
+    and stage manifest consume the identical contract whichever producer
+    froze the boundary.
 
     Raises:
         RuntimeError: On boundary drift (recorded vs recomputed split) or a
@@ -445,18 +458,14 @@ def _frozen_split_from_projection(
             )
     held_out_ids = [str(r["comment_id"]) for r in held_out]
     digest = gate_mod._split_digest(held_out_ids, seed)
-    digest_path = labels_path.name + ".gate-split.json"
-    sidecar = {
-        "digest": digest,
-        "seed": seed,
-        "held_out_fraction": held_out_fraction,
-        "held_out_ids": sorted(held_out_ids),
-        "train_ids": sorted(str(r["comment_id"]) for r in train),
-    }
-    sidecar_path = labels_path.parent / digest_path
-    tmp = sidecar_path.with_name(sidecar_path.name + ".tmp")
-    tmp.write_text(json.dumps(sidecar, indent=2, sort_keys=True))
-    os.replace(tmp, sidecar_path)
+    digest_path = gate_mod.write_split_sidecar(
+        labels_path,
+        digest=digest,
+        seed=seed,
+        held_out_fraction=held_out_fraction,
+        held_out_ids=held_out_ids,
+        train_ids=[str(r["comment_id"]) for r in train],
+    )
     return FrozenSplit(
         digest=digest,
         fingerprint=digest[:8],

--- a/daydream/training/coordinator.py
+++ b/daydream/training/coordinator.py
@@ -42,7 +42,6 @@ from __future__ import annotations
 import hashlib
 import json
 import os
-import re
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, cast
@@ -54,6 +53,7 @@ from daydream.training.gate import FrozenSplit, GateConfig, GateReport, freeze_s
 from daydream.training.lineage import ResumeAborted, RunIdentity, stage_digests, validate_resume
 from daydream.training.reward import DEFAULT_WEIGHTS, REWARD_VERSION
 from daydream.training.reward_model import OutcomeModel, train_outcome_model
+from daydream.training.rft import validate_full_sha
 from daydream.training.stacks_v2 import V2Projection, load_v2_projection, recompute_split_from_record_id
 
 __all__ = ["PipelineConfig", "run_pipeline"]
@@ -315,13 +315,6 @@ def _materialize_diff(rec: dict[str, Any]) -> str | None:
         return None
 
 
-def _is_full_sha(value: object) -> bool:
-    """Whether a value is a full-length hex SHA — at least a full 40-char git
-    commit SHA (longer sha256-style content-address stamps are tolerated).
-    Truncated or non-hex values are rejected."""
-    return bool(re.fullmatch(r"[0-9a-f]{40,}", str(value)))
-
-
 def _rft_rows(records: list[dict[str, Any]]) -> list[dict[str, Any]]:
     """Materialize Stage-2 RFT replay inputs from corpus records (M16).
 
@@ -332,8 +325,10 @@ def _rft_rows(records: list[dict[str, Any]]) -> list[dict[str, Any]]:
     base/head/diff raises naming it, so Stage 2 is never recorded complete
     over unrunnable inputs. base/head are read v2-first from
     ``task_identity`` with the v1 ``code_context`` fallback (Pattern A), and
-    must be full-length hex SHAs — a truncated SHA is refused like a missing
-    one.
+    must be full-length hex SHAs — validated through the shared
+    :func:`daydream.training.rft.validate_full_sha`, so Stage 2 and
+    ``run_rft`` enforce the identical full 40-hex contract; a truncated or
+    non-hex SHA is refused like a missing one.
 
     ``diff`` falls back to :func:`_materialize_diff` when the record carries
     no raw ``diff`` body: production ``run_build_corpus`` exports (schema v1,
@@ -372,13 +367,10 @@ def _rft_rows(records: list[dict[str, Any]]) -> list[dict[str, Any]]:
                 "record silently"
             )
         for name, value in (("base_sha", base_sha), ("head_sha", head_sha)):
-            if not _is_full_sha(value):
-                raise RuntimeError(
-                    f"stage2 refused: record {rid!r} carries a truncated or non-hex "
-                    f"{name} {value!r}; RFT rebuilds every task from full-length "
-                    "commit SHAs and never replays against a shortened identity"
-
-                )
+            try:
+                validate_full_sha(rid, name, value)
+            except ValueError as exc:
+                raise RuntimeError(str(exc)) from exc
         length = rec.get("length")
         if length is None:
             length = len(

--- a/daydream/training/coordinator.py
+++ b/daydream/training/coordinator.py
@@ -261,17 +261,31 @@ def _sft_rows(records: list[dict[str, Any]]) -> tuple[list[dict[str, Any]], dict
 
 
 def _sft_prompt(rec: dict[str, Any]) -> str:
-    """Deterministic SFT prompt built from a record's frozen review context."""
+    """Deterministic SFT prompt built from a record's frozen review context.
+
+    On corpus-v2 records the repo slug and task SHAs live under
+    ``task_identity`` (the repo slug also under ``lineage``); they are read
+    v2-first with the v1 top-level / ``code_context`` fallback (Pattern A, the
+    same order :func:`_rft_rows` uses), so a v2 prompt carries the record's
+    real repo slug and frozen task shas instead of degrading to 'unknown'.
+    """
     code_ctx: dict[str, Any] = {}
     raw_ctx = rec.get("code_context")
     if isinstance(raw_ctx, dict):
         code_ctx = raw_ctx
-    parts = [f"repo: {rec.get('repo_slug', 'unknown')}"]
+    task_identity = rec.get("task_identity")
+    identity = task_identity if isinstance(task_identity, dict) else {}
+    raw_lineage = rec.get("lineage")
+    lineage_obj = raw_lineage if isinstance(raw_lineage, dict) else {}
+    repo_slug = identity.get("repo_slug") or lineage_obj.get("repo_slug") or rec.get(
+        "repo_slug", "unknown"
+    )
+    parts = [f"repo: {repo_slug}"]
     stack = rec.get("stack") or rec.get("detected_stack")
     if stack:
         parts.append(f"stack: {stack}")
     for key in ("base_sha", "head_sha"):
-        value = rec.get(key) or code_ctx.get(key)
+        value = identity.get(key) or rec.get(key) or code_ctx.get(key)
         if value:
             parts.append(f"{key}: {value}")
     changed = code_ctx.get("changed_files") or []
@@ -322,16 +336,29 @@ def _rft_rows(records: list[dict[str, Any]]) -> list[dict[str, Any]]:
     rebuilds tasks from (``id``/``base_sha``/``head_sha``/``diff``) plus the
     intrinsic signals ``reward.score_trajectory`` consumes. Identity is
     validated fail-closed, matching ``run_rft``: a record missing
-    base/head/diff raises naming it, so Stage 2 is never recorded complete
-    over unrunnable inputs. base/head are read v2-first from
+    repo_slug/base/head/diff raises naming it — the same missing-gate
+    ``run_rft._reconstruct_task`` enforces — so Stage 2 is never recorded
+    complete over unrunnable inputs. base/head are read v2-first from
     ``task_identity`` with the v1 ``code_context`` fallback (Pattern A), and
     must be full-length hex SHAs — validated through the shared
     :func:`daydream.training.rft.validate_full_sha`, so Stage 2 and
     ``run_rft`` enforce the identical full 40-hex contract; a truncated or
     non-hex SHA is refused like a missing one. ``repo_slug`` is likewise read
     v2-first (``task_identity``, then ``lineage``) with the v1 top-level
-    fallback, so a v2 row never carries a null repo_slug that the replay's
-    ``_reconstruct_task`` would refuse.
+    fallback and is fail-closed like the SHAs, so a v2 row never carries a
+    null repo_slug that the replay's ``_reconstruct_task`` would refuse, and
+    a v1 row without one is refused at Stage 2 exactly where the replay
+    would refuse it.
+
+    On corpus-v2 records the intrinsic scoring signals are derived from the
+    record itself: the frozen projection record is admission/shape/drift-
+    validated, so ``format_valid`` is True (the v1 bronze-parse failure floor
+    cannot apply), and the record's adjudicated outcome is mapped onto the
+    shared verdict vocabulary (``accepted`` → ``consistent``, ``rejected`` →
+    ``contradicts``, ambiguous/unanswered/missing → ``uncertain``) so the
+    replay's winner filter reads a real correctness axis instead of scoring
+    every candidate at a flat 0.0 composite. ``grounding_rate`` stays absent
+    (unknown, never an invented zero).
 
     ``diff`` falls back to :func:`_materialize_diff` when the record carries
     no raw ``diff`` body: production ``run_build_corpus`` exports (schema v1,
@@ -340,9 +367,9 @@ def _rft_rows(records: list[dict[str, Any]]) -> list[dict[str, Any]]:
     stays runnable through Stage 2.
 
     Raises:
-        RuntimeError: When any record lacks ``base_sha``/``head_sha``/``diff``
-            identity or carries a truncated/non-hex SHA (never written, never
-            skipped silently).
+        RuntimeError: When any record lacks ``repo_slug``/``base_sha``/
+            ``head_sha``/``diff`` identity or carries a truncated/non-hex SHA
+            (never written, never skipped silently).
     """
     rows: list[dict[str, Any]] = []
     for rec in records:
@@ -355,6 +382,7 @@ def _rft_rows(records: list[dict[str, Any]]) -> list[dict[str, Any]]:
         raw_lineage = rec.get("lineage")
         lineage_obj = raw_lineage if isinstance(raw_lineage, dict) else {}
         rid = str(rec.get("comment_id") or rec.get("session_id") or "")
+        repo_slug = identity.get("repo_slug") or lineage_obj.get("repo_slug") or rec.get("repo_slug")
         base_sha = identity.get("base_sha") or rec.get("base_sha") or code_ctx.get("base_sha")
         head_sha = identity.get("head_sha") or rec.get("head_sha") or code_ctx.get("head_sha")
         diff = rec.get("diff")
@@ -362,20 +390,50 @@ def _rft_rows(records: list[dict[str, Any]]) -> list[dict[str, Any]]:
             diff = _materialize_diff(rec)
         missing = [
             name
-            for name, value in (("base_sha", base_sha), ("head_sha", head_sha), ("diff", diff))
+            for name, value in (
+                ("repo_slug", repo_slug),
+                ("base_sha", base_sha),
+                ("head_sha", head_sha),
+                ("diff", diff),
+            )
             if not value
         ]
         if missing:
             raise RuntimeError(
                 f"stage2 refused: record {rid!r} lacks frozen task identity field(s) {missing}; "
-                "RFT rebuilds every task from base/head/diff identity (M16) and never skips a "
-                "record silently"
+                "RFT rebuilds every task from repo/base/head/diff identity (M16) and never skips "
+                "a record silently"
             )
         for name, value in (("base_sha", base_sha), ("head_sha", head_sha)):
             try:
                 validate_full_sha(rid, name, value)
             except ValueError as exc:
                 raise RuntimeError(str(exc)) from exc
+        if identity:
+            # Corpus-v2 records carry no archived verifier-verdicts file; the
+            # record's own adjudicated outcome is its capture-time judgment.
+            # Map it onto the shared verdict vocabulary (the labels
+            # score_trajectory's verdict_map consumes) so the replay reads a
+            # real correctness axis instead of flooring every candidate at a
+            # 0.0 composite. grounding_rate stays absent (unknown, never an
+            # invented zero) and format_valid is True: a frozen v2 record is
+            # admission/shape/drift-validated, so the v1 bronze-parse failure
+            # floor cannot apply here.
+            disposition = rec.get("outcome_label") or rec.get("disposition")
+            verdict = {
+                "accepted": "consistent",
+                "rejected": "contradicts",
+                "ambiguous": "uncertain",
+                "unanswered": "uncertain",
+                "missing": "uncertain",
+            }.get(str(disposition))
+            verifier_verdicts: Any = (
+                [{"verdict": verdict}] if verdict is not None else rec.get("verifier_verdicts")
+            )
+            format_valid = True
+        else:
+            verifier_verdicts = rec.get("verifier_verdicts")
+            format_valid = bool(rec.get("format_valid", False))
         length = rec.get("length")
         if length is None:
             length = len(
@@ -384,19 +442,14 @@ def _rft_rows(records: list[dict[str, Any]]) -> list[dict[str, Any]]:
         rows.append(
             {
                 "id": rid,
-                # repo_slug is read v2-first (task_identity, then lineage) with
-                # the v1 top-level fallback, so a v2 record never emits a null
-                # repo_slug that run_rft's replay would refuse.
-                "repo_slug": identity.get("repo_slug")
-                or lineage_obj.get("repo_slug")
-                or rec.get("repo_slug"),
+                "repo_slug": repo_slug,
                 "base_sha": base_sha,
                 "head_sha": head_sha,
                 "diff": diff,
                 "findings": rec.get("findings", []),
-                "verifier_verdicts": rec.get("verifier_verdicts"),
+                "verifier_verdicts": verifier_verdicts,
                 "grounding_rate": rec.get("grounding_rate", rec.get("grounding_score")),
-                "format_valid": bool(rec.get("format_valid", False)),
+                "format_valid": format_valid,
                 "length": length,
             }
         )
@@ -404,7 +457,7 @@ def _rft_rows(records: list[dict[str, Any]]) -> list[dict[str, Any]]:
 
 
 def _frozen_split_from_projection(
-    projection: V2Projection, labels_path: Path, *, held_out_fraction: float, seed: int
+    projection: V2Projection, labels_path: Path, *, seed: int
 ) -> FrozenSplit:
     """Build the Stage-0 :class:`FrozenSplit` from the projector's frozen
     boundary instead of re-freezing at runtime.
@@ -422,7 +475,10 @@ def _frozen_split_from_projection(
     digest sidecar (``<labels>.gate-split.json``) is written by the shared
     :func:`daydream.training.gate.write_split_sidecar`, so the resume guard
     and stage manifest consume the identical contract whichever producer
-    froze the boundary.
+    froze the boundary. The reported ``held_out_fraction`` is the
+    projection's own frozen holdout rate (``lineage.holdout_rate``), never
+    the run-config tunable — matching :class:`FrozenSplit.held_out_fraction`'s
+    contract ("the fraction that determined the partition size").
 
     Raises:
         RuntimeError: On boundary drift (recorded vs recomputed split) or a
@@ -462,7 +518,7 @@ def _frozen_split_from_projection(
         labels_path,
         digest=digest,
         seed=seed,
-        held_out_fraction=held_out_fraction,
+        held_out_fraction=holdout_rate,
         held_out_ids=held_out_ids,
         train_ids=[str(r["comment_id"]) for r in train],
     )
@@ -473,7 +529,7 @@ def _frozen_split_from_projection(
         train_rows=train,
         held_out_rows=held_out,
         seed=seed,
-        held_out_fraction=held_out_fraction,
+        held_out_fraction=holdout_rate,
     )
 
 
@@ -505,7 +561,6 @@ def _run_stage0(
         split = _frozen_split_from_projection(
             projection,
             labels_path,
-            held_out_fraction=config.held_out_fraction,
             seed=config.seed,
         )
     else:

--- a/daydream/training/corpus_v2/projector.py
+++ b/daydream/training/corpus_v2/projector.py
@@ -915,6 +915,7 @@ def run_build_corpus_v2(config: BuildCorpusV2Config) -> dict[str, Any]:
         else:
             batch_manifest_row = {}
         digest_parts = [d for d in (batch.content_digest, snapshot_digest) if d]
+        batch_artifacts = read_batch_artifacts(config.bundle_dir, batch.session_id)
         trajectory_documents = _read_trajectory_documents(config.bundle_dir, batch.artifact_relpath)
         for trajectory in trajectory_documents:
             segs = segment(trajectory)
@@ -996,6 +997,42 @@ def run_build_corpus_v2(config: BuildCorpusV2Config) -> dict[str, Any]:
                         "repo_slug": record_decision["repo_slug"],
                         "license_decision": record_decision,
                     }
+                    # Additive enrichment from the batch's review artifacts
+                    # (findings.json / diff.patch / manifest.json): localized
+                    # finding text and a task-identity block. Every field is
+                    # opt-in on artifact presence — a missing artifact leaves
+                    # the field absent (the consumer fails closed, not the
+                    # projector), and record_id/tier/outcome_label are never
+                    # touched.
+                    finding_text = batch_artifacts.findings_by_fingerprint.get(fingerprint)
+                    if finding_text is not None:
+                        rec["finding_text"] = finding_text
+                        rec["finding_text_sha256"] = hashlib.sha256(
+                            finding_text.encode("utf-8")
+                        ).hexdigest()
+                    task_identity: dict[str, Any] = {
+                        "repo_slug": record_decision["repo_slug"],
+                    }
+                    manifest_git = batch_artifacts.manifest_git
+                    for sha_key in ("base_sha", "head_sha"):
+                        sha_value = manifest_git.get(sha_key)
+                        if isinstance(sha_value, str) and bool(sha_value):
+                            task_identity[sha_key] = sha_value
+                    if batch_artifacts.diff:
+                        diff_digest = hashlib.sha256(
+                            batch_artifacts.diff.encode("utf-8")
+                        ).hexdigest()
+                        diff_ref: dict[str, Any] = {
+                            "batch": batch.content_digest,
+                            "relpath": f"batches/{batch.session_id}/diff.patch",
+                        }
+                        task_identity["diff_digest"] = diff_digest
+                        task_identity["diff_ref"] = diff_ref
+                    rec["task_identity"] = task_identity
+                    if "diff_digest" in task_identity:
+                        lineage_fields = cast(dict[str, Any], rec["lineage"])
+                        lineage_fields["diff_digest"] = task_identity["diff_digest"]
+                        lineage_fields["diff_ref"] = task_identity["diff_ref"]
                     # v2 schema stamp: every projected record carries the
                     # training-record schema version it was emitted under.
                     rec["schema_version"] = "2"

--- a/daydream/training/corpus_v2/projector.py
+++ b/daydream/training/corpus_v2/projector.py
@@ -4,7 +4,9 @@ Each ``PerFindingResolution`` becomes its own record with a per-record
 ``outcome_label`` — a mixed session (some findings accepted, some rejected)
 never collapses into a run-level aggregate like v1's ``contested``
 ``outcome_label``. Non-decisive dispositions route to an adjudication
-report (report output, not a pipeline stage); the projector stays pure and
+report (report output, not a pipeline stage) unless the build opts in via
+``emit_process_traces``, which materializes them as schema-distinct
+``process-trace``/``task-only`` training records; the projector stays pure and
 deterministic.
 
 ``run_build_corpus_v2()`` is the top-level pure projection (no git, no
@@ -166,6 +168,15 @@ class BuildCorpusV2Config:
     # global license string to stamp (C5/C8, issue #1080).
     license_policy_path: Path | None = None
     allow_copyleft: frozenset[str] = frozenset()
+    # D8 opt-in (issue #1081): when False (default), non-decisive findings
+    # are adjudication-report output only — byte-identical to builds before
+    # the flag existed. When True, each finding the projector would route to
+    # adjudication is additionally materialized as two schema-distinct
+    # training records (a silver ``process-trace`` and a ``task-only``
+    # record, both with ``outcome_label=None``) instead of counting as a
+    # ``non-decisive-adjudication`` exclusion; the adjudication report
+    # itself is unchanged.
+    emit_process_traces: bool = False
 
     def __post_init__(self) -> None:
         if self.annotation_bundle_dir is None:
@@ -824,8 +835,9 @@ def run_build_corpus_v2(config: BuildCorpusV2Config) -> dict[str, Any]:
 
     Each finding is projected exactly once (the annotation resolutions are
     session-scoped, so sibling segments never fabricate per-segment copies);
-    non-decisive findings are excluded here and routed to the adjudication
-    report only.
+    by default non-decisive findings are excluded here and routed to the
+    adjudication report only — with ``emit_process_traces`` they additionally
+    join the emitted population as ``process-trace``/``task-only`` records.
 
     Returns a summary dict with ``total``/``emitted``, per-type/per-tier/
     per-split counts, the ``caps`` block (configured vs applied), the
@@ -834,7 +846,9 @@ def run_build_corpus_v2(config: BuildCorpusV2Config) -> dict[str, Any]:
     ``exclusions_by_reason`` — all derived from the final population in
     deterministic order. Non-decisive findings land in the human
     ``adjudication-report.json`` with their evidence (D8: report output, not
-    a pipeline stage). ``corpus.jsonl`` is also published as the versioned
+    a pipeline stage — unless ``emit_process_traces`` opts them into the
+    record population as schema-distinct ``process-trace``/``task-only``
+    records). ``corpus.jsonl`` is also published as the versioned
     twin ``corpus-v2.jsonl`` from the same in-memory bytes via the same
     atomic write, before ``_SUCCESS`` — covered by the identical fail-closed
     completeness gate, so the twin can never diverge from the canonical file.
@@ -897,6 +911,9 @@ def run_build_corpus_v2(config: BuildCorpusV2Config) -> dict[str, Any]:
     # could hash into different splits (D5 disjointness is per finding).
     seen_findings: set[tuple[str, str]] = set()
     adjudicated_findings: set[tuple[str, str]] = set()
+    # Adjudicated findings materialized as process-trace/task-only records
+    # under ``emit_process_traces`` — removed from the exclusion count.
+    materialized_adjudications: set[tuple[str, str]] = set()
     exclusions_by_reason: dict[str, int] = {}
     # lineage valid_at is pinned over the emitted records' evidence only —
     # annotation rows for sessions never admitted/emitted must not drift it.
@@ -952,91 +969,120 @@ def run_build_corpus_v2(config: BuildCorpusV2Config) -> dict[str, Any]:
                             "found at projection; refusing to project"
                         )
                     record_decision: dict[str, Any] = decision
-                    # Non-decisive findings are report output only (D8): they
-                    # never become training records, so corpus.jsonl and the
-                    # split manifests exclude them by construction while
-                    # lineage/summary count them under exclusions_by_reason.
+                    # Non-decisive findings are adjudication-report output
+                    # (D8): by default they never become training records, so
+                    # corpus.jsonl and the split manifests exclude them by
+                    # construction while lineage/summary count them under
+                    # exclusions_by_reason. With ``emit_process_traces`` the
+                    # finding is additionally materialized as a silver
+                    # ``process-trace`` record and a ``task-only`` record —
+                    # schema-distinct, never gold (``outcome_label=None``),
+                    # classified via ``classify_tier`` with the matching
+                    # ``record_type`` — and no longer counted as a
+                    # ``non-decisive-adjudication`` exclusion (the report
+                    # itself still carries it).
                     if str(rec["tier"]) == "task-only":
-                        continue
-                    _refuse_posterior_evidence(
-                        seg.session_id,
-                        fingerprint,
-                        cast(list[Record], rec["evidence"]),
-                        config.as_of,
-                    )
-                    split = assign_split(
-                        str(rec["record_id"]),
-                        holdout_rate=config.holdout_rate,
-                        val_rate=config.val_rate,
-                        salt=config.salt,
-                    )
-                    prov = _provenance_for(
-                        resolution_by_fp.get(fingerprint, {}), batch_manifest_row
-                    )
-                    rec_valid_at = _max_valid_at(
-                        cast(list[Record], rec["evidence"]), config.as_of
-                    )
-                    if rec_valid_at is not None and (
-                        valid_at is None
-                        or datetime.fromisoformat(rec_valid_at) > datetime.fromisoformat(valid_at)
-                    ):
-                        valid_at = rec_valid_at
-                    rec["profile"] = prov["profile"]
-                    rec["stack"] = prov["stack"]
-                    rec["lineage"] = {
-                        "hub_commit": bundle.source_hub_commit,
-                        "curation_id": bundle.curation_id,
-                        "content_digests": digest_parts,
-                        "labeler_policy_version": config.labeler_policy_version,
-                        "reply_classifier_version": config.reply_classifier_version,
-                        "rubric_schema_version": config.rubric_schema_version,
-                        "as_of": config.as_of,
-                        "valid_at": rec_valid_at,
-                        "split": split,
-                        "exclusion_reason": None,
-                        "repo_slug": record_decision["repo_slug"],
-                        "license_decision": record_decision,
-                    }
-                    # Additive enrichment from the batch's review artifacts
-                    # (findings.json / diff.patch / manifest.json): localized
-                    # finding text and a task-identity block. Every field is
-                    # opt-in on artifact presence — a missing artifact leaves
-                    # the field absent (the consumer fails closed, not the
-                    # projector), and record_id/tier/outcome_label are never
-                    # touched.
-                    finding_text = batch_artifacts.findings_by_fingerprint.get(fingerprint)
-                    if finding_text is not None:
-                        rec["finding_text"] = finding_text
-                        rec["finding_text_sha256"] = hashlib.sha256(
-                            finding_text.encode("utf-8")
-                        ).hexdigest()
-                    task_identity: dict[str, Any] = {
-                        "repo_slug": record_decision["repo_slug"],
-                    }
-                    manifest_git = batch_artifacts.manifest_git
-                    for sha_key in ("base_sha", "head_sha"):
-                        sha_value = manifest_git.get(sha_key)
-                        if isinstance(sha_value, str) and bool(sha_value):
-                            task_identity[sha_key] = sha_value
-                    if batch_artifacts.diff:
-                        diff_digest = hashlib.sha256(
-                            batch_artifacts.diff.encode("utf-8")
-                        ).hexdigest()
-                        diff_ref: dict[str, Any] = {
-                            "batch": batch.content_digest,
-                            "relpath": f"batches/{batch.session_id}/diff.patch",
+                        if not config.emit_process_traces:
+                            continue
+                        resolution = resolution_by_fp.get(fingerprint, {})
+                        emit_records: list[Record] = []
+                        for derived_type in ("process-trace", "task-only"):
+                            derived = dict(rec)
+                            derived["record_type"] = derived_type
+                            derived["tier"] = classify_tier(
+                                resolution, record_type=derived_type
+                            )
+                            derived["outcome_label"] = None
+                            derived["record_id"] = record_id(
+                                seg.session_id,
+                                seg.trajectory_id,
+                                seg.segment_id,
+                                f"{derived_type}:{fingerprint}",
+                            )
+                            emit_records.append(derived)
+                        materialized_adjudications.add(key)
+                    else:
+                        emit_records = [rec]
+                    for rec in emit_records:
+                        _refuse_posterior_evidence(
+                            seg.session_id,
+                            fingerprint,
+                            cast(list[Record], rec["evidence"]),
+                            config.as_of,
+                        )
+                        split = assign_split(
+                            str(rec["record_id"]),
+                            holdout_rate=config.holdout_rate,
+                            val_rate=config.val_rate,
+                            salt=config.salt,
+                        )
+                        prov = _provenance_for(
+                            resolution_by_fp.get(fingerprint, {}), batch_manifest_row
+                        )
+                        rec_valid_at = _max_valid_at(
+                            cast(list[Record], rec["evidence"]), config.as_of
+                        )
+                        if rec_valid_at is not None and (
+                            valid_at is None
+                            or datetime.fromisoformat(rec_valid_at) > datetime.fromisoformat(valid_at)
+                        ):
+                            valid_at = rec_valid_at
+                        rec["profile"] = prov["profile"]
+                        rec["stack"] = prov["stack"]
+                        rec["lineage"] = {
+                            "hub_commit": bundle.source_hub_commit,
+                            "curation_id": bundle.curation_id,
+                            "content_digests": digest_parts,
+                            "labeler_policy_version": config.labeler_policy_version,
+                            "reply_classifier_version": config.reply_classifier_version,
+                            "rubric_schema_version": config.rubric_schema_version,
+                            "as_of": config.as_of,
+                            "valid_at": rec_valid_at,
+                            "split": split,
+                            "exclusion_reason": None,
+                            "repo_slug": record_decision["repo_slug"],
+                            "license_decision": record_decision,
                         }
-                        task_identity["diff_digest"] = diff_digest
-                        task_identity["diff_ref"] = diff_ref
-                    rec["task_identity"] = task_identity
-                    if "diff_digest" in task_identity:
-                        lineage_fields = cast(dict[str, Any], rec["lineage"])
-                        lineage_fields["diff_digest"] = task_identity["diff_digest"]
-                        lineage_fields["diff_ref"] = task_identity["diff_ref"]
-                    # v2 schema stamp: every projected record carries the
-                    # training-record schema version it was emitted under.
-                    rec["schema_version"] = "2"
-                    records.append(rec)
+                        # Additive enrichment from the batch's review artifacts
+                        # (findings.json / diff.patch / manifest.json): localized
+                        # finding text and a task-identity block. Every field is
+                        # opt-in on artifact presence — a missing artifact leaves
+                        # the field absent (the consumer fails closed, not the
+                        # projector), and record_id/tier/outcome_label are never
+                        # touched.
+                        finding_text = batch_artifacts.findings_by_fingerprint.get(fingerprint)
+                        if finding_text is not None:
+                            rec["finding_text"] = finding_text
+                            rec["finding_text_sha256"] = hashlib.sha256(
+                                finding_text.encode("utf-8")
+                            ).hexdigest()
+                        task_identity: dict[str, Any] = {
+                            "repo_slug": record_decision["repo_slug"],
+                        }
+                        manifest_git = batch_artifacts.manifest_git
+                        for sha_key in ("base_sha", "head_sha"):
+                            sha_value = manifest_git.get(sha_key)
+                            if isinstance(sha_value, str) and bool(sha_value):
+                                task_identity[sha_key] = sha_value
+                        if batch_artifacts.diff:
+                            diff_digest = hashlib.sha256(
+                                batch_artifacts.diff.encode("utf-8")
+                            ).hexdigest()
+                            diff_ref: dict[str, Any] = {
+                                "batch": batch.content_digest,
+                                "relpath": f"batches/{batch.session_id}/diff.patch",
+                            }
+                            task_identity["diff_digest"] = diff_digest
+                            task_identity["diff_ref"] = diff_ref
+                        rec["task_identity"] = task_identity
+                        if "diff_digest" in task_identity:
+                            lineage_fields = cast(dict[str, Any], rec["lineage"])
+                            lineage_fields["diff_digest"] = task_identity["diff_digest"]
+                            lineage_fields["diff_ref"] = task_identity["diff_ref"]
+                        # v2 schema stamp: every projected record carries the
+                        # training-record schema version it was emitted under.
+                        rec["schema_version"] = "2"
+                        records.append(rec)
                 for entry in seg_adjudication:
                     key = (seg.session_id, str(entry["fingerprint"]))
                     if key not in adjudicated_findings:
@@ -1050,7 +1096,9 @@ def run_build_corpus_v2(config: BuildCorpusV2Config) -> dict[str, Any]:
     # assignment, over the deduplicated final population. Excess records of a
     # capped tier are excluded (never silently dropped) and named in the
     # summary, lineage, and exclusion reasons.
-    exclusions_by_reason["non-decisive-adjudication"] = len(adjudication)
+    exclusions_by_reason["non-decisive-adjudication"] = len(
+        adjudicated_findings - materialized_adjudications
+    )
     if config.caps:
         kept: list[Record] = []
         per_tier: dict[str, int] = {}

--- a/daydream/training/corpus_v2/projector.py
+++ b/daydream/training/corpus_v2/projector.py
@@ -40,7 +40,13 @@ from daydream.training.corpus_v2.splits import assign_split
 from daydream.training.corpus_v2.tiers import classify_tier
 from daydream.training.exclusion import EXCLUSION_PATH
 
-__all__ = ["BuildCorpusV2Config", "project_findings", "run_build_corpus_v2"]
+__all__ = [
+    "BatchArtifacts",
+    "BuildCorpusV2Config",
+    "project_findings",
+    "read_batch_artifacts",
+    "run_build_corpus_v2",
+]
 
 Record = dict[str, object]
 
@@ -49,6 +55,61 @@ _SPLIT_FILENAMES: dict[str, str] = {
     "validation": "validation.jsonl",
     "holdout": "holdout.jsonl",
 }
+
+
+@dataclass(frozen=True)
+class BatchArtifacts:
+    """Per-batch review artifacts read from a curated bundle's batch directory
+    (``batches/<session_id>/``). Producer-realistic shapes (confirmed by the
+    task-0 spike probe, tests/test_corpus_v2_spike_probe.py):
+
+    - ``findings.json`` — ``{"findings": [{"fingerprint": <64-hex>, "body":
+      <str>, ...}]}`` (the same artifact ``daydream/archive/__init__.py``
+      copies into the run bundle; fingerprints join 1:1 with the annotation
+      snapshot resolution rows).
+    - ``diff.patch`` — the run's diff text.
+    - ``manifest.json`` — ``git.head_sha`` plus ``code_context.{base_sha,
+      head_sha}`` (archive/manifest.py serialization).
+    """
+
+    findings_by_fingerprint: dict[str, str]
+    diff: str
+    manifest_git: dict[str, Any]
+
+
+def read_batch_artifacts(bundle_dir: Path, session_id: str) -> BatchArtifacts:
+    """Read the finding text / diff / git shas from a batch directory.
+
+    Pure filesystem read; every file is optional (an absent artifact yields an
+    empty value — the caller decides what is mandatory). Findings without both
+    a ``fingerprint`` and a ``body`` are skipped.
+    """
+    batch_dir = Path(bundle_dir) / "batches" / session_id
+    findings_by_fingerprint: dict[str, str] = {}
+    try:
+        data = json.loads((batch_dir / "findings.json").read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        data = None
+    for finding in (data.get("findings") if isinstance(data, dict) else None) or []:
+        if not isinstance(finding, dict):
+            continue
+        fingerprint, body = finding.get("fingerprint"), finding.get("body")
+        if isinstance(fingerprint, str) and isinstance(body, str):
+            findings_by_fingerprint[fingerprint] = body
+    try:
+        diff = (batch_dir / "diff.patch").read_text(encoding="utf-8")
+    except (OSError, ValueError):
+        diff = ""
+    try:
+        manifest = json.loads((batch_dir / "manifest.json").read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        manifest = {}
+    manifest_git = manifest.get("git") if isinstance(manifest, dict) else None
+    return BatchArtifacts(
+        findings_by_fingerprint=findings_by_fingerprint,
+        diff=diff,
+        manifest_git=manifest_git if isinstance(manifest_git, dict) else {},
+    )
 
 
 def _dump_jsonl(records: list[Record]) -> str:

--- a/daydream/training/corpus_v2/projector.py
+++ b/daydream/training/corpus_v2/projector.py
@@ -77,6 +77,7 @@ class BatchArtifacts:
     findings_by_fingerprint: dict[str, str]
     diff: str
     manifest_git: dict[str, Any]
+    manifest_code_context: dict[str, Any]
 
 
 def read_batch_artifacts(bundle_dir: Path, session_id: str) -> BatchArtifacts:
@@ -107,10 +108,16 @@ def read_batch_artifacts(bundle_dir: Path, session_id: str) -> BatchArtifacts:
     except (OSError, ValueError):
         manifest = {}
     manifest_git = manifest.get("git") if isinstance(manifest, dict) else None
+    manifest_code_context = (
+        manifest.get("code_context") if isinstance(manifest, dict) else None
+    )
     return BatchArtifacts(
         findings_by_fingerprint=findings_by_fingerprint,
         diff=diff,
         manifest_git=manifest_git if isinstance(manifest_git, dict) else {},
+        manifest_code_context=(
+            manifest_code_context if isinstance(manifest_code_context, dict) else {}
+        ),
     )
 
 
@@ -1060,10 +1067,22 @@ def run_build_corpus_v2(config: BuildCorpusV2Config) -> dict[str, Any]:
                             "repo_slug": record_decision["repo_slug"],
                         }
                         manifest_git = batch_artifacts.manifest_git
-                        for sha_key in ("base_sha", "head_sha"):
-                            sha_value = manifest_git.get(sha_key)
+                        manifest_code_context = batch_artifacts.manifest_code_context
+                        # Producer-realistic manifest namespaces
+                        # (archive/manifest.py:374-387): ``base_sha`` lives
+                        # under ``code_context`` and only ``head_sha`` under
+                        # ``git`` — mirroring corpus.py's v1 read of the same
+                        # manifest (code_context base, git head).
+                        for sha_name, sha_value in (
+                            ("base_sha", manifest_code_context.get("base_sha")),
+                            (
+                                "head_sha",
+                                manifest_git.get("head_sha")
+                                or manifest_code_context.get("head_sha"),
+                            ),
+                        ):
                             if isinstance(sha_value, str) and bool(sha_value):
-                                task_identity[sha_key] = sha_value
+                                task_identity[sha_name] = sha_value
                         if batch_artifacts.diff:
                             diff_digest = hashlib.sha256(
                                 batch_artifacts.diff.encode("utf-8")
@@ -1074,6 +1093,11 @@ def run_build_corpus_v2(config: BuildCorpusV2Config) -> dict[str, Any]:
                             }
                             task_identity["diff_digest"] = diff_digest
                             task_identity["diff_ref"] = diff_ref
+                            # The raw diff body is embedded on the record
+                            # (schema v2.json ``diff``) so Stage-2 RFT inputs
+                            # carry it without an archive-side materialization
+                            # step — the projection is the frozen boundary.
+                            rec["diff"] = batch_artifacts.diff
                         rec["task_identity"] = task_identity
                         if "diff_digest" in task_identity:
                             lineage_fields = cast(dict[str, Any], rec["lineage"])

--- a/daydream/training/gate.py
+++ b/daydream/training/gate.py
@@ -152,6 +152,48 @@ def _split_digest(held_out_ids: list[str], seed: int) -> str:
     return hashlib.sha256(payload.encode()).hexdigest()
 
 
+
+def write_split_sidecar(
+    labels_path: str | Path,
+    *,
+    digest: str,
+    seed: int,
+    held_out_fraction: float,
+    held_out_ids: list[str],
+    train_ids: list[str],
+) -> str:
+    """Write the canonical ``<labels>.gate-split.json`` digest sidecar.
+
+    Shared by every producer of the M18 resume-guard / stage-manifest split
+    contract (:func:`freeze_split` and the corpus-v2 frozen-boundary path in
+    :mod:`daydream.training.coordinator`), so the sidecar shape cannot drift
+    between them. Writes are atomic (tmp + ``os.replace``).
+
+    Args:
+        labels_path: Path of the labels file the sidecar sits beside.
+        digest: Content-addressed split digest (see :func:`_split_digest`).
+        seed: Seed that froze the split.
+        held_out_fraction: Fraction of admitted rows reserved for the gate.
+        held_out_ids: Held-out row ids (unsorted; stored sorted).
+        train_ids: Train row ids (unsorted; stored sorted).
+
+    Returns:
+        The sidecar filename, relative to the labels file's directory.
+    """
+    sidecar_path = Path(labels_path).parent / (Path(labels_path).name + ".gate-split.json")
+    sidecar = {
+        "digest": digest,
+        "seed": seed,
+        "held_out_fraction": held_out_fraction,
+        "held_out_ids": sorted(held_out_ids),
+        "train_ids": sorted(train_ids),
+    }
+    tmp = sidecar_path.with_name(sidecar_path.name + ".tmp")
+    tmp.write_text(json.dumps(sidecar, indent=2, sort_keys=True))
+    os.replace(tmp, sidecar_path)
+    return sidecar_path.name
+
+
 def freeze_split(
     labels_path: str | Path, *, held_out_fraction: float, seed: int
 ) -> FrozenSplit:
@@ -201,18 +243,14 @@ def freeze_split(
 
     held_out_ids = [str(r["comment_id"]) for r in held_out_rows]
     digest = _split_digest(held_out_ids, seed)
-    digest_path = labels_path.name + ".gate-split.json"
-    sidecar = {
-        "digest": digest,
-        "seed": seed,
-        "held_out_fraction": held_out_fraction,
-        "held_out_ids": sorted(held_out_ids),
-        "train_ids": sorted(str(r["comment_id"]) for r in train_rows),
-    }
-    sidecar_path = labels_path.parent / digest_path
-    tmp = sidecar_path.with_name(sidecar_path.name + ".tmp")
-    tmp.write_text(json.dumps(sidecar, indent=2, sort_keys=True))
-    os.replace(tmp, sidecar_path)
+    digest_path = write_split_sidecar(
+        labels_path,
+        digest=digest,
+        seed=seed,
+        held_out_fraction=held_out_fraction,
+        held_out_ids=held_out_ids,
+        train_ids=[str(r["comment_id"]) for r in train_rows],
+    )
 
     return FrozenSplit(
         digest=digest,

--- a/daydream/training/rft.py
+++ b/daydream/training/rft.py
@@ -30,13 +30,40 @@ from __future__ import annotations
 import hashlib
 import json
 import random
+import re
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Mapping
 
 from daydream.training.reward import RewardBreakdown, ScoringInputs, score_trajectory
 
-__all__ = ["RftConfig", "RftWinner", "RftResult", "run_rft"]
+__all__ = ["RftConfig", "RftWinner", "RftResult", "run_rft", "validate_full_sha"]
+
+# Full-SHA contract: RFT rebuilds every task from full-length hex commit
+# SHAs (Req 7, the #714 rebase target). A short, empty, or non-hex value is
+# refused with a ValueError naming the record id and field — shared with the
+# coordinator's ``_rft_rows`` so Stage 2 and the replay fail closed alike.
+# Longer sha256-style content-address stamps are tolerated, matching the
+# coordinator's pre-existing acceptance.
+_FULL_SHA_RE = re.compile(r"[0-9a-f]{40,}")
+
+
+def validate_full_sha(record_id: str, field: str, value: object) -> str:
+    """Validate one task-identity SHA as a full-length hex SHA (at least a full
+    40-char git commit SHA; longer sha256-style content-address stamps are
+    tolerated).
+
+    Raises:
+        ValueError: When ``value`` is absent, truncated, or non-hex — naming
+            the record id and field. Never returns a fabricated fallback.
+    """
+    if not isinstance(value, str) or not _FULL_SHA_RE.fullmatch(value):
+        raise ValueError(
+            f"record {record_id!r} carries an invalid {field} {value!r}: "
+            "RFT rebuilds every task from a full 40-hex commit sha and never "
+            "replays against a truncated or non-hex identity"
+        )
+    return value
 
 # Breakdown axes the winner spec may constrain: exactly the attribute names of
 # ``score_trajectory``'s ``RewardBreakdown`` (reward.py:316). Anything else is a
@@ -125,18 +152,30 @@ def _record_sort_key(rec: Mapping[str, Any]) -> str:
 
 
 def _reconstruct_task(rec: Mapping[str, Any]) -> tuple[str, str, str]:
-    """Return (record_id, base_sha, diff), failing closed on missing identity."""
+    """Return (record_id, base_sha, diff), failing closed on malformed identity.
+
+    ``repo_slug``, ``base_sha``, and ``head_sha`` are validated (including the
+    full 40-hex contract via :func:`validate_full_sha`) *before* any task or
+    image work — a truncated or non-hex SHA raises like a missing one.
+    """
     rid = str(rec.get("id", ""))
+    repo_slug = rec.get("repo_slug")
     base_sha = rec.get("base_sha")
     head_sha = rec.get("head_sha")
     diff = rec.get("diff")
-    missing = [name for name, value in (("base_sha", base_sha), ("head_sha", head_sha), ("diff", diff)) if not value]
+    missing = [
+        name
+        for name, value in (("repo_slug", repo_slug), ("base_sha", base_sha), ("head_sha", head_sha), ("diff", diff))
+        if not value
+    ]
     if missing:
         raise ValueError(
             f"record {rid!r} is missing frozen task identity field(s) {missing}; "
-            "RFT rebuilds every task from base/head/diff identity (M16) and never skips a "
+            "RFT rebuilds every task from repo/base/head/diff identity (M16) and never skips a "
             "record silently."
         )
+    for sha_field in ("base_sha", "head_sha"):
+        validate_full_sha(rid, sha_field, rec.get(sha_field))
     assert isinstance(base_sha, str) and isinstance(diff, str)
     return rid, base_sha, diff
 
@@ -227,14 +266,16 @@ def _fixed(value: Any) -> Any:
 def run_rft(config: RftConfig) -> RftResult:
     """Run one deterministic Stage-2 RFT replay over the frozen inputs.
 
-    Reconstructs each task from its recorded base/head/diff identity, samples
-    deterministic candidates, scores every candidate through
-    :func:`score_trajectory`, filters winners by the breakdown-shaped spec,
-    and writes a byte-identical-on-rerun winners JSON file.
+    Reconstructs each task from its recorded repo/base/head/diff identity —
+    validating ``repo_slug`` and full-length hex ``base_sha``/``head_sha``
+    (:func:`validate_full_sha`) before any task/image work (Req 7, the #714
+    rebase target) — samples deterministic candidates, scores every candidate
+    through :func:`score_trajectory`, filters winners by the breakdown-shaped
+    spec, and writes a byte-identical-on-rerun winners JSON file.
 
     Raises:
-        ValueError: When any record lacks base/head/diff identity (named by
-            record id) — never skipped silently.
+        ValueError: When any record lacks or carries malformed base/head/diff
+            identity (named by record id and field) — never skipped silently.
     """
     inputs_path = Path(config.inputs)
     raw = inputs_path.read_text(encoding="utf-8")

--- a/daydream/training/schema/v2.json
+++ b/daydream/training/schema/v2.json
@@ -93,6 +93,10 @@
     "completion": {
       "type": "string"
     },
+    "diff": {
+      "type": "string",
+      "description": "Raw diff body of the reviewed change, embedded from the curated bundle's batches/<session_id>/diff.patch so Stage-2 RFT inputs carry it without an archive-side materialization step."
+    },
     "task_identity": {
       "type": "object",
       "additionalProperties": false,

--- a/daydream/training/schema/v2.json
+++ b/daydream/training/schema/v2.json
@@ -111,11 +111,13 @@
         },
         "base_sha": {
           "type": "string",
-          "pattern": "^[0-9a-f]{40}$"
+          "pattern": "^[0-9a-f]{40,}$",
+          "description": "Full-length hex sha (40+ chars; sha256-style 64-hex content-address stamps tolerated, matching rft.validate_full_sha)."
         },
         "head_sha": {
           "type": "string",
-          "pattern": "^[0-9a-f]{40}$"
+          "pattern": "^[0-9a-f]{40,}$",
+          "description": "Full-length hex sha (40+ chars; sha256-style 64-hex content-address stamps tolerated, matching rft.validate_full_sha)."
         },
         "diff_digest": {
           "type": "string",

--- a/daydream/training/schema/v2.json
+++ b/daydream/training/schema/v2.json
@@ -28,7 +28,7 @@
       "description": "sha256 hex digest over the canonical (session_id, trajectory_id, segment_id, fingerprint) join."
     },
     "record_type": {
-      "enum": ["outcome-finding"]
+      "enum": ["outcome-finding", "process-trace", "task-only"]
     },
     "tier": {
       "enum": ["gold", "silver", "task-only"]
@@ -75,6 +75,53 @@
         },
         "profile_digest": {
           "type": ["string", "null"]
+        }
+      }
+    },
+    "finding_text": {
+      "type": "string",
+      "description": "Localized finding/comment text carried from the curated bundle."
+    },
+    "finding_text_sha256": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$",
+      "description": "sha256 of finding_text."
+    },
+    "prompt": {
+      "type": "string"
+    },
+    "completion": {
+      "type": "string"
+    },
+    "task_identity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["repo_slug"],
+      "properties": {
+        "repo_slug": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source": {
+          "type": "string"
+        },
+        "base_sha": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{40}$"
+        },
+        "head_sha": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{40}$"
+        },
+        "diff_digest": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "diff_ref": {
+          "type": "object"
+        },
+        "replay_verification": {
+          "type": ["object", "null"]
         }
       }
     },
@@ -135,6 +182,13 @@
         },
         "exclusion_reason": {
           "type": ["string", "null"]
+        },
+        "diff_digest": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "diff_ref": {
+          "type": "object"
         },
         "repo_slug": {
           "type": "string",

--- a/daydream/training/stacks_v2.py
+++ b/daydream/training/stacks_v2.py
@@ -182,12 +182,18 @@ def load_v2_projection(
         The :class:`V2Projection` for the directory.
 
     Raises:
-        ValueError: On any existing-gate failure, on a missing/malformed
-            ``lineage.json``, or on split drift (the offending record ids and
-            both splits are named).
+        ValueError: On any existing-gate failure, on a missing split file
+            or a missing/malformed ``lineage.json``, or on split drift (the
+            offending record ids and both splits are named).
     """
     projection_dir = Path(path)
-    records = load_dataset_v2(projection_dir, allow_copyleft=allow_copyleft)
+    try:
+        records = load_dataset_v2(projection_dir, allow_copyleft=allow_copyleft)
+    except FileNotFoundError as exc:
+        raise ValueError(
+            f"corpus v2 projection {projection_dir}: missing split file "
+            f"{exc.filename!r} — refusing an incomplete projection"
+        ) from exc
     lineage = _load_lineage(projection_dir)
     _enforce_split_consistency(records, lineage, projection_dir)
 
@@ -202,10 +208,15 @@ def load_v2_projection(
             )
         by_split[cast(str, split)].append(record)
 
-    split_digests = {
-        filename: _sha256_file(projection_dir / filename)
-        for filename in _SPLIT_FILENAMES.values()
-    }
+    split_digests: dict[str, str] = {}
+    for filename in _SPLIT_FILENAMES.values():
+        split_path = projection_dir / filename
+        if not split_path.is_file():
+            raise ValueError(
+                f"corpus v2 projection {projection_dir}: missing split file "
+                f"{filename!r} — refusing an incomplete projection"
+            )
+        split_digests[filename] = _sha256_file(split_path)
     return V2Projection(
         records=records,
         by_split=by_split,

--- a/daydream/training/stacks_v2.py
+++ b/daydream/training/stacks_v2.py
@@ -1,0 +1,215 @@
+"""V2 projection directory loader: per-split records, lineage, and digests.
+
+Wraps :func:`daydream.training.stacks.load_dataset_v2` (which enforces the
+``_SUCCESS`` completeness marker, the ``schema_version == "2"`` structural
+gate, the repo-identity/license-decision requirement, and the C5/C8
+fail-closed gates) and adds the boundary the downstream pipeline needs:
+
+- per-split record access derived from each record's ``lineage.split``;
+- the projection's ``lineage.json`` (salt, rates, provenance pins);
+- per-file sha256 digests and a deterministic directory-level digest over
+  the sorted ``(relpath, sha256(file_bytes))`` pairs — a pure function of
+  the directory bytes, so the same projection always yields the same digest;
+- a **split-drift gate**: the split is recomputed from every record's id via
+  :func:`daydream.training.corpus_v2.splits.assign_split` under the lineage's
+  pinned salt/rates, and any disagreement with the record's recorded
+  ``lineage.split`` refuses the whole load (``ValueError`` naming the
+  offending record id) — never a silent accept.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import cast
+
+from daydream.training.corpus_v2.splits import Split, assign_split
+from daydream.training.stacks import load_dataset_v2
+
+__all__ = ["V2Projection", "load_v2_projection", "recompute_split_from_record_id"]
+
+_SPLIT_FILENAMES = {
+    "train": "train.jsonl",
+    "validation": "validation.jsonl",
+    "holdout": "holdout.jsonl",
+}
+
+
+def recompute_split_from_record_id(
+    record_id: str,
+    *,
+    salt: str,
+    holdout_rate: float,
+    val_rate: float,
+) -> Split:
+    """Recompute the frozen content-derived split for one record id.
+
+    Thin named wrapper over :func:`assign_split` so the drift gate and its
+    tests share one call site for the recompute side of the comparison.
+    """
+    return assign_split(
+        record_id, salt=salt, holdout_rate=holdout_rate, val_rate=val_rate
+    )
+
+
+@dataclass(frozen=True)
+class V2Projection:
+    """A loaded corpus-v2 projection directory.
+
+    Attributes:
+        records: All v2 records, in split-file order (train, validation,
+            holdout), exactly as :func:`load_dataset_v2` returns them.
+        by_split: Records grouped by their recorded ``lineage.split``; all
+            three keys are always present.
+        lineage: The parsed ``lineage.json`` dict.
+        split_digests: sha256 of each split JSONL file's bytes, keyed by
+            filename.
+        digest: Deterministic directory-level digest: sha256 over the sorted
+            ``(relpath, sha256(file_bytes))`` pairs of every file in the
+            projection directory. A pure function of the directory bytes.
+    """
+
+    records: list[dict[str, object]]
+    by_split: dict[str, list[dict[str, object]]] = field(default_factory=dict)
+    lineage: dict[str, object] = field(default_factory=dict)
+    split_digests: dict[str, str] = field(default_factory=dict)
+    digest: str = ""
+
+
+def _sha256_file(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _directory_digest(projection_dir: Path) -> str:
+    """sha256 over sorted ``(relpath, sha256(file_bytes))`` pairs — the same
+    directory always yields the same digest."""
+    pairs: list[str] = []
+    for path in sorted(projection_dir.rglob("*")):
+        if path.is_file():
+            rel = path.relative_to(projection_dir).as_posix()
+            pairs.append(f"{rel}\x1f{_sha256_file(path)}")
+    return hashlib.sha256("\x1e".join(pairs).encode("utf-8")).hexdigest()
+
+
+def _load_lineage(projection_dir: Path) -> dict[str, object]:
+    lineage_path = projection_dir / "lineage.json"
+    if not lineage_path.is_file():
+        raise ValueError(
+            f"corpus v2 projection {projection_dir}: missing lineage.json — "
+            "refusing a projection without its pinned split parameters"
+        )
+    try:
+        lineage = json.loads(lineage_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ValueError(
+            f"corpus v2 projection {projection_dir}: lineage.json is not valid "
+            f"JSON: {exc}"
+        ) from exc
+    if not isinstance(lineage, dict):
+        raise ValueError(
+            f"corpus v2 projection {projection_dir}: lineage.json is not a JSON object"
+        )
+    for key in ("salt", "holdout_rate", "val_rate"):
+        if lineage.get(key) is None:
+            raise ValueError(
+                f"corpus v2 projection {projection_dir}: lineage.json missing "
+                f"{key!r} — refusing to recompute splits without the pinned "
+                "assignment parameters"
+            )
+    return lineage
+
+
+def _enforce_split_consistency(
+    records: list[dict[str, object]],
+    lineage: dict[str, object],
+    projection_dir: Path,
+) -> None:
+    """Split-drift gate: recompute each record's split from its record id and
+    refuse the load when it disagrees with the recorded ``lineage.split``."""
+    salt = str(lineage["salt"])
+    holdout_rate_obj = lineage["holdout_rate"]
+    val_rate_obj = lineage["val_rate"]
+    if not isinstance(holdout_rate_obj, (int, float)) or not isinstance(
+        val_rate_obj, (int, float)
+    ):
+        raise ValueError(
+            f"corpus v2 projection {projection_dir}: lineage.json holdout_rate/"
+            "val_rate must be numeric"
+        )
+    holdout_rate = float(holdout_rate_obj)
+    val_rate = float(val_rate_obj)
+    offenders: list[str] = []
+    for record in records:
+        record_id = str(record.get("record_id", ""))
+        recorded = None
+        lineage_obj = record.get("lineage")
+        if isinstance(lineage_obj, dict):
+            recorded = lineage_obj.get("split")
+        expected = recompute_split_from_record_id(
+            record_id, salt=salt, holdout_rate=holdout_rate, val_rate=val_rate
+        )
+        if recorded != expected:
+            offenders.append(f"{record_id} (recorded {recorded!r}, recomputed {expected!r})")
+    if offenders:
+        raise ValueError(
+            f"corpus v2 projection {projection_dir}: split drift detected for "
+            f"{len(offenders)} record(s): {', '.join(offenders)}. The recorded "
+            "lineage.split disagrees with the split recomputed from the record "
+            "id under the pinned salt/rates — refusing a drifted projection."
+        )
+
+
+def load_v2_projection(
+    path: str | Path,
+    *,
+    allow_copyleft: frozenset[str] | set[str] = frozenset(),
+) -> V2Projection:
+    """Load a corpus-v2 projection directory into a :class:`V2Projection`.
+
+    Reuses :func:`daydream.training.stacks.load_dataset_v2` for the existing
+    fail-closed gates (missing ``_SUCCESS``, non-``"2"`` ``schema_version``,
+    repo identity, license decisions, C5/C8), then parses ``lineage.json``,
+    recomputes every record's split from its id, and refuses any drift.
+
+    Args:
+        path: The projection output directory written by
+            ``run_build_corpus_v2``.
+        allow_copyleft: Passed through to the underlying v2 loader.
+
+    Returns:
+        The :class:`V2Projection` for the directory.
+
+    Raises:
+        ValueError: On any existing-gate failure, on a missing/malformed
+            ``lineage.json``, or on split drift (the offending record ids and
+            both splits are named).
+    """
+    projection_dir = Path(path)
+    records = load_dataset_v2(projection_dir, allow_copyleft=allow_copyleft)
+    lineage = _load_lineage(projection_dir)
+    _enforce_split_consistency(records, lineage, projection_dir)
+
+    by_split: dict[str, list[dict[str, object]]] = {name: [] for name in _SPLIT_FILENAMES}
+    for record in records:
+        lineage_obj = record.get("lineage")
+        split = lineage_obj.get("split") if isinstance(lineage_obj, dict) else None
+        if split not in by_split:
+            raise ValueError(
+                f"corpus v2 projection {projection_dir}: record "
+                f"{record.get('record_id')!r} carries unknown split {split!r}"
+            )
+        by_split[cast(str, split)].append(record)
+
+    split_digests = {
+        filename: _sha256_file(projection_dir / filename)
+        for filename in _SPLIT_FILENAMES.values()
+    }
+    return V2Projection(
+        records=records,
+        by_split=by_split,
+        lineage=lineage,
+        split_digests=split_digests,
+        digest=_directory_digest(projection_dir),
+    )

--- a/docs/runbooks/annotation-final-publish.md
+++ b/docs/runbooks/annotation-final-publish.md
@@ -11,10 +11,11 @@ repo name and provider credentials in their environment.
 
 Two operator-safety constraints frame every step:
 
-- **Success is defined only by the end of step 8.** A run is finished when a
-  clean-download verification passes and the bundle's `_SUCCESS` marker is
-  present. Anything before that — including a green `--dry-run` — is not
-  success.
+- **Success is defined only by the end of step 10.** A run is finished when a
+  clean-download verification passes, the bundle's `_SUCCESS` marker is
+  present, and a green `daydream train --corpus-v2` dry run consumes the
+  frozen projection. Anything before that — including a green
+  `--dry-run` on an intermediate command — is not success.
 - **The VM is expendable; the Hub checkpoint is not.** Step 2 recovers all
   published adjudication state from the Hub after VM loss. Re-run it any time
   you are unsure the local state is intact.
@@ -166,7 +167,7 @@ Project the curated bundle and the verified annotation bundle into the frozen
 corpus-v2 training records:
 
 ```bash
-daydream corpus build-v2 --bundle-root /tmp/daydream-hydrate/curated/<curation-id> --annotation-bundle-root /tmp/annotation-bundle --out /tmp/corpus-v2/corpus-v2.jsonl
+daydream corpus build-v2 --bundle-root /tmp/daydream-hydrate/curated/<curation-id> --annotation-bundle-root /tmp/annotation-bundle --license-policy <license-policy.json> --out /tmp/corpus-v2/corpus-v2.jsonl
 ```
 
 `build-v2` self-verifies the annotation bundle (`_SUCCESS`, `SHA256SUMS`,
@@ -174,6 +175,33 @@ daydream corpus build-v2 --bundle-root /tmp/daydream-hydrate/curated/<curation-i
 bundle root before projecting — `--bundle-root` is the hydration-produced
 curated bundle (`/tmp/daydream-hydrate/curated/<curation-id>/`, which carries
 `_SUCCESS`, `SHA256SUMS`, and `curation-manifest.json`), not the raw
-`downloads/<revision>` snapshot tree. It applies per-tier caps and writes the
-split manifests and lineage beside the output. A green run here is the end of
-the pipeline.
+`downloads/<revision>` snapshot tree. `--license-policy` is the digest-pinned
+license-policy JSON every record's per-repo license decision is resolved from
+(it is required — the command refuses to run without it). It applies per-tier
+caps and writes the split manifests and lineage beside the output.
+
+## 10. Train on the frozen corpus-v2 projection
+
+The projection directory written by step 9 is a frozen, immutable training
+input — do not edit, filter, or re-split it. Train the four-stage pipeline
+against it directly:
+
+```bash
+daydream train --corpus-v2 /tmp/corpus-v2 --out /tmp/train-out --dry-run
+```
+
+(Drop `--dry-run` for the real run; `--corpus-v2` is mutually exclusive with
+the v1 `--corpus` flag.) The loader fail-closes before any stage runs unless
+the directory's `_SUCCESS` marker and `lineage.json` are present, and it
+re-applies the C5 exclusion list and the C8 copyleft opt-in gate fail-closed
+on every load — the projector's decisions are never trusted on their own. The split is
+recomputed from each record id under the lineage's pinned salt and rates and
+compared against the recorded `lineage.split`; any drift refuses the entire
+load with the offending record id named, so Stage 0 always consumes exactly
+the projector's frozen split. Stage-2 RFT rebuilds replay tasks from the
+records' task-identity git SHAs (`base_sha`/`head_sha`), which are validated
+as full 40-hex SHAs before any rebuild.
+
+A green `daydream train --corpus-v2` dry run here is the end of the pipeline:
+the successfully frozen corpus-v2 bundle feeds Stage-0, SFT, and RFT directly,
+with no manual conversion to the legacy JSONL schema.

--- a/docs/runbooks/annotation-final-publish.md
+++ b/docs/runbooks/annotation-final-publish.md
@@ -20,8 +20,8 @@ Two operator-safety constraints frame every step:
   published adjudication state from the Hub after VM loss. Re-run it any time
   you are unsure the local state is intact.
 
-Every command below is a literal, single-line CLI invocation that parses against the real parser (enforced by
-`tests/test_cli_adjudicate.py::test_runbook_commands_parse_against_real_parser`).
+Every `daydream corpus adjudicate` command below (steps 1–8) is a literal, single-line CLI invocation that parses against the real parser (enforced by
+`tests/test_cli_adjudicate.py::test_runbook_commands_parse_against_real_parser`). The step 9 (`corpus build-v2`) and step 10 (`train --corpus-v2`) commands are not covered by that parser check — `tests/test_training_docs_v2.py` only asserts their presence.
 
 ---
 

--- a/docs/training-launch.md
+++ b/docs/training-launch.md
@@ -52,7 +52,7 @@ produced by the projector, not the v1 JSONL export. The real-corpus command
 sequence is:
 
 ```bash
-daydream corpus build-v2 --bundle-root BUNDLE_ROOT --annotation-bundle-root ANNOTATION_BUNDLE_ROOT --license-policy LICENSE_POLICY --out PROJECTION_DIR
+daydream corpus build-v2 --bundle-root BUNDLE_ROOT --annotation-bundle-root ANNOTATION_BUNDLE_ROOT --license-policy LICENSE_POLICY --out PROJECTION_DIR/corpus-v2.jsonl
 ```
 
 ```bash

--- a/docs/training-launch.md
+++ b/docs/training-launch.md
@@ -45,6 +45,51 @@ Stage 0 freezes the split before training (M16): 40 train / 10 held-out rows
 identical to `run_identity.split_digest`, which is how resume validation
 (`validate_resume`) detects a stale or drifted split (AC4).
 
+## Corpus v2: real-corpus training from a frozen projection
+
+For real-corpus training, the input is a frozen corpus-v2 projection directory
+produced by the projector, not the v1 JSONL export. The real-corpus command
+sequence is:
+
+```bash
+daydream corpus build-v2 --bundle-root <dir> --annotation-bundle-root <dir> --license-policy <file> --out <proj_dir>
+```
+
+```bash
+daydream train --corpus-v2 <proj_dir> --out <out_dir> --dry-run
+```
+
+(Drop `--dry-run` for the real run. `--corpus-v2` is mutually exclusive with
+`--corpus` on the train parser; the v1 `--corpus` path below remains valid and
+unchanged.)
+
+The projection directory is the immutable input contract for the run:
+
+- **`_SUCCESS`** — the completeness marker written last by the projector; a
+  directory without it is refused before any record is read.
+- **`lineage.json`** — pins the split salt, holdout/validation rates, and
+  provenance digests the loader re-checks.
+- **Split digests** — per-split JSONL sha256s plus a deterministic
+  directory-level digest over the sorted `(relpath, sha256(file_bytes))`
+  pairs; the directory digest replaces the v1 single-file corpus digest in
+  `run_identity.corpus_digest`.
+- **`base_sha` / `head_sha`** — the per-record task-identity git SHAs, used by
+  Stage-2 RFT to rebuild replay tasks; full-SHA values are validated before
+  any task rebuild.
+- **C5/C8 re-application** — the v2 loader re-applies the C5 exclusion list
+  and the C8 copyleft opt-in gate fail-closed on every load; the projector's
+  decision is never trusted on its own.
+- **Fail-closed drift** — the split recorded on each record's `lineage.split`
+  is recomputed from the record id under the lineage's pinned salt/rates, and
+  any disagreement refuses the entire load with the offending record id
+  named. Stage 0 consumes the projector's frozen split as-is (it is never
+  re-frozen), so drift is a hard stop, never a silent re-split.
+
+Because the directory-level digest is a pure function of the directory bytes,
+the same projection always yields the same run identity — a re-run over a
+modified directory aborts at the resume guard instead of training on drifted
+data.
+
 ## Legacy traces
 
 Legacy rows — runs admitted under the reply-count / merge-presence gold policy

--- a/docs/training-launch.md
+++ b/docs/training-launch.md
@@ -52,11 +52,11 @@ produced by the projector, not the v1 JSONL export. The real-corpus command
 sequence is:
 
 ```bash
-daydream corpus build-v2 --bundle-root <dir> --annotation-bundle-root <dir> --license-policy <file> --out <proj_dir>
+daydream corpus build-v2 --bundle-root BUNDLE_ROOT --annotation-bundle-root ANNOTATION_BUNDLE_ROOT --license-policy LICENSE_POLICY --out PROJECTION_DIR
 ```
 
 ```bash
-daydream train --corpus-v2 <proj_dir> --out <out_dir> --dry-run
+daydream train --corpus-v2 PROJECTION_DIR --out OUT_DIR --dry-run
 ```
 
 (Drop `--dry-run` for the real run. `--corpus-v2` is mutually exclusive with

--- a/tests/fixtures/training/build_corpus_v2_50.py
+++ b/tests/fixtures/training/build_corpus_v2_50.py
@@ -1,0 +1,263 @@
+"""50-record corpus-v2 integration fixture (mirrors the v1 ``records-50``).
+
+Builds a real corpus-v2 projection directory with :func:`run_build_corpus_v2`
+over a curated bundle + annotation snapshot — the same staging helpers
+``tests.test_corpus_v2`` uses — sized so that:
+
+- exactly 50 records are emitted,
+- both gold classes (accepted + rejected) are present, including on the
+  frozen holdout side (Stage 0's gate evaluates there),
+- silver ``process-trace`` and ``task-only`` records are present
+  (``emit_process_traces=True``),
+- every admitted batch carries ``findings.json`` (localized finding text),
+  ``diff.patch``, and a ``manifest.json`` with git ``base_sha``/``head_sha``,
+  so the additive v2 enrichment is exercised end-to-end.
+
+The build is fully deterministic: the same inputs produce byte-identical
+projection directories, so the loader's directory-level digest — and the
+pipeline run's ``run_identity.corpus_digest`` — is stable across runs.
+
+Diff-body materialization: the projector emits the content-addressed
+``task_identity.diff_ref`` pointer (never a raw diff body — the v2 schema is
+``additionalProperties: false``). This fixture resolves each record's pointer
+against the bundle and stamps the raw ``diff`` body onto the record, the same
+archive-side materialization ``coordinator._materialize_diff`` performs for
+v1 ``fix_diff_ref`` pointers, so Stage 2's raw-diff contract is exercised
+over a real projection without touching the coordinator.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+from daydream.training.corpus_v2.identity import record_id
+from daydream.training.corpus_v2.projector import run_build_corpus_v2
+from daydream.training.corpus_v2.splits import assign_split
+from tests.test_corpus_v2 import (
+    _policy_file,
+    _write_annotations_snapshot,
+    _write_bundle,
+    _write_sumsums,
+)
+
+SALT = "issue-1081-fixture-salt"
+HOLDOUT_RATE = 0.2
+VAL_RATE = 0.2
+
+ACCEPTED_TEXT = "exact localized finding body"
+REJECTED_TEXT = "rejected finding body"
+AMBIGUOUS_TEXT = "ambiguous finding body"
+
+_GOLD_SESSIONS = 23  # 2 gold findings each -> 46 gold outcome-finding records
+_AMBIGUOUS_SESSIONS = 2  # 1 non-decisive finding each -> 2 derived records
+# 46 gold + 2 process-trace + 2 task-only = 50 records.
+
+_SESSION_ORDER = ["sess-a"] + [
+    *(f"sess-gold-{i:02d}" for i in range(_GOLD_SESSIONS - 1)),
+    *(f"sess-amb-{c}" for c in "ab"),
+]
+
+
+def _fingerprints(session_id: str, *, prefixed: bool) -> list[str]:
+    """The fingerprint triple ``_write_annotations_snapshot`` derives for one
+    session: the first snapshot call writes unprefixed canonical fingerprints;
+    every later session's fingerprints are prefixed with ``sha256(sid)[:2]``
+    so globally keyed snapshots never collide."""
+    prefix = hashlib.sha256(session_id.encode()).hexdigest()[:2] if prefixed else ""
+    return [prefix + fp for fp in ("a1" * 32, "b2" * 32, "c3" * 32)]
+
+
+def _plan_dispositions() -> dict[str, list[str]]:
+    """Deterministic per-session dispositions guaranteeing both gold classes
+    on both sides of the frozen boundary. Labels are assigned over the
+    record ids the snapshot helper will derive, using the same
+    ``assign_split`` call the projector makes, so the plan matches the build."""
+    gold_pairs: list[tuple[str, str, str]] = []  # (session_id, fingerprint, split)
+    for index, sid in enumerate(_SESSION_ORDER):
+        if sid.startswith("sess-amb-"):
+            continue
+        fps = _fingerprints(sid, prefixed=index > 0)
+        for fp in fps[:2]:
+            rid = record_id(sid, f"{sid}:root", "seg-0", fp)
+            split = assign_split(
+                rid, salt=SALT, holdout_rate=HOLDOUT_RATE, val_rate=VAL_RATE
+            )
+            gold_pairs.append((sid, fp, split))
+
+    holdout = [pair for pair in gold_pairs if pair[2] == "holdout"]
+    assert len(holdout) >= 2, "fixture design requires >=2 holdout gold findings"
+    label_of: dict[tuple[str, str], str] = {}
+    # First two holdout findings pin the two classes on the evaluated side;
+    # everything else alternates, so the training side carries both too.
+    for position, pair in enumerate(holdout):
+        label_of[(pair[0], pair[1])] = "accepted" if position == 0 else (
+            "rejected" if position == 1 else ("accepted" if position % 2 == 0 else "rejected")
+        )
+    for position, pair in enumerate(p for p in gold_pairs if p[2] != "holdout"):
+        label_of[(pair[0], pair[1])] = "accepted" if position % 2 == 0 else "rejected"
+
+    dispositions: dict[str, list[str]] = {}
+    for index, sid in enumerate(_SESSION_ORDER):
+        if sid.startswith("sess-amb-"):
+            dispositions[sid] = ["ambiguous"]
+        else:
+            fps = _fingerprints(sid, prefixed=index > 0)
+            dispositions[sid] = [label_of[(sid, fp)] for fp in fps[:2]]
+    return dispositions
+
+
+def _body_for(label: str) -> str:
+    return {
+        "accepted": ACCEPTED_TEXT,
+        "rejected": REJECTED_TEXT,
+        "ambiguous": AMBIGUOUS_TEXT,
+    }[label]
+
+
+def _add_batch(
+    bundle_dir: Path,
+    manifest: dict[str, Any],
+    session_id: str,
+    dispositions: list[str],
+) -> None:
+    """One admitted batch directory: producer-realistic ``manifest.json``
+    (git base/head), ``findings.json`` (fingerprint-keyed bodies), and
+    ``diff.patch``, plus its curation-manifest row."""
+    batch_dir = bundle_dir / "batches" / session_id
+    batch_dir.mkdir(parents=True, exist_ok=True)
+    fps = _fingerprints(
+        session_id, prefixed=_SESSION_ORDER.index(session_id) > 0
+    )
+    (batch_dir / "manifest.json").write_text(
+        json.dumps(
+            {
+                "git": {
+                    "base_sha": hashlib.sha256(
+                        f"{session_id}-base".encode()
+                    ).hexdigest()[:40],
+                    "head_sha": hashlib.sha256(
+                        f"{session_id}-head".encode()
+                    ).hexdigest()[:40],
+                }
+            },
+            sort_keys=True,
+        )
+        + "\n"
+    )
+    (batch_dir / "findings.json").write_text(
+        json.dumps(
+            {
+                "findings": [
+                    {"fingerprint": fp, "body": _body_for(label)}
+                    for fp, label in zip(fps, dispositions)
+                ]
+            },
+            sort_keys=True,
+        )
+        + "\n"
+    )
+    (batch_dir / "diff.patch").write_text(
+        f"diff --git a/{session_id}.py b/{session_id}.py\n"
+        f"--- a/{session_id}.py\n+++ b/{session_id}.py\n"
+        f"@@ -1 +1 @@\n-pass\n+fixed-{session_id}\n"
+    )
+    batch_row = {
+        "session_id": session_id,
+        "content_digest": hashlib.sha256(session_id.encode()).hexdigest(),
+        "status": "admitted",
+        "reason_code": None,
+        "artifact_relpath": f"batches/{session_id}",
+        "artifact_digest": None,
+        "manifest_relpath": f"batches/{session_id}/manifest.json",
+        "repo_slug": f"owner/repo-{hashlib.sha256(session_id.encode()).hexdigest()[:6]}",
+        "license_evidence": {"spdx_id": "MIT", "source": "manifest"},
+    }
+    existing = {b["session_id"] for b in manifest["batches"]}
+    if session_id in existing:
+        # e.g. sess-a from the shared bundle helper: refresh identity in place
+        manifest["batches"] = [
+            {**b, "repo_slug": batch_row["repo_slug"], "license_evidence": batch_row["license_evidence"]}
+            if b["session_id"] == session_id else b
+            for b in manifest["batches"]
+        ]
+    else:
+        manifest["batches"].append(batch_row)
+
+
+def _materialize_diff_bodies(proj_dir: Path, bundle_dir: Path) -> None:
+    """Resolve each record's ``task_identity.diff_ref`` against the bundle and
+    stamp the raw ``diff`` body onto the record (see module docstring). The
+    split/corpus files are rewritten with the projector's own canonical JSONL
+    form, keeping the directory byte-deterministic."""
+    for filename in (
+        "corpus.jsonl",
+        "corpus-v2.jsonl",
+        "train.jsonl",
+        "validation.jsonl",
+        "holdout.jsonl",
+    ):
+        path = proj_dir / filename
+        if not path.is_file():
+            continue
+        records = [
+            json.loads(line) for line in path.read_text().splitlines() if line.strip()
+        ]
+        for record in records:
+            identity = record.get("task_identity")
+            ref = identity.get("diff_ref") if isinstance(identity, dict) else None
+            if isinstance(ref, dict) and isinstance(ref.get("relpath"), str):
+                record["diff"] = (bundle_dir / ref["relpath"]).read_text(encoding="utf-8")
+        path.write_text(
+            "".join(
+                json.dumps(r, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+                + "\n"
+                for r in records
+            ),
+            encoding="utf-8",
+        )
+
+
+def build_corpus_v2_50(tmp_path: Path) -> Path:
+    """Materialize the 50-record corpus-v2 projection under ``tmp_path``.
+
+    Returns:
+        The projection directory (the ``--corpus-v2`` input).
+
+    Raises:
+        AssertionError: When the deterministic build does not produce the
+            contracted population (50 records, both gold classes, silver +
+            task-only records) — a broken fixture is a test-authoring bug,
+            never a silently accepted projection.
+    """
+    from daydream.training.corpus_v2.projector import BuildCorpusV2Config
+
+    work = tmp_path / "corpus-v2-fixture"
+    bundle_dir = _write_bundle(work)
+    manifest = json.loads((bundle_dir / "curation-manifest.json").read_text())
+    dispositions = _plan_dispositions()
+    for sid in _SESSION_ORDER:
+        _add_batch(bundle_dir, manifest, sid, dispositions[sid])
+    (bundle_dir / "curation-manifest.json").write_text(json.dumps(manifest))
+    _write_sumsums(bundle_dir)
+
+    for sid in _SESSION_ORDER:
+        _write_annotations_snapshot(bundle_dir, session_id=sid, dispositions=dispositions[sid])
+
+    proj_dir = work / "proj"
+    run_build_corpus_v2(
+        BuildCorpusV2Config(
+            out_dir=proj_dir,
+            bundle_dir=bundle_dir,
+            annotation_bundle_dir=bundle_dir.parent / f"{bundle_dir.name}-annotations",
+            license_policy_path=_policy_file(work),
+            salt=SALT,
+            holdout_rate=HOLDOUT_RATE,
+            val_rate=VAL_RATE,
+            emit_process_traces=True,
+        )
+    )
+    _materialize_diff_bodies(proj_dir, bundle_dir)
+    return proj_dir

--- a/tests/fixtures/training/build_corpus_v2_50.py
+++ b/tests/fixtures/training/build_corpus_v2_50.py
@@ -10,20 +10,19 @@ over a curated bundle + annotation snapshot — the same staging helpers
 - silver ``process-trace`` and ``task-only`` records are present
   (``emit_process_traces=True``),
 - every admitted batch carries ``findings.json`` (localized finding text),
-  ``diff.patch``, and a ``manifest.json`` with git ``base_sha``/``head_sha``,
+  ``diff.patch``, and a ``manifest.json`` with ``git.head_sha`` plus
+  ``code_context.{base_sha, head_sha}`` (the producer-realistic namespaces),
   so the additive v2 enrichment is exercised end-to-end.
 
 The build is fully deterministic: the same inputs produce byte-identical
 projection directories, so the loader's directory-level digest — and the
 pipeline run's ``run_identity.corpus_digest`` — is stable across runs.
 
-Diff-body materialization: the projector emits the content-addressed
-``task_identity.diff_ref`` pointer (never a raw diff body — the v2 schema is
-``additionalProperties: false``). This fixture resolves each record's pointer
-against the bundle and stamps the raw ``diff`` body onto the record, the same
-archive-side materialization ``coordinator._materialize_diff`` performs for
-v1 ``fix_diff_ref`` pointers, so Stage 2's raw-diff contract is exercised
-over a real projection without touching the coordinator.
+The projector embeds the raw diff body on every record (schema v2.json
+``diff``) directly from the bundle's ``batches/<sid>/diff.patch``, so the
+fixture needs no post-processing: the real projector -> Stage-2 journey
+(``coordinator._rft_rows`` over ``run_build_corpus_v2`` output) carries the
+full RFT identity (repo_slug/base_sha/head_sha/diff) on its own.
 """
 
 from __future__ import annotations
@@ -124,8 +123,9 @@ def _add_batch(
     dispositions: list[str],
 ) -> None:
     """One admitted batch directory: producer-realistic ``manifest.json``
-    (git base/head), ``findings.json`` (fingerprint-keyed bodies), and
-    ``diff.patch``, plus its curation-manifest row."""
+    (``git.head_sha`` plus ``code_context.{base_sha, head_sha}``),
+    ``findings.json`` (fingerprint-keyed bodies), and ``diff.patch``, plus
+    its curation-manifest row."""
     batch_dir = bundle_dir / "batches" / session_id
     batch_dir.mkdir(parents=True, exist_ok=True)
     fps = _fingerprints(
@@ -135,13 +135,18 @@ def _add_batch(
         json.dumps(
             {
                 "git": {
+                    "head_sha": hashlib.sha256(
+                        f"{session_id}-head".encode()
+                    ).hexdigest()[:40],
+                },
+                "code_context": {
                     "base_sha": hashlib.sha256(
                         f"{session_id}-base".encode()
                     ).hexdigest()[:40],
                     "head_sha": hashlib.sha256(
                         f"{session_id}-head".encode()
                     ).hexdigest()[:40],
-                }
+                },
             },
             sort_keys=True,
         )
@@ -187,39 +192,6 @@ def _add_batch(
         manifest["batches"].append(batch_row)
 
 
-def _materialize_diff_bodies(proj_dir: Path, bundle_dir: Path) -> None:
-    """Resolve each record's ``task_identity.diff_ref`` against the bundle and
-    stamp the raw ``diff`` body onto the record (see module docstring). The
-    split/corpus files are rewritten with the projector's own canonical JSONL
-    form, keeping the directory byte-deterministic."""
-    for filename in (
-        "corpus.jsonl",
-        "corpus-v2.jsonl",
-        "train.jsonl",
-        "validation.jsonl",
-        "holdout.jsonl",
-    ):
-        path = proj_dir / filename
-        if not path.is_file():
-            continue
-        records = [
-            json.loads(line) for line in path.read_text().splitlines() if line.strip()
-        ]
-        for record in records:
-            identity = record.get("task_identity")
-            ref = identity.get("diff_ref") if isinstance(identity, dict) else None
-            if isinstance(ref, dict) and isinstance(ref.get("relpath"), str):
-                record["diff"] = (bundle_dir / ref["relpath"]).read_text(encoding="utf-8")
-        path.write_text(
-            "".join(
-                json.dumps(r, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
-                + "\n"
-                for r in records
-            ),
-            encoding="utf-8",
-        )
-
-
 def build_corpus_v2_50(tmp_path: Path) -> Path:
     """Materialize the 50-record corpus-v2 projection under ``tmp_path``.
 
@@ -259,5 +231,4 @@ def build_corpus_v2_50(tmp_path: Path) -> Path:
             emit_process_traces=True,
         )
     )
-    _materialize_diff_bodies(proj_dir, bundle_dir)
     return proj_dir

--- a/tests/test_corpus_v2.py
+++ b/tests/test_corpus_v2.py
@@ -1310,15 +1310,18 @@ def test_gold_accepted_record_carries_finding_text_and_task_identity(
     tmp_path: Path,
 ) -> None:
     """A bundle whose admitted batch carries findings.json / diff.patch /
-    manifest.json (git base_sha/head_sha) enriches the gold-accepted record
+    manifest.json (git head_sha / code_context base_sha) enriches the
+    gold-accepted record
     additively: localized finding text + its sha256, and a task_identity
     block threading the git shas and the batch's content-addressed diff
     pointer. The diff body round-trips via diff_ref."""
     bundle_dir = _write_bundle(tmp_path)
     batch_dir = bundle_dir / "batches" / "sess-a"
-    # Producer-realistic manifest: git shas under "git" (archive/manifest.py).
+    # Producer-realistic manifest: head SHA under "git", base SHA under
+    # "code_context" (archive/manifest.py:374-387).
     (batch_dir / "manifest.json").write_text(json.dumps({
-        "git": {"base_sha": "1" * 40, "head_sha": "2" * 40},
+        "git": {"head_sha": "2" * 40},
+        "code_context": {"base_sha": "1" * 40, "head_sha": "2" * 40},
     }))
     (batch_dir / "findings.json").write_text(json.dumps({
         "findings": [

--- a/tests/test_corpus_v2.py
+++ b/tests/test_corpus_v2.py
@@ -1304,3 +1304,59 @@ def test_end_to_end_clean_mixed_repo_publishes(
         assert lineage["license_decision"]["status"] == "admitted"
         assert lineage["license_decision"]["repo_slug"] == "owner/repo-a"
         assert lineage["license_decision"]["policy_version"] == "1"
+
+
+def test_gold_accepted_record_carries_finding_text_and_task_identity(
+    tmp_path: Path,
+) -> None:
+    """A bundle whose admitted batch carries findings.json / diff.patch /
+    manifest.json (git base_sha/head_sha) enriches the gold-accepted record
+    additively: localized finding text + its sha256, and a task_identity
+    block threading the git shas and the batch's content-addressed diff
+    pointer. The diff body round-trips via diff_ref."""
+    bundle_dir = _write_bundle(tmp_path)
+    batch_dir = bundle_dir / "batches" / "sess-a"
+    # Producer-realistic manifest: git shas under "git" (archive/manifest.py).
+    (batch_dir / "manifest.json").write_text(json.dumps({
+        "git": {"base_sha": "1" * 40, "head_sha": "2" * 40},
+    }))
+    (batch_dir / "findings.json").write_text(json.dumps({
+        "findings": [
+            {"fingerprint": "a1" * 32, "body": "exact localized finding body"},
+            {"fingerprint": "c3" * 32, "body": "ambiguous finding body"},
+        ],
+    }))
+    diff_text = "diff --git a/x.py b/x.py\n+print(1)\n"
+    (batch_dir / "diff.patch").write_text(diff_text)
+    snap = _write_annotations_snapshot(bundle_dir, dispositions=["accepted", "rejected"])
+    out = tmp_path / "proj"
+    run_build_corpus_v2(_cfg(out, bundle_dir, snap))
+    records = [
+        json.loads(line)
+        for line in (out / "corpus.jsonl").read_text().splitlines() if line.strip()
+    ]
+    accepted = next(r for r in records if r["outcome_label"] == "accepted")
+    assert accepted["finding_fingerprint"] == "a1" * 32
+    assert accepted["finding_text"] == "exact localized finding body"
+    assert accepted["finding_text_sha256"] == hashlib.sha256(
+        b"exact localized finding body"
+    ).hexdigest()
+    task_identity = accepted["task_identity"]
+    assert task_identity["repo_slug"] == "owner/repo-a"
+    assert task_identity["base_sha"] == "1" * 40
+    assert task_identity["head_sha"] == "2" * 40
+    assert task_identity["diff_ref"] == {
+        "batch": "1111111111111111111111111111111111111111111111111111111111111111",
+        "relpath": "batches/sess-a/diff.patch",
+    }
+    assert task_identity["diff_digest"] == hashlib.sha256(diff_text.encode()).hexdigest()
+    # The pointer resolves back to the diff body it was derived from.
+    ref = accepted["task_identity"]["diff_ref"]
+    assert (bundle_dir / ref["relpath"]).read_text() == diff_text
+    # Lineage carries the same diff pointer additively.
+    assert accepted["lineage"]["diff_digest"] == task_identity["diff_digest"]
+    assert accepted["lineage"]["diff_ref"] == task_identity["diff_ref"]
+    # Rejected finding with no matching body in findings.json: no text fields.
+    rejected = next(r for r in records if r["outcome_label"] == "rejected")
+    assert "finding_text" not in rejected
+    assert "finding_text_sha256" not in rejected

--- a/tests/test_corpus_v2_process_traces.py
+++ b/tests/test_corpus_v2_process_traces.py
@@ -33,7 +33,7 @@ def _records(out_dir: Path) -> list[dict[str, Any]]:
     ]
 
 
-def _build(tmp_path: Path, **kw: Any) -> tuple[Path, Path, Path]:
+def _build(tmp_path: Path, **kw: Any) -> tuple[Path, dict[str, Any], Path]:
     bundle_dir = _write_bundle(tmp_path)
     snap = _write_annotations_snapshot(
         bundle_dir, dispositions=["accepted", "ambiguous"]

--- a/tests/test_corpus_v2_process_traces.py
+++ b/tests/test_corpus_v2_process_traces.py
@@ -1,0 +1,130 @@
+"""Task: projector emits schema-distinct process-trace and task-only records
+behind the ``emit_process_traces`` flag (default off = byte-identical D8
+behavior: non-decisive findings land in the adjudication report only)."""
+
+import json
+from pathlib import Path
+from typing import Any
+
+from tests.test_corpus_v2 import (
+    _policy_file,
+    _write_annotations_snapshot,
+    _write_bundle,
+)
+
+
+def _cfg(out_dir: Path, bundle_dir: Path, snapshot: Path, **kw: Any) -> Any:
+    from daydream.training.corpus_v2.projector import BuildCorpusV2Config
+
+    return BuildCorpusV2Config(
+        out_dir=out_dir,
+        bundle_dir=bundle_dir,
+        annotation_bundle_dir=snapshot.parent,
+        license_policy_path=_policy_file(bundle_dir.parent),
+        **kw,
+    )
+
+
+def _records(out_dir: Path) -> list[dict[str, Any]]:
+    return [
+        json.loads(line)
+        for line in (out_dir / "corpus-v2.jsonl").read_text().splitlines()
+        if line.strip()
+    ]
+
+
+def _build(tmp_path: Path, **kw: Any) -> tuple[Path, Path, Path]:
+    bundle_dir = _write_bundle(tmp_path)
+    snap = _write_annotations_snapshot(
+        bundle_dir, dispositions=["accepted", "ambiguous"]
+    )
+    out_dir = tmp_path / "out"
+    from daydream.training.corpus_v2.projector import run_build_corpus_v2
+
+    out = run_build_corpus_v2(_cfg(out_dir, bundle_dir, snap, **kw))
+    return out_dir, out, snap
+
+
+def test_flag_off_emits_only_outcome_finding_records(tmp_path: Path) -> None:
+    out_dir, _out, _snap = _build(tmp_path)
+    records = _records(out_dir)
+    assert records
+    assert all(r["record_type"] == "outcome-finding" for r in records)
+    summary = _out
+    assert set(summary["records_by_type"]) == {"outcome-finding"}
+
+
+def test_flag_off_is_the_default(tmp_path: Path) -> None:
+    out_dir, _out, _snap = _build(tmp_path)
+    off_dir, _out_off, _snap2 = _build(tmp_path / "b", emit_process_traces=False)
+    assert (off_dir / "corpus-v2.jsonl").read_bytes() == (
+        out_dir / "corpus-v2.jsonl"
+    ).read_bytes()
+
+
+def test_flag_on_emits_process_trace_and_task_only_records(tmp_path: Path) -> None:
+    out_dir, out, _snap = _build(tmp_path, emit_process_traces=True)
+    records = _records(out_dir)
+    types = {r["record_type"] for r in records}
+    assert "process-trace" in types
+    assert "task-only" in types
+    assert "outcome-finding" in types
+    # The process-trace record is schema-distinct and NEVER gold: always
+    # silver with no outcome label.
+    traces = [r for r in records if r["record_type"] == "process-trace"]
+    assert traces
+    assert all(r["tier"] == "silver" for r in traces)
+    assert all(r["outcome_label"] is None for r in traces)
+    task_only = [r for r in records if r["record_type"] == "task-only"]
+    assert task_only
+    assert all(r["tier"] == "task-only" for r in task_only)
+    assert all(r["outcome_label"] is None for r in task_only)
+    # The summary counts the new types.
+    assert out["records_by_type"].get("process-trace", 0) >= 1
+    assert out["records_by_type"].get("task-only", 0) >= 1
+    # Process-trace records count under the silver tier population.
+    assert out["records_by_tier"].get("silver", 0) >= len(traces)
+
+
+def test_flag_on_records_carry_identity_lineage_and_distinct_ids(
+    tmp_path: Path,
+) -> None:
+    out_dir, _out, _snap = _build(tmp_path, emit_process_traces=True)
+    records = _records(out_dir)
+    derived = [
+        r for r in records if r["record_type"] in ("process-trace", "task-only")
+    ]
+    assert derived
+    ids = [r["record_id"] for r in records]
+    assert len(ids) == len(set(ids)), "record_ids must be unique across types"
+    for rec in derived:
+        assert rec["schema_version"] == "2"
+        assert rec["session_id"] == "sess-a"
+        lineage = rec["lineage"]
+        assert lineage["repo_slug"] == "owner/repo-a"
+        assert lineage["license_decision"]["status"] == "admitted"
+        assert lineage["split"] in ("train", "validation", "holdout")
+        assert lineage["exclusion_reason"] is None
+        # The adjudication report still carries the non-decisive finding (D8
+        # report output is preserved), but the finding is no longer counted
+        # as an exclusion — it was materialized as a record instead.
+    lineage = json.loads((out_dir / "lineage.json").read_text())
+    exclusions = lineage["exclusions_by_reason"]
+    assert exclusions.get("non-decisive-adjudication", 0) == 0
+    report = json.loads((out_dir / "adjudication-report.json").read_text())
+    assert report
+
+
+def test_flag_on_split_files_contain_derived_records(tmp_path: Path) -> None:
+    out_dir, _out, _snap = _build(tmp_path, emit_process_traces=True)
+    all_records = _records(out_dir)
+    derived_types = {"process-trace", "task-only"}
+    split_records: list[dict[str, Any]] = []
+    for name in ("train.jsonl", "validation.jsonl", "holdout.jsonl"):
+        split_records.extend(
+            json.loads(line)
+            for line in (out_dir / name).read_text().splitlines()
+            if line.strip()
+        )
+    assert len(split_records) == len(all_records)
+    assert any(r["record_type"] in derived_types for r in split_records)

--- a/tests/test_corpus_v2_reproducibility.py
+++ b/tests/test_corpus_v2_reproducibility.py
@@ -4,6 +4,7 @@ Mirrors ``tests/test_corpus_reproducibility.py``'s determinism standard and
 ``tests/test_corpus_leakage.py``'s as_of boundary standard.
 """
 
+import hashlib
 import json
 from pathlib import Path
 from typing import Any
@@ -47,6 +48,110 @@ def test_assign_split_is_deterministic_and_salted() -> None:
 def test_reprojection_is_byte_for_byte_deterministic(tmp_path: Path) -> None:
     bundle_dir = _write_bundle(tmp_path)
     snap = _write_annotations_snapshot(bundle_dir)
+    run_build_corpus_v2(_cfg(tmp_path / "a", bundle_dir, snap))
+    run_build_corpus_v2(_cfg(tmp_path / "b", bundle_dir, snap))
+    assert (tmp_path / "b" / "corpus.jsonl").read_bytes() == (tmp_path / "a" / "corpus.jsonl").read_bytes()
+    assert (tmp_path / "b" / "lineage.json").read_bytes() == (tmp_path / "a" / "lineage.json").read_bytes()
+    for name in ("train.jsonl", "validation.jsonl", "holdout.jsonl"):
+        assert (tmp_path / "b" / name).read_bytes() == (tmp_path / "a" / name).read_bytes()
+
+
+def _enrich_bundle(bundle_dir: Path) -> None:
+    """Give the admitted batch the review artifacts the projector joins on:
+    findings.json (bodies keyed by fingerprint), diff.patch, and a
+    producer-realistic manifest.json carrying the git shas."""
+    batch_dir = bundle_dir / "batches" / "sess-a"
+    (batch_dir / "manifest.json").write_text(json.dumps(
+        {"git": {"base_sha": "1" * 40, "head_sha": "2" * 40}}))
+    (batch_dir / "findings.json").write_text(json.dumps({"findings": [
+        {"fingerprint": "a1" * 32, "body": "exact localized finding body"},
+    ]}))
+    (batch_dir / "diff.patch").write_text("diff --git a/x.py b/x.py\n+print(1)\n")
+
+
+def test_enriched_projection_pins_exact_additive_record_shape(tmp_path: Path) -> None:
+    """The projected gold-accepted record from an enriched bundle is pinned
+    dict-for-dict at the additive v2 shape: finding_text + its sha256, the
+    task_identity block, and the diff pointer mirrored into lineage. The
+    exact equality IS the reproducibility contract — new projector keys must
+    regenerate this dict, never relax it to a subset check."""
+    bundle_dir = _write_bundle(tmp_path)
+    _enrich_bundle(bundle_dir)
+    snap = _write_annotations_snapshot(bundle_dir, dispositions=["accepted", "rejected"])
+    run_build_corpus_v2(_cfg(tmp_path / "out", bundle_dir, snap))
+    records = [json.loads(line) for line in
+               (tmp_path / "out" / "corpus.jsonl").read_text().splitlines() if line]
+    accepted = next(r for r in records if r["outcome_label"] == "accepted")
+    assert accepted == {
+        "disposition": "accepted",
+        "evidence": [
+            {"classifier_label": "accepted", "comment_id": 1,
+             "created_at": "2026-02-01T00:00:00+00:00",
+             "valid_at": "2026-01-01T00:00:00+00:00"},
+        ],
+        "finding_fingerprint": "a1" * 32,
+        "finding_text": "exact localized finding body",
+        "finding_text_sha256": hashlib.sha256(
+            b"exact localized finding body").hexdigest(),
+        "lineage": {
+            "as_of": None,
+            "content_digests": [
+                "1111111111111111111111111111111111111111111111111111111111111111",
+                "e12d0a7e8ecda05271e3faa36158292462221f5cf8c5cc530bc825f463e77b6d",
+            ],
+            "curation_id": "cur-0123456789abcdef",
+            "diff_digest": "4b7fad43c00ef2883fec22db7e9132310846cef11e0ec4cbbf936bc69a2c57a9",
+            "diff_ref": {
+                "batch": "1111111111111111111111111111111111111111111111111111111111111111",
+                "relpath": "batches/sess-a/diff.patch",
+            },
+            "exclusion_reason": None,
+            "hub_commit": "0123456789abcdef0123456789abcdef01234567",
+            "labeler_policy_version": "1",
+            "license_decision": {
+                "evidence_ref": "manifest", "policy_version": "1",
+                "reason_code": None, "repo_slug": "owner/repo-a",
+                "spdx_id": "MIT", "status": "admitted",
+            },
+            "reply_classifier_version": "1",
+            "repo_slug": "owner/repo-a",
+            "rubric_schema_version": "per-finding-resolutions-v1",
+            "split": "train",
+            "valid_at": "2026-01-01T00:00:00+00:00",
+        },
+        "outcome_label": "accepted",
+        "profile": {
+            "profile_digest": "d" * 64, "profile_name": "deep-review",
+            "profile_schema_version": 2, "profile_source_kind": "builtin",
+        },
+        "record_id": "6bfc34f5a65f3a68bd0409c7893b22a6d884e4c515a74ebe62b8b42e88e0dfda",
+        "record_type": "outcome-finding",
+        "schema_version": "2",
+        "session_id": "sess-a",
+        "stack": "python",
+        "task_identity": {
+            "base_sha": "1" * 40,
+            "diff_digest": "4b7fad43c00ef2883fec22db7e9132310846cef11e0ec4cbbf936bc69a2c57a9",
+            "diff_ref": {
+                "batch": "1111111111111111111111111111111111111111111111111111111111111111",
+                "relpath": "batches/sess-a/diff.patch",
+            },
+            "head_sha": "2" * 40,
+            "repo_slug": "owner/repo-a",
+        },
+        "task_segment": "seg-0",
+        "tier": "gold",
+        "trajectory_id": "sess-a:fix-0",
+    }
+
+
+def test_enriched_reprojection_is_byte_identical(tmp_path: Path) -> None:
+    """Reproducibility covers the additive enrichment: the same enriched
+    bundle projects byte-identically twice, so the emitted digests deterministically
+    cover finding_text / task_identity / lineage diff pointers."""
+    bundle_dir = _write_bundle(tmp_path)
+    _enrich_bundle(bundle_dir)
+    snap = _write_annotations_snapshot(bundle_dir, dispositions=["accepted", "rejected"])
     run_build_corpus_v2(_cfg(tmp_path / "a", bundle_dir, snap))
     run_build_corpus_v2(_cfg(tmp_path / "b", bundle_dir, snap))
     assert (tmp_path / "b" / "corpus.jsonl").read_bytes() == (tmp_path / "a" / "corpus.jsonl").read_bytes()

--- a/tests/test_corpus_v2_reproducibility.py
+++ b/tests/test_corpus_v2_reproducibility.py
@@ -61,8 +61,10 @@ def _enrich_bundle(bundle_dir: Path) -> None:
     findings.json (bodies keyed by fingerprint), diff.patch, and a
     producer-realistic manifest.json carrying the git shas."""
     batch_dir = bundle_dir / "batches" / "sess-a"
-    (batch_dir / "manifest.json").write_text(json.dumps(
-        {"git": {"base_sha": "1" * 40, "head_sha": "2" * 40}}))
+    (batch_dir / "manifest.json").write_text(json.dumps({
+        "git": {"head_sha": "2" * 40},
+        "code_context": {"base_sha": "1" * 40, "head_sha": "2" * 40},
+    }))
     (batch_dir / "findings.json").write_text(json.dumps({"findings": [
         {"fingerprint": "a1" * 32, "body": "exact localized finding body"},
     ]}))
@@ -84,6 +86,7 @@ def test_enriched_projection_pins_exact_additive_record_shape(tmp_path: Path) ->
     accepted = next(r for r in records if r["outcome_label"] == "accepted")
     assert accepted == {
         "disposition": "accepted",
+        "diff": "diff --git a/x.py b/x.py\n+print(1)\n",
         "evidence": [
             {"classifier_label": "accepted", "comment_id": 1,
              "created_at": "2026-02-01T00:00:00+00:00",

--- a/tests/test_corpus_v2_schema.py
+++ b/tests/test_corpus_v2_schema.py
@@ -105,3 +105,13 @@ def test_task_identity_with_bad_base_sha_is_rejected() -> None:
     record = _base_record(record_type="task-only", tier="task-only", task_identity=bad_identity)
     with pytest.raises(jsonschema.ValidationError):
         jsonschema.validate(record, SCHEMA)
+
+
+def test_task_identity_with_long_content_address_stamp_validates() -> None:
+    """The runtime validator tolerates sha256-style 64-hex content-address
+    stamps (``rft.validate_full_sha`` accepts 40+ hex, and v1 corpus shas are
+    64-hex), so the pinned schema must admit the same values — a record that
+    passes ``load_v2_projection``/``run_rft`` must never fail this schema."""
+    identity = dict(TASK_IDENTITY, base_sha="f" * 64, head_sha="e" * 64)
+    record = _base_record(record_type="task-only", tier="task-only", task_identity=identity)
+    jsonschema.validate(record, SCHEMA)

--- a/tests/test_corpus_v2_schema.py
+++ b/tests/test_corpus_v2_schema.py
@@ -1,0 +1,107 @@
+"""Schema tests for the extended corpus-v2 record schema (finding_text / task_identity)."""
+
+import json
+from pathlib import Path
+from typing import Any
+
+import jsonschema
+import pytest
+
+SCHEMA = json.loads((Path(__file__).parent.parent / "daydream/training/schema/v2.json").read_text())
+
+
+def _base_record(**overrides: Any) -> dict[str, Any]:
+    record: dict[str, Any] = {
+        "schema_version": "2",
+        "record_id": "a" * 64,
+        "record_type": "outcome-finding",
+        "tier": "gold",
+        "session_id": "session-1",
+        "trajectory_id": "traj-1",
+        "task_segment": "seg-1",
+        "finding_fingerprint": "b" * 64,
+        "disposition": "accepted",
+        "profile": {
+            "profile_schema_version": "1",
+            "profile_name": "default",
+            "profile_source_kind": "builtin",
+            "profile_digest": "c" * 64,
+        },
+        "stack": "python",
+        "outcome_label": "correct",
+        "lineage": {
+            "hub_commit": "d" * 40,
+            "curation_id": "cur-1",
+            "content_digests": ["e" * 64],
+            "labeler_policy_version": "1",
+            "reply_classifier_version": "1",
+            "rubric_schema_version": "1",
+            "as_of": "2026-01-01T00:00:00Z",
+            "valid_at": "2026-01-01T00:00:00Z",
+            "split": "train",
+            "exclusion_reason": None,
+            "repo_slug": "owner/repo",
+            "license_decision": {
+                "status": "admitted",
+                "reason_code": None,
+                "spdx_id": "MIT",
+                "policy_version": "1",
+                "evidence_ref": "evidence",
+                "repo_slug": "owner/repo",
+            },
+        },
+    }
+    record.update(overrides)
+    return record
+
+
+TASK_IDENTITY = {
+    "repo_slug": "owner/repo",
+    "source": "curation",
+    "base_sha": "1" * 40,
+    "head_sha": "2" * 40,
+    "diff_digest": "3" * 64,
+    "diff_ref": {"content_digest": "4" * 64, "path": "batches/s1/diff.patch"},
+    "replay_verification": {"status": "passed"},
+}
+
+
+def test_process_trace_record_validates() -> None:
+    record = _base_record(
+        record_type="process-trace",
+        tier="silver",
+        disposition="ambiguous",
+        prompt="prompt text",
+        completion="completion text",
+        task_identity=TASK_IDENTITY,
+    )
+    jsonschema.validate(record, SCHEMA)
+
+
+def test_task_only_record_validates() -> None:
+    record = _base_record(
+        record_type="task-only",
+        tier="task-only",
+        disposition="missing",
+        finding_fingerprint=None,
+        task_identity=TASK_IDENTITY,
+    )
+    jsonschema.validate(record, SCHEMA)
+
+
+def test_gold_outcome_finding_with_finding_text_and_task_identity_validates() -> None:
+    record = _base_record(
+        finding_text="The loop mutates the list while iterating.",
+        finding_text_sha256="5" * 64,
+        task_identity=TASK_IDENTITY,
+    )
+    record["lineage"]["diff_digest"] = "6" * 64
+    record["lineage"]["diff_ref"] = {"content_digest": "4" * 64, "path": "batches/s1/diff.patch"}
+    jsonschema.validate(record, SCHEMA)
+
+
+def test_task_identity_with_bad_base_sha_is_rejected() -> None:
+    bad_identity = dict(TASK_IDENTITY, base_sha="short")
+    record = _base_record(record_type="task-only", tier="task-only", task_identity=bad_identity)
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(record, SCHEMA)

--- a/tests/test_corpus_v2_spike_probe.py
+++ b/tests/test_corpus_v2_spike_probe.py
@@ -1,0 +1,85 @@
+"""Spike probe (task 0, issue #1081): force-check the two load-bearing
+assumptions of the corpus-v2 enrichment plan against a real-shaped curated
+bundle before any task writes code that depends on them:
+
+1. Extraction point — the curated bundle's batch directory
+   ``batches/<session_id>/`` carries ``findings.json`` (findings keyed by the
+   same 64-hex ``fingerprint`` as the annotation resolution rows, each with a
+   ``body`` string), ``diff.patch``, and a git-bearing ``manifest.json``.
+
+2. SHA coverage — all three files are covered by the curation bundle's
+   ``SHA256SUMS`` (content-addressed).
+
+Producer-realistic shapes confirmed against the archive writer
+(``daydream/archive/__init__.py`` copies the run's ``findings.json`` artifact
+into the batch dir; ``daydream/archive/manifest.py`` serializes the run
+manifest with ``git.head_sha`` and ``code_context.{base_sha,head_sha}``;
+``daydream/training/harvest.py:_row_recorded_fingerprints`` reads
+``findings.json`` as ``{"findings": [{"fingerprint": ..., "body": ...}]}``).
+"""
+
+import json
+from pathlib import Path
+
+from daydream.training.corpus_v2.projector import (
+    read_batch_artifacts,
+    run_build_corpus_v2,
+)
+from tests.test_corpus_v2 import (
+    _cfg,
+    _write_annotations_snapshot,
+    _write_bundle,
+    _write_sumsums,
+)
+
+
+def test_spike_probe_curated_batch_layout(tmp_path: Path) -> None:
+    bundle_dir = _write_bundle(tmp_path)
+    batch_dir = bundle_dir / "batches" / "sess-a"
+    # The batch finding's fingerprint must match an annotation resolution row's
+    # fingerprint — that is the join key the projector will use. The snapshot
+    # helper uses the canonical fingerprints for a lone session ("a1"*32 is the
+    # first, accepted), and the snapshot must be (re)harvested against the
+    # final batch fileset, so the artifacts land before the snapshot is
+    # written — mirroring the real curation order.
+    accepted_fp = "a1" * 32
+    finding_body = "Foo() leaks the pooled connection when the retry path raises."
+    (batch_dir / "findings.json").write_text(
+        json.dumps({"findings": [
+            {"fingerprint": accepted_fp, "body": finding_body,
+             "file": "pool.py", "line": 3, "placement": "inline"},
+        ]}) + "\n"
+    )
+    diff_body = "--- a/pool.py\n+++ b/pool.py\n@@ -1,2 +1,3 @@\n import ctx\n+pool.release()\n"
+    (batch_dir / "diff.patch").write_text(diff_body)
+    # Producer-realistic manifest shape: head SHA under ``git``, base SHA under
+    # ``code_context`` (archive/manifest.py:374-387).
+    batch_manifest = {
+        "git": {"head_sha": "h" * 40},
+        "code_context": {"base_sha": "b" * 40, "head_sha": "h" * 40},
+    }
+    (batch_dir / "manifest.json").write_text(json.dumps(batch_manifest) + "\n")
+    _write_sumsums(bundle_dir)
+    snap = _write_annotations_snapshot(bundle_dir, session_id="sess-a")
+    accepted_fp = "a1" * 32
+
+    # The projection pipeline accepts a bundle whose batches carry the three
+    # artifacts (no shape validation rejects them).
+    run_build_corpus_v2(_cfg(tmp_path / "out", bundle_dir, snap))
+
+    # THE RELATION TO PROVE: a helper read from the batch path resolves a
+    # resolution's finding text and diff exactly.
+    artifacts = read_batch_artifacts(bundle_dir, "sess-a")
+    assert artifacts.findings_by_fingerprint == {accepted_fp: finding_body}
+    assert artifacts.diff == diff_body
+    assert artifacts.manifest_git == batch_manifest["git"]
+
+    # SHA coverage: each of the three artifacts is covered by the curation
+    # bundle's SHA256SUMS (content-addressed).
+    sums = (bundle_dir / "SHA256SUMS").read_text().splitlines()
+    covered = [
+        line for line in sums
+        if any(f"batches/sess-a/{name}" in line
+               for name in ("findings.json", "diff.patch", "manifest.json"))
+    ]
+    assert len(covered) == 3, sums

--- a/tests/test_corpus_v2_spike_probe.py
+++ b/tests/test_corpus_v2_spike_probe.py
@@ -73,6 +73,7 @@ def test_spike_probe_curated_batch_layout(tmp_path: Path) -> None:
     assert artifacts.findings_by_fingerprint == {accepted_fp: finding_body}
     assert artifacts.diff == diff_body
     assert artifacts.manifest_git == batch_manifest["git"]
+    assert artifacts.manifest_code_context == batch_manifest["code_context"]
 
     # SHA coverage: each of the three artifacts is covered by the curation
     # bundle's SHA256SUMS (content-addressed).

--- a/tests/test_stacks_v2_load.py
+++ b/tests/test_stacks_v2_load.py
@@ -166,6 +166,17 @@ def test_load_v2_projection_missing_success_marker_fails_closed(
         load_v2_projection(out)
 
 
+def test_load_v2_projection_missing_split_file_fails_closed(
+    tmp_path: Path,
+) -> None:
+    """A missing split JSONL surfaces the documented ValueError, not a raw
+    FileNotFoundError/OSError."""
+    out = _write_projection(tmp_path, [f"rec-{i:04d}" for i in range(6)])
+    (out / "train.jsonl").unlink()
+    with pytest.raises(ValueError, match="missing split file"):
+        load_v2_projection(out)
+
+
 def test_load_v2_projection_non_v2_schema_version_fails_closed(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_stacks_v2_load.py
+++ b/tests/test_stacks_v2_load.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import json
 import shutil
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 import pytest
 
@@ -54,8 +54,10 @@ def _write_projection(tmp_path: Path, record_ids: list[str]) -> Path:
         "holdout": [],
     }
     for record_id in record_ids:
-        split = assign_split(
-            record_id, salt=SALT, holdout_rate=HOLDOUT_RATE, val_rate=VAL_RATE
+        split: str = cast(
+            str, assign_split(
+                record_id, salt=SALT, holdout_rate=HOLDOUT_RATE, val_rate=VAL_RATE
+            )
         )
         by_split[split].append(_make_record(record_id, split))
     for split, records in by_split.items():

--- a/tests/test_stacks_v2_load.py
+++ b/tests/test_stacks_v2_load.py
@@ -1,0 +1,197 @@
+"""Tests for the v2 directory loader wrapper (``load_v2_projection``).
+
+Enters from the production entrypoint over real projection directories on the
+real filesystem and asserts observable outcomes: per-split record access, a
+deterministic directory-level digest, and a fail-closed split-drift gate that
+refuses any record whose recorded ``lineage.split`` disagrees with the split
+recomputed from its record id.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from daydream.training.corpus_v2.splits import assign_split
+from daydream.training.stacks_v2 import V2Projection, load_v2_projection
+
+SALT = "issue-1081-salt"
+HOLDOUT_RATE = 0.2
+VAL_RATE = 0.2
+
+
+def _make_record(record_id: str, split: str) -> dict[str, Any]:
+    """A minimal v2 record passing the existing identity/license gates."""
+    return {
+        "schema_version": "2",
+        "record_id": record_id,
+        "record_type": "outcome-finding",
+        "tier": "gold",
+        "lineage": {
+            "repo_slug": "owner/repo",
+            "split": split,
+            "license_decision": {
+                "status": "admitted",
+                "repo_slug": "owner/repo",
+                "reason_code": None,
+            },
+        },
+    }
+
+
+def _write_projection(tmp_path: Path, record_ids: list[str]) -> Path:
+    """Build a real projection directory: records placed in the split file
+    their record id deterministically assigns, plus lineage.json + _SUCCESS."""
+    out = tmp_path / "proj"
+    out.mkdir()
+    by_split: dict[str, list[dict[str, Any]]] = {
+        "train": [],
+        "validation": [],
+        "holdout": [],
+    }
+    for record_id in record_ids:
+        split = assign_split(
+            record_id, salt=SALT, holdout_rate=HOLDOUT_RATE, val_rate=VAL_RATE
+        )
+        by_split[split].append(_make_record(record_id, split))
+    for split, records in by_split.items():
+        (out / f"{split}.jsonl").write_text(
+            "".join(json.dumps(r) + "\n" for r in records), encoding="utf-8"
+        )
+    (out / "lineage.json").write_text(
+        json.dumps(
+            {
+                "schema_version": "corpus-v2",
+                "salt": SALT,
+                "holdout_rate": HOLDOUT_RATE,
+                "val_rate": VAL_RATE,
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (out / "_SUCCESS").write_text("ok\n", encoding="utf-8")
+    return out
+
+
+def test_load_v2_projection_returns_per_split_records_lineage_and_digests(
+    tmp_path: Path,
+) -> None:
+    record_ids = [f"rec-{i:04d}" for i in range(30)]
+    out = _write_projection(tmp_path, record_ids)
+
+    proj = load_v2_projection(out)
+
+    assert isinstance(proj, V2Projection)
+    assert set(proj.by_split) == {"train", "validation", "holdout"}
+    # Every record lands in the split its id deterministically assigns.
+    for record in proj.records:
+        expected = assign_split(
+            str(record["record_id"]), salt=SALT, holdout_rate=HOLDOUT_RATE, val_rate=VAL_RATE
+        )
+        assert proj.by_split[expected] is not None
+        assert record in proj.by_split[expected]
+    assert len(proj.records) == len(record_ids)
+    assert sum(len(v) for v in proj.by_split.values()) == len(record_ids)
+    assert proj.lineage["salt"] == SALT
+    assert set(proj.split_digests) == {
+        "train.jsonl",
+        "validation.jsonl",
+        "holdout.jsonl",
+    }
+    for name, digest in proj.split_digests.items():
+        import hashlib
+
+        assert digest == hashlib.sha256((out / name).read_bytes()).hexdigest()
+
+
+def test_load_v2_projection_digest_is_deterministic(tmp_path: Path) -> None:
+    record_ids = [f"rec-{i:04d}" for i in range(12)]
+    out = _write_projection(tmp_path, record_ids)
+
+    first = load_v2_projection(out)
+    second = load_v2_projection(out)
+
+    assert first.digest == second.digest
+    # An identical copy of the directory yields the same digest.
+    copy = tmp_path / "copy"
+    shutil.copytree(out, copy)
+    assert load_v2_projection(copy).digest == first.digest
+    # And the digest is actually content-sensitive.
+    (out / "train.jsonl").write_text(
+        (out / "train.jsonl").read_text(encoding="utf-8") + "\n", encoding="utf-8"
+    )
+    assert load_v2_projection(out).digest != first.digest
+
+
+def test_load_v2_projection_raises_on_split_drift(tmp_path: Path) -> None:
+    record_ids = [f"rec-{i:04d}" for i in range(20)]
+    out = _write_projection(tmp_path, record_ids)
+
+    # Tamper: change one record's recorded lineage.split without moving it
+    # between files — the recompute gate must catch the drift fail-closed.
+    lines = (out / "train.jsonl").read_text(encoding="utf-8").splitlines()
+    if not lines:  # train may be empty for tiny id sets; use whatever exists
+        for name in ("validation.jsonl", "holdout.jsonl"):
+            lines = (out / name).read_text(encoding="utf-8").splitlines()
+            if lines:
+                break
+    records = [json.loads(line) for line in lines]
+    target = records[0]
+    tampered_split = next(
+        s for s in ("train", "validation", "holdout")
+        if s != str(target["lineage"]["split"])
+    )
+    target["lineage"]["split"] = tampered_split
+    (out / "train.jsonl").write_text(
+        "".join(json.dumps(r) + "\n" for r in records), encoding="utf-8"
+    )
+
+    with pytest.raises(ValueError, match="split drift"):
+        load_v2_projection(out)
+
+
+def test_load_v2_projection_missing_success_marker_fails_closed(
+    tmp_path: Path,
+) -> None:
+    out = _write_projection(tmp_path, [f"rec-{i:04d}" for i in range(6)])
+    (out / "_SUCCESS").unlink()
+    with pytest.raises(ValueError, match="_SUCCESS"):
+        load_v2_projection(out)
+
+
+def test_load_v2_projection_non_v2_schema_version_fails_closed(
+    tmp_path: Path,
+) -> None:
+    out = _write_projection(tmp_path, [f"rec-{i:04d}" for i in range(6)])
+    records = [
+        json.loads(line)
+        for line in (out / "train.jsonl").read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+    if records:
+        records[0]["schema_version"] = "1"
+        (out / "train.jsonl").write_text(
+            "".join(json.dumps(r) + "\n" for r in records), encoding="utf-8"
+        )
+    else:
+        # Deterministic splits may leave train empty for this id set; tamper
+        # whichever split file actually holds records.
+        for name in ("validation.jsonl", "holdout.jsonl"):
+            recs = [
+                json.loads(line)
+                for line in (out / name).read_text(encoding="utf-8").splitlines()
+                if line.strip()
+            ]
+            if recs:
+                recs[0]["schema_version"] = "1"
+                (out / name).write_text(
+                    "".join(json.dumps(r) + "\n" for r in recs), encoding="utf-8"
+                )
+                break
+    with pytest.raises(ValueError, match="schema_version"):
+        load_v2_projection(out)

--- a/tests/test_training_contract_v1_v2.py
+++ b/tests/test_training_contract_v1_v2.py
@@ -29,7 +29,7 @@ COORDINATOR = REPO_ROOT / "daydream" / "training" / "coordinator.py"
 # The only functions allowed to read v2-only record fields. Everything else in
 # the coordinator (and any code reached by a v1-shaped corpus) must never
 # touch them.
-V2_FIELD_ALLOWED_BUILDERS = {"_outcome_rows", "_sft_rows", "_rft_rows", "_run_stage0"}
+V2_FIELD_ALLOWED_BUILDERS = {"_outcome_rows", "_sft_rows", "_sft_prompt", "_rft_rows", "_run_stage0"}
 
 # The canonical combined suite (preamble task Step 1).
 COMBINED_SUITE = [

--- a/tests/test_training_contract_v1_v2.py
+++ b/tests/test_training_contract_v1_v2.py
@@ -1,0 +1,208 @@
+"""The v1/v2 divergence audit and full-suite gate (final parallel-implementation gate).
+
+The v1 ``--corpus`` path is the canonical existing consumer; the v2
+``--corpus-v2`` path is its sibling behind the same loaders and stages. These
+tests run the contract that both stay behaviorally coherent and that the
+combined v1 + v2 suite is green in a single invocation:
+
+- the v1 branch in :func:`run_pipeline` is untouched and still gated on
+  ``config.corpus`` (never silently rerouted through the v2 loader);
+- v2-only record fields (``finding_text``/``task_identity``) are read only by
+  the v2-aware row builders, so a v1 corpus never hits them;
+- a v1 pipeline and a v2 pipeline produce behaviorally coherent manifests;
+- the combined v1-contract and v2 suites pass together.
+
+The structural audits parse ``daydream/training/coordinator.py`` with ``ast``
+rather than substring grep so they name the enclosing function exactly.
+"""
+
+import ast
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+COORDINATOR = REPO_ROOT / "daydream" / "training" / "coordinator.py"
+
+# The only functions allowed to read v2-only record fields. Everything else in
+# the coordinator (and any code reached by a v1-shaped corpus) must never
+# touch them.
+V2_FIELD_ALLOWED_BUILDERS = {"_outcome_rows", "_sft_rows", "_rft_rows", "_run_stage0"}
+
+# The canonical combined suite (preamble task Step 1).
+COMBINED_SUITE = [
+    "tests/test_stacks_v2_gate.py",
+    "tests/test_stacks_v2_load.py",
+    "tests/test_training_coordinator.py",
+    "tests/test_training_coordinator_v2.py",
+    "tests/test_training_rft_v2_sha.py",
+    "tests/test_corpus_v2.py",
+    "tests/test_corpus_v2_reproducibility.py",
+]
+
+
+def _v2_field_reads() -> list[tuple[str, str | None, int]]:
+    """Find every ``rec.get("finding_text"/"task_identity")`` call and the
+    function it lives in (``None`` for module level)."""
+    tree = ast.parse(COORDINATOR.read_text(encoding="utf-8"))
+    reads: list[tuple[str, str | None, int]] = []
+    stack: list[str] = []
+
+    class Visitor(ast.NodeVisitor):
+        def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+            stack.append(node.name)
+            self.generic_visit(node)
+            stack.pop()
+
+        def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+            stack.append(node.name)
+            self.generic_visit(node)
+            stack.pop()
+
+        def visit_Call(self, node: ast.Call) -> None:
+            func = node.func
+            if (
+                isinstance(func, ast.Attribute)
+                and func.attr == "get"
+                and node.args
+                and isinstance(node.args[0], ast.Constant)
+                and node.args[0].value in ("finding_text", "task_identity")
+            ):
+                reads.append(
+                    (str(node.args[0].value), stack[-1] if stack else None, node.lineno)
+                )
+            self.generic_visit(node)
+
+    Visitor().visit(tree)
+    return reads
+
+
+def test_v1_load_path_untouched_and_gated_on_config_corpus() -> None:
+    """The v1 branch still calls ``stacks.load_dataset`` + ``_file_digest`` on
+    the corpus path, inside the ``else`` arm of the ``config.corpus_v2`` check —
+    the v1 ``--corpus`` journey is byte-identical to before the v2 branch."""
+    source = COORDINATOR.read_text(encoding="utf-8")
+    assert "stacks.load_dataset(corpus_path" in source, (
+        "the v1 load_dataset call was removed or rerouted — v1 must keep its "
+        "canonical loader call"
+    )
+    assert "_file_digest(corpus_path" in source, (
+        "the v1 single-file corpus digest was removed — v1 run identity must "
+        "be unchanged"
+    )
+
+    tree = ast.parse(source)
+    run_pipeline = next(
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.FunctionDef) and node.name == "run_pipeline"
+    )
+    ifs = [n for n in ast.walk(run_pipeline) if isinstance(n, ast.If)]
+    v2_guard = next(
+        n
+        for n in ifs
+        if isinstance(n.test, ast.Compare)
+        and isinstance(n.test.left, ast.Attribute)
+        and n.test.left.attr == "corpus_v2"
+    )
+    # The v2 loader is inside the corpus_v2 guard...
+    v2_body_source = "\n".join(ast.unparse(n) for n in v2_guard.body)
+    assert "load_v2_projection(" in v2_body_source
+    # ...and the v1 loader is not — it lives in the else arm only.
+    assert "stacks.load_dataset" not in v2_body_source
+
+
+def test_v2_only_fields_never_read_outside_v2_aware_builders() -> None:
+    """``finding_text``/``task_identity`` reads are confined to the row
+    builders and Stage-0, so a v1 corpus (records lacking them) never hits
+    them and the v1 gold/positive counts stay v2-field-free."""
+    offenders = [
+        (field, owner, lineno)
+        for field, owner, lineno in _v2_field_reads()
+        if owner not in V2_FIELD_ALLOWED_BUILDERS
+    ]
+    assert not offenders, (
+        f"v2-only fields read outside the v2-aware builders (add a v1-shape "
+        f"guard or move the read): {offenders}"
+    )
+    # The audit must actually see the v2 reads somewhere — otherwise the
+    # allowlist is vacuous.
+    assert _v2_field_reads(), "no v2-field reads found — audit is vacuous"
+
+
+def _write_corpus(path: Path, n: int = 50) -> Path:
+    """Write an n-record v1-shaped corpus: both gold classes, full diff identity."""
+    rows = []
+    for i in range(n):
+        accepted = i % 2 == 0
+        rows.append(
+            {
+                "session_id": f"sess-{i:04d}",
+                "repo_slug": f"acme/tooling-{i % 7}",
+                "comment_id": f"c{i:04d}",
+                "text": f"grounded actionable finding {i}" if accepted else f"noise chatter {i}",
+                "label": "accepted" if accepted else "rejected",
+                "labeler_policy_version": "980-policy-r1",
+                "base_sha": f"a{i:064x}",
+                "head_sha": f"b{i:064x}",
+                "diff": f"diff --git a/f.py b/f.py\n--- a/f.py\n+++ b/f.py\n@@ for sess-{i:04d}\n",
+            }
+        )
+    path.write_text("\n".join(json.dumps(r) for r in rows))
+    return path
+
+
+def test_v1_and_v2_manifests_are_behaviorally_coherent(tmp_path: Path) -> None:
+    """A v1 dry run and a v2 dry run of the same size produce manifests with
+    the same contract shape: identical stage sets, identical run-identity
+    fields, and non-empty corpus/split digests."""
+    from daydream.training.coordinator import PipelineConfig, run_pipeline
+    from tests.fixtures.training.build_corpus_v2_50 import build_corpus_v2_50
+
+    v1_manifest = run_pipeline(
+        PipelineConfig(corpus=_write_corpus(tmp_path / "corpus.jsonl"), out_dir=tmp_path / "out-v1"),
+        dry_run=True,
+    )
+    proj_dir = build_corpus_v2_50(tmp_path)
+    v2_manifest = run_pipeline(
+        PipelineConfig(corpus_v2=proj_dir, out_dir=tmp_path / "out-v2"),
+        dry_run=True,
+    )
+
+    assert set(v1_manifest) == set(v2_manifest)
+    assert set(v1_manifest["stages"]) == set(v2_manifest["stages"])
+    for stage, entry in v1_manifest["stages"].items():
+        assert entry["status"] == v2_manifest["stages"][stage]["status"], (
+            f"stage {stage} diverges between v1 and v2 for equivalent input"
+        )
+    identity_keys_v1 = set(v1_manifest["run_identity"])
+    identity_keys_v2 = set(v2_manifest["run_identity"])
+    assert identity_keys_v1 == identity_keys_v2
+    for field in ("corpus_digest", "split_digest"):
+        assert v1_manifest["run_identity"][field], f"v1 {field} empty"
+        assert v2_manifest["run_identity"][field], f"v2 {field} empty"
+
+    # Both manifests are loadable JSON on disk in the same place.
+    for out in ("out-v1", "out-v2"):
+        payload: dict[str, Any] = json.loads(
+            (tmp_path / out / "manifest.json").read_text(encoding="utf-8")
+        )
+        assert payload["stages"].keys() == v1_manifest["stages"].keys()
+
+
+def test_combined_v1_and_v2_suites_green_in_one_invocation() -> None:
+    """The full gate: the canonical v1 contract suite and the v2 suite pass
+    together in a single pytest invocation (the parallel-implementation gate)."""
+    result = subprocess.run(
+        [sys.executable, "-m", "pytest", "-q", *COMBINED_SUITE],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=1800,
+    )
+    assert result.returncode == 0, (
+        f"combined v1+v2 suite failed:\n{result.stdout[-4000:]}\n{result.stderr[-2000:]}"
+    )
+    assert "no tests ran" not in result.stdout

--- a/tests/test_training_coordinator_v2.py
+++ b/tests/test_training_coordinator_v2.py
@@ -258,6 +258,11 @@ def test_stage0_v2_frozen_split_sft_and_rft_rows(tmp_path: Path) -> None:
         assert len(row["base_sha"]) == 40 and all(c in "0123456789abcdef" for c in row["base_sha"])
         assert len(row["head_sha"]) == 40 and all(c in "0123456789abcdef" for c in row["head_sha"])
         assert row["diff"] == DIFF_BODY
+        # V2 rows carry intrinsic scoring signals: the frozen projection
+        # record is format-valid, and the replay scores its adjudicated
+        # outcome through the shared verdict vocabulary — never a flat 0.0.
+        assert row["format_valid"] is True
+        assert row["verifier_verdicts"]
 
 
 def test_stage0_v2_gold_record_without_finding_text_fails_closed(tmp_path: Path) -> None:
@@ -375,6 +380,13 @@ def test_integration_50_real_projection_full_pipeline(tmp_path: Path) -> None:
         )
     )
     assert replay.winners_path.is_file()
+    # Winner selection over the real projection is not degenerate: accepted
+    # gold rows score through a real correctness axis (composite > 0), so the
+    # winner filter reads a breakdown that discriminates instead of pinning
+    # every candidate at composite 0.0.
+    winners = json.loads(replay.winners_path.read_text())["winners"]
+    assert winners
+    assert any(float(w["breakdown"]["composite"]) > 0 for w in winners)
 
     # The run's corpus digest is the projection's directory-level digest and
     # is stable across runs (deterministic fixture bytes).

--- a/tests/test_training_coordinator_v2.py
+++ b/tests/test_training_coordinator_v2.py
@@ -1,0 +1,282 @@
+"""Corpus-v2 integration tests for the four-stage training coordinator.
+
+Enters from the production entrypoint (``run_pipeline``) with a real corpus-v2
+projection directory on the real filesystem (mocking nothing — every stage
+here is CPU-bound) and asserts observable outcomes: Stage 0 consumes the
+projector's frozen split rather than re-freezing at runtime, the manifest
+carries the projection's directory-level digest, and the Stage-1/2 row
+builders read the v2 fields (``finding_text``, ``task_identity``) fail-closed.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from daydream.training.coordinator import PipelineConfig, run_pipeline
+from daydream.training.corpus_v2.splits import assign_split
+from daydream.training.gate import _split_digest
+from daydream.training.stacks_v2 import load_v2_projection
+
+SALT = "issue-1081-coordinator-salt"
+HOLDOUT_RATE = 0.2
+VAL_RATE = 0.2
+BASE_SHA = "a" * 40
+HEAD_SHA = "b" * 40
+ACCEPTED_TEXT = "exact localized finding body"
+REJECTED_TEXT = "rejected finding body"
+DIFF_BODY = "diff --git a/x.py b/x.py\n--- a/x.py\n+++ b/x.py\n@@ -1 +1 @@\n-bad\n+good\n"
+
+
+def _record_id(session_id: str, fingerprint: str) -> str:
+    """The v2 record id: sha256 over the canonical (session, fingerprint) join."""
+    return hashlib.sha256(f"{session_id}\x1f{fingerprint}".encode("utf-8")).hexdigest()
+
+
+def _v2_record(
+    *,
+    session_id: str,
+    split: str,
+    label: str | None,
+    fingerprint: str,
+    record_type: str = "outcome-finding",
+    tier: str = "gold",
+    finding_text: str | None = None,
+    base_sha: str = BASE_SHA,
+) -> dict[str, Any]:
+    """A full v2 record the projector would emit for one finding."""
+    record: dict[str, Any] = {
+        "schema_version": "2",
+        "record_id": _record_id(session_id, fingerprint),
+        "record_type": record_type,
+        "tier": tier,
+        "session_id": session_id,
+        "trajectory_id": f"traj-{session_id}",
+        "task_segment": "segment-0",
+        "finding_fingerprint": fingerprint,
+        "disposition": label if label is not None else "ambiguous",
+        "evidence": [],
+        "profile": {
+            "profile_schema_version": 1,
+            "profile_name": "decisive-only",
+            "profile_source_kind": "curation",
+            "profile_digest": hashlib.sha256(b"profile").hexdigest(),
+        },
+        "stack": "python",
+        "outcome_label": label,
+        "lineage": {
+            "hub_commit": None,
+            "curation_id": "cur-1",
+            "content_digests": [],
+            "labeler_policy_version": "labeler-v3",
+            "reply_classifier_version": "rc-1",
+            "rubric_schema_version": "rubric-v2",
+            "as_of": "2026-01-01T00:00:00Z",
+            "valid_at": "2026-01-01T00:00:00Z",
+            "split": split,
+            "exclusion_reason": None,
+            "repo_slug": "owner/repo",
+            "license_decision": {
+                "status": "admitted",
+                "repo_slug": "owner/repo",
+                "reason_code": None,
+            },
+        },
+        "task_identity": {
+            "repo_slug": "owner/repo",
+            "source": "curation-bundle",
+            "base_sha": base_sha,
+            "head_sha": HEAD_SHA,
+            "diff_digest": hashlib.sha256(DIFF_BODY.encode("utf-8")).hexdigest(),
+            "diff_ref": {
+                "content_digest": hashlib.sha256(DIFF_BODY.encode("utf-8")).hexdigest(),
+                "relpath": f"batches/{session_id}/diff.patch",
+            },
+            "replay_verification": None,
+        },
+        # The materialized diff body the RFT replay rebuilds the task from.
+        "diff": DIFF_BODY,
+    }
+    if finding_text is not None:
+        record["finding_text"] = finding_text
+        record["finding_text_sha256"] = hashlib.sha256(finding_text.encode("utf-8")).hexdigest()
+    return record
+
+
+def _build_projection(
+    tmp_path: Path,
+    *,
+    omit_finding_text: bool = False,
+    base_sha: str = BASE_SHA,
+    n_sessions: int = 80,
+) -> Path:
+    """Build a real corpus-v2 projection directory with accepted + rejected
+    gold outcome findings (plus one silver process-trace and one task-only
+    record), placed in the split file each record id deterministically
+    assigns. Label assignment is seeded off the deterministic holdout
+    membership so the holdout side always carries both gold classes."""
+    session_ids = [f"sess-{i:04d}" for i in range(n_sessions)]
+    split_of = {
+        sid: assign_split(
+            _record_id(sid, "fp"),
+            salt=SALT,
+            holdout_rate=HOLDOUT_RATE,
+            val_rate=VAL_RATE,
+        )
+        for sid in session_ids
+    }
+    holdout_sessions = [sid for sid in session_ids if split_of[sid] == "holdout"]
+    assert len(holdout_sessions) >= 2
+    # Deterministic labels: first holdout session accepted, second rejected,
+    # everything else alternating — both classes on both sides of the boundary.
+    label_of: dict[str, str] = {
+        holdout_sessions[0]: "accepted",
+        holdout_sessions[1]: "rejected",
+    }
+    others = [sid for sid in session_ids if sid not in label_of]
+    for idx, sid in enumerate(others):
+        label_of[sid] = "accepted" if idx % 2 == 0 else "rejected"
+
+    records_by_split: dict[str, list[dict[str, Any]]] = {
+        "train": [],
+        "validation": [],
+        "holdout": [],
+    }
+
+    def _place(record: dict[str, Any]) -> None:
+        split = str(record["lineage"]["split"])
+        records_by_split[split].append(record)
+
+    for sid in session_ids:
+        label = label_of[sid]
+        _place(
+            _v2_record(
+                session_id=sid,
+                split=split_of[sid],
+                label=label,
+                fingerprint="fp",
+                finding_text=None if (omit_finding_text and label == "accepted") else (
+                    ACCEPTED_TEXT if label == "accepted" else REJECTED_TEXT
+                ),
+                base_sha=base_sha,
+            )
+        )
+    # A silver process-trace and a task-only record — schema-distinct
+    # non-gold types that must not become gold outcome rows. Each lands in
+    # the split its own record id deterministically assigns.
+    for sid, fingerprint, rtype, tier, text in (
+        ("sess-silver", "fp-silver", "process-trace", "silver", "process commentary"),
+        ("sess-task", "fp-task", "task-only", "task-only", None),
+    ):
+        record = _v2_record(
+            session_id=sid,
+            split="train",
+            label=None,
+            fingerprint=fingerprint,
+            record_type=rtype,
+            tier=tier,
+            finding_text=text,
+        )
+        record["lineage"]["split"] = assign_split(
+            str(record["record_id"]),
+            salt=SALT,
+            holdout_rate=HOLDOUT_RATE,
+            val_rate=VAL_RATE,
+        )
+        _place(record)
+
+    out = tmp_path / "proj"
+    out.mkdir()
+    for split, records in records_by_split.items():
+        (out / f"{split}.jsonl").write_text(
+            "".join(json.dumps(r, sort_keys=True) + "\n" for r in records), encoding="utf-8"
+        )
+    (out / "lineage.json").write_text(
+        json.dumps(
+            {
+                "schema_version": "corpus-v2",
+                "salt": SALT,
+                "holdout_rate": HOLDOUT_RATE,
+                "val_rate": VAL_RATE,
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (out / "_SUCCESS").write_text("ok\n", encoding="utf-8")
+    return out
+
+
+def _holdout_gold_comment_ids(proj_dir: Path) -> list[str]:
+    proj = load_v2_projection(proj_dir)
+    ids = []
+    for record in proj.by_split["holdout"]:
+        if record.get("tier") == "gold" and record.get("outcome_label") in ("accepted", "rejected"):
+            ids.append(str(record["session_id"]))
+    return ids
+
+
+def test_stage0_v2_frozen_split_sft_and_rft_rows(tmp_path: Path) -> None:
+    proj_dir = _build_projection(tmp_path)
+    cfg = PipelineConfig(corpus_v2=proj_dir, out_dir=tmp_path / "out")
+    manifest = run_pipeline(cfg, dry_run=False)
+
+    # Stage 0 runs to completion on the FROZEN split (not re-frozen at runtime).
+    assert manifest["stages"]["stage0"]["status"] == "complete"
+    split = json.loads((tmp_path / "out/stage0/split.json").read_text())
+    held_out_ids = sorted(_holdout_gold_comment_ids(proj_dir))
+    assert split["held_out_rows"] == len(held_out_ids)
+    # The split digest is exactly the frozen projector boundary: the content
+    # digest of the holdout gold comment ids under the run seed.
+    assert split["digest"] == _split_digest(held_out_ids, cfg.seed)
+
+    # The manifest's corpus digest is the projection's directory-level digest.
+    assert manifest["run_identity"]["corpus_digest"] == load_v2_projection(proj_dir).digest
+
+    # SFT: non-empty accepted-only completions carrying the real finding text.
+    sft_lines = (tmp_path / "out/stage1/sft-dataset.jsonl").read_text().splitlines()
+    assert sft_lines
+    sft_rows = [json.loads(line) for line in sft_lines]
+    assert sft_rows[0]["completion"] == ACCEPTED_TEXT
+    assert all(row["completion"] != REJECTED_TEXT for row in sft_rows)
+
+    # SFT tier counts separate silver process traces from gold rows.
+    assert manifest["stages"]["stage1"]["tier_counts"]["silver"] == 1
+
+    # RFT: non-empty inputs with full-length validated SHAs and a diff body.
+    rft_lines = (tmp_path / "out/stage2/rft-inputs.jsonl").read_text().splitlines()
+    assert rft_lines
+    rft_rows = [json.loads(line) for line in rft_lines]
+    for row in rft_rows:
+        assert len(row["base_sha"]) == 40 and all(c in "0123456789abcdef" for c in row["base_sha"])
+        assert len(row["head_sha"]) == 40 and all(c in "0123456789abcdef" for c in row["head_sha"])
+        assert row["diff"] == DIFF_BODY
+
+
+def test_stage0_v2_gold_record_without_finding_text_fails_closed(tmp_path: Path) -> None:
+    proj_dir = _build_projection(tmp_path, omit_finding_text=True)
+    cfg = PipelineConfig(corpus_v2=proj_dir, out_dir=tmp_path / "out")
+    with pytest.raises(RuntimeError, match="finding_text"):
+        run_pipeline(cfg, dry_run=False)
+
+
+def test_stage2_v2_truncated_sha_fails_closed(tmp_path: Path) -> None:
+    proj_dir = _build_projection(tmp_path, base_sha="abc123")
+    cfg = PipelineConfig(corpus_v2=proj_dir, out_dir=tmp_path / "out")
+    with pytest.raises(RuntimeError, match="base_sha"):
+        run_pipeline(cfg, dry_run=False)
+
+
+def test_corpus_and_corpus_v2_are_mutually_exclusive(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        PipelineConfig(
+            corpus=tmp_path / "corpus.jsonl",
+            corpus_v2=tmp_path / "proj",
+            out_dir=tmp_path / "out",
+        )
+    with pytest.raises(ValueError, match="exactly one"):
+        PipelineConfig(out_dir=tmp_path / "out")

--- a/tests/test_training_coordinator_v2.py
+++ b/tests/test_training_coordinator_v2.py
@@ -15,7 +15,7 @@ import json
 import sys
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Any
+from typing import Any, cast
 
 import pytest
 
@@ -311,6 +311,60 @@ def test_cli_corpus_and_corpus_v2_mutually_exclusive(tmp_path: Path, cli_runner:
         ["train", "--corpus", "x.jsonl", "--corpus-v2", str(proj_dir), "--out", str(tmp_path / "o")]
     )
     assert res.exit_code == 1
+
+
+def test_integration_50_real_projection_full_pipeline(tmp_path: Path) -> None:
+    """AC6: the 50-record real-projection fixture feeds the full pipeline.
+
+    The fixture materializes a corpus-v2 projection with the real
+    ``run_build_corpus_v2`` over a curated bundle + annotation snapshot
+    (finding text, diff pointers, and git shas present), sized so both gold
+    classes are present plus silver process-trace and task-only records.
+    The full pipeline completes over it and the run's corpus digest is
+    stable across runs.
+    """
+    from tests.fixtures.training.build_corpus_v2_50 import build_corpus_v2_50
+
+    proj_dir = build_corpus_v2_50(tmp_path)
+    projection = load_v2_projection(proj_dir)
+    assert len(projection.records) == 50
+    gold_labels = {
+        cast(str, r["outcome_label"])
+        for r in projection.records
+        if r.get("tier") == "gold"
+    }
+    assert {"accepted", "rejected"} <= gold_labels
+    record_types = {cast(str, r["record_type"]) for r in projection.records}
+    assert {"process-trace", "task-only"} <= record_types
+
+    manifest = run_pipeline(
+        PipelineConfig(corpus_v2=proj_dir, out_dir=tmp_path / "out"), dry_run=False
+    )
+    assert manifest["stages"]["stage0"]["status"] == "complete"
+    sft_rows = [
+        json.loads(line)
+        for line in (tmp_path / "out/stage1/sft-dataset.jsonl").read_text().splitlines()
+        if line
+    ]
+    rft_rows = [
+        json.loads(line)
+        for line in (tmp_path / "out/stage2/rft-inputs.jsonl").read_text().splitlines()
+        if line
+    ]
+    assert sft_rows and rft_rows
+    for row in rft_rows:
+        assert len(row["base_sha"]) == 40
+        assert len(row["head_sha"]) == 40
+        assert row["diff"]
+
+    # The run's corpus digest is the projection's directory-level digest and
+    # is stable across runs (deterministic fixture bytes).
+    first = manifest["run_identity"]["corpus_digest"]
+    assert first == projection.digest
+    manifest2 = run_pipeline(
+        PipelineConfig(corpus_v2=proj_dir, out_dir=tmp_path / "out2"), dry_run=False
+    )
+    assert manifest2["run_identity"]["corpus_digest"] == first
 
 
 def test_corpus_and_corpus_v2_are_mutually_exclusive(tmp_path: Path) -> None:

--- a/tests/test_training_coordinator_v2.py
+++ b/tests/test_training_coordinator_v2.py
@@ -22,6 +22,7 @@ import pytest
 from daydream.training.coordinator import PipelineConfig, run_pipeline
 from daydream.training.corpus_v2.splits import assign_split
 from daydream.training.gate import _split_digest
+from daydream.training.rft import RftConfig, run_rft
 from daydream.training.stacks_v2 import load_v2_projection
 
 SALT = "issue-1081-coordinator-salt"
@@ -318,10 +319,13 @@ def test_integration_50_real_projection_full_pipeline(tmp_path: Path) -> None:
 
     The fixture materializes a corpus-v2 projection with the real
     ``run_build_corpus_v2`` over a curated bundle + annotation snapshot
-    (finding text, diff pointers, and git shas present), sized so both gold
-    classes are present plus silver process-trace and task-only records.
-    The full pipeline completes over it and the run's corpus digest is
-    stable across runs.
+    (finding text, git shas, and diff bodies present — the producer-shaped
+    manifest puts base_sha under ``code_context``; the projector embeds each
+    raw diff body directly), sized so both gold classes are present plus
+    silver process-trace and task-only records. The full pipeline completes
+    over it, the run's corpus digest is stable across runs, and the emitted
+    Stage-2 rows are replayable through ``run_rft`` with no fixture
+    post-processing.
     """
     from tests.fixtures.training.build_corpus_v2_50 import build_corpus_v2_50
 
@@ -355,7 +359,22 @@ def test_integration_50_real_projection_full_pipeline(tmp_path: Path) -> None:
     for row in rft_rows:
         assert len(row["base_sha"]) == 40
         assert len(row["head_sha"]) == 40
+        assert row["repo_slug"]
         assert row["diff"]
+
+    # The emitted v2 rows are replayable: run_rft rebuilds each task from
+    # the full frozen identity (repo_slug/base_sha/head_sha/diff) carried by
+    # the projection itself — the real-projector -> Stage-2 journey, with no
+    # fixture-side diff materialization step.
+    replay = run_rft(
+        RftConfig(
+            inputs=tmp_path / "out/stage2/rft-inputs.jsonl",
+            seed=7,
+            rubric_version="2026.08.29-1",
+            output_dir=tmp_path / "out/replay",
+        )
+    )
+    assert replay.winners_path.is_file()
 
     # The run's corpus digest is the projection's directory-level digest and
     # is stable across runs (deterministic fixture bytes).

--- a/tests/test_training_coordinator_v2.py
+++ b/tests/test_training_coordinator_v2.py
@@ -12,7 +12,9 @@ from __future__ import annotations
 
 import hashlib
 import json
+import sys
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
 
 import pytest
@@ -269,6 +271,46 @@ def test_stage2_v2_truncated_sha_fails_closed(tmp_path: Path) -> None:
     cfg = PipelineConfig(corpus_v2=proj_dir, out_dir=tmp_path / "out")
     with pytest.raises(RuntimeError, match="base_sha"):
         run_pipeline(cfg, dry_run=False)
+
+
+@pytest.fixture
+def cli_runner() -> Any:
+    """Invoke ``daydream`` in-process; SystemExit code becomes exit_code."""
+    class _Runner:
+        def invoke(self, argv: list[str]) -> Any:
+            from daydream import cli
+
+            saved = sys.argv
+            sys.argv = ["daydream", *argv]
+            code = 0
+            try:
+                cli.main()
+            except SystemExit as exc:
+                code = int(exc.code or 0)
+            finally:
+                sys.argv = saved
+            return SimpleNamespace(exit_code=code)
+
+    return _Runner()
+
+
+def test_cli_corpus_v2_wiring(tmp_path: Path, cli_runner: Any) -> None:
+    """``daydream train --corpus-v2 DIR --dry-run`` drives run_pipeline end-to-end."""
+    proj_dir = _build_projection(tmp_path)
+    out = tmp_path / "cli-out"
+    res = cli_runner.invoke(["train", "--corpus-v2", str(proj_dir), "--out", str(out), "--dry-run"])
+    assert res.exit_code == 0, res
+    manifest = json.loads((out / "manifest.json").read_text())
+    assert manifest["run_identity"]["corpus_digest"] == load_v2_projection(proj_dir).digest
+
+
+def test_cli_corpus_and_corpus_v2_mutually_exclusive(tmp_path: Path, cli_runner: Any) -> None:
+    """Passing both inputs is refused, not silently preferring one."""
+    proj_dir = _build_projection(tmp_path)
+    res = cli_runner.invoke(
+        ["train", "--corpus", "x.jsonl", "--corpus-v2", str(proj_dir), "--out", str(tmp_path / "o")]
+    )
+    assert res.exit_code == 1
 
 
 def test_corpus_and_corpus_v2_are_mutually_exclusive(tmp_path: Path) -> None:

--- a/tests/test_training_docs_v2.py
+++ b/tests/test_training_docs_v2.py
@@ -1,0 +1,38 @@
+"""Documentation-contract test for the corpus-v2 real-corpus train flow (issue #1081).
+
+Pins that docs/training-launch.md and docs/runbooks/annotation-final-publish.md
+state the exact real-corpus v2 build + train commands and the immutable-input
+contract (verification markers, lineage, split digests, git SHAs, C5/C8
+re-application, fail-closed drift). Mirrors the doc-contract pattern in
+tests/test_calibration_docs.py (which itself mirrors tests/test_benchmark_docs.py,
+the #991 pattern).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+LAUNCH = ROOT / "docs" / "training-launch.md"
+RUNBOOK = ROOT / "docs" / "runbooks" / "annotation-final-publish.md"
+
+
+def test_training_launch_documents_v2_command_and_immutable_inputs() -> None:
+    text = LAUNCH.read_text()
+    assert "corpus build-v2" in text
+    assert "daydream train --corpus-v2" in text
+    assert "_SUCCESS" in text and "lineage" in text
+    assert "base_sha" in text and "head_sha" in text
+    assert "C5" in text and "C8" in text
+    assert "fail-closed" in text
+    assert "drift" in text
+
+
+def test_annotation_runbook_points_to_v2_train_command() -> None:
+    text = RUNBOOK.read_text()
+    assert "corpus build-v2" in text
+    assert "daydream train --corpus-v2" in text
+    assert "_SUCCESS" in text and "lineage" in text
+    assert "base_sha" in text and "head_sha" in text
+    assert "C5" in text and "C8" in text
+    assert "fail-closed" in text
+    assert "drift" in text

--- a/tests/test_training_rft_v2_sha.py
+++ b/tests/test_training_rft_v2_sha.py
@@ -1,0 +1,83 @@
+"""Full-SHA validation on v2 task records before RFT rebuild (Req 7 / #714 rebase).
+
+A v2 record's ``task_identity`` block is the frozen truth RFT replays against;
+a truncated or malformed SHA must fail closed with a ``ValueError`` naming the
+record id and field *before* any task reconstruction, never run against a
+shortened identity. Mirrors the coordinator ``_rft_rows`` contract so Stage 2
+and the replay agree on what a valid identity is.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from daydream.training.rft import RftConfig, run_rft
+
+
+def _record(rid: str = "r1", **overrides: object) -> dict[str, object]:
+    rec: dict[str, object] = {
+        "id": rid,
+        "repo_slug": "owner/repo",
+        "base_sha": "a" * 40,
+        "head_sha": "b" * 40,
+        "diff": f"diff --git a/f.py b/f.py\n--- a/f.py\n+++ b/f.py\n@@ {rid}\n",
+        "findings": [
+            {"id": f"{rid}-f1", "text": "Fix the off-by-one.", "grounded": True, "verdict": "consistent"},
+        ],
+        "format_valid": True,
+        "length": 400,
+    }
+    rec.update(overrides)
+    return rec
+
+
+def _write_corpus(tmp_path: Path, records: list[dict[str, object]]) -> Path:
+    path = tmp_path / "rft-inputs.jsonl"
+    path.write_text("".join(json.dumps(r, sort_keys=True) + "\n" for r in records), encoding="utf-8")
+    return path
+
+
+def _config(tmp_path: Path, records: list[dict[str, object]]) -> RftConfig:
+    return RftConfig(
+        inputs=_write_corpus(tmp_path, records),
+        seed=7,
+        rubric_version="2026.08.29-1",
+        output_dir=tmp_path / "out",
+    )
+
+
+def test_valid_full_shas_build_the_task(tmp_path: Path) -> None:
+    """A record with valid 40-hex base/head shas replays and writes winners."""
+    cfg = _config(tmp_path, [_record("r1"), _record("r2")])
+    result = run_rft(cfg)
+    assert result.winners_path.is_file()
+    assert result.inputs_sha256
+
+
+def test_short_base_sha_fails_closed(tmp_path: Path) -> None:
+    """A 6-char short sha is refused with ValueError before any rebuild."""
+    cfg = _config(tmp_path, [_record("r1", base_sha="abc123")])
+    with pytest.raises(ValueError, match=r"full sha|40"):
+        run_rft(cfg)
+
+
+def test_missing_head_sha_fails_before_task_work(tmp_path: Path) -> None:
+    """A malformed identity (missing head_sha) raises before task/image work."""
+    cfg = _config(tmp_path, [{"id": "r1", "base_sha": "a" * 40, "diff": "diff"}])
+    with pytest.raises(ValueError, match="head_sha"):
+        run_rft(cfg)
+
+
+def test_non_hex_sha_fails_closed(tmp_path: Path) -> None:
+    cfg = _config(tmp_path, [_record("r1", head_sha="z" * 40)])
+    with pytest.raises(ValueError, match="full sha|40"):
+        run_rft(cfg)
+
+
+def test_missing_repo_slug_fails_closed(tmp_path: Path) -> None:
+    cfg = _config(tmp_path, [_record("r1", repo_slug="")])
+    with pytest.raises(ValueError, match="repo_slug"):
+        run_rft(cfg)


### PR DESCRIPTION
## Summary

Makes a frozen corpus-v2 bundle directly consumable by training (issue #1081):

- Extend the corpus-v2 schema/projection with `finding_text` and task-identity fields on outcome-finding records, plus process-trace and task-only record contracts.
- Add a v2 directory loader with per-split access.
- `daydream train --corpus-v2` flag consumes the frozen corpus-v2 directory in `run_pipeline` (Stage 0 / SFT / RFT paths).
- Full-SHA immutable-revision validation on v2 task records before Stage 2.
- v1/v2 divergence audit + full-suite gate; 50-record corpus-v2 integration fixture.
- Carry intrinsic v2 signals into RFT rows.

## Test Plan

- `make check` green on branch tip (194 passed, 2 skipped).
- Two sequential daydream deep-precision review rounds completed (8 findings, all resolved and auto-fixed).

Closes #1081
