### PR TITLE
feat(backends): snapshot source local branch refs into read-only clones (#1121)

### DIFF
--- a/daydream/backends/codex.py
+++ b/daydream/backends/codex.py
@@ -77,10 +77,17 @@ def _prepare_read_only_checkout(source: Path, destination: Path) -> Path:
     # the remote is removed: after a plain clone the clone only exposes the
     # source's checked-out branch under refs/heads/* (the rest exist only as
     # refs/remotes/origin/*), so re-create each same-named ref by explicit OID
-    # — never a symbolic ref — with update_ref's validation as the gate. Any
-    # GitError propagates fail-closed: no half-snapshotted clone is used.
-    for name, oid in git_ops.list_local_branches(source).items():
-        git_ops.update_ref(destination, f"refs/heads/{name}", oid)
+    # — never a symbolic ref — with update_refs' validation as the gate. All
+    # branches go through one `git update-ref --stdin` transaction, so prep
+    # costs a single git call regardless of branch count, and any GitError
+    # (invalid name, failed transaction) propagates fail-closed: no
+    # half-snapshotted clone is used.
+    branches = git_ops.list_local_branches(source)
+    if branches:
+        git_ops.update_refs(
+            destination,
+            {f"refs/heads/{name}": oid for name, oid in branches.items()},
+        )
     git_ops.remove_remote(destination)
     # ls-files and ls-files --others --exclude-standard are disjoint by
     # construction, so one loop covers both. Enumerate strictly so a mid-prep

--- a/daydream/backends/codex.py
+++ b/daydream/backends/codex.py
@@ -66,9 +66,21 @@ def _prepare_read_only_checkout(source: Path, destination: Path) -> Path:
     Raises:
         GitError / OSError / shutil.Error: Underlying git or filesystem
             failure; the caller wraps these in ``CodexError``.
+
+    Local branch refs are snapshotted by OID from the source so base-branch
+    names resolve and ``git diff <base>...HEAD`` works inside the clone,
+    without keeping any remote.
     """
     git_ops.clone(str(source), destination)
     git_ops.checkout_detach(destination, git_ops.head_sha(source))
+    # Snapshot every source local branch (name -> OID) into the clone before
+    # the remote is removed: after a plain clone the clone only exposes the
+    # source's checked-out branch under refs/heads/* (the rest exist only as
+    # refs/remotes/origin/*), so re-create each same-named ref by explicit OID
+    # — never a symbolic ref — with update_ref's validation as the gate. Any
+    # GitError propagates fail-closed: no half-snapshotted clone is used.
+    for name, oid in git_ops.list_local_branches(source).items():
+        git_ops.update_ref(destination, f"refs/heads/{name}", oid)
     git_ops.remove_remote(destination)
     # ls-files and ls-files --others --exclude-standard are disjoint by
     # construction, so one loop covers both. Enumerate strictly so a mid-prep

--- a/daydream/git_ops.py
+++ b/daydream/git_ops.py
@@ -335,6 +335,7 @@ def _run_git(
     timeout: int = 5,
     capture_bytes: Literal[True],
     retries: int = _GIT_TIMEOUT_RETRIES,
+    input_text: str | None = None,
     env_cmd: Any | None = None,
 ) -> subprocess.CompletedProcess[bytes]:
     """Binary-capture variant: ``capture_bytes=True`` reads bytes stdout."""
@@ -348,6 +349,7 @@ def _run_git(
     timeout: int = 5,
     capture_bytes: Literal[False] = False,
     retries: int = _GIT_TIMEOUT_RETRIES,
+    input_text: str | None = None,
     env_cmd: Any | None = None,
 ) -> subprocess.CompletedProcess[str]:
     """Text-capture variant (the default): decoded ``str`` stdout."""
@@ -360,12 +362,16 @@ def _run_git(
     timeout: int = 5,
     capture_bytes: bool = False,
     retries: int = _GIT_TIMEOUT_RETRIES,
+    input_text: str | None = None,
     env_cmd: Any | None = None,
 ) -> subprocess.CompletedProcess[Any]:
     """Run ``git`` in *repo* with hardened defaults.
 
     Args:
         capture_bytes: When True, capture stdout/stderr as bytes (no decoding).
+        input_text: Optional text piped to the subprocess on **stdin** (used
+            for ``git update-ref --stdin`` batch transactions whose payload
+            cannot express the whole ref set on argv).
         retries: How many additional attempts to make after a
             :class:`subprocess.TimeoutExpired` (total attempts = ``retries + 1``).
             Only timeouts are retried; other failures raise immediately.
@@ -398,6 +404,7 @@ def _run_git(
                 timeout=timeout,
                 shell=False,
                 check=False,
+                input=input_text,
                 env=env_cmd,
             )
         except subprocess.TimeoutExpired as exc:
@@ -1697,10 +1704,11 @@ def update_ref(repo: Path, ref: str, oid: str) -> None:
     * *ref* is checked with ``git check-ref-format`` (git's own ref-format
       authority), plus two Python-side guards git cannot express: names
       beginning with ``-`` (git would parse them as options, never as a ref)
-      and names whose final component ends in ``lock`` (case-insensitive, so
-      both ``.lock`` — forbidden by git — and ``xLock``-style lock-file
-      lookalikes are rejected). Anything invalid raises ``GitError`` without
-      invoking ``update-ref``.
+      and names whose final component ends in the literal ``.lock`` suffix
+      (case-insensitive — git forbids exactly that suffix, so ``unlock``,
+      ``block``, ``deadlock`` and ``xLock`` are valid names and snapshot
+      cleanly, while ``topic.lock``/``topic.LOCK`` stay rejected). Anything
+      invalid raises ``GitError`` without invoking ``update-ref``.
 
     * *oid* must be a full 40-character hex object ID (upper- or lowercase);
       anything else raises ``GitError`` and is never passed through to git.
@@ -1715,14 +1723,49 @@ def update_ref(repo: Path, ref: str, oid: str) -> None:
         raise GitError(f"invalid OID: {oid}")
     if ref.startswith("-"):
         raise GitError(f"invalid ref name: {ref}")
-    if ref.rsplit("/", 1)[-1].lower().endswith("lock"):
+    if ref.rsplit("/", 1)[-1].lower().endswith(".lock"):
         raise GitError(f"invalid ref name: {ref}")
-    proc = _run_git(repo, ["check-ref-format", ref], timeout=10, retries=0)
+    # check-ref-format is a read-only query, so it inherits the retrying
+    # default; only the update-ref mutation below passes retries=0.
+    proc = _run_git(repo, ["check-ref-format", ref], timeout=10)
     if proc.returncode != 0:
         raise GitError(f"invalid ref name: {ref}")
     proc = _run_git(repo, ["update-ref", ref, oid], timeout=10, retries=0)
     if proc.returncode != 0:
         raise GitError(f"git update-ref {ref} failed in {repo}: {proc.stderr.strip()}")
+
+
+def update_refs(repo: Path, ref_oids: dict[str, str]) -> None:
+    """Point many *ref* -> *oid* pairs at once (``git update-ref --stdin``).
+
+    Fail-closed mutating wrapper for the branch-snapshot loop — ``retries=0``
+    so a timed-out ref mutation is never re-run. Every pair is validated
+    **before** any shell-out with the same Python-side guards as
+    :func:`update_ref` (full 40-hex OID; ref must not start with ``-``; final
+    component must not end in the literal ``.lock`` suffix, case-insensitive).
+    Git's own ref-format validation — the same authority ``check-ref-format``
+    consults — then gates the whole batch as a single transaction, so either
+    every ref is written or (if any line is invalid) none are: a half-written
+    snapshot is never produced. An empty *ref_oids* is a no-op.
+
+    Raises:
+        GitError: If any ref or OID is invalid or the batch fails.
+    """
+    if not ref_oids:
+        return
+    for ref, oid in ref_oids.items():
+        if _OBJECT_ID_RE.fullmatch(oid) is None:
+            raise GitError(f"invalid OID: {oid}")
+        if ref.startswith("-"):
+            raise GitError(f"invalid ref name: {ref}")
+        if ref.rsplit("/", 1)[-1].lower().endswith(".lock"):
+            raise GitError(f"invalid ref name: {ref}")
+    lines = "".join(f"update {ref} {oid}\n" for ref, oid in ref_oids.items())
+    proc = _run_git(
+        repo, ["update-ref", "--stdin"], timeout=30, retries=0, input_text=lines
+    )
+    if proc.returncode != 0:
+        raise GitError(f"git update-ref --stdin failed in {repo}: {proc.stderr.strip()}")
 
 
 def apply_staged_patch(repo: Path, patch: bytes) -> None:

--- a/daydream/git_ops.py
+++ b/daydream/git_ops.py
@@ -1685,6 +1685,46 @@ def remove_remote(repo: Path, remote: str = "origin") -> None:
         raise GitError(f"git remote remove {remote} failed in {repo}: {proc.stderr.strip()}")
 
 
+_OBJECT_ID_RE = re.compile(r"[0-9a-fA-F]{40}")
+
+
+def update_ref(repo: Path, ref: str, oid: str) -> None:
+    """Point *ref* at the explicit *oid* in *repo* (``git update-ref <ref> <oid>``).
+
+    Fail-closed mutating wrapper — ``retries=0`` so a timed-out ref mutation is
+    never re-run. Both arguments are validated **before** any shell-out:
+
+    * *ref* is checked with ``git check-ref-format`` (git's own ref-format
+      authority), plus two Python-side guards git cannot express: names
+      beginning with ``-`` (git would parse them as options, never as a ref)
+      and names whose final component ends in ``lock`` (case-insensitive, so
+      both ``.lock`` — forbidden by git — and ``xLock``-style lock-file
+      lookalikes are rejected). Anything invalid raises ``GitError`` without
+      invoking ``update-ref``.
+
+    * *oid* must be a full 40-character hex object ID (upper- or lowercase);
+      anything else raises ``GitError`` and is never passed through to git.
+
+    The ``update-ref`` subprocess never substitutes a fallback value: a
+    non-zero exit raises ``GitError`` with git's stderr.
+
+    Raises:
+        GitError: If *ref* or *oid* is invalid or ``git update-ref`` fails.
+    """
+    if _OBJECT_ID_RE.fullmatch(oid) is None:
+        raise GitError(f"invalid OID: {oid}")
+    if ref.startswith("-"):
+        raise GitError(f"invalid ref name: {ref}")
+    if ref.rsplit("/", 1)[-1].lower().endswith("lock"):
+        raise GitError(f"invalid ref name: {ref}")
+    proc = _run_git(repo, ["check-ref-format", ref], timeout=10, retries=0)
+    if proc.returncode != 0:
+        raise GitError(f"invalid ref name: {ref}")
+    proc = _run_git(repo, ["update-ref", ref, oid], timeout=10, retries=0)
+    if proc.returncode != 0:
+        raise GitError(f"git update-ref {ref} failed in {repo}: {proc.stderr.strip()}")
+
+
 def apply_staged_patch(repo: Path, patch: bytes) -> None:
     """Apply a staged index patch to *repo*'s index (``git apply --cached --binary``).
 

--- a/daydream/git_ops.py
+++ b/daydream/git_ops.py
@@ -550,6 +550,36 @@ def head_sha(repo: Path) -> str:
     return proc.stdout.strip()
 
 
+def list_local_branches(repo: Path) -> dict[str, str]:
+    """Return a snapshot of local branch names mapped to their full OIDs.
+
+    Read-only. Runs ``git for-each-ref refs/heads`` and parses each output
+    line into ``short_name -> full OID``. An empty dict is returned only when
+    the repository genuinely has zero local branches and git exits 0; any
+    non-zero return code raises.
+
+    Raises:
+        GitError: If ``git for-each-ref`` fails (e.g. *repo* is not a
+            repository).
+    """
+    proc = _run_git(
+        repo,
+        ["for-each-ref", "refs/heads", "--format=%(refname:short) %(objectname)"],
+        timeout=10,
+    )
+    if proc.returncode != 0:
+        raise GitError(
+            f"cannot list local branches in {repo}: {proc.stderr.strip()}",
+        )
+    branches: dict[str, str] = {}
+    for line in proc.stdout.splitlines():
+        if not line.strip():
+            continue
+        name, _, oid = line.strip().partition(" ")
+        branches[name] = oid
+    return branches
+
+
 def head_commit_message(repo: Path) -> str:
     """Return the full commit message of ``HEAD``.
 

--- a/daydream/git_ops.py
+++ b/daydream/git_ops.py
@@ -371,7 +371,9 @@ def _run_git(
         capture_bytes: When True, capture stdout/stderr as bytes (no decoding).
         input_text: Optional text piped to the subprocess on **stdin** (used
             for ``git update-ref --stdin`` batch transactions whose payload
-            cannot express the whole ref set on argv).
+            cannot express the whole ref set on argv). Encoded to UTF-8 when
+            *capture_bytes* is set so the binary variant never feeds ``str``
+            to the subprocess.
         retries: How many additional attempts to make after a
             :class:`subprocess.TimeoutExpired` (total attempts = ``retries + 1``).
             Only timeouts are retried; other failures raise immediately.
@@ -404,7 +406,14 @@ def _run_git(
                 timeout=timeout,
                 shell=False,
                 check=False,
-                input=input_text,
+                # capture_bytes=True reads bytes stdout/stderr, so a str
+                # input_text must be encoded: subprocess.run raises a raw
+                # TypeError for str input with text=False.
+                input=(
+                    input_text.encode("utf-8")
+                    if capture_bytes and input_text is not None
+                    else input_text
+                ),
                 env=env_cmd,
             )
         except subprocess.TimeoutExpired as exc:
@@ -1695,6 +1704,33 @@ def remove_remote(repo: Path, remote: str = "origin") -> None:
 _OBJECT_ID_RE = re.compile(r"[0-9a-fA-F]{40}")
 
 
+def _validate_ref_oid_pair(ref: str, oid: str) -> None:
+    """Validate one *ref* -> *oid* pair with the shared fail-closed guards.
+
+    Every ref-writing mutator runs these checks **before** any shell-out, so
+    the two mutators (:func:`update_ref` and :func:`update_refs`) can never
+    drift apart. In order: *oid* must be a full 40-hex object ID; *ref* must
+    not start with ``-`` (git would parse it as an option, never as a ref);
+    *ref*'s final component must not end in the literal lowercase ``.lock``
+    suffix — git's own rule, which accepts case-variants like
+    ``release.LOCK``/``x.lOck``, so those stay valid; and *ref* must not
+    contain whitespace or control characters (the ``check-ref-format`` rules
+    that, in the batch variant, would otherwise split a line or smuggle extra
+    ``update`` lines into the ``update-ref --stdin`` payload).
+
+    Raises:
+        GitError: If *ref* or *oid* is invalid, naming the offender.
+    """
+    if _OBJECT_ID_RE.fullmatch(oid) is None:
+        raise GitError(f"invalid OID: {oid}")
+    if ref.startswith("-"):
+        raise GitError(f"invalid ref name: {ref}")
+    if ref.rsplit("/", 1)[-1].endswith(".lock"):
+        raise GitError(f"invalid ref name: {ref}")
+    if any(ord(ch) <= 0x20 or ord(ch) == 0x7F for ch in ref):
+        raise GitError(f"invalid ref name: {ref}")
+
+
 def update_ref(repo: Path, ref: str, oid: str) -> None:
     """Point *ref* at the explicit *oid* in *repo* (``git update-ref <ref> <oid>``).
 
@@ -1702,13 +1738,16 @@ def update_ref(repo: Path, ref: str, oid: str) -> None:
     never re-run. Both arguments are validated **before** any shell-out:
 
     * *ref* is checked with ``git check-ref-format`` (git's own ref-format
-      authority), plus two Python-side guards git cannot express: names
-      beginning with ``-`` (git would parse them as options, never as a ref)
-      and names whose final component ends in the literal ``.lock`` suffix
-      (case-insensitive — git forbids exactly that suffix, so ``unlock``,
-      ``block``, ``deadlock`` and ``xLock`` are valid names and snapshot
-      cleanly, while ``topic.lock``/``topic.LOCK`` stay rejected). Anything
-      invalid raises ``GitError`` without invoking ``update-ref``.
+      authority), plus the shared Python-side guards of
+      :func:`_validate_ref_oid_pair` (also used by :func:`update_refs`):
+      names beginning with ``-`` (git would parse them as options, never as a
+      ref), names whose final component ends in the literal lowercase
+      ``.lock`` suffix — git forbids exactly that, so ``unlock``, ``block``,
+      ``deadlock`` and ``xLock`` are valid names and snapshot cleanly, while
+      ``topic.lock`` stays rejected and case-variants git accepts
+      (``topic.LOCK``, ``x.lOck``, ``release.LOCK``) stay valid — and names
+      containing whitespace or control characters. Anything invalid raises
+      ``GitError`` without invoking ``update-ref``.
 
     * *oid* must be a full 40-character hex object ID (upper- or lowercase);
       anything else raises ``GitError`` and is never passed through to git.
@@ -1719,12 +1758,7 @@ def update_ref(repo: Path, ref: str, oid: str) -> None:
     Raises:
         GitError: If *ref* or *oid* is invalid or ``git update-ref`` fails.
     """
-    if _OBJECT_ID_RE.fullmatch(oid) is None:
-        raise GitError(f"invalid OID: {oid}")
-    if ref.startswith("-"):
-        raise GitError(f"invalid ref name: {ref}")
-    if ref.rsplit("/", 1)[-1].lower().endswith(".lock"):
-        raise GitError(f"invalid ref name: {ref}")
+    _validate_ref_oid_pair(ref, oid)
     # check-ref-format is a read-only query, so it inherits the retrying
     # default; only the update-ref mutation below passes retries=0.
     proc = _run_git(repo, ["check-ref-format", ref], timeout=10)
@@ -1740,13 +1774,16 @@ def update_refs(repo: Path, ref_oids: dict[str, str]) -> None:
 
     Fail-closed mutating wrapper for the branch-snapshot loop — ``retries=0``
     so a timed-out ref mutation is never re-run. Every pair is validated
-    **before** any shell-out with the same Python-side guards as
-    :func:`update_ref` (full 40-hex OID; ref must not start with ``-``; final
-    component must not end in the literal ``.lock`` suffix, case-insensitive).
-    Git's own ref-format validation — the same authority ``check-ref-format``
-    consults — then gates the whole batch as a single transaction, so either
-    every ref is written or (if any line is invalid) none are: a half-written
-    snapshot is never produced. An empty *ref_oids* is a no-op.
+    **before** any shell-out with the same shared guards as
+    :func:`update_ref` via :func:`_validate_ref_oid_pair` (full 40-hex OID;
+    ref must not start with ``-``; final component must not end in the literal
+    ``.lock`` suffix — git's own rule, which accepts case-variants like
+    ``topic.LOCK``/``x.lOck`` so those stay valid; no whitespace or control
+    characters in the ref). Git's own ref-format validation — the same authority
+    ``check-ref-format`` consults — then gates the whole batch as a single
+    transaction, so either every ref is written or (if any line is invalid)
+    none are: a half-written snapshot is never produced. An empty *ref_oids*
+    is a no-op.
 
     Raises:
         GitError: If any ref or OID is invalid or the batch fails.
@@ -1754,12 +1791,7 @@ def update_refs(repo: Path, ref_oids: dict[str, str]) -> None:
     if not ref_oids:
         return
     for ref, oid in ref_oids.items():
-        if _OBJECT_ID_RE.fullmatch(oid) is None:
-            raise GitError(f"invalid OID: {oid}")
-        if ref.startswith("-"):
-            raise GitError(f"invalid ref name: {ref}")
-        if ref.rsplit("/", 1)[-1].lower().endswith(".lock"):
-            raise GitError(f"invalid ref name: {ref}")
+        _validate_ref_oid_pair(ref, oid)
     lines = "".join(f"update {ref} {oid}\n" for ref, oid in ref_oids.items())
     proc = _run_git(
         repo, ["update-ref", "--stdin"], timeout=30, retries=0, input_text=lines

--- a/tests/test_backend_codex.py
+++ b/tests/test_backend_codex.py
@@ -4,6 +4,7 @@
 import asyncio
 import json
 import logging
+import subprocess
 from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -281,6 +282,64 @@ async def test_codex_read_only_uses_read_only_sandbox(
     assert str(source).encode() not in written
     # Temp dir removed after execute.
     assert not isolated.exists()
+
+
+@pytest.mark.asyncio
+async def test_codex_read_only_snapshot_all_branches_diff_and_source_immutable(
+    tmp_path: Path, linked_worktree: tuple[Path, Path],
+) -> None:
+    """Issue #1121: a source with >=3 branches (incl. a slash name) snapshots
+    ALL of them into the clone by OID; git diff <base>...HEAD works; the
+    clone has no remote and no source path in its config; ref mutation in
+    the clone cannot alter the source's HEAD, refs, or index."""
+    _main, source = linked_worktree
+    # Third branch with a slash-containing name, branched off main.
+    _git(source, "branch", "release/9.9", "main")
+    source_branches = git_ops.list_local_branches(source)
+    assert set(source_branches) == {"main", "feature", "release/9.9"}
+    head_before = git_ops.head_sha(source)
+
+    captured: dict[str, Any] = {}
+    mock_proc = make_mock_process_from_fixture("simple_text.jsonl")
+
+    async def fake_exec(*args: Any, **kwargs: Any) -> Any:
+        isolated = Path(list(args)[list(args).index("--cd") + 1])
+        captured["branches"] = git_ops.list_local_branches(isolated)
+        # git diff main...HEAD must succeed inside the clone (the exact
+        # command from the archived failure: 'ambiguous argument main...HEAD').
+        captured["diff_rc"] = subprocess.run(
+            ["git", "diff", "main...HEAD", "--stat"], cwd=isolated,
+            capture_output=True, text=True,
+        ).returncode
+        captured["diff_feature_rc"] = subprocess.run(
+            ["git", "diff", "release/9.9...HEAD", "--stat"], cwd=isolated,
+            capture_output=True, text=True,
+        ).returncode
+        captured["head"] = git_ops.head_sha(isolated)
+        captured["config"] = subprocess.run(
+            ["git", "config", "--local", "--list"], cwd=isolated,
+            capture_output=True, text=True,
+        ).stdout
+        # Source-immutability sentinel: mutate a ref inside the clone, then
+        # verify the source's refs and HEAD are untouched.
+        git_ops.update_ref(isolated, "refs/heads/main", git_ops.head_sha(isolated))
+        return mock_proc
+
+    with patch("daydream.backends._transport.asyncio.create_subprocess_exec", fake_exec):
+        async for _ in CodexBackend(model="fixture-model").execute(
+            source, "Audit repository", read_only=True,
+        ):
+            pass
+
+    assert captured["branches"] == source_branches  # all names, exact OIDs
+    assert captured["head"] == head_before  # still detached at source HEAD
+    assert captured["diff_rc"] == 0
+    assert captured["diff_feature_rc"] == 0
+    assert "remote" not in captured["config"]
+    assert str(source) not in captured["config"]
+    # Source untouched by the in-clone ref mutation.
+    assert git_ops.head_sha(source) == head_before
+    assert git_ops.list_local_branches(source) == source_branches
 
 
 @pytest.mark.asyncio

--- a/tests/test_backend_codex.py
+++ b/tests/test_backend_codex.py
@@ -383,7 +383,7 @@ async def test_codex_read_only_snapshot_failure_is_fail_closed(
     def boom(*args: Any, **kwargs: Any) -> None:
         raise git_ops.GitError("snapshot ref failure")
 
-    monkeypatch.setattr("daydream.backends.codex.git_ops.update_ref", boom)
+    monkeypatch.setattr("daydream.backends.codex.git_ops.update_refs", boom)
     mock_proc = make_mock_process_from_fixture("simple_text.jsonl")
     with patch("daydream.backends._transport.asyncio.create_subprocess_exec", return_value=mock_proc) as exec_mock:
         with pytest.raises(CodexError, match="failed to create disposable read-only checkout"):

--- a/tests/test_backend_codex.py
+++ b/tests/test_backend_codex.py
@@ -246,6 +246,8 @@ async def test_codex_read_only_uses_read_only_sandbox(
         captured["has_notes"] = (isolated / "notes.md").exists()
         captured["notes"] = (isolated / "notes.md").read_text() if captured["has_notes"] else None
         captured["remote"] = git_ops.remote_url(isolated)
+        captured["branches"] = git_ops.list_local_branches(isolated)
+        captured["source_branches"] = git_ops.list_local_branches(source)
         captured["args"] = flat
         return mock_proc
 
@@ -267,6 +269,11 @@ async def test_codex_read_only_uses_read_only_sandbox(
     assert captured["has_notes"] is True
     assert captured["notes"] == notes.read_text()
     assert captured["remote"] is None
+    # Issue #1121: every source local branch resolves in the clone by name,
+    # to the exact OID it had on the source at snapshot time.
+    assert captured["branches"] == captured["source_branches"]
+    assert "main" in captured["branches"]
+    assert "feature" in captured["branches"]
     # Prompt rebound: isolated path present, source path absent in stdin bytes.
     written = mock_proc.stdin.write.call_args.args[0]
     assert isinstance(written, bytes)

--- a/tests/test_backend_codex.py
+++ b/tests/test_backend_codex.py
@@ -371,6 +371,30 @@ async def test_codex_read_only_isolation_failure_is_fail_closed(
     assert git_ops.staged_patch(source) == before_patch
 
 
+@pytest.mark.asyncio
+async def test_codex_read_only_snapshot_failure_is_fail_closed(
+    tmp_path: Path, linked_worktree: tuple[Path, Path], monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A GitError during branch snapshotting aborts preparation: CodexError
+    raised, no codex process launched, source git state untouched."""
+    _main, source = linked_worktree
+    before_head = git_ops.head_sha(source)
+
+    def boom(*args: Any, **kwargs: Any) -> None:
+        raise git_ops.GitError("snapshot ref failure")
+
+    monkeypatch.setattr("daydream.backends.codex.git_ops.update_ref", boom)
+    mock_proc = make_mock_process_from_fixture("simple_text.jsonl")
+    with patch("daydream.backends._transport.asyncio.create_subprocess_exec", return_value=mock_proc) as exec_mock:
+        with pytest.raises(CodexError, match="failed to create disposable read-only checkout"):
+            async for _ in CodexBackend(model="fixture-model").execute(
+                source, "Audit repository", read_only=True,
+            ):
+                pass
+    exec_mock.assert_not_called()
+    assert git_ops.head_sha(source) == before_head
+
+
 def test_rebind_source_paths_preserves_sibling_paths() -> None:
     """The prompt rebind is anchored at path boundaries (issues #1/#9): sibling
     paths that merely share the source prefix survive, while sub-paths, the exact

--- a/tests/test_git_ops.py
+++ b/tests/test_git_ops.py
@@ -893,6 +893,19 @@ def test_run_git_timeout_retry_behavior(monkeypatch: pytest.MonkeyPatch, tmp_pat
     assert calls["n"] == 1  # no retries for non-timeout failures
 
 
+def test_run_git_encodes_input_text_when_capturing_bytes(tmp_path: Path) -> None:
+    """`_run_git(capture_bytes=True, input_text=...)` encodes the payload to
+    bytes: subprocess.run raises a raw TypeError for str input with text=False,
+    which in a retry loop would mask a genuine git failure."""
+    repo = _make_repo_with_main(tmp_path)
+    bytes_proc = git_ops._run_git(
+        repo, ["hash-object", "--stdin"], capture_bytes=True, input_text="abc\n"
+    )
+    text_proc = git_ops._run_git(repo, ["hash-object", "--stdin"], input_text="abc\n")
+    assert bytes_proc.returncode == 0
+    assert bytes_proc.stdout == text_proc.stdout.encode()
+
+
 @pytest.mark.parametrize(
     "operation",
     [
@@ -1590,11 +1603,13 @@ def test_update_ref_sets_explicit_oid(tmp_path: Path) -> None:
 
 
 def test_update_ref_accepts_names_merely_ending_in_lock(tmp_path: Path) -> None:
-    """git forbids only the literal ``.lock`` component suffix, so branches
-    like unlock/block/deadlock/xLock are valid refs and snapshot cleanly."""
+    """git forbids only the literal lowercase ``.lock`` component suffix, so
+    branches like unlock/block/deadlock/xLock as well as case-variants git
+    accepts (topic.LOCK, release.LOCK, x.lOck) are valid refs and snapshot
+    cleanly."""
     repo = _make_repo_with_main(tmp_path, name="update_ref_lockish")
     oid = _git(repo, "rev-parse", "HEAD")
-    for name in ("unlock", "block", "deadlock", "xLock"):
+    for name in ("unlock", "block", "deadlock", "xLock", "topic.LOCK", "release.LOCK", "x.lOck"):
         ref = f"refs/heads/{name}"
         git_ops.update_ref(repo, ref, oid)
         assert _git(repo, "rev-parse", ref) == oid
@@ -1605,20 +1620,28 @@ def test_update_refs_snapshots_a_batch_and_aborts_atomically(tmp_path: Path) -> 
     ref aborts the whole batch: nothing is written."""
     repo = _make_repo_with_main(tmp_path, name="update_refs")
     oid = _git(repo, "rev-parse", "HEAD")
-    good = {f"refs/heads/{name}": oid for name in ("main", "unlock", "release/9.9")}
+    good = {f"refs/heads/{name}": oid for name in ("main", "unlock", "release/9.9", "topic.LOCK")}
     git_ops.update_refs(repo, good)
     for ref, expected in good.items():
         assert _git(repo, "rev-parse", ref) == expected
 
     with pytest.raises(git_ops.GitError, match="git update-ref --stdin failed"):
-        git_ops.update_refs(repo, {"refs/heads/ok": oid, "refs/heads/bad name": oid})
+        # ".." passes the Python guards but git rejects it, so the whole
+        # batch still aborts atomically on git's side: nothing is written.
+        git_ops.update_refs(repo, {"refs/heads/ok": oid, "refs/heads/foo..bar": oid})
     assert "ok" not in git_ops.list_local_branches(repo)  # whole batch rolled back
 
 
 def test_update_ref_rejects_invalid_ref_name(tmp_path: Path) -> None:
     repo = _make_repo_with_main(tmp_path, name="update_ref_bad")
     oid = git_ops.head_sha(repo)
-    for bad in ("refs/heads/..", "refs/heads/foo bar", "-dash-start", "refs/heads/topic.lock"):
+    for bad in (
+        "refs/heads/..",
+        "refs/heads/foo bar",
+        "refs/heads/bad\nname",
+        "-dash-start",
+        "refs/heads/topic.lock",
+    ):
         with pytest.raises(git_ops.GitError, match="invalid ref name"):
             git_ops.update_ref(repo, bad, oid)
 
@@ -1627,6 +1650,21 @@ def test_update_ref_rejects_malformed_oid(tmp_path: Path) -> None:
     repo = _make_repo_with_main(tmp_path, name="update_ref_badoid")
     with pytest.raises(git_ops.GitError, match="invalid OID"):
         git_ops.update_ref(repo, "refs/heads/newbranch", "not-a-sha")
+
+
+def test_update_refs_rejects_injectable_ref_names_before_shell_out(tmp_path: Path) -> None:
+    """update_refs rejects refs carrying whitespace/control characters up
+    front, naming the ref, so a newline can never smuggle extra ``update``
+    lines into the stdin payload; a malformed OID is rejected the same way."""
+    repo = _make_repo_with_main(tmp_path, name="update_refs_inject")
+    oid = git_ops.head_sha(repo)
+    for bad in ("refs/heads/bad\nname", "refs/heads/two words", "-dash-start"):
+        with pytest.raises(git_ops.GitError, match="invalid ref name"):
+            git_ops.update_refs(repo, {bad: oid})
+    with pytest.raises(git_ops.GitError, match="invalid OID"):
+        git_ops.update_refs(repo, {"refs/heads/ok": "not-a-sha"})
+    assert "bad" not in git_ops.list_local_branches(repo)
+    assert "two" not in git_ops.list_local_branches(repo)
 
 
 def test_staged_patch_round_trips_index_state(tmp_path: Path) -> None:

--- a/tests/test_git_ops.py
+++ b/tests/test_git_ops.py
@@ -118,6 +118,26 @@ def test_default_branch_falls_back_to_main(tmp_path: Path) -> None:
     assert git_ops.default_branch(repo) == "main"
 
 
+def test_list_local_branches_maps_names_to_oids(tmp_path: Path) -> None:
+    repo = _make_repo_with_main(tmp_path, name="list_branches")
+    _git(repo, "checkout", "-b", "feat/slash-name")
+    (repo / "feature.txt").write_text("feature\n")
+    _git(repo, "add", "feature.txt")
+    _commit(repo, "on feature")
+    _git(repo, "checkout", "main")
+
+    branches = git_ops.list_local_branches(repo)
+
+    assert set(branches) == {"main", "feat/slash-name"}
+    assert branches["main"] == git_ops.head_sha(repo)  # main is checked out here
+    assert branches["feat/slash-name"] == _git(repo, "rev-parse", "feat/slash-name")
+
+
+def test_list_local_branches_raises_on_failure(tmp_path: Path) -> None:
+    with pytest.raises(git_ops.GitError):
+        git_ops.list_local_branches(tmp_path / "not-a-repo")
+
+
 @pytest.mark.parametrize(
     ("init_branch", "expected"),
     [

--- a/tests/test_git_ops.py
+++ b/tests/test_git_ops.py
@@ -1571,20 +1571,54 @@ def test_remove_remote_deletes_configured_remote(tmp_path: Path) -> None:
     assert git_ops.head_sha(clone) == before
 
 
-def test_update_ref_sets_explicit_oid_and_rejects_bad_names(tmp_path: Path) -> None:
+def test_update_ref_sets_explicit_oid(tmp_path: Path) -> None:
+    """update_ref repoints an existing ref to a *different* OID: the ref is
+    seeded to HEAD and repointed at a newer commit, so a no-op write path
+    cannot satisfy the assertion."""
     repo = _make_repo_with_main(tmp_path, name="update_ref")
-    other = _git(repo, "rev-parse", "HEAD")  # any valid OID in this repo
-    _git(repo, "update-ref", "refs/heads/scratch", other)  # seed a ref to repoint
+    start = _git(repo, "rev-parse", "HEAD")
+    _git(repo, "update-ref", "refs/heads/scratch", start)  # seed a ref to repoint
+    (repo / "second.txt").write_text("second\n")
+    _git(repo, "add", "second.txt")
+    _commit(repo, "second")  # HEAD moves, so update_ref must write a new OID
+    target = _git(repo, "rev-parse", "HEAD")
+    assert target != start
 
-    git_ops.update_ref(repo, "refs/heads/scratch", other)
+    git_ops.update_ref(repo, "refs/heads/scratch", target)
 
-    assert _git(repo, "rev-parse", "refs/heads/scratch") == other
+    assert _git(repo, "rev-parse", "refs/heads/scratch") == target
+
+
+def test_update_ref_accepts_names_merely_ending_in_lock(tmp_path: Path) -> None:
+    """git forbids only the literal ``.lock`` component suffix, so branches
+    like unlock/block/deadlock/xLock are valid refs and snapshot cleanly."""
+    repo = _make_repo_with_main(tmp_path, name="update_ref_lockish")
+    oid = _git(repo, "rev-parse", "HEAD")
+    for name in ("unlock", "block", "deadlock", "xLock"):
+        ref = f"refs/heads/{name}"
+        git_ops.update_ref(repo, ref, oid)
+        assert _git(repo, "rev-parse", ref) == oid
+
+
+def test_update_refs_snapshots_a_batch_and_aborts_atomically(tmp_path: Path) -> None:
+    """update_refs writes many refs in one transactional git call, and a bad
+    ref aborts the whole batch: nothing is written."""
+    repo = _make_repo_with_main(tmp_path, name="update_refs")
+    oid = _git(repo, "rev-parse", "HEAD")
+    good = {f"refs/heads/{name}": oid for name in ("main", "unlock", "release/9.9")}
+    git_ops.update_refs(repo, good)
+    for ref, expected in good.items():
+        assert _git(repo, "rev-parse", ref) == expected
+
+    with pytest.raises(git_ops.GitError, match="git update-ref --stdin failed"):
+        git_ops.update_refs(repo, {"refs/heads/ok": oid, "refs/heads/bad name": oid})
+    assert "ok" not in git_ops.list_local_branches(repo)  # whole batch rolled back
 
 
 def test_update_ref_rejects_invalid_ref_name(tmp_path: Path) -> None:
     repo = _make_repo_with_main(tmp_path, name="update_ref_bad")
     oid = git_ops.head_sha(repo)
-    for bad in ("refs/heads/..", "refs/heads/foo bar", "-dash-start", "refs/heads/xLock"):
+    for bad in ("refs/heads/..", "refs/heads/foo bar", "-dash-start", "refs/heads/topic.lock"):
         with pytest.raises(git_ops.GitError, match="invalid ref name"):
             git_ops.update_ref(repo, bad, oid)
 

--- a/tests/test_git_ops.py
+++ b/tests/test_git_ops.py
@@ -1571,6 +1571,30 @@ def test_remove_remote_deletes_configured_remote(tmp_path: Path) -> None:
     assert git_ops.head_sha(clone) == before
 
 
+def test_update_ref_sets_explicit_oid_and_rejects_bad_names(tmp_path: Path) -> None:
+    repo = _make_repo_with_main(tmp_path, name="update_ref")
+    other = _git(repo, "rev-parse", "HEAD")  # any valid OID in this repo
+    _git(repo, "update-ref", "refs/heads/scratch", other)  # seed a ref to repoint
+
+    git_ops.update_ref(repo, "refs/heads/scratch", other)
+
+    assert _git(repo, "rev-parse", "refs/heads/scratch") == other
+
+
+def test_update_ref_rejects_invalid_ref_name(tmp_path: Path) -> None:
+    repo = _make_repo_with_main(tmp_path, name="update_ref_bad")
+    oid = git_ops.head_sha(repo)
+    for bad in ("refs/heads/..", "refs/heads/foo bar", "-dash-start", "refs/heads/xLock"):
+        with pytest.raises(git_ops.GitError, match="invalid ref name"):
+            git_ops.update_ref(repo, bad, oid)
+
+
+def test_update_ref_rejects_malformed_oid(tmp_path: Path) -> None:
+    repo = _make_repo_with_main(tmp_path, name="update_ref_badoid")
+    with pytest.raises(git_ops.GitError, match="invalid OID"):
+        git_ops.update_ref(repo, "refs/heads/newbranch", "not-a-sha")
+
+
 def test_staged_patch_round_trips_index_state(tmp_path: Path) -> None:
     """A staged index patch from source reproduces source's staged index in a clone.
 


### PR DESCRIPTION
## Summary
- Read-only prep clones now snapshot the source repo's local branch refs, so `git diff base...HEAD` and multi-branch workflows work against the original branches
- Snapshot failure during read-only prep is fail-closed
- Batched branch snapshot via `update-ref --stdin`; round-2 review fixes: binary stdin encoding, shared ref/OID guard, `.lock` case-sensitivity, control-char rejection

Closes #1121

## Test Plan
- [x] 6057 tests passed, 21 skipped (round-2 review VM)
- [x] CI green