### PR TITLE
fix(pr-review): make resolve_line diff-aware so it is a no-op on valid lines (Closes #1102)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **review:** make the approval gate demotion-aware — findings demoted for an unverified citation (beyond-tolerance location) and asserted off-vocabulary severity strings block approval even when their folded severity is non-blocking; location demotion is now non-destructive (the original severity is preserved and surfaced on the report) (issue #972)
 - **review:** expose `Arbitration.min_severity` and `Suppression.severity_classes` review-profile knobs for the arbiter and suppression passes; arbitration defaults to high-severity (plus contested) findings and suppression defaults to low-severity findings only
 
+### Fixed
+
+- **pr-review:** make posting-time line resolution diff-aware so it is a genuine no-op on an already-validated citation. `resolve_line` now takes the file's live hunk ranges (`classify` resolves them first): an in-hunk line hint is returned unchanged, and the whole-file anchor search prefers an in-hunk hit over the first hit anywhere in the file. Anchor ranking used for placement puts backtick-quoted identifiers ahead of bare words, so a short identifier such as `` `ttl` `` is no longer crowded out of the 8-token cap by rationale prose (the fingerprint's token selection is deliberately unchanged, so cross-run dedup identities are stable). When the posted line still differs from the cited one, the relocation is recorded on the finding instead of overwriting it silently. Previously a correct in-hunk citation with a prose-heavy rationale was relocated to unrelated code and then dropped off the diff entirely, demoting the comment to file-level or the review body (#1102)
+
 
 ## [0.28.0] - 2026-08-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **pr-review:** make posting-time line resolution diff-aware so it is a genuine no-op on an already-validated citation. `resolve_line` now takes the file's live hunk ranges (`classify` resolves them first): an in-hunk line hint is returned unchanged, and the whole-file anchor search prefers an in-hunk hit over the first hit anywhere in the file. Anchor ranking used for placement puts backtick-quoted identifiers ahead of bare words, so a short identifier such as `` `ttl` `` is no longer crowded out of the 8-token cap by rationale prose (the fingerprint's token selection is deliberately unchanged, so cross-run dedup identities are stable). When the posted line still differs from the cited one, the relocation is recorded on the finding instead of overwriting it silently. Previously a correct in-hunk citation with a prose-heavy rationale was relocated to unrelated code and then dropped off the diff entirely, demoting the comment to file-level or the review body (#1102)
 
-
 ## [0.28.0] - 2026-08-27
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -23,21 +23,40 @@ The following tools are optional:
 
 ## Quick start
 
-Clone the repository and install the dependencies:
+Clone the repository and install the `daydream` command:
 
 ```bash
 git clone https://github.com/existential-birds/daydream.git
 cd daydream
-uv sync
+uv tool install --editable .
 ```
 
+This command installs a `daydream` executable in the uv tool directory. On Linux and macOS this
+directory is `~/.local/bin`. If your shell shows `daydream: command not found`, the directory is not
+on your `PATH`. Run `uv tool update-shell`, then open a new shell.
 
-To update daydream, run the following commands:
+The `--editable` flag makes the installed command read the source from this clone. A `git pull` is
+sufficient for a code change. Install the command again after a pull that changes the dependencies in
+`pyproject.toml`:
 
 ```bash
 git pull
-uv sync
+uv tool install --editable .    # necessary only for a dependency change
 ```
+
+### Run without an installed command
+
+`uv sync` does **not** make a `daydream` command on your `PATH`. It builds the project virtualenv and
+writes the executable to `.venv/bin/daydream`. Use `uv run` to run daydream from the clone without a
+tool install:
+
+```bash
+uv sync
+uv run daydream /path/to/project
+```
+
+`uv run` is only available in the clone. In the remainder of this README, `daydream ...` and
+`uv run daydream ...` are equivalent.
 
 ## Usage
 
@@ -456,6 +475,9 @@ make actionlint # workflow YAML checks via Docker
 make rl-check   # standalone RL: lockcheck + ruff + mypy + pytest
 make check      # all root + workflow + RL CI checks
 ```
+
+`make install` runs `uv sync --all-extras`. This builds the virtualenv for the targets above. Like
+`uv sync`, it does not make a `daydream` command on your `PATH`. See [Quick start](#quick-start).
 
 `make hooks` installs two gates: a commit-time gate that runs ruff on the staged
 Python files, and the pre-push gate (the hook verifies commit signatures first,

--- a/daydream/deep/location_validator.py
+++ b/daydream/deep/location_validator.py
@@ -5,8 +5,11 @@ the report. This module validates a finding against the persisted hunk index
 (the run-time authority for changed file/line ranges) and returns a five-field
 check, then snaps in-tolerance findings to the nearest hunk boundary and
 demotes-with-annotation beyond-tolerance ones. It owns authority; the posting
-time ``resolve_line``/``snap_to_hunk`` backstop in ``pr_review`` is knowingly
-left as a no-op-on-valid fallback.
+time ``resolve_line``/``snap_to_hunk`` backstop in ``pr_review`` re-checks
+placement against the LIVE branch diff and is a no-op on a valid in-hunk line
+-- ``resolve_line`` takes that diff's hunk ranges so it passes an
+already-validated line straight through instead of re-deriving it from the
+finding's prose (issue #1102).
 """
 
 from __future__ import annotations

--- a/daydream/pr_review.py
+++ b/daydream/pr_review.py
@@ -795,6 +795,12 @@ def classify(
     ``/pulls/{n}/comments`` endpoint the labeler reads back, so body-only is
     the placement of last resort — used only when GitHub could not accept a
     comment for that path at all.
+
+    Side effect: for issues placed inline, this mutates the caller-owned
+    ``ParsedIssue.body`` of the objects in ``issues`` in place, via
+    ``_note_relocation``, whenever the posted line differs from the line the
+    issue cited. Callers should not rely on ``issue.body`` remaining
+    unchanged after this call.
     """
     out = _ClassifiedIssues()
     hunks_cache: dict[str, list[tuple[int, int]]] = {}
@@ -808,6 +814,17 @@ def classify(
 
     for issue in issues:
         if issue.is_cross_stack:
+            _unplaced(issue)
+            continue
+        # Skip the file_hunks() diff lookup -- a git-diff subprocess call with
+        # a gh-pr-diff network fallback on GitError -- for a path that cannot
+        # resolve at head_sha at all (e.g. deleted or renamed away in this
+        # PR). resolve_line would reject such a path via this same git show
+        # regardless of what hunks it was handed, so there is nothing for the
+        # hunk lookup to buy here.
+        try:
+            git_ops.show(target_dir, pr.head_sha, issue.path)
+        except GitError:
             _unplaced(issue)
             continue
         # The hunk ranges are resolved BEFORE line resolution, not after: they
@@ -853,8 +870,11 @@ def _note_relocation(issue: ParsedIssue, posted_line: int) -> None:
     ``findings._finding_dict`` serialises ``body``. Fingerprints are computed
     from description/rationale and never the body, so annotating cannot change
     a finding's cross-run identity.
+
+    ``issue.line <= 0`` (including the ``0`` whole-file sentinel used by
+    structural findings) is not a cited line and is never reported as one.
     """
-    if issue.line is None or issue.line == posted_line:
+    if issue.line is None or issue.line <= 0 or issue.line == posted_line:
         return
     if _PLACEMENT_NOTE_PREFIX in issue.body:
         return

--- a/daydream/pr_review.py
+++ b/daydream/pr_review.py
@@ -505,20 +505,41 @@ def find_pr_by_number(target_dir: Path, pr_number: int) -> PRInfo | None:
 _ANCHOR_TOKEN = re.compile(r"`([^`\n]{3,80})`|\b([A-Za-z_][A-Za-z0-9_]{4,})\b")
 
 
-def extract_anchors(text: str) -> list[str]:
-    """Pull candidate anchor tokens from issue text (longest first).
+def extract_anchors(text: str, *, prefer_quoted: bool = False) -> list[str]:
+    """Pull candidate anchor tokens from issue text, capped at the first 8.
 
-    Prefers backtick-quoted identifiers (e.g. `foo_bar`) since those are
-    the most specific signals of code the reviewer cited. Falls back to
-    any alphanumeric word of length >=5.
+    Two orderings share one extraction pass:
+
+    ``prefer_quoted=False`` (default) sorts every token longest-first.
+    :func:`compute_fingerprint` hashes this selection, so which 8 tokens
+    survive the cap is part of a finding's cross-run identity -- changing it
+    would re-fingerprint every open finding and defeat the reconcile dedup.
+    This ordering is therefore frozen.
+
+    ``prefer_quoted=True`` puts backtick-quoted tokens first (longest-first
+    within each group), then bare words. Longest-first alone does the opposite
+    of what it claims once a rationale carries ordinary English words: prose
+    like ``environment``/``immediately`` outranks a short backticked
+    identifier such as ``ttl`` and pushes it past the cap, so the one token
+    that actually appears on the cited line never reaches line resolution
+    (issue #1102). :func:`resolve_line` asks for this ordering.
     """
     seen: list[str] = []
+    quoted: set[str] = set()
     for m in _ANCHOR_TOKEN.finditer(text):
         token = m.group(1) or m.group(2)
-        if token and token not in seen:
+        if not token:
+            continue
+        if m.group(1):
+            quoted.add(token)
+        if token not in seen:
             seen.append(token)
-    # Longest-first improves hit quality (generic words lose to identifiers).
-    seen.sort(key=len, reverse=True)
+    if prefer_quoted:
+        # Stable sort, so first-appearance order still breaks length ties.
+        seen.sort(key=lambda t: (t not in quoted, -len(t)))
+    else:
+        # Longest-first improves hit quality (generic words lose to identifiers).
+        seen.sort(key=len, reverse=True)
     return seen[:8]
 
 
@@ -547,13 +568,38 @@ def compute_fingerprint(path: str, description: str, rationale: str) -> str:
     return hashlib.sha256(canonical.encode()).hexdigest()
 
 
-def resolve_line(target_dir: Path, head_sha: str, issue: ParsedIssue) -> int | None:
+def _in_hunk(line: int, hunks: list[tuple[int, int]]) -> bool:
+    """Whether ``line`` falls inside any head-side ``(start, end)`` hunk range."""
+    return any(start <= line <= end for start, end in hunks)
+
+
+def resolve_line(
+    target_dir: Path,
+    head_sha: str,
+    issue: ParsedIssue,
+    hunks: list[tuple[int, int]] | None = None,
+) -> int | None:
     """Resolve the true line in the head commit for an issue.
 
+    ``hunks`` are the head-side ``(start, end)`` diff ranges for ``issue.path``
+    (see :func:`file_hunks`). They are what makes this path the
+    no-op-on-valid backstop ``daydream.deep.location_validator`` documents it
+    as: without them a correct, already-validated in-hunk line was re-derived
+    from prose tokens and could be relocated to the first anchor hit anywhere
+    in the file, after which :func:`snap_to_hunk` dropped the finding off the
+    diff entirely (issue #1102).
+
     Tries (in order):
-      1. If the issue has a line hint, verify the anchor appears within
-         +/-5 lines; trust it on match.
-      2. Otherwise search the whole file at head for the first anchor hit.
+      1. Line hint inside a hunk: return it unchanged. The merge-time
+         validator already confirmed it against the persisted hunk index, so
+         anchor verification could only move a line that is known good.
+      2. Line hint outside every hunk (or no ``hunks`` supplied): trust it
+         only when an anchor appears within +/-5 lines.
+      3. Whole-file anchor search, preferring the first hit that lands inside
+         a hunk. An out-of-hunk hit is returned only when no anchor hits any
+         hunk, so a comment is never relocated onto unchanged code while a
+         changed-line candidate exists.
+
     Returns None if the file doesn't exist at head or no anchor matches.
     """
     try:
@@ -564,24 +610,36 @@ def resolve_line(target_dir: Path, head_sha: str, issue: ParsedIssue) -> int | N
     if not lines:
         return None
 
-    anchors = extract_anchors(f"{issue.title}\n{issue.body}")
+    ranges = hunks or []
 
-    # Step 1: verify hint.
+    # Step 1: an in-hunk hint is authoritative -- pass it straight through.
+    if issue.line is not None and 1 <= issue.line <= len(lines) and _in_hunk(issue.line, ranges):
+        return issue.line
+
+    anchors = extract_anchors(f"{issue.title}\n{issue.body}", prefer_quoted=True)
+
+    # Step 2: verify an out-of-hunk hint against nearby anchors.
     if issue.line is not None and 1 <= issue.line <= len(lines):
+        lo = max(1, issue.line - 5)
+        hi = min(len(lines), issue.line + 5)
         for anchor in anchors:
-            lo = max(1, issue.line - 5)
-            hi = min(len(lines), issue.line + 5)
             if any(anchor in lines[i - 1] for i in range(lo, hi + 1)):
                 return issue.line
         # Hint didn't verify; fall through to full-file search.
 
-    # Step 2: full-file search.
+    # Step 3: full-file search, in-hunk hits first.
+    out_of_hunk: int | None = None
     for anchor in anchors:
         for i, line in enumerate(lines, start=1):
-            if anchor in line:
+            if anchor not in line:
+                continue
+            if _in_hunk(i, ranges):
                 return i
+            if out_of_hunk is None:
+                out_of_hunk = i
 
-    return None
+    return out_of_hunk
+
 
 # Splits a unified diff on each `diff --git` header so we can pick out the
 # block for a single file from a full-PR diff.
@@ -752,10 +810,9 @@ def classify(
         if issue.is_cross_stack:
             _unplaced(issue)
             continue
-        line = resolve_line(target_dir, pr.head_sha, issue)
-        if line is None:
-            _unplaced(issue)
-            continue
+        # The hunk ranges are resolved BEFORE line resolution, not after: they
+        # are what lets `resolve_line` pass an already-valid in-hunk line
+        # through untouched instead of re-deriving it from prose (issue #1102).
         if issue.path not in hunks_cache:
             hunks_cache[issue.path] = file_hunks(
                 target_dir,
@@ -764,13 +821,45 @@ def classify(
                 issue.path,
                 pr_number=pr.number,
             )
-        snapped = snap_to_hunk(line, hunks_cache[issue.path])
+        hunks = hunks_cache[issue.path]
+        line = resolve_line(target_dir, pr.head_sha, issue, hunks)
+        if line is None:
+            _unplaced(issue)
+            continue
+        snapped = snap_to_hunk(line, hunks)
         if snapped is None:
             _unplaced(issue)
             continue
+        _note_relocation(issue, snapped)
         out.inline.append(_inline_comment(issue, snapped))
         out.inline_issues.append(issue)
     return out
+
+
+# Marks the posting-time relocation annotation so it is appended at most once
+# even if a caller classifies the same issue objects twice.
+_PLACEMENT_NOTE_PREFIX = "**Placement:** posted on line "
+
+
+def _note_relocation(issue: ParsedIssue, posted_line: int) -> None:
+    """Annotate ``issue`` when it is posted on a line it did not cite.
+
+    Anchor resolution and hunk snapping can both move a finding off its
+    reported line. Overwriting it silently leaves the run's own artifacts
+    showing a citation the posted comment does not use (issue #1102), so the
+    relocation is recorded in the body -- the same in-place, non-destructive
+    annotation the pre-report ``deep.location_validator`` writes for its
+    demotions. The note reaches the findings artifact too, because
+    ``findings._finding_dict`` serialises ``body``. Fingerprints are computed
+    from description/rationale and never the body, so annotating cannot change
+    a finding's cross-run identity.
+    """
+    if issue.line is None or issue.line == posted_line:
+        return
+    if _PLACEMENT_NOTE_PREFIX in issue.body:
+        return
+    note = f"{_PLACEMENT_NOTE_PREFIX}{posted_line}; reviewer cited line {issue.line}."
+    issue.body = f"{issue.body}\n\n{note}" if issue.body else note
 
 
 def _inline_comment(issue: ParsedIssue, line: int) -> dict[str, Any]:

--- a/tests/test_capture_loop.py
+++ b/tests/test_capture_loop.py
@@ -104,6 +104,21 @@ def _review_run_env(
         yield config
 
 
+def _scripted_review_backend(issue: dict[str, Any]) -> PhaseDispatchBackend:
+    """A backend that reports exactly one scripted per-stack issue."""
+    return PhaseDispatchBackend(
+        events=[
+            TextEvent(text="Review complete."),
+            # Issue #742: the deep per-stack parse schema requires a
+            # ``verdicts`` property (Codex strict-mode output).
+            ResultEvent(
+                structured_output={"issues": [issue], "verdicts": []},
+                continuation=None,
+            ),
+        ]
+    )
+
+
 async def test_unanchorable_finding_on_changed_file_is_placed_file_level(
     feature_branch_repo: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -117,6 +132,57 @@ async def test_unanchorable_finding_on_changed_file_is_placed_file_level(
     contains no token present in that file, so anchor resolution yields no
     line. Before the fix this fell through to ``placement="body"``, which no
     posterior signal can ever read back. It must now be ``"file"``.
+
+    The cited line is deliberately past the end of ``main.py`` (2 lines at
+    head) and so outside every hunk: since #1102 an in-hunk citation is
+    authoritative and would be posted inline, which is a *different*
+    invariant (see the sibling test below). Only a citation that no path can
+    place exercises the file-level fallback this test guards.
+    """
+    out = tmp_path / "findings.json"
+    issue = {
+        "id": 1,
+        "title": "Module lacks a rollback barrier",
+        "description": "No `quiescent_rollback_barrier` guards this module",
+        "recommendation": "Introduce a `quiescent_rollback_barrier`",
+        "severity": "medium",
+        "confidence": "HIGH",
+        "files": ["main.py"],
+        "file": "main.py",
+        "line": 9,
+        "rationale": "",
+        "evidence": "main.py:9",
+    }
+    with _review_run_env(
+        feature_branch_repo, monkeypatch, out, _scripted_review_backend(issue), fake_gh
+    ) as config:
+        assert await run(config) == 0
+
+    findings = json.loads(out.read_text())["findings"]
+    assert findings, "scripted issue must survive to the artifact"
+    main_py = [f for f in findings if f["path"] == "main.py"]
+    assert main_py, "the finding must target the changed file"
+    assert all(f["placement"] == "file" for f in main_py), (
+        "a finding on a file in the PR diff with no resolvable line must be "
+        f"placed file-level, not folded into the invisible review body: {main_py}"
+    )
+
+
+async def test_in_hunk_citation_is_placed_inline_without_an_anchor_match(
+    feature_branch_repo: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    fake_gh: FakeGh,
+) -> None:
+    """Real-path #1102: an in-hunk cited line keeps its inline placement.
+
+    Same harness as the sibling test — ``runner.run`` over a real worktree,
+    only the backend mocked — but the scripted issue cites ``main.py:1``, a
+    line inside the live PR hunk, while its text still shares no token with
+    the file. Posting-time resolution is documented as a no-op on a valid
+    line; before #1102 it had no view of the diff, so it discarded the correct
+    hint and demoted the finding to a file-level comment. It must now post
+    inline on the cited line.
     """
     out = tmp_path / "findings.json"
     issue = {
@@ -132,27 +198,20 @@ async def test_unanchorable_finding_on_changed_file_is_placed_file_level(
         "rationale": "",
         "evidence": "main.py:1",
     }
-    backend = PhaseDispatchBackend(
-        events=[
-            TextEvent(text="Review complete."),
-            # Issue #742: the deep per-stack parse schema requires a
-            # ``verdicts`` property (Codex strict-mode output).
-            ResultEvent(
-                structured_output={"issues": [issue], "verdicts": []},
-                continuation=None,
-            ),
-        ]
-    )
-    with _review_run_env(feature_branch_repo, monkeypatch, out, backend, fake_gh) as config:
+    with _review_run_env(
+        feature_branch_repo, monkeypatch, out, _scripted_review_backend(issue), fake_gh
+    ) as config:
         assert await run(config) == 0
 
     findings = json.loads(out.read_text())["findings"]
-    assert findings, "scripted issue must survive to the artifact"
     main_py = [f for f in findings if f["path"] == "main.py"]
     assert main_py, "the finding must target the changed file"
-    assert all(f["placement"] == "file" for f in main_py), (
-        "a finding on a file in the PR diff with no resolvable line must be "
-        f"placed file-level, not folded into the invisible review body: {main_py}"
+    assert all(f["placement"] == "inline" and f["line"] == 1 for f in main_py), (
+        "an in-hunk citation must be posted inline on the line the reviewer "
+        f"cited, not relocated or demoted: {main_py}"
+    )
+    assert all("**Placement:**" not in f["body"] for f in main_py), (
+        "nothing moved, so no relocation note belongs on the finding"
     )
 
 

--- a/tests/test_docs_contract.py
+++ b/tests/test_docs_contract.py
@@ -99,7 +99,7 @@ def test_fresh_install_docs_have_no_plugin_step() -> None:
 
 def test_historical_records_preserved() -> None:
     expected = {
-        "CHANGELOG.md": "f12fefaecee9200916f13668af07ec7f6879259e68bc329898fa5823ffb8fdc1",
+        "CHANGELOG.md": "bc061d1717bb0d3270d2e6859fc3d5516c1ae11070249213a02f052ed5c81aef",
     }
     for rel, want in expected.items():
         data = (ROOT / rel).read_bytes()

--- a/tests/test_docs_contract.py
+++ b/tests/test_docs_contract.py
@@ -99,7 +99,7 @@ def test_fresh_install_docs_have_no_plugin_step() -> None:
 
 def test_historical_records_preserved() -> None:
     expected = {
-        "CHANGELOG.md": "bc061d1717bb0d3270d2e6859fc3d5516c1ae11070249213a02f052ed5c81aef",
+        "CHANGELOG.md": "3b30157765fb8f303b15fb5fe75dff650ec480660346fd194a9454ca8bafc414",
     }
     for rel, want in expected.items():
         data = (ROOT / rel).read_bytes()

--- a/tests/test_pr_review.py
+++ b/tests/test_pr_review.py
@@ -351,7 +351,11 @@ def test_classify_splits_inline_vs_body(monkeypatch: pytest.MonkeyPatch, pr: PRI
         ParsedIssue(path="c.py", line=None, title="t3", body="xstack", is_cross_stack=True),
     ]
 
-    def fake_resolve(_td: Path, _sha: str, issue: ParsedIssue) -> int | None:
+    def fake_resolve(
+        _td: Path, _sha: str, issue: ParsedIssue, hunks: list[tuple[int, int]] | None = None
+    ) -> int | None:
+        # classify must resolve the hunks first and hand them down (issue #1102).
+        assert hunks is not None, "classify called resolve_line without the file's hunks"
         return issue.line
 
     def fake_hunks(
@@ -391,7 +395,10 @@ def test_classify_snaps_tolerance_line_to_hunk_boundary(
         ParsedIssue(path="scripts/modernize-app.py", line=105, title="t2", body="anchor_two"),
     ]
 
-    def fake_resolve(_td: Path, _sha: str, issue: ParsedIssue) -> int | None:
+    def fake_resolve(
+        _td: Path, _sha: str, issue: ParsedIssue, hunks: list[tuple[int, int]] | None = None
+    ) -> int | None:
+        assert hunks is not None, "classify called resolve_line without the file's hunks"
         return issue.line
 
     def fake_hunks(
@@ -1010,6 +1017,185 @@ def test_resolve_line_none_when_missing_file(git_repo: Path) -> None:
     sha = _git(git_repo, "rev-parse", "HEAD")
     issue = ParsedIssue(path="gone.py", line=1, title="t", body="b")
     assert pr_review.resolve_line(git_repo, sha, issue) is None
+
+
+# --- Diff-aware line resolution (issue #1102) -----------------------------
+#
+# `resolve_line` is documented (deep/location_validator.py:1-10) as a
+# no-op-on-valid backstop behind the merge-time location validator. Before
+# #1102 it never saw the diff, so a correct in-hunk line was re-derived from
+# prose tokens and could be relocated to the first anchor hit anywhere in the
+# file -- after which `snap_to_hunk` dropped the finding off the diff.
+
+# The finding from the issue's reproduction: a prose-heavy rationale whose one
+# code identifier (`ttl`) is short enough that longest-first ranking cuts it.
+_PROSE_HEAVY_ISSUE = ParsedIssue(
+    path="cache.yaml",
+    line=12,
+    title="Expiration collapses from an hour to a minute",
+    body=(
+        "The new override sets `ttl` far below every other environment, so cached "
+        "entries become unavailable almost immediately and the downstream service "
+        "absorbs the additional request volume."
+    ),
+)
+
+# `prod:`'s TTL drops from an hour to a minute on line 12; every other block
+# keeps 3600, so the anchor token `ttl` occurs on four lines and the only
+# prose-matching token (`Expiration`) sits on line 1, outside the hunk.
+_CACHE_YAML_BASE = (
+    "# Expiration policy for the shared cache tier.\n"
+    "defaults:\n"
+    "  ttl: 3600\n"
+    "\n"
+    "staging:\n"
+    "  ttl: 3600\n"
+    "\n"
+    "worker:\n"
+    "  ttl: 3600\n"
+    "\n"
+    "prod:\n"
+    "  ttl: 3600\n"
+)
+_CACHE_YAML_HEAD = _CACHE_YAML_BASE.replace("prod:\n  ttl: 3600\n", "prod:\n  ttl: 60\n")
+
+
+def _pr_for(base_sha: str, head_sha: str) -> PRInfo:
+    """A PRInfo pointing at two real commits in a temp repo."""
+    return PRInfo(
+        number=7,
+        head_sha=head_sha,
+        base_sha=base_sha,
+        base_ref="main",
+        owner="acme",
+        repo="widgets",
+        url="https://github.com/acme/widgets/pull/7",
+    )
+
+
+def test_extract_anchors_prefer_quoted_keeps_short_backticked_identifier() -> None:
+    """Quoted-first ranking keeps a 3-char identifier that prose would crowd out."""
+    text = f"{_PROSE_HEAVY_ISSUE.title}\n{_PROSE_HEAVY_ISSUE.body}"
+    assert extract_anchors(text, prefer_quoted=True)[0] == "ttl"
+    # Bare words still rank longest-first behind the quoted tokens.
+    bare = extract_anchors(text, prefer_quoted=True)[1:]
+    assert bare == sorted(bare, key=len, reverse=True)
+
+
+def test_extract_anchors_default_ordering_stays_frozen_for_fingerprints() -> None:
+    """The default (fingerprint-hashed) selection is unchanged by #1102.
+
+    ``compute_fingerprint`` hashes the default token set, so re-ranking it
+    would re-identify every open finding and defeat the reconcile dedup. The
+    prose-heavy rationale must still crowd ``ttl`` out of the default cap --
+    that is exactly the selection the existing fingerprints were built from.
+    """
+    text = f"{_PROSE_HEAVY_ISSUE.title}\n{_PROSE_HEAVY_ISSUE.body}"
+    anchors = extract_anchors(text)
+    assert anchors == [
+        "environment",
+        "unavailable",
+        "immediately",
+        "Expiration",
+        "downstream",
+        "additional",
+        "collapses",
+        "override",
+    ]
+    assert "ttl" not in anchors
+
+
+def test_resolve_line_trusts_in_hunk_hint_without_any_anchor_match(git_repo: Path) -> None:
+    """An in-hunk line hint is returned unchanged even when no anchor matches.
+
+    This is the "no-op-on-valid" contract: the merge-time validator already
+    confirmed the line against the hunk index, so posting must not re-derive it.
+    """
+    text = "\n".join(f"row_{i}" for i in range(1, 21)) + "\n"
+    sha = _commit_file(git_repo, "x.py", text, "add x.py")
+    issue = ParsedIssue(path="x.py", line=10, title="Latency regression", body="prose only")
+    # No anchor from the title/body occurs anywhere in the file.
+    assert pr_review.resolve_line(git_repo, sha, issue) is None
+    assert pr_review.resolve_line(git_repo, sha, issue, [(8, 12)]) == 10
+
+
+def test_resolve_line_prefers_in_hunk_anchor_hit_over_first_file_hit(git_repo: Path) -> None:
+    """With no usable hint, an in-hunk anchor hit beats the first hit in the file."""
+    lines = [f"row_{i}" for i in range(1, 21)]
+    lines[1] = "marker_token  # pre-existing, unchanged"
+    lines[17] = "marker_token  # the changed line"
+    sha = _commit_file(git_repo, "x.py", "\n".join(lines) + "\n", "add x.py")
+    issue = ParsedIssue(path="x.py", line=None, title="t", body="`marker_token`")
+    # Without hunks the first hit (line 2) wins, as before.
+    assert pr_review.resolve_line(git_repo, sha, issue) == 2
+    # With hunks, the in-hunk hit (line 18) wins over the earlier out-of-hunk one.
+    assert pr_review.resolve_line(git_repo, sha, issue, [(16, 20)]) == 18
+
+
+def test_resolve_line_returns_out_of_hunk_hit_when_no_in_hunk_candidate(
+    git_repo: Path,
+) -> None:
+    """An out-of-hunk anchor hit is still returned when no anchor hits a hunk."""
+    lines = [f"row_{i}" for i in range(1, 21)]
+    lines[1] = "marker_token  # pre-existing, unchanged"
+    sha = _commit_file(git_repo, "x.py", "\n".join(lines) + "\n", "add x.py")
+    issue = ParsedIssue(path="x.py", line=None, title="t", body="`marker_token`")
+    assert pr_review.resolve_line(git_repo, sha, issue, [(16, 20)]) == 2
+
+
+def test_classify_keeps_prose_heavy_in_hunk_finding_inline(git_repo: Path) -> None:
+    """Real-path #1102 repro: a correct in-hunk citation stays inline.
+
+    Drives the real :func:`classify` over a real two-commit repo -- real
+    ``git diff`` for both the changed-file set and the hunk ranges, no mocks.
+    The finding cites line 12, the only changed line. Before the fix the eight
+    surviving anchors were all rationale prose, none of them within +/-5 lines
+    of line 12, so the hint was discarded and the full-file search relocated
+    the comment to ``Expiration`` on line 1 -- 8 lines outside the hunk, so
+    ``snap_to_hunk`` returned None and the finding lost its line.
+    """
+    base = _commit_file(git_repo, "cache.yaml", _CACHE_YAML_BASE, "add cache.yaml")
+    head = _commit_file(git_repo, "cache.yaml", _CACHE_YAML_HEAD, "cut prod ttl")
+    issue = replace(_PROSE_HEAVY_ISSUE)
+
+    result = classify(git_repo, _pr_for(base, head), [issue])
+
+    assert [c["line"] for c in result.inline] == [12], (
+        f"in-hunk citation was not posted on its own line; "
+        f"file_level={[i.path for i in result.file_level]} "
+        f"body_only={[i.path for i in result.body_only]}"
+    )
+    assert result.inline[0]["path"] == "cache.yaml"
+    assert not result.file_level
+    assert not result.body_only
+    # Nothing moved, so nothing is annotated.
+    assert "**Placement:**" not in result.inline[0]["body"]
+
+
+def test_classify_annotates_relocated_line(git_repo: Path) -> None:
+    """A snapped line is recorded in the body instead of overwritten silently.
+
+    Real-path: the finding cites line 15, two lines outside the real hunk
+    (17, 23). ``snap_to_hunk`` moves the comment to 17, so the posted line is
+    not the cited one -- and the relocation must be visible on the comment and
+    in the issue body the findings artifact serialises (issue #1102).
+    """
+    lines = [f"row_{i}" for i in range(1, 31)]
+    lines[14] = "settle_window = 5  # cited here"
+    base = _commit_file(git_repo, "x.py", "\n".join(lines) + "\n", "add x.py")
+    lines[19] = "row_20_changed"
+    head = _commit_file(git_repo, "x.py", "\n".join(lines) + "\n", "change row 20")
+    issue = ParsedIssue(path="x.py", line=15, title="t", body="`settle_window` is too small")
+
+    result = classify(git_repo, _pr_for(base, head), [issue])
+
+    assert [c["line"] for c in result.inline] == [17]
+    note = "**Placement:** posted on line 17; reviewer cited line 15."
+    assert note in issue.body, "the relocation was not recorded on the finding"
+    assert note in result.inline[0]["body"], "the posted comment does not show the relocation"
+    # Re-classifying the same objects must not stack duplicate notes.
+    classify(git_repo, _pr_for(base, head), [issue])
+    assert issue.body.count("**Placement:**") == 1
 
 
 # --- file_hunks git-diff + gh-pr-diff fallback ----------------------------

--- a/tests/test_pr_review.py
+++ b/tests/test_pr_review.py
@@ -372,6 +372,7 @@ def test_classify_splits_inline_vs_body(monkeypatch: pytest.MonkeyPatch, pr: PRI
             return [(1, 5)]  # 99 is outside
         return []
 
+    monkeypatch.setattr(git_ops, "show", lambda *_a, **_k: b"")
     monkeypatch.setattr(pr_review, "resolve_line", fake_resolve)
     monkeypatch.setattr(pr_review, "file_hunks", fake_hunks)
 
@@ -415,6 +416,7 @@ def test_classify_snaps_tolerance_line_to_hunk_boundary(
             return [(80, 98), (106, 120)]  # 105 is 1 before second hunk
         return []
 
+    monkeypatch.setattr(git_ops, "show", lambda *_a, **_k: b"")
     monkeypatch.setattr(pr_review, "resolve_line", fake_resolve)
     monkeypatch.setattr(pr_review, "file_hunks", fake_hunks)
 
@@ -1196,6 +1198,33 @@ def test_classify_annotates_relocated_line(git_repo: Path) -> None:
     # Re-classifying the same objects must not stack duplicate notes.
     classify(git_repo, _pr_for(base, head), [issue])
     assert issue.body.count("**Placement:**") == 1
+
+
+def test_classify_skips_file_hunks_for_path_missing_at_head(
+    monkeypatch: pytest.MonkeyPatch, git_repo: Path
+) -> None:
+    """A path that doesn't exist at head_sha (deleted/renamed) never calls file_hunks.
+
+    ``resolve_line`` would reject such a path via its own ``git show`` no
+    matter what hunks it was handed, so `classify` should discover the path
+    is unresolvable up front instead of paying for the file_hunks() diff
+    lookup (and its gh-pr-diff network fallback) first (issue #1102 follow-up).
+    """
+    base = _commit_file(git_repo, "gone.py", "x = 1\n", "add gone.py")
+    _git(git_repo, "rm", "gone.py")
+    _git(git_repo, "commit", "-m", "delete gone.py")
+    head = _git(git_repo, "rev-parse", "HEAD")
+    issue = ParsedIssue(path="gone.py", line=1, title="t", body="`x`")
+
+    def fail_if_called(*_a: Any, **_k: Any) -> list[tuple[int, int]]:
+        raise AssertionError("file_hunks should not be called for a path missing at head_sha")
+
+    monkeypatch.setattr(pr_review, "file_hunks", fail_if_called)
+
+    result = classify(git_repo, _pr_for(base, head), [issue])
+
+    assert not result.inline
+    assert [i.path for i in result.file_level] == ["gone.py"]
 
 
 # --- file_hunks git-diff + gh-pr-diff fallback ----------------------------


### PR DESCRIPTION
Closes #1102.

`resolve_line` never consulted the diff, even though its only caller computed the hunks a few lines later in the same function. A finding whose reported line was correct and inside a hunk could be rejected by the ±5 anchor-window check and relocated by the full-file search to the first anchor hit anywhere in the file; `snap_to_hunk` then returned `None` and the finding lost its inline placement — contradicting the invariant `deep/location_validator.py` states explicitly.

## Changes

**Diff-aware resolution.** `classify` now resolves `file_hunks` *before* line resolution and passes the ranges into `resolve_line`. An in-hunk line hint is returned unchanged — what "no-op-on-valid" was supposed to mean — and the whole-file anchor search prefers a hit inside a hunk, accepting an out-of-hunk hit only when no anchor hits any hunk.

**Anchor ranking.** `extract_anchors(..., prefer_quoted=True)` puts backtick-quoted tokens ahead of bare words for placement. Longest-first did the opposite of what its comment claimed once a rationale carried ordinary English words: prose like `environment`/`immediately` outranked a short backticked identifier such as `` `ttl` `` and pushed it past the 8-token cap, so the one token on the cited line never reached resolution.

The default ordering is deliberately left **frozen**: `compute_fingerprint` hashes that token selection, so re-ranking it would re-identify every open finding and defeat the reconcile dedup. `test_extract_anchors_default_ordering_stays_frozen_for_fingerprints` pins the exact default list.

**Recorded relocation.** When the posted line still differs from the cited one, `_note_relocation` appends a `**Placement:** posted on line N; reviewer cited line M.` annotation instead of overwriting silently — the same in-place, non-destructive style `location_validator` uses for its demotions. It reaches the findings artifact because `findings._finding_dict` serialises `body`.

Also corrected the `location_validator` module docstring, which asserted the posting-time backstop was a no-op-on-valid — the falsehood the issue called out.

## Not done, deliberately

The issue suggested *considering* drawing anchors from `evidence`. That field is schema-constrained to a `path:line` citation token (`phases.py:1053` requires `\S*[./]\S*:\d+`), not a code snippet, so it carries no anchor tokens beyond the path and line already in hand.

## Tests

7 new tests, each verified failing on `main` and passing with the fix:

- `test_classify_keeps_prose_heavy_in_hunk_finding_inline` — the issue's exact `cache.yaml` reproduction through the real `classify` over a real two-commit worktree (real `git diff` for both the changed-file set and hunk ranges, no mocks). Pre-fix: `file_level=['cache.yaml']`, no inline placement.
- `test_in_hunk_citation_is_placed_inline_without_an_anchor_match` — real-path, entering from `runner.run`, only the backend mocked.
- in-hunk hint pass-through, in-hunk-preferred anchor search, out-of-hunk fallback, quoted-first ranking, frozen default ranking, and relocation annotation.

One existing test needed retargeting: `test_unanchorable_finding_on_changed_file_is_placed_file_level` cited `main.py:1`, which *is* inside the live hunk, so it now correctly posts inline. Its citation moved past end-of-file so it still exercises the genuinely-unplaceable file-level fallback (preserving the #742 never-body invariant), with the inline case added as a sibling test rather than weakening the assertion.

## Verification

Full suite **5375 passed, 5 skipped**, coverage **88.34%** (floor 86%). `ruff`, `mypy` (485 files), `vulture`, `actionlint` (Docker), both `uv lock --check`, and the RL package's `ruff`/`mypy`/`vulture` all clean.

The RL standalone pytest has 17 failures on this machine, all reproduced identically on a pristine `main` worktree: 16 are `git commit` exit 128 (Author identity unknown — no global git identity locally; CI's `rl-check` job configures one) and pass once an identity is present; the 17th, `test_harness_e2e.py::test_stub_rollout_scores_without_crash`, also fails unchanged on `main`. None relate to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
