### PR TITLE
Pin Daydream workflow installs to immutable release commits (#713)

### DIFF
--- a/.github/workflows/daydream-post.yml
+++ b/.github/workflows/daydream-post.yml
@@ -42,7 +42,7 @@ jobs:
         # Pinned to an immutable release commit (the peeled target of the release
         # tag) so the bot runs exactly the reviewed source: a moved or compromised
         # tag can't change it. Bump in lockstep with the package version on release
-        # (a test enforces this; see _DAYDREAM_RELEASE_COMMITS).
+        # (pin the peeled target: git ls-remote origin 'refs/tags/vX.Y.Z^{}').
         run: uv tool install git+https://github.com/existential-birds/daydream@e7741f17fc998a675ed2fe3f364d2e646cde5518
 
       - name: Mint posting token

--- a/.github/workflows/daydream-post.yml
+++ b/.github/workflows/daydream-post.yml
@@ -39,10 +39,11 @@ jobs:
         uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4.2.0
 
       - name: Install daydream
-        # Pinned to a release tag (not `main`) so the bot runs a known daydream
-        # version: reproducible and immune to main-drift / uv-cache staleness.
-        # Bump in lockstep with the package version on release (a test enforces this).
-        run: uv tool install git+https://github.com/existential-birds/daydream@v0.28.0
+        # Pinned to an immutable release commit (the peeled target of the release
+        # tag) so the bot runs exactly the reviewed source: a moved or compromised
+        # tag can't change it. Bump in lockstep with the package version on release
+        # (a test enforces this; see _DAYDREAM_RELEASE_COMMITS).
+        run: uv tool install git+https://github.com/existential-birds/daydream@e7741f17fc998a675ed2fe3f364d2e646cde5518
 
       - name: Mint posting token
         id: token

--- a/.github/workflows/daydream-review.yml
+++ b/.github/workflows/daydream-review.yml
@@ -117,10 +117,11 @@ jobs:
         uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4.2.0
 
       - name: Install daydream
-        # Pinned to a release tag (not `main`) so the bot runs a known daydream
-        # version: reproducible and immune to main-drift / uv-cache staleness.
-        # Bump in lockstep with the package version on release (a test enforces this).
-        run: uv tool install git+https://github.com/existential-birds/daydream@v0.28.0
+        # Pinned to an immutable release commit (the peeled target of the release
+        # tag) so the bot runs exactly the reviewed source: a moved or compromised
+        # tag can't change it. Bump in lockstep with the package version on release
+        # (a test enforces this; see _DAYDREAM_RELEASE_COMMITS).
+        run: uv tool install git+https://github.com/existential-birds/daydream@e7741f17fc998a675ed2fe3f364d2e646cde5518
 
       # Codex backend: daydream spawns `codex exec` as a subprocess, so the CLI
       # must be on PATH. Pinned because the backend parses `codex exec

--- a/.github/workflows/daydream-review.yml
+++ b/.github/workflows/daydream-review.yml
@@ -120,7 +120,7 @@ jobs:
         # Pinned to an immutable release commit (the peeled target of the release
         # tag) so the bot runs exactly the reviewed source: a moved or compromised
         # tag can't change it. Bump in lockstep with the package version on release
-        # (a test enforces this; see _DAYDREAM_RELEASE_COMMITS).
+        # (pin the peeled target: git ls-remote origin 'refs/tags/vX.Y.Z^{}').
         run: uv tool install git+https://github.com/existential-birds/daydream@e7741f17fc998a675ed2fe3f364d2e646cde5518
 
       # Codex backend: daydream spawns `codex exec` as a subprocess, so the CLI

--- a/daydream/templates/workflows/daydream-post.yml
+++ b/daydream/templates/workflows/daydream-post.yml
@@ -42,7 +42,7 @@ jobs:
         # Pinned to an immutable release commit (the peeled target of the release
         # tag) so the bot runs exactly the reviewed source: a moved or compromised
         # tag can't change it. Bump in lockstep with the package version on release
-        # (a test enforces this; see _DAYDREAM_RELEASE_COMMITS).
+        # (pin the peeled target: git ls-remote origin 'refs/tags/vX.Y.Z^{}').
         run: uv tool install git+https://github.com/existential-birds/daydream@e7741f17fc998a675ed2fe3f364d2e646cde5518
 
       - name: Mint posting token

--- a/daydream/templates/workflows/daydream-post.yml
+++ b/daydream/templates/workflows/daydream-post.yml
@@ -39,10 +39,11 @@ jobs:
         uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4.2.0
 
       - name: Install daydream
-        # Pinned to a release tag (not `main`) so the bot runs a known daydream
-        # version: reproducible and immune to main-drift / uv-cache staleness.
-        # Bump in lockstep with the package version on release (a test enforces this).
-        run: uv tool install git+https://github.com/existential-birds/daydream@v0.28.0
+        # Pinned to an immutable release commit (the peeled target of the release
+        # tag) so the bot runs exactly the reviewed source: a moved or compromised
+        # tag can't change it. Bump in lockstep with the package version on release
+        # (a test enforces this; see _DAYDREAM_RELEASE_COMMITS).
+        run: uv tool install git+https://github.com/existential-birds/daydream@e7741f17fc998a675ed2fe3f364d2e646cde5518
 
       - name: Mint posting token
         id: token

--- a/daydream/templates/workflows/daydream-review.yml
+++ b/daydream/templates/workflows/daydream-review.yml
@@ -120,7 +120,7 @@ jobs:
         # Pinned to an immutable release commit (the peeled target of the release
         # tag) so the bot runs exactly the reviewed source: a moved or compromised
         # tag can't change it. Bump in lockstep with the package version on release
-        # (a test enforces this; see _DAYDREAM_RELEASE_COMMITS).
+        # (pin the peeled target: git ls-remote origin 'refs/tags/vX.Y.Z^{}').
         run: uv tool install git+https://github.com/existential-birds/daydream@e7741f17fc998a675ed2fe3f364d2e646cde5518
 
       - name: Run daydream review

--- a/daydream/templates/workflows/daydream-review.yml
+++ b/daydream/templates/workflows/daydream-review.yml
@@ -117,10 +117,11 @@ jobs:
         uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4.2.0
 
       - name: Install daydream
-        # Pinned to a release tag (not `main`) so the bot runs a known daydream
-        # version: reproducible and immune to main-drift / uv-cache staleness.
-        # Bump in lockstep with the package version on release (a test enforces this).
-        run: uv tool install git+https://github.com/existential-birds/daydream@v0.28.0
+        # Pinned to an immutable release commit (the peeled target of the release
+        # tag) so the bot runs exactly the reviewed source: a moved or compromised
+        # tag can't change it. Bump in lockstep with the package version on release
+        # (a test enforces this; see _DAYDREAM_RELEASE_COMMITS).
+        run: uv tool install git+https://github.com/existential-birds/daydream@e7741f17fc998a675ed2fe3f364d2e646cde5518
 
       - name: Run daydream review
         env:

--- a/daydream/templates/workflows/single/daydream.yml
+++ b/daydream/templates/workflows/single/daydream.yml
@@ -207,7 +207,7 @@ jobs:
         # Pinned to an immutable release commit (the peeled target of the release
         # tag) so the bot runs exactly the reviewed source: a moved or compromised
         # tag can't change it. Bump in lockstep with the package version on release
-        # (a test enforces this; see _DAYDREAM_RELEASE_COMMITS).
+        # (pin the peeled target: git ls-remote origin 'refs/tags/vX.Y.Z^{}').
         run: uv tool install git+https://github.com/existential-birds/daydream@e7741f17fc998a675ed2fe3f364d2e646cde5518
 
       # Runs the DEFAULT deep-review pipeline (not --review). In --non-interactive
@@ -275,6 +275,10 @@ jobs:
         uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4.2.0
 
       - name: Install daydream
+        # Pinned to an immutable release commit (the peeled target of the release
+        # tag) so the bot runs exactly the reviewed source: a moved or compromised
+        # tag can't change it. Bump in lockstep with the package version on release
+        # (pin the peeled target: git ls-remote origin 'refs/tags/vX.Y.Z^{}').
         run: uv tool install git+https://github.com/existential-birds/daydream@e7741f17fc998a675ed2fe3f364d2e646cde5518
 
       - name: Download findings artifact

--- a/daydream/templates/workflows/single/daydream.yml
+++ b/daydream/templates/workflows/single/daydream.yml
@@ -204,10 +204,11 @@ jobs:
         uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4.2.0
 
       - name: Install daydream
-        # Pinned to a release tag (not `main`) so the bot runs a known daydream
-        # version: reproducible and immune to main-drift / uv-cache staleness.
-        # Bump in lockstep with the package version on release (a test enforces this).
-        run: uv tool install git+https://github.com/existential-birds/daydream@v0.28.0
+        # Pinned to an immutable release commit (the peeled target of the release
+        # tag) so the bot runs exactly the reviewed source: a moved or compromised
+        # tag can't change it. Bump in lockstep with the package version on release
+        # (a test enforces this; see _DAYDREAM_RELEASE_COMMITS).
+        run: uv tool install git+https://github.com/existential-birds/daydream@e7741f17fc998a675ed2fe3f364d2e646cde5518
 
       # Runs the DEFAULT deep-review pipeline (not --review). In --non-interactive
       # the deep run auto-declines the post/fix gates, so it still only produces a
@@ -274,7 +275,7 @@ jobs:
         uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4.2.0
 
       - name: Install daydream
-        run: uv tool install git+https://github.com/existential-birds/daydream@v0.28.0
+        run: uv tool install git+https://github.com/existential-birds/daydream@e7741f17fc998a675ed2fe3f364d2e646cde5518
 
       - name: Download findings artifact
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0

--- a/tests/test_workflow_templates.py
+++ b/tests/test_workflow_templates.py
@@ -8,7 +8,7 @@ cannot verify and that a careless edit could silently break:
 - No untrusted event data is interpolated into a ``run:`` body (injection).
 - Every non-local action ``uses:`` in the live and shipped bot workflows
   resolves to a full commit SHA (never a mutable tag/branch/expression).
-- The daydream install stays pinned to the current release tag (cross-file
+- The daydream install stays pinned to an immutable release commit (cross-file
   drift against ``pyproject.toml``), in every live and shipped workflow.
 - Every App-token action in the live and packaged posting workflows stays pinned to the approved v3.2.0 commit.
 - The privilege split holds: the job that checks out untrusted PR code never
@@ -110,6 +110,19 @@ _PINNED_ACTION_VERSIONS = {
 }
 
 _USES_LINE_RE = re.compile(r"^\s*uses:\s*(?P<ref>\S+)(?:\s*#\s*(?P<comment>\S+))?$")
+
+# Release tag → PEELED commit SHA for every daydream release the workflow pins
+# may reference. Values are the peeled (`^{}` target) commits of annotated tags,
+# NOT tag-object SHAs — `git ls-remote origin 'refs/tags/vX.Y.Z'` on an
+# annotated tag reports the tag object (e.g. `9abbaeb3…` for v0.26.0), which is
+# the classic trap; use `git ls-remote origin 'refs/tags/vX.Y.Z^{}'` instead.
+# History is retained (never prune old entries) for provenance.
+_DAYDREAM_RELEASE_COMMITS: dict[str, str] = {
+    "v0.27.0": "805fd0f105fe803a90a6a8b2c2d9646a4041eccc",
+    "v0.28.0": "e7741f17fc998a675ed2fe3f364d2e646cde5518",
+}
+
+_RELEASE_COMMIT_RE = re.compile(r"^[0-9a-f]{40}$")
 
 _DAYDREAM_INSTALL_WORKFLOW_PATHS = [
     REPO_WORKFLOWS_DIR / "daydream-review.yml",
@@ -503,16 +516,42 @@ def _package_version() -> str:
     _DAYDREAM_INSTALL_WORKFLOW_PATHS,
     ids=lambda p: p.relative_to(_REPO_ROOT).as_posix(),
 )
-def test_daydream_install_is_pinned_to_current_release_tag(wf_path: Path) -> None:
+def test_daydream_install_is_pinned_to_release_commit(wf_path: Path) -> None:
     text = wf_path.read_text(encoding="utf-8")
     refs = [m.group("ref") for m in _INSTALL_RE.finditer(text)]
     rel = wf_path.relative_to(_REPO_ROOT).as_posix()
     assert refs, f"{rel} must install daydream via `uv tool install git+…`"
-    expected = f"@v{_package_version()}"
+    version = _package_version()
+    key = f"v{version}"
+    commit = _DAYDREAM_RELEASE_COMMITS.get(key)
+    assert commit is not None, (
+        f"No release→commit map entry for {key}. The release process is manual: "
+        f"(1) bump project.version in pyproject.toml, (2) tag the release, "
+        f"(3) get the PEELED commit: git ls-remote origin 'refs/tags/{key}^{{}}' "
+        f"(annotated tags report a tag-object SHA on the bare ref — use the ^{{}} target), "
+        f"(4) add the entry to _DAYDREAM_RELEASE_COMMITS in tests/test_workflow_templates.py, "
+        f"(5) update all six workflow install refs in lockstep "
+        f"(.github/workflows/daydream-review.yml, .github/workflows/daydream-post.yml, "
+        f"daydream/templates/workflows/daydream-review.yml, "
+        f"daydream/templates/workflows/daydream-post.yml, "
+        f"daydream/templates/workflows/single/daydream.yml ×2)."
+    )
+    expected = f"@{commit}"
     for ref in refs:
         assert ref == expected, (
             f"{rel} pins the daydream install to {ref or '(unpinned main)'}, but must pin to "
-            f"{expected}. Bump the template pin in lockstep with the package version on release."
+            f"the immutable release commit {expected} for {key}. Update all six install refs "
+            f"in lockstep with the _DAYDREAM_RELEASE_COMMITS entry."
+        )
+
+
+def test_release_commit_map_values_are_immutable_full_shas() -> None:
+    for tag, commit in _DAYDREAM_RELEASE_COMMITS.items():
+        assert _RELEASE_COMMIT_RE.fullmatch(commit), (
+            f"_DAYDREAM_RELEASE_COMMITS[{tag!r}] = {commit!r} is not a full lowercase "
+            f"40-char hex commit SHA. Mutable refs (tags, branches), short hashes, "
+            f"uppercase hex, and annotated-tag OBJECT shas are all rejected — record the "
+            f"peeled commit: git ls-remote origin 'refs/tags/{tag}^{{}}'."
         )
 
 

--- a/tests/test_workflow_templates.py
+++ b/tests/test_workflow_templates.py
@@ -114,9 +114,11 @@ _USES_LINE_RE = re.compile(r"^\s*uses:\s*(?P<ref>\S+)(?:\s*#\s*(?P<comment>\S+))
 # Release tag → PEELED commit SHA for every daydream release the workflow pins
 # may reference. Values are the peeled (`^{}` target) commits of annotated tags,
 # NOT tag-object SHAs — `git ls-remote origin 'refs/tags/vX.Y.Z'` on an
-# annotated tag reports the tag object (e.g. `9abbaeb3…` for v0.26.0), which is
+# annotated tag reports the tag object (e.g. `9abbaeb3…` for v0.28.0), which is
 # the classic trap; use `git ls-remote origin 'refs/tags/vX.Y.Z^{}'` instead.
-# History is retained (never prune old entries) for provenance.
+# History is retained (never prune old entries) for provenance. A cross-check
+# enforces both sides: every entry is either pinned by a workflow install ref
+# or a strictly older release retained for provenance.
 _DAYDREAM_RELEASE_COMMITS: dict[str, str] = {
     "v0.27.0": "805fd0f105fe803a90a6a8b2c2d9646a4041eccc",
     "v0.28.0": "e7741f17fc998a675ed2fe3f364d2e646cde5518",
@@ -549,9 +551,46 @@ def test_release_commit_map_values_are_immutable_full_shas() -> None:
     for tag, commit in _DAYDREAM_RELEASE_COMMITS.items():
         assert _RELEASE_COMMIT_RE.fullmatch(commit), (
             f"_DAYDREAM_RELEASE_COMMITS[{tag!r}] = {commit!r} is not a full lowercase "
-            f"40-char hex commit SHA. Mutable refs (tags, branches), short hashes, "
-            f"uppercase hex, and annotated-tag OBJECT shas are all rejected — record the "
-            f"peeled commit: git ls-remote origin 'refs/tags/{tag}^{{}}'."
+            f"40-char hex commit SHA. Mutable refs (tags, branches), short hashes, and "
+            f"uppercase hex are rejected; the form gate can't tell an annotated-tag "
+            f"OBJECT sha from a peeled commit, so record the peeled commit: "
+            f"git ls-remote origin 'refs/tags/{tag}^{{}}'."
+        )
+
+
+def _release_version(tag: str) -> tuple[int, int, int] | None:
+    """Parse a vX.Y.Z release tag into a sortable version tuple."""
+    m = re.fullmatch(r"v(\d+)\.(\d+)\.(\d+)", tag)
+    if m is None:
+        return None
+    return (int(m.group(1)), int(m.group(2)), int(m.group(3)))
+
+
+def test_release_commit_map_entries_are_pinned_or_retained_provenance() -> None:
+    """Cross-check _DAYDREAM_RELEASE_COMMITS against the workflow install refs
+    so an entry cannot ship as dead data: every entry's commit must be referenced
+    by at least one install pin, or the entry must be a strictly older release
+    deliberately retained for provenance (the map never prunes history). A
+    malformed tag key, a pin that lost its map entry, or a stale commit that outlived
+    its installs all fail here — the provenance entries are accounted for, not
+    unnoticed.
+    """
+    current_version = _release_version(f"v{_package_version()}")
+    assert current_version is not None
+    pinned_commits = {
+        m.group("ref")[1:]
+        for wf_path in _DAYDREAM_INSTALL_WORKFLOW_PATHS
+        for m in _INSTALL_RE.finditer(wf_path.read_text(encoding="utf-8"))
+    }
+    assert pinned_commits, "no daydream install pins to cross-check the map against"
+    for tag, commit in _DAYDREAM_RELEASE_COMMITS.items():
+        if commit in pinned_commits:
+            continue
+        version = _release_version(tag)
+        assert version is not None and version < current_version, (
+            f"_DAYDREAM_RELEASE_COMMITS[{tag!r}] = {commit!r} is neither pinned by "
+            f"any workflow install nor an older release retained for provenance, so "
+            f"it ships as dead data: reference it with an install pin or remove it."
         )
 
 

--- a/tests/test_workflow_templates.py
+++ b/tests/test_workflow_templates.py
@@ -34,6 +34,7 @@ PyYAML parses the bare ``on:`` key as boolean ``True``; ``wf_on()`` normalizes i
 from __future__ import annotations
 
 import re
+import subprocess
 import tomllib
 from pathlib import Path
 from typing import Any, cast
@@ -118,7 +119,11 @@ _USES_LINE_RE = re.compile(r"^\s*uses:\s*(?P<ref>\S+)(?:\s*#\s*(?P<comment>\S+))
 # the classic trap; use `git ls-remote origin 'refs/tags/vX.Y.Z^{}'` instead.
 # History is retained (never prune old entries) for provenance. A cross-check
 # enforces both sides: every entry is either pinned by a workflow install ref
-# or a strictly older release retained for provenance.
+# or a strictly older release retained for provenance. Values are also
+# verified offline against this repo's own release-tag refs (peeled targets),
+# the only way to tell the annotated-tag OBJECT sha from the peeled commit; a
+# checkout that carries no tags skips that check, so the refs are trusted,
+# never fetched or verified against GitHub (intentionally offline).
 _DAYDREAM_RELEASE_COMMITS: dict[str, str] = {
     "v0.27.0": "805fd0f105fe803a90a6a8b2c2d9646a4041eccc",
     "v0.28.0": "e7741f17fc998a675ed2fe3f364d2e646cde5518",
@@ -558,6 +563,74 @@ def test_release_commit_map_values_are_immutable_full_shas() -> None:
         )
 
 
+def _repo_release_tags() -> list[str]:
+    """Release tag names present in this checkout's local refs. A shallow,
+    tagless checkout (e.g. CI's plain ``actions/checkout``) yields an empty
+    list, which the peel cross-check treats as ``cannot verify offline``,
+    never as ``no releases exist``.
+    """
+    result = subprocess.run(
+        ["git", "tag", "--list", "v*"],
+        cwd=_REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        return []
+    return result.stdout.splitlines()
+
+
+def _peeled_commit_for_tag(tag: str) -> str | None:
+    """Resolve ``refs/tags/<tag>`` to its peeled (``^{}``) commit via the repo's
+    own local refs, or None when the tag does not exist in this checkout. On an
+    annotated tag the bare ref resolves to the tag OBJECT; the ``^{}`` target
+    is the commit the release actually points at.
+    """
+    result = subprocess.run(
+        ["git", "rev-parse", "--verify", "--quiet", f"refs/tags/{tag}^{{}}"],
+        cwd=_REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip()
+
+
+def test_release_commit_map_values_are_peeled_release_commits() -> None:
+    """Every map value must be the PEELED commit of its release tag, verified
+    offline against this repo's own refs: the only check that can tell an
+    annotated-tag OBJECT sha (what the bare ref reports) from its peeled
+    commit, and the only check that distinguishes a real released version from
+    a phantom key masquerading as retained history. A checkout that carries no
+    release tags at all (CI's shallow clone) skips: there is no local data to
+    verify against, and the check is intentionally offline (never GitHub).
+    """
+    tags = _repo_release_tags()
+    if not tags:
+        pytest.skip(
+            "this checkout carries no release tags (e.g. a shallow CI clone), "
+            "so the offline peel cross-check cannot run"
+        )
+    tag_set = set(tags)
+    for tag, commit in _DAYDREAM_RELEASE_COMMITS.items():
+        assert tag in tag_set, (
+            f"_DAYDREAM_RELEASE_COMMITS key {tag!r} is not a real release tag "
+            f"in this repo (no refs/tags/{tag}), so it cannot be retained "
+            f"provenance: remove the entry or name a version that was actually released."
+        )
+        peeled = _peeled_commit_for_tag(tag)
+        assert peeled is not None  # tag_set membership already proved the ref exists
+        assert peeled == commit, (
+            f"_DAYDREAM_RELEASE_COMMITS[{tag!r}] = {commit!r} is not the peeled "
+            f"commit of refs/tags/{tag} (got {peeled!r}): on an annotated tag the "
+            f"bare ref reports the tag OBJECT sha, not the commit — record the "
+            f"peeled commit: git ls-remote origin 'refs/tags/{tag}^{{}}'."
+        )
+
+
 def _release_version(tag: str) -> tuple[int, int, int] | None:
     """Parse a vX.Y.Z release tag into a sortable version tuple."""
     m = re.fullmatch(r"v(\d+)\.(\d+)\.(\d+)", tag)
@@ -581,6 +654,7 @@ def test_release_commit_map_entries_are_pinned_or_retained_provenance() -> None:
         m.group("ref")[1:]
         for wf_path in _DAYDREAM_INSTALL_WORKFLOW_PATHS
         for m in _INSTALL_RE.finditer(wf_path.read_text(encoding="utf-8"))
+        if m.group("ref") is not None
     }
     assert pinned_commits, "no daydream install pins to cross-check the map against"
     for tag, commit in _DAYDREAM_RELEASE_COMMITS.items():


### PR DESCRIPTION
## Summary
- Pins every Daydream workflow install to immutable release commits (release pin map), replacing floating version installs
- Adds a workflow test validating installs against the immutable release-commit map, cross-checked against peeled release tags
- Fixes guard filtering for None ref groups; updates doc pin-recipe guidance

Closes #713

## Test Plan
- [x] Round-2 daydream deep-precision review passed (6/6 findings resolved, fix 45a9758)
- [x] make check green: 5350 passed, 5 skipped
- [x] Authorship gate AUTHORS_OK