### PR TITLE
[daydream] Consolidated: add delete_runs to archive index for hydration rerun pruning

### DIFF
--- a/daydream/archive/index.py
+++ b/daydream/archive/index.py
@@ -22,6 +22,9 @@ Exports:
         then recency) label_observations row for each session in a collection —
         single round-trip alternative to calling ``latest_label_observation`` in
         a loop.
+    delete_runs: Delete ``runs`` rows whose ``session_id`` matches any member of
+        a collection (exact match, parameterized ``IN``); return the ``int``
+        count of rows deleted. ``label_observations`` is untouched.
     reviewer_set_penalty_prior: Pooled mean false-positive penalty over prior
         runs sharing a reviewer (strict ``valid_at`` cutoff), for the posterior
         outcome prior (C4).
@@ -101,6 +104,7 @@ __all__ = [
     "append_label_observation",
     "latest_label_observation",
     "bulk_latest_label_observations",
+    "delete_runs",
     "reviewer_set_penalty_prior",
     "label_observation_history",
     "label_count_summary",

--- a/daydream/archive/index.py
+++ b/daydream/archive/index.py
@@ -70,6 +70,7 @@ spelling is ``datetime.isoformat()`` in UTC — ``YYYY-MM-DDTHH:MM:SS[.ffffff]+0
 from __future__ import annotations
 
 import json
+import shutil
 import sqlite3
 import warnings
 from collections.abc import Iterable
@@ -694,9 +695,17 @@ def bulk_latest_label_observations(
 def delete_runs(archive_dir: Path, session_ids: Iterable[object]) -> int:
     """Destructively prune ``runs`` rows for the given session ids.
 
-    Deletes rows from the ``runs`` table only; the append-only
+    Deletes rows from the ``runs`` table and removes the on-disk bundle
+    directory each row points at (``archive_path``); the append-only
     ``label_observations`` history is never touched, so label provenance
     survives hydration reruns that prune rejected sessions.
+
+    The bundle removal matters for consistency: ``rebuild_index`` re-upserts
+    every directory under ``runs/``, so an index-only deletion would be
+    silently resurrected by the next filesystem-driven hydrate/sanitize
+    pass.  Only bundles located inside ``<archive_dir>/runs/`` are removed;
+    rows pointing elsewhere are pruned from the index but their directories
+    are left untouched.
 
     Every member is coerced via ``str()`` during normalization, so ints,
     UUIDs, and Path-like objects are accepted.
@@ -722,9 +731,29 @@ def delete_runs(archive_dir: Path, session_ids: Iterable[object]) -> int:
         )
         deleted = int(cursor.rowcount)
         conn.commit()
+        _remove_bundles(archive_dir, ids)
         return deleted
     finally:
         conn.close()
+
+
+def _remove_bundles(archive_dir: Path, ids: list[str]) -> None:
+    """Remove on-disk bundles for deleted sessions so rebuild cannot resurrect them.
+
+    Mirrors the sibling hydrate/sanitize contract where ``rebuild_index``
+    reflects the on-disk ``runs/`` tree: a surviving bundle directory would
+    be re-upserted by the next filesystem-driven pass.  Only bare session-id
+    directories under ``<archive_dir>/runs/`` are removed; anything else
+    (including traversal-shaped ids or archive paths outside ``runs/``) is
+    left untouched.
+    """
+    runs_root = (archive_dir / "runs").resolve()
+    for sid in ids:
+        if not sid or Path(sid).name != sid:
+            continue
+        bundle = runs_root / sid
+        if bundle.is_dir():
+            shutil.rmtree(bundle, ignore_errors=True)
 
 
 def reviewer_set_penalty_prior(

--- a/daydream/archive/index.py
+++ b/daydream/archive/index.py
@@ -687,12 +687,15 @@ def bulk_latest_label_observations(
         conn.close()
 
 
-def delete_runs(archive_dir: Path, session_ids: Iterable[str]) -> int:
+def delete_runs(archive_dir: Path, session_ids: Iterable[object]) -> int:
     """Destructively prune ``runs`` rows for the given session ids.
 
     Deletes rows from the ``runs`` table only; the append-only
     ``label_observations`` history is never touched, so label provenance
     survives hydration reruns that prune rejected sessions.
+
+    Every member is coerced via ``str()`` during normalization, so ints,
+    UUIDs, and Path-like objects are accepted.
 
     Session ids missing from the index are silent no-ops. The deletion runs as
     a single ``DELETE ... WHERE session_id IN (?, ...)`` statement, which is

--- a/daydream/archive/index.py
+++ b/daydream/archive/index.py
@@ -69,6 +69,7 @@ from __future__ import annotations
 import json
 import sqlite3
 import warnings
+from collections.abc import Iterable
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
@@ -682,6 +683,39 @@ def bulk_latest_label_observations(
             params,
         )
         return {row["session_id"]: dict(row) for row in cursor.fetchall()}
+    finally:
+        conn.close()
+
+
+def delete_runs(archive_dir: Path, session_ids: Iterable[str]) -> int:
+    """Destructively prune ``runs`` rows for the given session ids.
+
+    Deletes rows from the ``runs`` table only; the append-only
+    ``label_observations`` history is never touched, so label provenance
+    survives hydration reruns that prune rejected sessions.
+
+    Session ids missing from the index are silent no-ops. The deletion runs as
+    a single ``DELETE ... WHERE session_id IN (?, ...)`` statement, which is
+    bounded by SQLite's host-parameter limit; per-stage run counts sit far
+    below that limit, so no chunking is performed today.
+
+    Returns:
+        The number of rows deleted (``0`` when ``session_ids`` is empty —
+        the database is never opened in that case).
+    """
+    ids = [str(item) for item in session_ids]
+    if not ids:
+        return 0
+    placeholders = ",".join("?" * len(ids))
+    conn = _get_connection(archive_dir)
+    try:
+        cursor = conn.execute(
+            f"DELETE FROM runs WHERE session_id IN ({placeholders})",
+            ids,
+        )
+        deleted = int(cursor.rowcount)
+        conn.commit()
+        return deleted
     finally:
         conn.close()
 

--- a/daydream/archive/index.py
+++ b/daydream/archive/index.py
@@ -22,6 +22,9 @@ Exports:
         then recency) label_observations row for each session in a collection —
         single round-trip alternative to calling ``latest_label_observation`` in
         a loop.
+    delete_runs: Delete ``runs`` rows whose ``session_id`` matches any member of
+        a collection (exact match, parameterized ``IN``); return the ``int``
+        count of rows deleted. ``label_observations`` is untouched.
     reviewer_set_penalty_prior: Pooled mean false-positive penalty over prior
         runs sharing a reviewer (strict ``valid_at`` cutoff), for the posterior
         outcome prior (C4).
@@ -69,6 +72,7 @@ from __future__ import annotations
 import json
 import sqlite3
 import warnings
+from collections.abc import Iterable
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
@@ -100,6 +104,7 @@ __all__ = [
     "append_label_observation",
     "latest_label_observation",
     "bulk_latest_label_observations",
+    "delete_runs",
     "reviewer_set_penalty_prior",
     "label_observation_history",
     "label_count_summary",
@@ -682,6 +687,42 @@ def bulk_latest_label_observations(
             params,
         )
         return {row["session_id"]: dict(row) for row in cursor.fetchall()}
+    finally:
+        conn.close()
+
+
+def delete_runs(archive_dir: Path, session_ids: Iterable[object]) -> int:
+    """Destructively prune ``runs`` rows for the given session ids.
+
+    Deletes rows from the ``runs`` table only; the append-only
+    ``label_observations`` history is never touched, so label provenance
+    survives hydration reruns that prune rejected sessions.
+
+    Every member is coerced via ``str()`` during normalization, so ints,
+    UUIDs, and Path-like objects are accepted.
+
+    Session ids missing from the index are silent no-ops. The deletion runs as
+    a single ``DELETE ... WHERE session_id IN (?, ...)`` statement, which is
+    bounded by SQLite's host-parameter limit; per-stage run counts sit far
+    below that limit, so no chunking is performed today.
+
+    Returns:
+        The number of rows deleted (``0`` when ``session_ids`` is empty —
+        the database is never opened in that case).
+    """
+    ids = [str(item) for item in session_ids]
+    if not ids:
+        return 0
+    placeholders = ",".join("?" * len(ids))
+    conn = _get_connection(archive_dir)
+    try:
+        cursor = conn.execute(
+            f"DELETE FROM runs WHERE session_id IN ({placeholders})",
+            ids,
+        )
+        deleted = int(cursor.rowcount)
+        conn.commit()
+        return deleted
     finally:
         conn.close()
 

--- a/daydream/archive/index.py
+++ b/daydream/archive/index.py
@@ -22,9 +22,6 @@ Exports:
         then recency) label_observations row for each session in a collection —
         single round-trip alternative to calling ``latest_label_observation`` in
         a loop.
-    delete_runs: Delete ``runs`` rows whose ``session_id`` matches any member of
-        a collection (exact match, parameterized ``IN``); return the ``int``
-        count of rows deleted. ``label_observations`` is untouched.
     reviewer_set_penalty_prior: Pooled mean false-positive penalty over prior
         runs sharing a reviewer (strict ``valid_at`` cutoff), for the posterior
         outcome prior (C4).
@@ -72,7 +69,6 @@ from __future__ import annotations
 import json
 import sqlite3
 import warnings
-from collections.abc import Iterable
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
@@ -104,7 +100,6 @@ __all__ = [
     "append_label_observation",
     "latest_label_observation",
     "bulk_latest_label_observations",
-    "delete_runs",
     "reviewer_set_penalty_prior",
     "label_observation_history",
     "label_count_summary",
@@ -687,42 +682,6 @@ def bulk_latest_label_observations(
             params,
         )
         return {row["session_id"]: dict(row) for row in cursor.fetchall()}
-    finally:
-        conn.close()
-
-
-def delete_runs(archive_dir: Path, session_ids: Iterable[object]) -> int:
-    """Destructively prune ``runs`` rows for the given session ids.
-
-    Deletes rows from the ``runs`` table only; the append-only
-    ``label_observations`` history is never touched, so label provenance
-    survives hydration reruns that prune rejected sessions.
-
-    Every member is coerced via ``str()`` during normalization, so ints,
-    UUIDs, and Path-like objects are accepted.
-
-    Session ids missing from the index are silent no-ops. The deletion runs as
-    a single ``DELETE ... WHERE session_id IN (?, ...)`` statement, which is
-    bounded by SQLite's host-parameter limit; per-stage run counts sit far
-    below that limit, so no chunking is performed today.
-
-    Returns:
-        The number of rows deleted (``0`` when ``session_ids`` is empty —
-        the database is never opened in that case).
-    """
-    ids = [str(item) for item in session_ids]
-    if not ids:
-        return 0
-    placeholders = ",".join("?" * len(ids))
-    conn = _get_connection(archive_dir)
-    try:
-        cursor = conn.execute(
-            f"DELETE FROM runs WHERE session_id IN ({placeholders})",
-            ids,
-        )
-        deleted = int(cursor.rowcount)
-        conn.commit()
-        return deleted
     finally:
         conn.close()
 

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -2498,3 +2498,10 @@ def test_append_label_observation_rejects_non_iso_observed_at(tmp_path: Path) ->
             labeler_version="1055-human-r1", evidence_sha=None, source="human",
             observed_at="not-a-timestamp")
     assert label_observation_history(tmp_path, "sess-bad") == []
+
+
+def test_delete_runs_is_exported() -> None:
+    import daydream.archive.index as index_module
+
+    assert "delete_runs" in index_module.__all__
+    assert "delete_runs:" in index_module.__doc__

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -20,7 +20,6 @@ from daydream.archive.index import (
     append_label_observation,
     bulk_latest_label_observations,
     canonical_utc_iso,
-    delete_runs,
     label_count_summary,
     label_observation_history,
     latest_label_observation,
@@ -1287,57 +1286,6 @@ def test_archive_run_round_trip(tmp_path: Path, archive_dir: Path) -> None:
 # index: label_observations (Task 12)
 
 
-def test_delete_runs_removes_matching_rows_and_returns_count(tmp_path: Path) -> None:
-    _seed_one_run(tmp_path, "sess-a")
-    _seed_one_run(tmp_path, "sess-b")
-
-    deleted = delete_runs(tmp_path, ["sess-a", "sess-missing"])
-
-    assert deleted == 1
-    remaining = [r["session_id"] for r in query_runs(tmp_path)]
-    assert remaining == ["sess-b"]
-
-
-def test_delete_runs_empty_collection_noop(tmp_path: Path) -> None:
-    _seed_one_run(tmp_path, "sess-a")
-
-    assert delete_runs(tmp_path, []) == 0
-    assert len(query_runs(tmp_path)) == 1
-
-
-def test_delete_runs_coerces_non_string_members(tmp_path: Path) -> None:
-    _seed_one_run(tmp_path, "42")
-
-    assert delete_runs(tmp_path, [42]) == 1
-    assert query_runs(tmp_path) == []
-
-
-def test_delete_runs_matches_exactly_no_like_semantics(tmp_path: Path) -> None:
-    _seed_one_run(tmp_path, "sess-a")
-    _seed_one_run(tmp_path, "sess-a%")  # LIKE wildcard sibling must survive
-    _seed_one_run(tmp_path, "sess-a_x")  # LIKE single-char wildcard sibling
-
-    assert delete_runs(tmp_path, ["sess-a"]) == 1
-    remaining = {r["session_id"] for r in query_runs(tmp_path)}
-    assert remaining == {"sess-a%", "sess-a_x"}
-
-
-def test_delete_runs_hydration_rerun_reflects_only_kept_session(tmp_path: Path) -> None:
-    # Prior hydration run admitted both sessions.
-    _seed_one_run(tmp_path, "sess-kept")
-    _seed_one_run(tmp_path, "sess-rejected")
-    assert len(query_runs(tmp_path)) == 2
-
-    # Rerun admission: prune the rejected session's index row.
-    deleted = delete_runs(tmp_path, ["sess-rejected"])
-
-    assert deleted == 1
-    visible = query_runs(tmp_path)
-    assert [r["session_id"] for r in visible] == ["sess-kept"]
-    # The kept session's harvest-visible row is fully intact.
-    assert visible[0]["status"] == "complete"
-
-
 def _seed_one_run(archive_dir: Path, session_id: str) -> None:
     upsert_run(
         archive_dir,
@@ -1359,24 +1307,6 @@ def test_label_observations_has_bitemporal_reward_columns(tmp_path: Path) -> Non
     conn.close()
     assert {"valid_at", "reward_version", "reward_json"} <= lo_cols
     assert "composite_reward" in runs_cols
-
-
-def test_delete_runs_leaves_label_observations_intact(tmp_path: Path) -> None:
-    _seed_one_run(tmp_path, "sess-a")
-    append_label_observation(
-        tmp_path,
-        "sess-a",
-        labels=["rejected"],
-        pr_state=None,
-        labeler_version="v1",
-        evidence_sha=None,
-    )
-
-    assert delete_runs(tmp_path, ["sess-a"]) == 1
-    assert query_runs(tmp_path) == []
-    history = label_observation_history(tmp_path, "sess-a")
-    assert len(history) == 1
-    assert json.loads(history[0]["labels"]) == ["rejected"]
 
 
 _OLD_LABEL_OBSERVATIONS_DDL = """
@@ -2514,10 +2444,3 @@ def test_append_label_observation_rejects_non_iso_observed_at(tmp_path: Path) ->
             labeler_version="1055-human-r1", evidence_sha=None, source="human",
             observed_at="not-a-timestamp")
     assert label_observation_history(tmp_path, "sess-bad") == []
-
-
-def test_delete_runs_is_exported() -> None:
-    import daydream.archive.index as index_module
-
-    assert "delete_runs" in index_module.__all__
-    assert "delete_runs:" in index_module.__doc__

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -20,6 +20,7 @@ from daydream.archive.index import (
     append_label_observation,
     bulk_latest_label_observations,
     canonical_utc_iso,
+    delete_runs,
     label_count_summary,
     label_observation_history,
     latest_label_observation,
@@ -1286,6 +1287,57 @@ def test_archive_run_round_trip(tmp_path: Path, archive_dir: Path) -> None:
 # index: label_observations (Task 12)
 
 
+def test_delete_runs_removes_matching_rows_and_returns_count(tmp_path: Path) -> None:
+    _seed_one_run(tmp_path, "sess-a")
+    _seed_one_run(tmp_path, "sess-b")
+
+    deleted = delete_runs(tmp_path, ["sess-a", "sess-missing"])
+
+    assert deleted == 1
+    remaining = [r["session_id"] for r in query_runs(tmp_path)]
+    assert remaining == ["sess-b"]
+
+
+def test_delete_runs_empty_collection_noop(tmp_path: Path) -> None:
+    _seed_one_run(tmp_path, "sess-a")
+
+    assert delete_runs(tmp_path, []) == 0
+    assert len(query_runs(tmp_path)) == 1
+
+
+def test_delete_runs_coerces_non_string_members(tmp_path: Path) -> None:
+    _seed_one_run(tmp_path, "42")
+
+    assert delete_runs(tmp_path, [42]) == 1
+    assert query_runs(tmp_path) == []
+
+
+def test_delete_runs_matches_exactly_no_like_semantics(tmp_path: Path) -> None:
+    _seed_one_run(tmp_path, "sess-a")
+    _seed_one_run(tmp_path, "sess-a%")  # LIKE wildcard sibling must survive
+    _seed_one_run(tmp_path, "sess-a_x")  # LIKE single-char wildcard sibling
+
+    assert delete_runs(tmp_path, ["sess-a"]) == 1
+    remaining = {r["session_id"] for r in query_runs(tmp_path)}
+    assert remaining == {"sess-a%", "sess-a_x"}
+
+
+def test_delete_runs_hydration_rerun_reflects_only_kept_session(tmp_path: Path) -> None:
+    # Prior hydration run admitted both sessions.
+    _seed_one_run(tmp_path, "sess-kept")
+    _seed_one_run(tmp_path, "sess-rejected")
+    assert len(query_runs(tmp_path)) == 2
+
+    # Rerun admission: prune the rejected session's index row.
+    deleted = delete_runs(tmp_path, ["sess-rejected"])
+
+    assert deleted == 1
+    visible = query_runs(tmp_path)
+    assert [r["session_id"] for r in visible] == ["sess-kept"]
+    # The kept session's harvest-visible row is fully intact.
+    assert visible[0]["status"] == "complete"
+
+
 def _seed_one_run(archive_dir: Path, session_id: str) -> None:
     upsert_run(
         archive_dir,
@@ -1307,6 +1359,24 @@ def test_label_observations_has_bitemporal_reward_columns(tmp_path: Path) -> Non
     conn.close()
     assert {"valid_at", "reward_version", "reward_json"} <= lo_cols
     assert "composite_reward" in runs_cols
+
+
+def test_delete_runs_leaves_label_observations_intact(tmp_path: Path) -> None:
+    _seed_one_run(tmp_path, "sess-a")
+    append_label_observation(
+        tmp_path,
+        "sess-a",
+        labels=["rejected"],
+        pr_state=None,
+        labeler_version="v1",
+        evidence_sha=None,
+    )
+
+    assert delete_runs(tmp_path, ["sess-a"]) == 1
+    assert query_runs(tmp_path) == []
+    history = label_observation_history(tmp_path, "sess-a")
+    assert len(history) == 1
+    assert json.loads(history[0]["labels"]) == ["rejected"]
 
 
 _OLD_LABEL_OBSERVATIONS_DDL = """
@@ -2444,3 +2514,10 @@ def test_append_label_observation_rejects_non_iso_observed_at(tmp_path: Path) ->
             labeler_version="1055-human-r1", evidence_sha=None, source="human",
             observed_at="not-a-timestamp")
     assert label_observation_history(tmp_path, "sess-bad") == []
+
+
+def test_delete_runs_is_exported() -> None:
+    import daydream.archive.index as index_module
+
+    assert "delete_runs" in index_module.__all__
+    assert "delete_runs:" in index_module.__doc__

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -20,6 +20,7 @@ from daydream.archive.index import (
     append_label_observation,
     bulk_latest_label_observations,
     canonical_utc_iso,
+    delete_runs,
     label_count_summary,
     label_observation_history,
     latest_label_observation,
@@ -1284,6 +1285,17 @@ def test_archive_run_round_trip(tmp_path: Path, archive_dir: Path) -> None:
 
 
 # index: label_observations (Task 12)
+
+
+def test_delete_runs_removes_matching_rows_and_returns_count(tmp_path: Path) -> None:
+    _seed_one_run(tmp_path, "sess-a")
+    _seed_one_run(tmp_path, "sess-b")
+
+    deleted = delete_runs(tmp_path, ["sess-a", "sess-missing"])
+
+    assert deleted == 1
+    remaining = [r["session_id"] for r in query_runs(tmp_path)]
+    assert remaining == ["sess-b"]
 
 
 def _seed_one_run(archive_dir: Path, session_id: str) -> None:

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -1298,10 +1298,19 @@ def test_delete_runs_removes_matching_rows_and_returns_count(tmp_path: Path) -> 
     assert remaining == ["sess-b"]
 
 
-def test_delete_runs_empty_collection_noop(tmp_path: Path) -> None:
+def test_delete_runs_empty_collection_noop(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     _seed_one_run(tmp_path, "sess-a")
 
+    def _fail_open(archive_dir: Path) -> sqlite3.Connection:
+        raise AssertionError("delete_runs must not open the database for an empty collection")
+
+    monkeypatch.setattr("daydream.archive.index._get_connection", _fail_open)
+
     assert delete_runs(tmp_path, []) == 0
+
+    monkeypatch.undo()
     assert len(query_runs(tmp_path)) == 1
 
 
@@ -1336,6 +1345,36 @@ def test_delete_runs_hydration_rerun_reflects_only_kept_session(tmp_path: Path) 
     assert [r["session_id"] for r in visible] == ["sess-kept"]
     # The kept session's harvest-visible row is fully intact.
     assert visible[0]["status"] == "complete"
+
+
+def test_delete_runs_removes_bundle_directory_under_runs(tmp_path: Path) -> None:
+    # Sibling contract (hydrate/sanitize): the on-disk ``runs/`` tree is the
+    # source of truth for ``rebuild_index``, so a surviving bundle directory
+    # would silently resurrect the pruned row.
+    _seed_one_run(tmp_path, "sess-a")
+    runs_root = tmp_path / "runs"
+    bundle = runs_root / "sess-a"
+    bundle.mkdir(parents=True)
+    (bundle / "manifest.json").write_text("{}", encoding="utf-8")
+    conn = sqlite3.connect(str(tmp_path / "index.db"))
+    conn.execute(
+        "UPDATE runs SET archive_path = ? WHERE session_id = 'sess-a'",
+        (str(bundle),),
+    )
+    conn.commit()
+    conn.close()
+
+    assert delete_runs(tmp_path, ["sess-a"]) == 1
+    assert query_runs(tmp_path) == []
+    assert not bundle.exists()
+
+
+def test_delete_runs_leaves_bundle_outside_runs_untouched(tmp_path: Path) -> None:
+    _seed_one_run(tmp_path, "sess-a")  # archive_path: archive_dir/sess-a
+    (tmp_path / "sess-a").mkdir()
+
+    assert delete_runs(tmp_path, ["sess-a"]) == 1
+    assert (tmp_path / "sess-a").is_dir()
 
 
 def _seed_one_run(archive_dir: Path, session_id: str) -> None:

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -1345,6 +1345,24 @@ def test_label_observations_has_bitemporal_reward_columns(tmp_path: Path) -> Non
     assert "composite_reward" in runs_cols
 
 
+def test_delete_runs_leaves_label_observations_intact(tmp_path: Path) -> None:
+    _seed_one_run(tmp_path, "sess-a")
+    append_label_observation(
+        tmp_path,
+        "sess-a",
+        labels=["rejected"],
+        pr_state=None,
+        labeler_version="v1",
+        evidence_sha=None,
+    )
+
+    assert delete_runs(tmp_path, ["sess-a"]) == 1
+    assert query_runs(tmp_path) == []
+    history = label_observation_history(tmp_path, "sess-a")
+    assert len(history) == 1
+    assert json.loads(history[0]["labels"]) == ["rejected"]
+
+
 _OLD_LABEL_OBSERVATIONS_DDL = """
 CREATE TABLE IF NOT EXISTS label_observations (
     session_id       TEXT NOT NULL,

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -1298,6 +1298,30 @@ def test_delete_runs_removes_matching_rows_and_returns_count(tmp_path: Path) -> 
     assert remaining == ["sess-b"]
 
 
+def test_delete_runs_empty_collection_noop(tmp_path: Path) -> None:
+    _seed_one_run(tmp_path, "sess-a")
+
+    assert delete_runs(tmp_path, []) == 0
+    assert len(query_runs(tmp_path)) == 1
+
+
+def test_delete_runs_coerces_non_string_members(tmp_path: Path) -> None:
+    _seed_one_run(tmp_path, "42")
+
+    assert delete_runs(tmp_path, [42]) == 1
+    assert query_runs(tmp_path) == []
+
+
+def test_delete_runs_matches_exactly_no_like_semantics(tmp_path: Path) -> None:
+    _seed_one_run(tmp_path, "sess-a")
+    _seed_one_run(tmp_path, "sess-a%")  # LIKE wildcard sibling must survive
+    _seed_one_run(tmp_path, "sess-a_x")  # LIKE single-char wildcard sibling
+
+    assert delete_runs(tmp_path, ["sess-a"]) == 1
+    remaining = {r["session_id"] for r in query_runs(tmp_path)}
+    assert remaining == {"sess-a%", "sess-a_x"}
+
+
 def _seed_one_run(archive_dir: Path, session_id: str) -> None:
     upsert_run(
         archive_dir,

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -1322,6 +1322,22 @@ def test_delete_runs_matches_exactly_no_like_semantics(tmp_path: Path) -> None:
     assert remaining == {"sess-a%", "sess-a_x"}
 
 
+def test_delete_runs_hydration_rerun_reflects_only_kept_session(tmp_path: Path) -> None:
+    # Prior hydration run admitted both sessions.
+    _seed_one_run(tmp_path, "sess-kept")
+    _seed_one_run(tmp_path, "sess-rejected")
+    assert len(query_runs(tmp_path)) == 2
+
+    # Rerun admission: prune the rejected session's index row.
+    deleted = delete_runs(tmp_path, ["sess-rejected"])
+
+    assert deleted == 1
+    visible = query_runs(tmp_path)
+    assert [r["session_id"] for r in visible] == ["sess-kept"]
+    # The kept session's harvest-visible row is fully intact.
+    assert visible[0]["status"] == "complete"
+
+
 def _seed_one_run(archive_dir: Path, session_id: str) -> None:
     upsert_run(
         archive_dir,


### PR DESCRIPTION
Closes #1024.

## Summary
- Adds `delete_runs` to `daydream/archive/index.py` for pruning runs rows by session id (hydration rerun pruning)
- Exported via `__all__` with full docstring semantics (empty/coercion/exact-match) pinned by tests
- Preserves append-only label history (tested)
- Round-2 review fix (db0ec60): `delete_runs` now also removes pruned sessions' on-disk bundle dirs so `rebuild_index` can't resurrect rows

## Test Plan
- New/updated archive tests: empty/coercion/exact-match semantics, append-only label history, hydration-rerun pruning scenario, bundle-dir removal
- Round-1 baseline: 5324 passed / 21 skipped; round-2 fix tests run green pre-push
- Two sequential daydream deep-precision review rounds completed