### PR TITLE
ui: render Bash command in quiet-mode tool panels (Closes #1108)

### DIFF
--- a/daydream/agent.py
+++ b/daydream/agent.py
@@ -54,6 +54,7 @@ from daydream.ui import (
 from daydream.ui import (
     prompt_user as prompt_user,
 )
+from daydream.ui.tools import _PRIMARY_TOOL_ARG
 
 _logger = logging.getLogger(__name__)
 
@@ -407,11 +408,12 @@ def _summarize_input(input_data: dict[str, Any]) -> str:
     """One-line summary of tool input for log output."""
     if not input_data:
         return ""
-    # For known tools, pick the most informative key. The COMPLETE selected
-    # string is redacted before any [:200] slice — redact-after-slice would
-    # truncate a credential into an unmatchable fragment.
-    if "command" in input_data:
-        return redact_structured_text(input_data["command"])[:200]
+    # The COMPLETE selected string is redacted before any [:200] slice —
+    # redact-after-slice would truncate a credential into an unmatchable fragment.
+    for key in _PRIMARY_TOOL_ARG["Bash"]:
+        value = input_data.get(key)
+        if isinstance(value, str) and value:
+            return redact_structured_text(value)[:200]
     if "path" in input_data:
         complete = f"{input_data['path']}" + (
             f" -> {input_data.get('new_path', '')}" if "new_path" in input_data else ""

--- a/daydream/agent.py
+++ b/daydream/agent.py
@@ -404,13 +404,17 @@ def is_environmental_failure(test_output: str) -> bool:
     return any(signature in output_lower for signature in infra_signatures)
 
 
-def _summarize_input(input_data: dict[str, Any]) -> str:
+def _summarize_input(input_data: dict[str, Any], name: str) -> str:
     """One-line summary of tool input for log output."""
     if not input_data:
         return ""
     # The COMPLETE selected string is redacted before any [:_BASH_COMMAND_MAX_CHARS]
     # slice — redact-after-slice would truncate a credential into an unmatchable fragment.
-    for key in _PRIMARY_TOOL_ARG["Bash"]:
+    # Key the shared primary table by tool name the way ui.tools._primary_tool_value
+    # does instead of hard-applying the Bash-only (command, description) preference:
+    # TaskCreate/Agent inputs also carry "description", and letting the Bash pair
+    # shadow it would replace their short subject with the long field.
+    for key in _PRIMARY_TOOL_ARG.get(name, ()):
         value = input_data.get(key)
         if isinstance(value, str) and value:
             return redact_structured_text(value)[:_BASH_COMMAND_MAX_CHARS]
@@ -712,7 +716,7 @@ async def run_agent(
                             elif isinstance(event, ToolStartEvent):
                                 if _state.log_mode:
                                     tool_names[event.id] = event.name
-                                    _print_log(f"[tool:{event.name}] {_summarize_input(event.input)}")
+                                    _print_log(f"[tool:{event.name}] {_summarize_input(event.input, event.name)}")
                                 elif progress_callback is not None:
                                     # Record the originating call so a backgrounded launch's result
                                     # can later resolve a Task-family label for the progress line.

--- a/daydream/agent.py
+++ b/daydream/agent.py
@@ -54,7 +54,7 @@ from daydream.ui import (
 from daydream.ui import (
     prompt_user as prompt_user,
 )
-from daydream.ui.tools import _PRIMARY_TOOL_ARG
+from daydream.ui.tools import _BASH_COMMAND_MAX_CHARS, _PRIMARY_TOOL_ARG
 
 _logger = logging.getLogger(__name__)
 
@@ -408,12 +408,12 @@ def _summarize_input(input_data: dict[str, Any]) -> str:
     """One-line summary of tool input for log output."""
     if not input_data:
         return ""
-    # The COMPLETE selected string is redacted before any [:200] slice —
-    # redact-after-slice would truncate a credential into an unmatchable fragment.
+    # The COMPLETE selected string is redacted before any [:_BASH_COMMAND_MAX_CHARS]
+    # slice — redact-after-slice would truncate a credential into an unmatchable fragment.
     for key in _PRIMARY_TOOL_ARG["Bash"]:
         value = input_data.get(key)
         if isinstance(value, str) and value:
-            return redact_structured_text(value)[:200]
+            return redact_structured_text(value)[:_BASH_COMMAND_MAX_CHARS]
     if "path" in input_data:
         complete = f"{input_data['path']}" + (
             f" -> {input_data.get('new_path', '')}" if "new_path" in input_data else ""
@@ -422,8 +422,8 @@ def _summarize_input(input_data: dict[str, Any]) -> str:
     # Generic: first value that's a string
     for v in input_data.values():
         if isinstance(v, str):
-            return redact_structured_text(v)[:200]
-    return redact_structured_text(str(input_data))[:200]
+            return redact_structured_text(v)[:_BASH_COMMAND_MAX_CHARS]
+    return redact_structured_text(str(input_data))[:_BASH_COMMAND_MAX_CHARS]
 
 
 def _summarize_output(output: str) -> str:

--- a/daydream/ui/tools.py
+++ b/daydream/ui/tools.py
@@ -59,6 +59,7 @@ _CALLBACK_TOOL_ICONS = {
     "TodoWrite": "🔧",
     **{name: "🎠" for name in (*_BACKGROUND_TASK_TOOLS, *_TODO_TASK_TOOLS)},
 }
+_BASH_COMMAND_MAX_CHARS = 200  # Keep aligned with agent._summarize_input's command cap.
 _PRIMARY_TOOL_ARG = {
     "Read": ("file_path",),
     "Write": ("file_path",),
@@ -469,12 +470,17 @@ def _build_tool_header(
             content.append("\n")
             content.append(description, style=STYLE_CYAN)
 
-        if not quiet_mode:
-            command = str(args.get("command", ""))
-            if command:
-                content.append("\n")
-                content.append("$ ", style=STYLE_DIM)
-                content.append(command, style=STYLE_DIM)
+        # Import lazily because trajectory initializes the UI facade used to
+        # reach this renderer while the application import graph is loading.
+        from daydream.trajectory import redact_structured_text
+
+        # Redact the complete command before slicing so a credential crossing
+        # the display boundary cannot be truncated into an unmatchable fragment.
+        command = redact_structured_text(str(args.get("command", "")))[:_BASH_COMMAND_MAX_CHARS]
+        if command.strip():
+            content.append("\n")
+            content.append("$ ", style=STYLE_DIM)
+            content.append(command, style=STYLE_DIM)
 
         return content
 

--- a/daydream/ui/tools.py
+++ b/daydream/ui/tools.py
@@ -44,9 +44,8 @@ _TASKCREATE_ID_PATTERN = re.compile(r"Task #(\d+)")
 
 # Single-line icon + primary-arg spec for the callback/parallel render path,
 # which cannot open Rich panels (concurrent agents would each fight for the
-# shared console's Live context). These mirror the per-tool choices baked into
-# ``_build_tool_header`` so a parallel-fix line names the same icon and primary
-# argument the panel header would lead with.
+# shared console's Live context). ``_PRIMARY_TOOL_ARG`` is the shared source of
+# truth for primary argument selection across single-line render surfaces.
 _CALLBACK_TOOL_ICONS = {
     "Read": "📜",
     "Write": "⛏️",
@@ -67,8 +66,8 @@ _PRIMARY_TOOL_ARG = {
     "NotebookEdit": ("notebook_path", "file_path"),
     "Glob": ("pattern",),
     "Grep": ("pattern",),
-    "Bash": ("description", "command"),
-    "shell": ("description", "command"),
+    "Bash": ("command", "description"),
+    "shell": ("command", "description"),
     "Skill": ("skill",),
 }
 
@@ -76,11 +75,12 @@ _PRIMARY_TOOL_ARG = {
 def _primary_tool_value(name: str, args: dict[str, object]) -> tuple[str, str | None]:
     """Return the meaningful primary-argument value for a tool's progress line.
 
-    Mirrors the per-tool choice in ``_build_tool_header`` (Read/Edit/Write →
-    ``file_path``, Grep/Glob → ``pattern``, Bash → ``description``/``command``).
-    Falls back to the first non-mechanical, non-boolean value so an unknown tool
-    still shows something meaningful rather than a stray flag — the old blind
-    ``next(iter(args.values()))`` surfaced ``replace_all=False`` as ``"False"``.
+    ``_PRIMARY_TOOL_ARG`` is the source of truth shared by the callback path
+    and the ``--log`` summary, with Bash preferring required ``command`` over
+    optional ``description``. Falls back to the first non-mechanical,
+    non-boolean value so an unknown tool still shows something meaningful
+    rather than a stray flag — the old blind ``next(iter(args.values()))``
+    surfaced ``replace_all=False`` as ``"False"``.
 
     Returns:
         ``(value, key)`` — the primary value as a string and the arg key it came

--- a/daydream/ui/tools.py
+++ b/daydream/ui/tools.py
@@ -58,7 +58,7 @@ _CALLBACK_TOOL_ICONS = {
     "TodoWrite": "🔧",
     **{name: "🎠" for name in (*_BACKGROUND_TASK_TOOLS, *_TODO_TASK_TOOLS)},
 }
-_BASH_COMMAND_MAX_CHARS = 200  # Keep aligned with agent._summarize_input's command cap.
+_BASH_COMMAND_MAX_CHARS = 200  # Shared truncation cap for Bash command display; agent._summarize_input imports it.
 _PRIMARY_TOOL_ARG = {
     "Read": ("file_path",),
     "Write": ("file_path",),
@@ -243,8 +243,15 @@ def format_callback_progress(
 
     value, key = _primary_tool_value(name, args)
     if value:
+        # Import lazily because trajectory initializes the UI facade used to
+        # reach this renderer while the application import graph is loading.
+        from daydream.trajectory import redact_structured_text
+
+        # Redact the complete value before slicing (same invariant the panel
+        # header and agent._summarize_input hold) so a credential crossing the
+        # display boundary cannot be truncated into an unmatchable fragment.
         line.append(" ")
-        line.append(value[:max_len], style=_primary_value_style(key))
+        line.append(redact_structured_text(value)[:max_len], style=_primary_value_style(key))
     return line
 
 
@@ -476,7 +483,10 @@ def _build_tool_header(
 
         # Redact the complete command before slicing so a credential crossing
         # the display boundary cannot be truncated into an unmatchable fragment.
-        command = redact_structured_text(str(args.get("command", "")))[:_BASH_COMMAND_MAX_CHARS]
+        full_command = redact_structured_text(str(args.get("command", "")))
+        command = full_command[:_BASH_COMMAND_MAX_CHARS]
+        if len(full_command) > _BASH_COMMAND_MAX_CHARS:
+            command = f"{command}..."
         if command.strip():
             content.append("\n")
             content.append("$ ", style=STYLE_DIM)

--- a/daydream/ui/tools.py
+++ b/daydream/ui/tools.py
@@ -205,7 +205,7 @@ def format_callback_progress(
     name: str,
     args: dict[str, object],
     label: str | None,
-    max_len: int = 80,
+    max_len: int = _BASH_COMMAND_MAX_CHARS,
 ) -> Text:
     """Build a styled one-line progress entry for the callback render path.
 
@@ -247,11 +247,18 @@ def format_callback_progress(
         # reach this renderer while the application import graph is loading.
         from daydream.trajectory import redact_structured_text
 
-        # Redact the complete value before slicing (same invariant the panel
-        # header and agent._summarize_input hold) so a credential crossing the
-        # display boundary cannot be truncated into an unmatchable fragment.
+        # Redact only the Bash command — the same scope the panel header applies
+        # in _build_tool_header's Bash branch, where paths and grep patterns
+        # render raw. Redacting every primary value would rewrite the operator's
+        # own /home/<user>/ paths into [REDACTED_USER] markers on the callback
+        # line. Redact the complete value before slicing so a credential
+        # crossing the display boundary cannot be truncated into an unmatchable
+        # fragment.
+        display_value = value
+        if name in ("Bash", "shell") and key == "command":
+            display_value = redact_structured_text(value)
         line.append(" ")
-        line.append(redact_structured_text(value)[:max_len], style=_primary_value_style(key))
+        line.append(display_value[:max_len], style=_primary_value_style(key))
     return line
 
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -405,6 +405,52 @@ async def test_quiet_mode_shows_header_only(monkeypatch: pytest.MonkeyPatch) -> 
 
 
 @pytest.mark.asyncio
+async def test_quiet_mode_bash_panel_shows_command(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Quiet-mode Bash panel shows the command (issue #1108), like Read shows file_path."""
+    tool_use_id = "test-bash-quiet-1108"
+    events = [
+        ToolStartEvent(id=tool_use_id, name="Bash", input={"command": "git diff --stat"}),
+        ToolResultEvent(id=tool_use_id, output="", is_error=False),
+        CostEvent(cost_usd=0.001, input_tokens=None, output_tokens=None),
+        ResultEvent(structured_output=None, continuation=None),
+    ]
+    plain_text = strip_ansi(await render_agent(monkeypatch, events, quiet=True))
+    assert "$ git diff --stat" in plain_text
+
+
+@pytest.mark.asyncio
+async def test_quiet_mode_bash_panel_renders_more_than_bare_name_without_description(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A description-less Bash call renders more than the bare `🔨 Bash` line."""
+    tool_use_id = "test-bash-quiet-nodesc-1108"
+    events = [
+        ToolStartEvent(id=tool_use_id, name="Bash", input={"command": "ls -la /tmp"}),
+        ToolResultEvent(id=tool_use_id, output="", is_error=False),
+        CostEvent(cost_usd=0.001, input_tokens=None, output_tokens=None),
+        ResultEvent(structured_output=None, continuation=None),
+    ]
+    plain_text = strip_ansi(await render_agent(monkeypatch, events, quiet=True))
+    assert "ls -la /tmp" in plain_text or "ls -la /tm" in plain_text
+    assert "$ ls" in plain_text
+
+
+@pytest.mark.asyncio
+async def test_quiet_mode_bash_panel_redacts_command_secrets(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Panel command is redacted via redact_structured_text before display."""
+    tool_use_id = "test-bash-quiet-redact-1108"
+    events = [
+        ToolStartEvent(id=tool_use_id, name="Bash", input={"command": "DB_PASSWORD=hunter2 make db-up"}),
+        ToolResultEvent(id=tool_use_id, output="", is_error=False),
+        CostEvent(cost_usd=0.001, input_tokens=None, output_tokens=None),
+        ResultEvent(structured_output=None, continuation=None),
+    ]
+    plain_text = strip_ansi(await render_agent(monkeypatch, events, quiet=True))
+    assert "hunter2" not in plain_text
+    assert "$ DB_PASSWORD=[REDACTED_ENV_VAR] make db-up" in plain_text
+
+
+@pytest.mark.asyncio
 async def test_quiet_mode_empty_result_shows_header_only(monkeypatch: pytest.MonkeyPatch) -> None:
     """Test that quiet mode shows header only for empty results (no output section)."""
     tool_use_id = "test-empty-result-002"

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -451,6 +451,30 @@ async def test_quiet_mode_bash_panel_redacts_command_secrets(monkeypatch: pytest
 
 
 @pytest.mark.asyncio
+async def test_quiet_mode_bash_panel_redacts_before_truncating(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Secret redaction happens on the complete command before the 200-char slice."""
+    # 'x'*180 + ' token=opaque-test-12345': redaction of the COMPLETE string
+    # lengthens it so the [REDACTED_CREDENTIAL] marker sits at column 194 —
+    # still inside the [:200] slice. A slice-first impl would cut the RAW
+    # string at 200 (mid-secret) and later redaction would print a partial
+    # secret fragment.
+    filler = "x" * 180
+    command = f"{filler} token=opaque-test-12345"
+    tool_use_id = "test-bash-redact-order-1108"
+    events = [
+        ToolStartEvent(id=tool_use_id, name="Bash", input={"command": command}),
+        ToolResultEvent(id=tool_use_id, output="", is_error=False),
+        CostEvent(cost_usd=0.001, input_tokens=None, output_tokens=None),
+        ResultEvent(structured_output=None, continuation=None),
+    ]
+    plain_text = strip_ansi(await render_agent(monkeypatch, events, quiet=True))
+    assert "opaque-test-12345" not in plain_text, "secret must never reach the panel"
+    assert "opaque" not in plain_text, "a partial secret must not survive truncation"
+    assert 'token="[REDA' in plain_text, "the truncated redaction marker must reach the panel"
+    assert "[REDACTED_CREDENTIAL]" not in plain_text, "the complete command must be redacted before slicing"
+
+
+@pytest.mark.asyncio
 async def test_quiet_mode_empty_result_shows_header_only(monkeypatch: pytest.MonkeyPatch) -> None:
     """Test that quiet mode shows header only for empty results (no output section)."""
     tool_use_id = "test-empty-result-002"

--- a/tests/test_log_mode.py
+++ b/tests/test_log_mode.py
@@ -224,6 +224,17 @@ def test_log_mode_redacts_tool_summary_before_200_truncation() -> None:
     assert "[REDACTED" in out
 
 
+def test_log_summary_and_callback_agree_on_bash_primary_field() -> None:
+    """`--log` summary and callback line key Bash from the shared _PRIMARY_TOOL_ARG table."""
+    from daydream.agent import _summarize_input
+    from daydream.ui.tools import _primary_tool_value
+
+    args: dict[str, object] = {"command": "git diff --stat", "description": "Show changes"}
+    assert _summarize_input(args) == "git diff --stat"
+    value, key = _primary_tool_value("Bash", args)
+    assert key == "command", "both surfaces must key Bash from command-first _PRIMARY_TOOL_ARG"
+
+
 def test_log_mode_summaries_redact_structured_credentials() -> None:
     """Log-mode summaries must use the structured redactor, not the flat one.
 

--- a/tests/test_log_mode.py
+++ b/tests/test_log_mode.py
@@ -211,7 +211,7 @@ def test_log_mode_redacts_tool_summary_before_200_truncation() -> None:
     # into it — a redact-after implementation leaks the unmatchable ``ghp_yyyyy``
     # fragment (the ``{6,}`` rule needs 6+ chars after the prefix).
     command = "x" * 190 + " " + "ghp_" + "y" * 8 + "z" * 10   # [:200] cuts into the token
-    out = _summarize_input({"command": command})
+    out = _summarize_input({"command": command}, "Bash")
     assert "ghp_" not in out        # no raw fragment survives the 200-cut
     assert "[REDACTED" in out       # redaction marker (even truncated) present
 
@@ -230,9 +230,26 @@ def test_log_summary_and_callback_agree_on_bash_primary_field() -> None:
     from daydream.ui.tools import _primary_tool_value
 
     args: dict[str, object] = {"command": "git diff --stat", "description": "Show changes"}
-    assert _summarize_input(args) == "git diff --stat"
+    assert _summarize_input(args, "Bash") == "git diff --stat"
     value, key = _primary_tool_value("Bash", args)
     assert key == "command", "both surfaces must key Bash from command-first _PRIMARY_TOOL_ARG"
+
+
+def test_log_summary_task_tools_not_subject_to_bash_primary_table() -> None:
+    """The (command, description) preference is Bash-only in the --log summary.
+
+    TaskCreate/Agent inputs carry a long ``description`` field; the Bash-only pair
+    must not shadow the short ``subject`` the generic fallback surfaces (mirrors
+    ``_derive_task_label``'s subject-before-description ordering).
+    """
+    from daydream.agent import _summarize_input
+
+    args: dict[str, object] = {
+        "subject": "Add rate limiting",
+        "description": "Investigate and implement rate limiting for the API gateway",
+        "prompt": "Add rate limiting",
+    }
+    assert _summarize_input(args, "TaskCreate") == "Add rate limiting"
 
 
 def test_log_mode_summaries_redact_structured_credentials() -> None:
@@ -248,7 +265,7 @@ def test_log_mode_summaries_redact_structured_credentials() -> None:
     from daydream.agent import _print_log, _summarize_input, _summarize_output
 
     # Nested assignment under a sensitive key: flat redaction leaks the token.
-    out = _summarize_input({"command": "the config: token=opaque-test-12345"})
+    out = _summarize_input({"command": "the config: token=opaque-test-12345"}, "Bash")
     assert "opaque-test-12345" not in out
     assert "[REDACTED" in out
 

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -445,3 +445,30 @@ def test_format_callback_progress_bash_shows_command() -> None:
     text = c.export_text()
     assert "git diff --stat" in text
     assert "Show changes" not in text
+
+
+def test_bash_primary_field_consistent_across_three_render_surfaces() -> None:
+    """Issue #1108 acceptance oracle: same input renders the command on all three surfaces."""
+    from io import StringIO
+
+    from rich.console import Console
+
+    from daydream.agent import _summarize_input
+    from daydream.ui.tools import _build_tool_header, format_callback_progress
+
+    args: dict[str, object] = {"command": "git diff --stat"}
+    header = _build_tool_header("Bash", args, quiet_mode=True)
+    c = Console(file=StringIO(), force_terminal=True, width=120, record=True)
+    c.print(header)
+    header_text = c.export_text()
+
+    line = format_callback_progress("Bash", args, None)
+    c2 = Console(file=StringIO(), force_terminal=True, width=120, record=True)
+    c2.print(line)
+    line_text = c2.export_text()
+
+    log_summary = _summarize_input(args)
+
+    assert "git diff --stat" in header_text
+    assert "git diff --stat" in line_text
+    assert log_summary == "git diff --stat"

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -172,6 +172,21 @@ def test_bash_panel_shows_command_drops_mechanical_keys() -> None:
     assert "block" not in out and "timeout" not in out
 
 
+def test_bash_panel_command_truncation_shows_ellipsis() -> None:
+    """A >200-char Bash command is cut with an explicit marker, never silently."""
+    from daydream.ui.tools import _build_tool_header
+
+    header = _build_tool_header("Bash", {"command": "x" * 250}, quiet_mode=False)
+    text = header.plain
+    assert "x" * 200 in text
+    assert "x" * 201 not in text
+    assert text.rstrip().endswith("...")
+
+    # Short commands are never marked.
+    short_header = _build_tool_header("Bash", {"command": "true"}, quiet_mode=False)
+    assert not short_header.plain.rstrip().endswith("...")
+
+
 def _render_panel_text(reg: LiveToolPanelRegistry, tool_use_id: str) -> str:
     from rich.console import Console
 
@@ -432,7 +447,12 @@ def test_primary_tool_value_bash_prefers_command() -> None:
 
 
 def test_format_callback_progress_bash_shows_command() -> None:
-    """Callback single-line path renders the command, not the paraphrase (issue #1108)."""
+    """Callback single-line path renders the command, not the paraphrase (issue #1108).
+
+    The command is redacted before the width slice — the same redact-before-truncate
+    invariant the panel header and --log summary hold, so the callback line cannot
+    print a secret the other surfaces would redact.
+    """
     from io import StringIO
 
     from rich.console import Console
@@ -445,6 +465,13 @@ def test_format_callback_progress_bash_shows_command() -> None:
     text = c.export_text()
     assert "git diff --stat" in text
     assert "Show changes" not in text
+
+    secret_line = format_callback_progress("Bash", {"command": "DB_PASSWORD=hunter2 make db-up"}, None)
+    c3 = Console(file=StringIO(), force_terminal=True, width=120, record=True)
+    c3.print(secret_line)
+    secret_text = c3.export_text()
+    assert "hunter2" not in secret_text
+    assert "DB_PASSWORD=[REDACTED_ENV_VAR]" in secret_text
 
 
 def test_bash_primary_field_consistent_across_three_render_surfaces() -> None:
@@ -472,3 +499,14 @@ def test_bash_primary_field_consistent_across_three_render_surfaces() -> None:
     assert "git diff --stat" in header_text
     assert "git diff --stat" in line_text
     assert log_summary == "git diff --stat"
+
+    # Cap equality: the three surfaces truncate at the shared constant, so the
+    # panel and --log copies can never silently desync (the #1108 oracle pins
+    # key consistency; this pins cap consistency too).
+    from daydream.ui.tools import _BASH_COMMAND_MAX_CHARS
+
+    long_command = "b" * (_BASH_COMMAND_MAX_CHARS + 25)
+    long_header = _build_tool_header("Bash", {"command": long_command}, quiet_mode=True)
+    assert "b" * _BASH_COMMAND_MAX_CHARS in long_header.plain
+    assert long_header.plain.rstrip().endswith("...")
+    assert len(_summarize_input({"command": long_command})) == _BASH_COMMAND_MAX_CHARS

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -417,3 +417,31 @@ async def test_run_agent_callback_path_edit_shows_file_not_bool(tmp_path: Path) 
     joined = "\n".join(line.plain for line in lines)
     assert "/repo/daydream/git_ops.py" in joined  # the meaningful primary arg
     assert "Edit False" not in joined  # the stray-boolean dump is gone
+
+
+def test_primary_tool_value_bash_prefers_command() -> None:
+    """Bash primary arg is `command` (required, always present) over `description`."""
+    from daydream.ui.tools import _primary_tool_value
+
+    value, key = _primary_tool_value("Bash", {"command": "git diff --stat", "description": "Show changes"})
+    assert (value, key) == ("git diff --stat", "command")
+
+    # description-less call still resolves via the table, not the mechanical fallback.
+    value, key = _primary_tool_value("Bash", {"command": "ls -la /tmp"})
+    assert (value, key) == ("ls -la /tmp", "command")
+
+
+def test_format_callback_progress_bash_shows_command() -> None:
+    """Callback single-line path renders the command, not the paraphrase (issue #1108)."""
+    from io import StringIO
+
+    from rich.console import Console
+
+    from daydream.ui.tools import format_callback_progress
+
+    line = format_callback_progress("Bash", {"command": "git diff --stat", "description": "Show changes"}, None)
+    c = Console(file=StringIO(), force_terminal=True, width=120, record=True)
+    c.print(line)
+    text = c.export_text()
+    assert "git diff --stat" in text
+    assert "Show changes" not in text

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -474,6 +474,34 @@ def test_format_callback_progress_bash_shows_command() -> None:
     assert "DB_PASSWORD=[REDACTED_ENV_VAR]" in secret_text
 
 
+def test_format_callback_progress_redacts_only_bash_commands() -> None:
+    """Callback redaction is scoped to the Bash command, like the panel header.
+
+    Paths and grep patterns render raw on the panel header; the callback line
+    must not rewrite the operator's own /home/<user>/ paths into [REDACTED_USER]
+    markers or chew grep patterns into [REDACTED_CREDENTIAL].
+    """
+    from daydream.ui.tools import format_callback_progress
+
+    edit_line = format_callback_progress(
+        "Edit",
+        {"file_path": "/home/user/work/daydream/git_ops.py", "old_string": "a", "new_string": "b"},
+        None,
+    )
+    assert "/home/user/work/daydream/git_ops.py" in edit_line.plain
+    assert "[REDACTED" not in edit_line.plain
+
+    grep_line = format_callback_progress(
+        "Grep", {"pattern": "the config: token=opaque-test-12345", "path": "/home/user/work"}, None
+    )
+    assert "opaque-test-12345" in grep_line.plain
+    assert "[REDACTED" not in grep_line.plain
+
+    bash_line = format_callback_progress("Bash", {"command": "the config: token=opaque-test-12345"}, None)
+    assert "opaque-test-12345" not in bash_line.plain
+    assert "[REDACTED" in bash_line.plain
+
+
 def test_bash_primary_field_consistent_across_three_render_surfaces() -> None:
     """Issue #1108 acceptance oracle: same input renders the command on all three surfaces."""
     from io import StringIO
@@ -494,7 +522,7 @@ def test_bash_primary_field_consistent_across_three_render_surfaces() -> None:
     c2.print(line)
     line_text = c2.export_text()
 
-    log_summary = _summarize_input(args)
+    log_summary = _summarize_input(args, "Bash")
 
     assert "git diff --stat" in header_text
     assert "git diff --stat" in line_text
@@ -509,4 +537,6 @@ def test_bash_primary_field_consistent_across_three_render_surfaces() -> None:
     long_header = _build_tool_header("Bash", {"command": long_command}, quiet_mode=True)
     assert "b" * _BASH_COMMAND_MAX_CHARS in long_header.plain
     assert long_header.plain.rstrip().endswith("...")
-    assert len(_summarize_input({"command": long_command})) == _BASH_COMMAND_MAX_CHARS
+    long_line = format_callback_progress("Bash", {"command": long_command}, None)
+    assert "b" * _BASH_COMMAND_MAX_CHARS in long_line.plain
+    assert len(_summarize_input({"command": long_command}, "Bash")) == _BASH_COMMAND_MAX_CHARS


### PR DESCRIPTION
## Summary
- Bash tool panels in quiet mode rendered only the description (or nothing at all), hiding the command that actually ran — the Bash panel was the only one missing its identifying argument.
- Prefer the command itself as the primary arg for Bash in the shared tool-arg table (`e3c183a`), and render the redacted, truncated command in the quiet-mode Bash panel (`843744e`).
- Round-2 daydream review fix: scope tool summaries and redaction by tool name (`_summarize_input` keyed by tool name; callback redaction scoped to Bash; callback max_len=`_BASH_COMMAND_MAX_CHARS`) — `0eb78c4`.

## Test Plan
- New tests pin redact-before-slice ordering for quiet Bash panel commands
- Rendering consistency pinned across panel, callback, and --log surfaces
- Two sequential daydream deep-precision review rounds passed (rounds on fresh VMs, trajectories on HF)

Closes #1108