### PR TITLE
fix(backends): reject negative osprey telemetry at the JSONL boundary (Closes #710)

### DIFF
--- a/daydream/backends/osprey.py
+++ b/daydream/backends/osprey.py
@@ -182,6 +182,8 @@ def _parse_cost(value: Any, *, event_name: str) -> float | None:
         raise OspreyProtocolError(f"event {event_name!r} has invalid cost_usd") from exc
     if not math.isfinite(parsed):
         raise OspreyProtocolError(f"event {event_name!r} has non-finite cost_usd")
+    if parsed < 0:
+        raise OspreyProtocolError(f"event {event_name!r} has negative cost_usd")
     return parsed
 
 

--- a/daydream/backends/osprey.py
+++ b/daydream/backends/osprey.py
@@ -703,7 +703,7 @@ class OspreyBackend:
                     content = event.get("content")
                     if not isinstance(content, str):
                         raise OspreyProtocolError("tool_result requires string content")
-                    _required_int(event, "duration_ms")
+                    _required_non_negative_int(event, "duration_ms")
                     protocol_state.finish_tool_call(call_id)
                     yield ToolResultEvent(call_id, content, status == "error")
                 elif event_name == "tool_update":
@@ -722,18 +722,14 @@ class OspreyBackend:
                     if not isinstance(usage_reported, bool):
                         raise OspreyProtocolError("turn_end requires boolean usage_reported")
                     if usage_reported:
-                        _required_int(event, "duration_ms")
+                        _required_non_negative_int(event, "duration_ms")
                     else:
-                        _optional_int(event, "duration_ms")
+                        _optional_non_negative_int(event, "duration_ms")
                     if usage_reported:
-                        prompt_tokens = _required_int(event, "prompt_tokens")
-                        completion_tokens = _required_int(event, "completion_tokens")
-                        cached_tokens = _optional_int(event, "cached_tokens")
-                        reasoning_tokens = _optional_int(event, "thinking_tokens")
-                        if reasoning_tokens is not None and reasoning_tokens < 0:
-                            raise OspreyProtocolError(
-                                "turn_end thinking_tokens must be non-negative"
-                            )
+                        prompt_tokens = _required_non_negative_int(event, "prompt_tokens")
+                        completion_tokens = _required_non_negative_int(event, "completion_tokens")
+                        cached_tokens = _optional_non_negative_int(event, "cached_tokens")
+                        reasoning_tokens = _optional_non_negative_int(event, "thinking_tokens")
                         cost = _parse_cost(event.get("cost_usd"), event_name=event_name)
                         turn_model = event.get("model")
                         if turn_model is not None and not isinstance(turn_model, str):

--- a/daydream/backends/osprey.py
+++ b/daydream/backends/osprey.py
@@ -157,6 +157,20 @@ def _optional_int(event: dict[str, Any], key: str) -> int | None:
     return value
 
 
+def _required_non_negative_int(event: dict[str, Any], key: str) -> int:
+    value = _required_int(event, key)
+    if value < 0:
+        raise OspreyProtocolError(f"event {event.get('event')!r} has negative {key!r}")
+    return value
+
+
+def _optional_non_negative_int(event: dict[str, Any], key: str) -> int | None:
+    value = _optional_int(event, key)
+    if value is not None and value < 0:
+        raise OspreyProtocolError(f"event {event.get('event')!r} has negative {key!r}")
+    return value
+
+
 def _parse_cost(value: Any, *, event_name: str) -> float | None:
     if value is None:
         return None

--- a/daydream/backends/osprey.py
+++ b/daydream/backends/osprey.py
@@ -703,7 +703,7 @@ class OspreyBackend:
                     content = event.get("content")
                     if not isinstance(content, str):
                         raise OspreyProtocolError("tool_result requires string content")
-                    _required_non_negative_int(event, "duration_ms")
+                    _required_int(event, "duration_ms")
                     protocol_state.finish_tool_call(call_id)
                     yield ToolResultEvent(call_id, content, status == "error")
                 elif event_name == "tool_update":

--- a/daydream/backends/osprey.py
+++ b/daydream/backends/osprey.py
@@ -171,19 +171,19 @@ def _optional_non_negative_int(event: dict[str, Any], key: str) -> int | None:
     return value
 
 
-def _parse_cost(value: Any, *, event_name: str) -> float | None:
+def _parse_cost(value: Any, *, event_name: str, field: str = "cost_usd") -> float | None:
     if value is None:
         return None
     if not isinstance(value, str):
-        raise OspreyProtocolError(f"event {event_name!r} has non-string cost_usd")
+        raise OspreyProtocolError(f"event {event_name!r} has non-string {field!r}")
     try:
         parsed = float(value)
     except ValueError as exc:
-        raise OspreyProtocolError(f"event {event_name!r} has invalid cost_usd") from exc
+        raise OspreyProtocolError(f"event {event_name!r} has invalid {field!r}") from exc
     if not math.isfinite(parsed):
-        raise OspreyProtocolError(f"event {event_name!r} has non-finite cost_usd")
+        raise OspreyProtocolError(f"event {event_name!r} has non-finite {field!r}")
     if parsed < 0:
-        raise OspreyProtocolError(f"event {event_name!r} has negative cost_usd")
+        raise OspreyProtocolError(f"event {event_name!r} has negative {field!r}")
     return parsed
 
 
@@ -668,7 +668,7 @@ class OspreyBackend:
                     terminal_exit_code = exit_code
                     terminal_structured_output = event.get("structured_output")
                     saw_session_end = True
-                    final_cost = _parse_cost(event.get("total_cost_usd"), event_name=event_name)
+                    final_cost = _parse_cost(event.get("total_cost_usd"), event_name=event_name, field="total_cost_usd")
                     if final_cost is not None and not saw_metric_cost:
                         total_cost = final_cost
                     continue

--- a/tests/test_backend_osprey.py
+++ b/tests/test_backend_osprey.py
@@ -726,7 +726,7 @@ async def test_negative_session_total_cost_is_rejected() -> None:
     lines, _ = _stream()
     lines[-1]["total_cost_usd"] = "-0.125"
 
-    with pytest.raises(OspreyError, match="cost_usd"):
+    with pytest.raises(OspreyError, match="total_cost_usd"):
         await _collect(OspreyBackend(osprey_binary="fake"), lines)
 
 
@@ -734,8 +734,6 @@ async def test_negative_session_total_cost_is_rejected() -> None:
 @pytest.mark.parametrize(
     "events, field",
     [
-        ([{"event": "tool_result", "tool_call_id": "c-1", "tool_name": "n",
-           "status": "success", "content": "ok", "duration_ms": -1}], "duration_ms"),
         ([{"event": "turn_start", "turn_id": "t-1", "timestamp": "now"},
           {"event": "turn_end", "turn_id": "t-1", "usage_reported": True,
            "duration_ms": -1, "prompt_tokens": 0, "completion_tokens": 0}], "duration_ms"),

--- a/tests/test_backend_osprey.py
+++ b/tests/test_backend_osprey.py
@@ -731,21 +731,43 @@ async def test_negative_session_total_cost_is_rejected() -> None:
 
 
 @pytest.mark.asyncio
-async def test_negative_thinking_tokens_are_rejected() -> None:
-    lines, _ = _stream(
-        {"event": "turn_start", "turn_id": "t-1", "timestamp": "now"},
-        {
-            "event": "turn_end",
-            "turn_id": "t-1",
-            "usage_reported": True,
-            "duration_ms": 0,
-            "prompt_tokens": 0,
-            "completion_tokens": 0,
-            "thinking_tokens": -1,
-        },
-    )
+@pytest.mark.parametrize(
+    "events, field",
+    [
+        ([{"event": "tool_result", "tool_call_id": "c-1", "tool_name": "n",
+           "status": "success", "content": "ok", "duration_ms": -1}], "duration_ms"),
+        ([{"event": "turn_start", "turn_id": "t-1", "timestamp": "now"},
+          {"event": "turn_end", "turn_id": "t-1", "usage_reported": True,
+           "duration_ms": -1, "prompt_tokens": 0, "completion_tokens": 0}], "duration_ms"),
+        ([{"event": "turn_start", "turn_id": "t-1", "timestamp": "now"},
+          {"event": "turn_end", "turn_id": "t-1", "usage_reported": False,
+           "duration_ms": -1}], "duration_ms"),
+        ([{"event": "turn_start", "turn_id": "t-1", "timestamp": "now"},
+          {"event": "turn_end", "turn_id": "t-1", "usage_reported": True,
+           "duration_ms": 0, "prompt_tokens": -1, "completion_tokens": 0}], "prompt_tokens"),
+        ([{"event": "turn_start", "turn_id": "t-1", "timestamp": "now"},
+          {"event": "turn_end", "turn_id": "t-1", "usage_reported": True,
+           "duration_ms": 0, "prompt_tokens": 0, "completion_tokens": -1}], "completion_tokens"),
+        ([{"event": "turn_start", "turn_id": "t-1", "timestamp": "now"},
+          {"event": "turn_end", "turn_id": "t-1", "usage_reported": True,
+           "duration_ms": 0, "prompt_tokens": 0, "completion_tokens": 0,
+           "cached_tokens": -1}], "cached_tokens"),
+        ([{"event": "turn_start", "turn_id": "t-1", "timestamp": "now"},
+          {"event": "turn_end", "turn_id": "t-1", "usage_reported": True,
+           "duration_ms": 0, "prompt_tokens": 0, "completion_tokens": 0,
+           "thinking_tokens": -1}], "thinking_tokens"),
+        ([{"event": "turn_start", "turn_id": "t-1", "timestamp": "now"},
+          {"event": "turn_end", "turn_id": "t-1", "usage_reported": True,
+           "duration_ms": 0, "prompt_tokens": 0, "completion_tokens": 0,
+           "cost_usd": "-0.125"}], "cost_usd"),
+    ],
+)
+async def test_negative_osprey_telemetry_is_rejected(
+    events: list[dict[str, object]], field: str
+) -> None:
+    lines, _ = _stream(*events)
 
-    with pytest.raises(OspreyError, match="thinking_tokens"):
+    with pytest.raises(OspreyError, match=field):
         await _collect(OspreyBackend(osprey_binary="fake"), lines)
 
 

--- a/tests/test_backend_osprey.py
+++ b/tests/test_backend_osprey.py
@@ -722,6 +722,15 @@ def test_non_negative_int_helpers_reject_below_zero() -> None:
 
 
 @pytest.mark.asyncio
+async def test_negative_session_total_cost_is_rejected() -> None:
+    lines, _ = _stream()
+    lines[-1]["total_cost_usd"] = "-0.125"
+
+    with pytest.raises(OspreyError, match="cost_usd"):
+        await _collect(OspreyBackend(osprey_binary="fake"), lines)
+
+
+@pytest.mark.asyncio
 async def test_negative_thinking_tokens_are_rejected() -> None:
     lines, _ = _stream(
         {"event": "turn_start", "turn_id": "t-1", "timestamp": "now"},

--- a/tests/test_backend_osprey.py
+++ b/tests/test_backend_osprey.py
@@ -28,6 +28,8 @@ from daydream.backends.osprey import (
     OspreyProtocolError,
     OspreyTerminalError,
     OspreyUnsupportedOption,
+    _optional_non_negative_int,
+    _required_non_negative_int,
     _stderr_diagnostic_sink,
 )
 from daydream.trajectory import DaydreamPhase, DaydreamRunFlow, TrajectoryRecorder
@@ -706,6 +708,17 @@ async def test_terminal_exit_code_must_match_process_status() -> None:
 
     with pytest.raises(OspreyError, match="exit_code"):
         await _collect(OspreyBackend(osprey_binary="fake"), lines)
+
+
+def test_non_negative_int_helpers_reject_below_zero() -> None:
+    event = {"event": "turn_end", "k": -1}
+    with pytest.raises(OspreyProtocolError, match="has negative 'k'"):
+        _required_non_negative_int(event, "k")
+    with pytest.raises(OspreyProtocolError, match="has negative 'k'"):
+        _optional_non_negative_int(event, "k")
+    assert _optional_non_negative_int({"event": "turn_end", "k": None}, "k") is None
+    assert _required_non_negative_int({"event": "turn_end", "k": 0}, "k") == 0
+    assert _optional_non_negative_int({"event": "turn_end", "k": 0}, "k") == 0
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Reject negative osprey telemetry values at the JSONL boundary (Closes #710)
- Report actual field in osprey cost parse errors
- Allow negative duration_ms on osprey tool_result
- Includes round-2 daydream review fixes (head 53113d1)

## Test Plan
- [x] 5321 tests passed, 21 skipped (round-2 review verify)
- [x] Two sequential daydream deep-precision reviews complete (all findings low, resolved)