### PR TITLE
fix: preserve failure metadata on interrupted tool calls (#1126)

### DIFF
--- a/daydream/backends/__init__.py
+++ b/daydream/backends/__init__.py
@@ -88,12 +88,27 @@ class ToolResultEvent:
         id: Tool call identifier matching the prior ToolStartEvent.id.
         output: Tool output as a string.
         is_error: True if the tool reported an error.
+        exit_code: Exit code as reported by the backend; None when the
+            backend has no structured exit code (Claude/Pi).
+        status: Backend-native status string (e.g. Codex's
+            "completed"/"declined"); None when unavailable.
+        duration_ms: Wall-clock duration in milliseconds; None when
+            unavailable.
+        cancelled: True if the backend reported the tool call as cancelled.
+        truncated: True if the backend marked the output as truncated.
+        All five are optional; they default to None/False for backends
+        without structured metadata (Claude/Pi).
         timestamp: ISO 8601 UTC timestamp populated at backend yield time.
     """
 
     id: str
     output: str
     is_error: bool
+    exit_code: int | None = None
+    status: str | None = None
+    duration_ms: float | None = None
+    cancelled: bool = False
+    truncated: bool = False
     timestamp: str = field(default_factory=now_iso)
 
 

--- a/daydream/backends/__init__.py
+++ b/daydream/backends/__init__.py
@@ -88,6 +88,7 @@ class ToolResultEvent:
         id: Tool call identifier matching the prior ToolStartEvent.id.
         output: Tool output as a string.
         is_error: True if the tool reported an error.
+        timestamp: ISO 8601 UTC timestamp populated at backend yield time.
         exit_code: Exit code as reported by the backend; None when the
             backend has no structured exit code (Claude/Pi).
         status: Backend-native status string (e.g. Codex's
@@ -98,18 +99,20 @@ class ToolResultEvent:
         truncated: True if the backend marked the output as truncated.
         All five are optional; they default to None/False for backends
         without structured metadata (Claude/Pi).
-        timestamp: ISO 8601 UTC timestamp populated at backend yield time.
     """
 
     id: str
     output: str
     is_error: bool
+    timestamp: str = field(default_factory=now_iso)
+    # Keep these after timestamp so existing positional ToolResultEvent
+    # callers continue to interpret their arguments up to is_error/timestamp
+    # as-is; the metadata fields are optional and defaulted.
     exit_code: int | None = None
     status: str | None = None
     duration_ms: float | None = None
     cancelled: bool = False
     truncated: bool = False
-    timestamp: str = field(default_factory=now_iso)
 
 
 @dataclass

--- a/daydream/backends/codex.py
+++ b/daydream/backends/codex.py
@@ -536,12 +536,17 @@ class CodexBackend:
                                 id=item_id,
                                 output="Command declined by sandbox",
                                 is_error=True,
+                                status="declined",
                             )
                         else:
+                            # Forward exit status metadata alongside is_error so
+                            # trajectories preserve the structured signal.
                             yield ToolResultEvent(
                                 id=item_id,
                                 output=output,
                                 is_error=exit_code != 0,
+                                exit_code=exit_code,
+                                status=status or None,
                             )
 
                     elif item_type == "file_change":

--- a/daydream/trajectory.py
+++ b/daydream/trajectory.py
@@ -1431,15 +1431,72 @@ class Invocation:
         Args:
             snapshot_step_id: Pre-allocated step ID for the partial step. When multiple
                 invocations are active, the caller allocates unique IDs to avoid duplicates.
+
+        In-flight tool calls carry the same interrupted markers ``finish()``
+        emits, so a partial flush and the final record agree about in-flight
+        tool outcomes. Unlike ``finish()`` this never mutates: ``_in_flight_tools``
+        stays populated (a later ``finish()`` still marks the same calls) and no
+        Step is replaced in place.
         """
+        in_flight = list(self._in_flight_tools.values())
         if self._open_step_dict is None:
-            return list(self.steps)
-        d = self._open_step_dict
-        extra_overrides: dict[str, Any] = {"partial_step": True}
-        if d["_unmatched_tool_results"]:
-            extra_overrides["unmatched_tool_results"] = list(d["_unmatched_tool_results"])
-        step_id = snapshot_step_id if snapshot_step_id is not None else self.recorder._step_id_counter + 1
-        return [*self.steps, self._materialize_agent_step(d, step_id=step_id, extra_overrides=extra_overrides)]
+            steps = list(self.steps)
+        else:
+            d = self._open_step_dict
+            extra_overrides: dict[str, Any] = {"partial_step": True}
+            if d["_unmatched_tool_results"]:
+                extra_overrides["unmatched_tool_results"] = list(d["_unmatched_tool_results"])
+            step_id = snapshot_step_id if snapshot_step_id is not None else self.recorder._step_id_counter + 1
+            steps = [
+                *self.steps,
+                self._materialize_agent_step(d, step_id=step_id, extra_overrides=extra_overrides),
+            ]
+        # Markers land per host Step in the same LIFO order finish()'s popitem loop uses.
+        for host in reversed(in_flight):
+            if host["closed_index"] is not None:
+                steps[host["closed_index"]] = self._with_observation_result(
+                    steps[host["closed_index"]], self._interrupted_marker()
+                )
+            elif self._open_step_dict is not None and host["open_dict"] is self._open_step_dict:
+                steps[-1] = self._with_observation_result(steps[-1], self._interrupted_marker())
+        return steps
+
+    @staticmethod
+    def _interrupted_marker() -> ObservationResult:
+        """Synthetic terminal outcome for a tool call still in flight.
+
+        Deliberately carries NO ``source_call_id``: consumers derive completed
+        tool calls from an observation result's string ``source_call_id``
+        (``deep/coverage._completed_read_paths``, shared by the uncovered-file
+        sweep, per-stack verdict evidence and diagram-grounding receipts), so
+        stamping the in-flight tool's id here would make an interrupted read
+        derive as completed and flip their fail-open invariant ("an interrupted
+        read must NOT count as coverage") to fail-closed. Null ``source_call_id``
+        is the ATIF v1.7 encoding for "not a standard tool-call result" and
+        keeps the marker schema-valid. Content is fixed ASCII and ``extra``
+        carries only the two fixed keys, so the marker is redaction-stable.
+        """
+        return ObservationResult(
+            source_call_id=None,
+            content=INCOMPLETE_CALL_CONTENT,
+            extra={"is_error": True, "status": "interrupted"},
+        )
+
+    @staticmethod
+    def _with_observation_result(step: Step, result: ObservationResult) -> Step:
+        """Return a copy of *step* with *result* appended to its observation.
+
+        Non-mutating twin of ``_amend_closed_step_observation`` for the
+        signal-safe snapshot path. No re-redaction pass needed: the Step is
+        already a redacted copy and the marker content is fixed ASCII.
+        """
+        if step.observation is None:
+            observation = Observation(results=[result])
+        else:
+            observation = step.observation.model_copy(
+                update={"results": [*step.observation.results, result]}
+            )
+        return step.model_copy(update={"observation": observation})
 
     def _emit_incomplete_call_markers(self) -> None:
         """Append a synthetic failure observation for every still-in-flight tool call.
@@ -1448,19 +1505,16 @@ class Invocation:
         entry's ``open_dict`` is nulled when its Step closes, so each marker
         lands on the closed Step via ``closed_index`` (the open-dict arm is
         unreachable by construction and omitted). Popping entries as we go
-        makes this idempotent — a second ``finish()`` finds nothing. Content is
-        a fixed ASCII string, never formatted with tool data, so it is
-        redaction-stable; ``extra`` carries only the two fixed keys.
+        makes this idempotent — a second ``finish()`` finds nothing. Each
+        marker is ``_interrupted_marker()``: fixed ASCII content, the two fixed
+        ``extra`` keys, and no ``source_call_id`` so no consumer derives an
+        interrupted call as completed (see ``_interrupted_marker``).
         """
         while self._in_flight_tools:
-            tool_id, host = self._in_flight_tools.popitem()
+            _, host = self._in_flight_tools.popitem()
             self._amend_closed_step_observation(
                 closed_index=host["closed_index"],
-                result=ObservationResult(
-                    source_call_id=tool_id,
-                    content=INCOMPLETE_CALL_CONTENT,
-                    extra={"is_error": True, "status": "interrupted"},
-                ),
+                result=self._interrupted_marker(),
             )
 
     def finish(self) -> None:

--- a/daydream/trajectory.py
+++ b/daydream/trajectory.py
@@ -1444,27 +1444,24 @@ class Invocation:
     def _emit_incomplete_call_markers(self) -> None:
         """Append a synthetic failure observation for every still-in-flight tool call.
 
-        Called from ``finish()`` after ``_close_open_step()`` so each marker
-        lands on a closed Step (via the same open-dict / closed-index two-path
-        idiom the ``ToolResultEvent`` branch uses). Popping entries as we go
+        Called from ``finish()`` after ``_close_open_step()``, and every host
+        entry's ``open_dict`` is nulled when its Step closes, so each marker
+        lands on the closed Step via ``closed_index`` (the open-dict arm is
+        unreachable by construction and omitted). Popping entries as we go
         makes this idempotent — a second ``finish()`` finds nothing. Content is
         a fixed ASCII string, never formatted with tool data, so it is
         redaction-stable; ``extra`` carries only the two fixed keys.
         """
         while self._in_flight_tools:
             tool_id, host = self._in_flight_tools.popitem()
-            result = ObservationResult(
-                source_call_id=tool_id,
-                content=INCOMPLETE_CALL_CONTENT,
-                extra={"is_error": True, "status": "interrupted"},
+            self._amend_closed_step_observation(
+                closed_index=host["closed_index"],
+                result=ObservationResult(
+                    source_call_id=tool_id,
+                    content=INCOMPLETE_CALL_CONTENT,
+                    extra={"is_error": True, "status": "interrupted"},
+                ),
             )
-            open_dict = host["open_dict"]
-            if open_dict is not None:
-                open_dict["_observation_results"].append(result)
-            else:
-                self._amend_closed_step_observation(
-                    closed_index=host["closed_index"], result=result
-                )
 
     def finish(self) -> None:
         """Close any open step, mark in-flight tool calls interrupted, and flush.

--- a/daydream/trajectory.py
+++ b/daydream/trajectory.py
@@ -52,7 +52,7 @@ _TRAJECTORIES_SUBDIR = "trajectories"
 _DAYDREAM_DIRNAME = ".daydream"
 
 if TYPE_CHECKING:
-    from daydream.backends import AgentEvent, CostEvent
+    from daydream.backends import AgentEvent, CostEvent, ToolResultEvent
 
 _console = create_console()
 _INITIAL_TOTALS: dict[str, Any] = {"prompt": 0, "completion": 0, "cached": 0, "cost": 0.0, "any_cost_seen": False}  # noqa: E501 - module-level constant cloned via dict.copy() at recorder init
@@ -849,6 +849,28 @@ def _reset_recorder_for_tests() -> None:
     _ACTIVE_RECORDERS.clear()
 
 
+def _result_extra(event: ToolResultEvent) -> dict[str, Any]:
+    """Build ``ObservationResult.extra`` from a ToolResultEvent (issue #1126).
+
+    Deterministic scalar-only metadata: ``is_error`` always, then each
+    structured field only when the backend supplied it. Values are bool/int/
+    float/fixed-ASCII strings — never tool output or arguments — so nothing
+    free-text ever enters ``extra`` and redaction needs no special casing.
+    """
+    extra: dict[str, Any] = {"is_error": event.is_error}
+    if event.exit_code is not None:
+        extra["exit_code"] = event.exit_code
+    if event.status:
+        extra["status"] = event.status
+    if event.duration_ms is not None:
+        extra["duration_ms"] = event.duration_ms
+    if event.cancelled:
+        extra["cancelled"] = True
+    if event.truncated:
+        extra["truncated"] = True
+    return extra
+
+
 @dataclass
 class Invocation:
     """Per-``run_agent()`` recording scope for one model conversation.
@@ -1126,8 +1148,15 @@ class Invocation:
             open_dict = host["open_dict"]
             if open_dict is not None:
                 # Host Step is still open — append to its observation buffer.
+                # Failure metadata (is_error/exit_code/status, issue #1126)
+                # rides ObservationResult.extra alongside source_call_id and
+                # content.
                 open_dict["_observation_results"].append(
-                    ObservationResult(source_call_id=event.id, content=event.output)
+                    ObservationResult(
+                        source_call_id=event.id,
+                        content=event.output,
+                        extra=_result_extra(event),
+                    )
                 )
             else:
                 # Host Step was closed by an intervening TurnEndEvent. Patch the
@@ -1135,7 +1164,11 @@ class Invocation:
                 # bound to its originating turn.
                 self._amend_closed_step_observation(
                     closed_index=host["closed_index"],
-                    result=ObservationResult(source_call_id=event.id, content=event.output),
+                    result=ObservationResult(
+                        source_call_id=event.id,
+                        content=event.output,
+                        extra=_result_extra(event),
+                    ),
                 )
         elif isinstance(event, MetricsEvent):
             # EVNT-02 attribute names verbatim. prompt_tokens is the total

--- a/daydream/trajectory.py
+++ b/daydream/trajectory.py
@@ -197,6 +197,11 @@ _PEM_KEY_PATTERN = re.compile(
 #: Replacement marker for PEM private-key blocks. Shared (imported) by the
 #: benchmark's buffering anchors so every redaction site emits one marker.
 _PEM_KEY_REDACTED_MARKER = "[REDACTED_PEM_KEY]"
+
+# Fixed-ASCII synthetic content for the incomplete-call marker emitted by
+# ``Invocation.finish()`` for tool calls still in flight. Never formatted with
+# tool data, so it is redaction-stable.
+INCOMPLETE_CALL_CONTENT = "[interrupted: call did not complete before invocation ended]"
 #: Replacement marker for credential values under sensitive keys (issue #455).
 #: Distinct from every existing [REDACTED_*] marker so consumers can tell a
 #: key-aware credential redaction from a flat regex hit.
@@ -1436,9 +1441,41 @@ class Invocation:
         step_id = snapshot_step_id if snapshot_step_id is not None else self.recorder._step_id_counter + 1
         return [*self.steps, self._materialize_agent_step(d, step_id=step_id, extra_overrides=extra_overrides)]
 
+    def _emit_incomplete_call_markers(self) -> None:
+        """Append a synthetic failure observation for every still-in-flight tool call.
+
+        Called from ``finish()`` after ``_close_open_step()`` so each marker
+        lands on a closed Step (via the same open-dict / closed-index two-path
+        idiom the ``ToolResultEvent`` branch uses). Popping entries as we go
+        makes this idempotent — a second ``finish()`` finds nothing. Content is
+        a fixed ASCII string, never formatted with tool data, so it is
+        redaction-stable; ``extra`` carries only the two fixed keys.
+        """
+        while self._in_flight_tools:
+            tool_id, host = self._in_flight_tools.popitem()
+            result = ObservationResult(
+                source_call_id=tool_id,
+                content=INCOMPLETE_CALL_CONTENT,
+                extra={"is_error": True, "status": "interrupted"},
+            )
+            open_dict = host["open_dict"]
+            if open_dict is not None:
+                open_dict["_observation_results"].append(result)
+            else:
+                self._amend_closed_step_observation(
+                    closed_index=host["closed_index"], result=result
+                )
+
     def finish(self) -> None:
-        """Close any open step and flush all steps to the parent recorder."""
+        """Close any open step, mark in-flight tool calls interrupted, and flush.
+
+        After the final step close, every tool call still in flight (no
+        matching ``ToolResultEvent`` arrived) gets a synthetic
+        ``ObservationResult`` marker appended to its host Step so no tool call
+        dangles without a terminal outcome.
+        """
         self._close_open_step()
+        self._emit_incomplete_call_markers()
         self.recorder._extend_steps(self.steps)
 
 

--- a/tests/contract/test_backend_codex_trajectory.py
+++ b/tests/contract/test_backend_codex_trajectory.py
@@ -253,3 +253,36 @@ async def test_codex_multi_turn_final_metrics_equal_step_sum(tmp_path: Path) -> 
     )
     assert step_prompt == 34594 + 36000
     assert traj["final_metrics"]["total_prompt_tokens"] == step_prompt
+
+
+@pytest.mark.asyncio
+async def test_issue_1126_failure_status_and_incomplete_marker(tmp_path: Path) -> None:
+    """Issue #1126: nonzero-exit results carry failure metadata; a started-but-
+    never-completed call gets a schema-valid interrupted marker, and the whole
+    trajectory validates against ATIF v1.7."""
+    _, recorder = await _drive_codex_through_recorder(
+        tmp_path, fixture="command_failures_issue1126.jsonl"
+    )
+    # Mirror the golden round-trip test: filter agent steps to those actually
+    # carrying observation results, so indices pin assertion targets.
+    steps = [
+        s
+        for s in recorder.steps
+        if s.source == "agent" and s.observation and s.observation.results
+    ]
+    assert steps, "no agent steps with observation results"
+
+    failed = steps[0].observation.results[0]  # type: ignore[union-attr]  # filtered above
+    assert failed.extra == {"is_error": True, "exit_code": 128, "status": "completed"}
+    ok = steps[0].observation.results[1]  # type: ignore[union-attr]  # filtered above
+    assert ok.extra == {"is_error": False, "exit_code": 0, "status": "completed"}
+
+    dangling = steps[-1].observation.results[-1]  # type: ignore[union-attr]  # filtered above
+    assert dangling.source_call_id == "item_20"
+    assert dangling.content == "[interrupted: call did not complete before invocation ended]"
+    assert dangling.extra == {"is_error": True, "status": "interrupted"}
+
+    traj_path = tmp_path / "trajectory.json"
+    assert traj_path.exists()
+    validator = TrajectoryValidator()  # type: ignore[no-untyped-call]  # vendored atif (untyped)
+    assert validator.validate(traj_path), validator.get_errors() or "validation failed"

--- a/tests/contract/test_backend_codex_trajectory.py
+++ b/tests/contract/test_backend_codex_trajectory.py
@@ -150,7 +150,13 @@ async def test_codex_trajectory_golden_round_trip(tmp_path: Path) -> None:
             f"ACT span on step {act_step.step_id}: observation/results missing"
         )
         call_ids = {tc.tool_call_id for tc in (act_step.tool_calls or [])}
-        result_ids = {r.source_call_id for r in observation.results}
+        # Interrupted markers deliberately carry NO source_call_id (null =
+        # "not a standard tool-call result", ATIF v1.7) so coverage consumers
+        # never derive an interrupted read as completed; only linked results
+        # must pair with a tool call.
+        result_ids = {
+            r.source_call_id for r in observation.results if r.source_call_id is not None
+        }
         # issubset, not intersection: intersection (&) would only prove at
         # least one match, letting a step with mixed matched/unmatched results
         # pass false-green. Every result id must correspond to a call id.
@@ -278,7 +284,10 @@ async def test_issue_1126_failure_status_and_incomplete_marker(tmp_path: Path) -
     assert ok.extra == {"is_error": False, "exit_code": 0, "status": "completed"}
 
     dangling = steps[-1].observation.results[-1]  # type: ignore[union-attr]  # filtered above
-    assert dangling.source_call_id == "item_20"
+    # The marker records the interruption WITHOUT source_call_id: stamping the
+    # in-flight id would let _completed_read_paths derive the interrupted call
+    # as completed and flip fail-open coverage to fail-closed.
+    assert dangling.source_call_id is None
     assert dangling.content == "[interrupted: call did not complete before invocation ended]"
     assert dangling.extra == {"is_error": True, "status": "interrupted"}
 

--- a/tests/fixtures/codex_jsonl/command_failures_issue1126.jsonl
+++ b/tests/fixtures/codex_jsonl/command_failures_issue1126.jsonl
@@ -1,4 +1,7 @@
 {"type":"thread.started","thread_id":"th_fail"}
 {"type":"item.started","item":{"type":"command_execution","id":"cmd_1","command":"false","status":"running"}}
 {"type":"item.completed","item":{"type":"command_execution","id":"cmd_1","command":"false","status":"completed","exit_code":128,"aggregated_output":"fatal: not a git repository"}}
+{"type":"item.started","item":{"type":"command_execution","id":"cmd_2","command":"true","status":"running"}}
 {"type":"item.completed","item":{"type":"command_execution","id":"cmd_2","command":"true","status":"completed","exit_code":0,"aggregated_output":"ok"}}
+{"type":"item.started","item":{"type":"command_execution","id":"item_20","command":"tail -f log","status":"running"}}
+{"type":"turn.completed","usage":{"input_tokens":10,"output_tokens":5}}

--- a/tests/fixtures/codex_jsonl/command_failures_issue1126.jsonl
+++ b/tests/fixtures/codex_jsonl/command_failures_issue1126.jsonl
@@ -1,0 +1,4 @@
+{"type":"thread.started","thread_id":"th_fail"}
+{"type":"item.started","item":{"type":"command_execution","id":"cmd_1","command":"false","status":"running"}}
+{"type":"item.completed","item":{"type":"command_execution","id":"cmd_1","command":"false","status":"completed","exit_code":128,"aggregated_output":"fatal: not a git repository"}}
+{"type":"item.completed","item":{"type":"command_execution","id":"cmd_2","command":"true","status":"completed","exit_code":0,"aggregated_output":"ok"}}

--- a/tests/test_backend_codex.py
+++ b/tests/test_backend_codex.py
@@ -1087,3 +1087,18 @@ def test_codex_fanout_concurrency_honours_the_shared_env_override(
         monkeypatch.setenv("DAYDREAM_FANOUT_CONCURRENCY", raw)
 
     assert effective_fanout_concurrency(ceiling, CodexBackend("gpt-test")) == expected
+
+
+@pytest.mark.asyncio
+async def test_codex_preserves_exit_code_and_status_on_results() -> None:
+    backend = CodexBackend(model="fixture-model")
+    events = await _run_fixture(backend, "Run failing command", "command_failures_issue1126.jsonl")
+    results = [e for e in events if isinstance(e, ToolResultEvent)]
+    failed = results[0]
+    assert failed.is_error is True
+    assert failed.exit_code == 128
+    assert failed.status == "completed"
+    ok = results[1]
+    assert ok.is_error is False
+    assert ok.exit_code == 0
+    assert ok.status == "completed"

--- a/tests/test_backends_events.py
+++ b/tests/test_backends_events.py
@@ -194,3 +194,18 @@ def test_turn_end_event_is_in_agent_event_union() -> None:
     assert isinstance(ev.timestamp, str) and ev.timestamp.endswith("Z")
     # Runtime confirmation that TurnEndEvent is part of the AgentEvent union.
     assert isinstance(ev, AgentEvent)
+
+
+def test_tool_result_event_status_fields_default_to_none() -> None:
+    ev = ToolResultEvent(id="t1", output="ok", is_error=False)
+    assert ev.exit_code is None
+    assert ev.status is None
+    assert ev.duration_ms is None
+    assert ev.cancelled is False
+    assert ev.truncated is False
+
+
+def test_tool_result_event_accepts_status_metadata() -> None:
+    ev = ToolResultEvent(id="t2", output="boom", is_error=True, exit_code=128, status="completed")
+    assert ev.exit_code == 128
+    assert ev.status == "completed"

--- a/tests/test_trajectory.py
+++ b/tests/test_trajectory.py
@@ -212,6 +212,53 @@ async def test_late_result_on_closed_step_carries_extra(tmp_path: Path) -> None:
     assert result.extra == {"is_error": True, "exit_code": 1, "status": "completed"}
 
 
+# Behavior: finish() emits incomplete-call markers for in-flight tools
+# (issue #1126, Task 4).
+
+INCOMPLETE_CONTENT = "[interrupted: call did not complete before invocation ended]"
+
+
+async def test_finish_marks_in_flight_tool_on_open_step(tmp_path: Path) -> None:
+    """A tool call still in flight when the invocation ends gets a marker observation."""
+    inv, steps = await _record_events(
+        tmp_path,
+        ToolStartEvent(id="d1", name="shell", input={"command": "sleep 999"}),
+        ResultEvent(structured_output=None, continuation=None),
+    )
+    result = _single_observation_result(steps, 0)
+    assert result.source_call_id == "d1"
+    assert result.content == INCOMPLETE_CONTENT
+    assert result.extra == {"is_error": True, "status": "interrupted"}
+
+
+async def test_finish_marks_in_flight_tool_on_closed_step(tmp_path: Path) -> None:
+    """An in-flight call whose host step closed still gets its marker, amended onto it."""
+    inv, steps = await _record_events(
+        tmp_path,
+        ToolStartEvent(id="d2", name="shell", input={}),
+        TurnEndEvent(message_id="m1"),
+        ResultEvent(structured_output=None, continuation=None),
+    )
+    result = _single_observation_result(steps, 0)
+    assert result.source_call_id == "d2"
+    assert result.content == INCOMPLETE_CONTENT
+    assert result.extra == {"is_error": True, "status": "interrupted"}
+
+
+async def test_late_result_before_finish_still_amends_normally(tmp_path: Path) -> None:
+    """A result arriving before the final flush amends its step and suppresses the marker."""
+    inv, steps = await _record_events(
+        tmp_path,
+        ToolStartEvent(id="d3", name="shell", input={}),
+        TurnEndEvent(message_id="m1"),
+        ToolResultEvent(id="d3", output="made", is_error=False, exit_code=0, status="completed"),
+        ResultEvent(structured_output=None, continuation=None),
+    )
+    result = _single_observation_result(steps, 0)
+    assert result.content == "made"
+    assert result.extra == {"is_error": False, "exit_code": 0, "status": "completed"}
+
+
 # Behavior: mark_aborted stamps extra["stop_reason"] on the closing step
 # and the trajectory stays schema-valid (Task 2).
 

--- a/tests/test_trajectory.py
+++ b/tests/test_trajectory.py
@@ -226,7 +226,9 @@ async def test_finish_marks_in_flight_tool_on_open_step(tmp_path: Path) -> None:
         ResultEvent(structured_output=None, continuation=None),
     )
     result = _single_observation_result(steps, 0)
-    assert result.source_call_id == "d1"
+    # No source_call_id: a marker must never derive as a completed tool call
+    # (deep/coverage._completed_read_paths keys on results' source_call_id).
+    assert result.source_call_id is None
     assert result.content == INCOMPLETE_CONTENT
     assert result.extra == {"is_error": True, "status": "interrupted"}
 
@@ -240,7 +242,7 @@ async def test_finish_marks_in_flight_tool_on_closed_step(tmp_path: Path) -> Non
         ResultEvent(structured_output=None, continuation=None),
     )
     result = _single_observation_result(steps, 0)
-    assert result.source_call_id == "d2"
+    assert result.source_call_id is None
     assert result.content == INCOMPLETE_CONTENT
     assert result.extra == {"is_error": True, "status": "interrupted"}
 
@@ -257,6 +259,68 @@ async def test_late_result_before_finish_still_amends_normally(tmp_path: Path) -
     result = _single_observation_result(steps, 0)
     assert result.content == "made"
     assert result.extra == {"is_error": False, "exit_code": 0, "status": "completed"}
+
+
+# Regression: interruption markers vs the deep-flow completed-read derivation.
+# deep/coverage._completed_read_paths -- shared by the uncovered-file sweep,
+# the per-stack verdict evidence gate and diagram-grounding receipts -- treats
+# every observation result with a STRING source_call_id as a completed tool
+# call, so an interrupted read's marker must carry NO source_call_id: otherwise
+# a diff file mid-read at interruption would derive as covered/reviewed and the
+# documented fail-open invariant ("an interrupted read must NOT count as
+# coverage") flips to fail-closed.
+
+
+async def test_completed_read_derivation_sees_finished_read(tmp_path: Path) -> None:
+    """Positive control: a Read paired with its result IS a completed read."""
+    from daydream.deep.coverage import _completed_read_paths
+
+    traj = await _drive(
+        tmp_path,
+        ToolStartEvent(id="done-read", name="Read", input={"file_path": "src/app.py"}),
+        ToolResultEvent(id="done-read", output="print('ok')", is_error=False),
+        ResultEvent(structured_output=None, continuation=None),
+    )
+    assert "src/app.py" in _completed_read_paths(traj)
+
+
+async def test_interrupted_read_never_completes_in_fork_review_trajectory(
+    tmp_path: Path,
+) -> None:
+    """A Read still in flight at finish() stays derivable-uncovered in a deep-<stack> fork.
+
+    Recording an in-flight Read through the recorder (the exact failure shape
+    of budget truncation / backend cancel / CLI death mid-read) and deriving
+    completed reads the way the deep-flow consumers do must NOT yield the file:
+    fail-open means the sweep still sees it.
+    """
+    from daydream.deep.coverage import _completed_read_paths
+
+    recorder = make_recorder(tmp_path)
+    async with recorder:
+        async with recorder.fork("deep-python") as child:
+            async with child.invocation(phase=DaydreamPhase.DEEP) as inv:
+                inv.observe(
+                    ToolStartEvent(id="hung-read", name="Read", input={"file_path": "src/app.py"})
+                )
+    # finish() marked the in-flight read interrupted when the invocation exited.
+    fork_traj = read_trajectory(child.path)
+    assert "src/app.py" not in _completed_read_paths(fork_traj)
+    agent_steps = [s for s in fork_traj["steps"] if s["source"] == "agent"]
+    results = [
+        r
+        for s in agent_steps
+        for r in (s.get("observation") or {}).get("results") or []
+    ]
+    assert results == [
+        {
+            "content": INCOMPLETE_CONTENT,
+            "extra": {"is_error": True, "status": "interrupted"},
+        }
+    ]
+    # The marker serializes with NO source_call_id key (null excludes from
+    # JSON), so no consumer can derive it as a completed tool call.
+    assert "source_call_id" not in results[0]
 
 
 # Behavior: mark_aborted stamps extra["stop_reason"] on the closing step
@@ -1117,6 +1181,38 @@ async def test_write_partial_captures_in_flight_invocation_steps(tmp_path: Path)
     assert any("hello" in (m or "") for m in messages), (
         f"User step prompt not in partial: {messages!r}"
     )
+
+
+async def test_write_partial_records_in_flight_tool_like_finish(tmp_path: Path) -> None:
+    """A partial flush mid-invocation carries the same interrupted marker the
+    final flush (finish()) emits, and the snapshot leaves live state untouched."""
+    recorder = make_recorder(tmp_path)
+    async with recorder:
+        async with recorder.invocation(phase=DaydreamPhase.REVIEW) as inv:
+            inv.observe(
+                ToolStartEvent(id="ip1", name="Read", input={"file_path": "a.py"})
+            )
+            recorder.write_partial()
+            # Signal-safe snapshot: nothing consumed; finish() still marks the call.
+            assert "ip1" in inv._in_flight_tools
+
+    partial_path = recorder.path.with_suffix(recorder.path.suffix + ".partial")
+    partial = json.loads(partial_path.read_text(encoding="utf-8"))
+    final = read_trajectory(recorder.path)
+
+    def marker_results(traj: dict[str, Any]) -> list[dict[str, Any]]:
+        return [
+            r
+            for s in traj["steps"]
+            if s["source"] == "agent"
+            for r in (s.get("observation") or {}).get("results") or []
+            if r.get("extra", {}).get("status") == "interrupted"
+        ]
+
+    expected = [{"content": INCOMPLETE_CONTENT,
+                 "extra": {"is_error": True, "status": "interrupted"}}]
+    assert marker_results(partial) == expected
+    assert marker_results(final) == expected
 
 
 async def test_write_partial_no_double_count_after_invocation_exit(tmp_path: Path) -> None:

--- a/tests/test_trajectory.py
+++ b/tests/test_trajectory.py
@@ -15,6 +15,7 @@ from unittest.mock import patch
 import pytest
 
 from daydream.atif import validate as atif_validate
+from daydream.atif.models import Step
 from daydream.backends import (
     AgentEvent,
     MetricsEvent,
@@ -22,6 +23,7 @@ from daydream.backends import (
     TextEvent,
     ToolResultEvent,
     ToolStartEvent,
+    TurnEndEvent,
 )
 from daydream.trajectory import (
     DaydreamPhase,
@@ -135,6 +137,79 @@ async def test_tool_call_and_result_land_on_same_step(tmp_path: Path) -> None:
     step = agent_steps[0]
     assert step["tool_calls"][0]["tool_call_id"] == "tool-1"
     assert step["observation"]["results"][0]["source_call_id"] == "tool-1"
+
+
+# Behavior: ToolResultEvent failure metadata round-trips into
+# ObservationResult.extra (issue #1126, Task 3).
+
+
+async def _record_events(
+    tmp_path: Path, *events: AgentEvent
+) -> tuple[Invocation, list[Step]]:
+    """Observe *events* in one invocation; return it with its materialized steps."""
+    recorder = make_recorder(tmp_path)
+    async with recorder:
+        async with recorder.invocation(phase=DaydreamPhase.REVIEW) as inv:
+            for event in events:
+                inv.observe(event)
+    return inv, inv.steps
+
+
+def _single_observation_result(steps: list[Step], index: int) -> Any:
+    """The single ObservationResult of *steps[index]*, asserting the shape."""
+    step = steps[index]
+    assert step.observation is not None
+    assert len(step.observation.results) == 1
+    return step.observation.results[0]
+
+
+async def test_result_metadata_round_trips_into_observation_extra(tmp_path: Path) -> None:
+    """exit_code/status on an error ToolResultEvent persist into result extra."""
+    inv, steps = await _record_events(
+        tmp_path,
+        ToolStartEvent(id="c1", name="shell", input={"command": "false"}),
+        ToolResultEvent(id="c1", output="fatal", is_error=True, exit_code=128, status="completed"),
+    )
+    result = _single_observation_result(steps, 0)
+    assert result.source_call_id == "c1"
+    assert result.extra == {"is_error": True, "exit_code": 128, "status": "completed"}
+
+
+async def test_success_metadata_round_trips_not_just_errors(tmp_path: Path) -> None:
+    """Metadata persists on success too — is_error is False, not omitted."""
+    inv, steps = await _record_events(
+        tmp_path,
+        ToolStartEvent(id="c2", name="shell", input={"command": "true"}),
+        ToolResultEvent(id="c2", output="ok", is_error=False, exit_code=0, status="completed"),
+    )
+    assert _single_observation_result(steps, 0).extra == {
+        "is_error": False,
+        "exit_code": 0,
+        "status": "completed",
+    }
+
+
+async def test_is_error_only_metadata_round_trips_for_scarce_backends(tmp_path: Path) -> None:
+    """Backends with no structured fields still round-trip is_error."""
+    inv, steps = await _record_events(
+        tmp_path,
+        ToolStartEvent(id="c3", name="bash", input={"command": "x"}),
+        ToolResultEvent(id="c3", output="err", is_error=True),
+    )
+    assert _single_observation_result(steps, 0).extra == {"is_error": True}
+
+
+async def test_late_result_on_closed_step_carries_extra(tmp_path: Path) -> None:
+    """The closed-step amendment path persists extra too, not just content."""
+    inv, steps = await _record_events(
+        tmp_path,
+        ToolStartEvent(id="c4", name="shell", input={}),
+        TurnEndEvent(message_id="m1"),
+        ToolResultEvent(id="c4", output="late", is_error=True, exit_code=1, status="completed"),
+        ResultEvent(structured_output=None, continuation=None),
+    )
+    result = _single_observation_result(steps, 0)
+    assert result.extra == {"is_error": True, "exit_code": 1, "status": "completed"}
 
 
 # Behavior: mark_aborted stamps extra["stop_reason"] on the closing step


### PR DESCRIPTION
## Summary
- Interrupted tool-call markers no longer carry source_call_id, preserving the fail-open coverage invariant
- Partial-flush marker parity for interrupted tool calls
- Regression tests for issue 1126 failure metadata and interrupted markers

## Test Plan
- Full suite: 6060 passed, 21 skipped
- Two sequential daydream deep-precision reviews passed (round-2 fix: ede960c)

Closes #1126