### PR TITLE
feat(adjudication): hydrated-stage materialization + preview/import pipeline (Closes #1095)

### DIFF
--- a/daydream/cli.py
+++ b/daydream/cli.py
@@ -1392,12 +1392,15 @@ def _handle_harvest_command(argv: list[str]) -> int:
     module attribute so test monkeypatches take effect). ``run_harvest`` is a
     coroutine in production, so it is driven through :func:`anyio.run`; a
     synchronous test double that returns a summary directly is used as-is.
-    Returns an exit code; ``main`` translates it to a process exit. Per-row
-    harvest errors do not escalate to a non-zero exit — the summary's
-    ``errors`` counter surfaces them.
+    Returns an exit code; ``main`` translates it to a process exit. An
+    aborted summary (``aborted >= 1``) or any per-row harvest errors
+    (``errors > 0``) exits ``1``; a clean partial completion with unresolved
+    findings still exits ``0`` (unresolved findings in the data are not
+    process failure).
 
     Returns:
-        ``0`` on success; ``1`` on a validation error.
+        ``0`` on success; ``1`` on a validation error or an aborted/errored
+        harvest summary.
     """
     import daydream.archive as _archive
     import daydream.training.harvest as _harvest
@@ -1434,6 +1437,8 @@ def _handle_harvest_command(argv: list[str]) -> int:
         # always async, so mypy only sees the coroutine type here.
         summary = run_harvest(config)  # type: ignore[assignment]
     print_info(console, str(summary))
+    if summary.get("aborted", 0) >= 1 or summary.get("errors", 0) > 0:
+        return 1
     return 0
 
 

--- a/daydream/training/adjudication/canonical.py
+++ b/daydream/training/adjudication/canonical.py
@@ -52,6 +52,17 @@ _MANIFEST_FILENAME = "preview-manifest.json"
 
 _HUMAN_ROLES = frozenset({"rater", "adjudicator"})
 
+# Disposition written for a conflicted generation's corpus-v2 projection input
+# (annotations.jsonl). Corpus-v2's gold gate (``tiers.classify_tier``) keys
+# solely on disposition/evidence/evidence_after_as_of and never reads the
+# ``conflicting`` flag, so a conflicted generation that kept its decisive
+# disposition would still classify gold. A non-decisive disposition forces
+# classify_tier to ``task-only`` (routed to adjudication, never gold);
+# ``ambiguous`` is the faithful label for generations that disagree. The
+# archive ``rubric_json`` keeps the record's real decisive disposition for
+# provenance -- this value only shapes the projection-facing annotations row.
+_CONFLICTED_DISPOSITION = "ambiguous"
+
 
 def _canonical(payload: dict[str, Any]) -> str:
     return json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
@@ -261,10 +272,12 @@ def run_canonical_harvest(
         # ones: a session whose harvester generations disagree is non-gold per
         # existing precedence — its dispositions never project into
         # ``finding-<disposition>`` labels. The full record (``conflicting``
-        # flag included) still lands in ``rubric_json`` and annotations.jsonl —
+        # flag included) still lands in the archive ``rubric_json`` —
         # provenance preserved, and acceptance is never inferred from merge
         # state (the flag is set by the materializer and merely carried
-        # through the merge loop above).
+        # through the merge loop above). The ``annotations.jsonl`` projection
+        # row (written below) neutralizes the conflicted disposition so the
+        # corpus-v2 gate never classifies it gold.
         labels = sorted(
             {
                 f"finding-{record['disposition']}"
@@ -311,10 +324,26 @@ def run_canonical_harvest(
             skipped_sessions += 1
 
     # annotations.jsonl from the same in-memory merged records — no second shape.
+    # The corpus-v2 gold gate (``tiers.classify_tier``) reads only
+    # disposition/evidence/evidence_after_as_of, never the ``conflicting``
+    # flag, so a conflicted record must not carry its decisive disposition
+    # here or it would project gold with ``outcome_label`` set. Emit the
+    # record (``conflicting`` rides through; provenance preserved in the
+    # archive rubric_json above) with the disposition neutralized to
+    # ``_CONFLICTED_DISPOSITION`` so the projection routes it to task-only
+    # adjudication, never gold.
+    def _annotation_row(record: dict[str, Any]) -> dict[str, Any]:
+        if record.get("conflicting"):
+            row = dict(record)
+            row["disposition"] = _CONFLICTED_DISPOSITION
+            return row
+        return record
+
     records_path = materialize_dir / _ANNOTATIONS_FILENAME
     tmp_path = records_path.with_name(records_path.name + ".tmp")
     tmp_path.write_text(
-        "".join(_canonical(record) + "\n" for record in merged_records), encoding="utf-8"
+        "".join(_canonical(_annotation_row(record)) + "\n" for record in merged_records),
+        encoding="utf-8",
     )
     tmp_path.replace(records_path)
 

--- a/daydream/training/adjudication/canonical.py
+++ b/daydream/training/adjudication/canonical.py
@@ -32,6 +32,7 @@ from typing import Any
 
 from daydream.archive.index import append_label_observation
 from daydream.training.adjudication.materialize import (
+    _CONFLICTED_DISPOSITION,
     _SESSIONS_OUT_FILENAME,
     _sessions_from_hydrated_stage,
 )
@@ -51,17 +52,6 @@ _ANNOTATIONS_FILENAME = "annotations.jsonl"
 _MANIFEST_FILENAME = "preview-manifest.json"
 
 _HUMAN_ROLES = frozenset({"rater", "adjudicator"})
-
-# Disposition written for a conflicted generation's corpus-v2 projection input
-# (annotations.jsonl). Corpus-v2's gold gate (``tiers.classify_tier``) keys
-# solely on disposition/evidence/evidence_after_as_of and never reads the
-# ``conflicting`` flag, so a conflicted generation that kept its decisive
-# disposition would still classify gold. A non-decisive disposition forces
-# classify_tier to ``task-only`` (routed to adjudication, never gold);
-# ``ambiguous`` is the faithful label for generations that disagree. The
-# archive ``rubric_json`` keeps the record's real decisive disposition for
-# provenance -- this value only shapes the projection-facing annotations row.
-_CONFLICTED_DISPOSITION = "ambiguous"
 
 
 def _canonical(payload: dict[str, Any]) -> str:
@@ -197,6 +187,17 @@ def run_canonical_harvest(
     fresh_by_record_id = {
         str(item["record_id"]): item for item in build_queue(sessions, include_decisive=True)
     }
+    # The fresh session derivation is the conflict authority, never the
+    # materialized snapshot's flags: a session turned conflicting *after*
+    # materialize (runbook step-3b import appending a disagreeing generation
+    # to the same index.db) passes the evidence-digest drift gate below unless
+    # the stack re-derives its ``conflicting`` verdict here and stamps it onto
+    # the merged records before the decisive-label projection.
+    fresh_conflicting_sessions = {
+        str(session.get("session_id"))
+        for session in sessions
+        if session.get("conflicting")
+    }
 
     # Fail-closed drift gate: verify BEFORE any write.
     drifted: list[str] = []
@@ -238,6 +239,12 @@ def run_canonical_harvest(
     for record in materialized:
         record = dict(record)
         record_id = str(record["record_id"])
+        if str(record.get("session_id")) in fresh_conflicting_sessions:
+            # Freshly re-derived conflict verdict (never trusted from the
+            # materialized snapshot's merge state): decisive dispositions from
+            # a session that became conflicting after materialize must not
+            # feed the ``finding-*`` labels or the annotations projection.
+            record["conflicting"] = True
         if record_id in grouped:
             resolved = effective_adjudication(grouped[record_id])
             if (
@@ -248,7 +255,23 @@ def run_canonical_harvest(
                 record["disposition"] = resolved["disposition"]
                 record["human_labeler"] = resolved["labeler"]
                 record["human_role"] = resolved["role"]
+                # A decisive human adjudication resolves the session conflict:
+                # the operator's judgment overrides the disagreeing
+                # generations, so the flag is cleared -- the resolution must
+                # not be suppressed to non-gold.
+                if record.get("conflicting"):
+                    record["conflicting"] = False
                 human_adjudicated += 1
+        if record.get("conflicting"):
+            # The materializer neutralizes a conflicted record's disposition
+            # (``_CONFLICTED_DISPOSITION``) so the operator queue routes it to
+            # task-only adjudication and the bundle carries one disposition;
+            # restore the real decisive disposition here for the archive
+            # ``rubric_json`` provenance, from the fresh complete queue that
+            # the drift gate just verified against this record's evidence.
+            fresh = fresh_by_record_id.get(record_id)
+            if fresh is not None:
+                record["disposition"] = str(fresh["disposition"])
         record["evidence_after_as_of"] = _evidence_after_as_of(record, pin.get("as_of"))
         if record["evidence_after_as_of"]:
             flagged_after_as_of.append(record_id)

--- a/daydream/training/adjudication/canonical.py
+++ b/daydream/training/adjudication/canonical.py
@@ -257,11 +257,20 @@ def run_canonical_harvest(
             "rubric_version": pin["rubric_version"],
         }
         rubric_json = _canonical(rubric)
+        # Decisive labels come from every decisive record EXCEPT conflicted
+        # ones: a session whose harvester generations disagree is non-gold per
+        # existing precedence — its dispositions never project into
+        # ``finding-<disposition>`` labels. The full record (``conflicting``
+        # flag included) still lands in ``rubric_json`` and annotations.jsonl —
+        # provenance preserved, and acceptance is never inferred from merge
+        # state (the flag is set by the materializer and merely carried
+        # through the merge loop above).
         labels = sorted(
             {
                 f"finding-{record['disposition']}"
                 for record in session_records
                 if record["disposition"] in DECISIVE_DISPOSITIONS
+                and not record.get("conflicting")
             }
         )
         # Pin member of the auto dedup key. The dedup tuple (M14) omits

--- a/daydream/training/adjudication/cli.py
+++ b/daydream/training/adjudication/cli.py
@@ -54,6 +54,7 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
+import shutil
 import sqlite3
 import tempfile
 from collections.abc import Mapping, Sequence
@@ -527,8 +528,18 @@ def handle_export(argv: list[str]) -> int:
         parser.error("--out is required unless --dry-run")
     ledger_path = args.state_dir / _PREVIEW_LEDGER_FILENAME
     try:
-        if not ledger_path.is_file():
-            run_preview(args.index_root, ledger_path)
+        # Regenerate the ledger on every run: a re-export after a snapshot
+        # re-materialization must re-pin the digest reference, or the stale
+        # ledger would fail the runbook's 3a "re-run it any time the snapshot
+        # or the observations change" path with AdjudicationDriftError instead
+        # of being the documented recovery (run_preview compares against the
+        # prior ledger and overwrites it).
+        preview = run_preview(args.index_root, ledger_path)
+        if preview["drifted_record_ids"]:
+            print(
+                f"preview drift: {len(preview['drifted_record_ids'])} record(s) changed "
+                f"evidence since the prior ledger: {preview['drifted_record_ids']}"
+            )
         rows = build_export_entries(
             args.index_root, ledger_path,
             observations_path=args.state_dir / _OBSERVATIONS_FILENAME,
@@ -1304,14 +1315,19 @@ def _build_import_report(
     return report
 
 
-def _publish_import_state(state_dir: Path, hub_repo: str, manifest: Path) -> dict[str, Any]:
+def _publish_import_state(
+    archive_dir: Path, state_dir: Path, hub_repo: str, manifest: Path
+) -> dict[str, Any]:
     """Publish the imported adjudication state additively to the private Hub.
 
     The publish composition requires the adjudication-state payload
     (queue.json / observations.jsonl / preview-ledger.json) and the state
-    archive index (index.db — the ``--archive-dir`` merge target staged into
-    the state dir for publication) to exist; fail closed with a prerequisite
-    hint on a fresh state-dir instead of a bare ``FileNotFoundError``.
+    archive index (index.db) to exist; fail closed with a prerequisite hint
+    on a fresh state-dir instead of a bare ``FileNotFoundError``. The import
+    merges into the ``--archive-dir`` index (never the state-dir index), so
+    the merged index is staged byte-for-byte into the state dir here before
+    the gate; a fresh-VM resume from the published checkpoint then restores
+    the import's rows, not just the queue/report.
     Reuses the existing publication: the private repo hard-fail and the S1
     secret scan are ``publish_annotation_state``'s own fail-closed gates, so
     a public destination or a credential-shaped payload is refused before
@@ -1327,8 +1343,16 @@ def _publish_import_state(state_dir: Path, hub_repo: str, manifest: Path) -> dic
         _ImportPublishError: When the state archive is missing a publishable
             adjudication-state file.
         ValueError/HubUnavailableError/HydrationError/PublicDestinationError/
-        FileNotFoundError: Propagated from the publication steps.
+        OSError: Propagated from the staging copy (OSError) and the
+            publication steps.
     """
+    # Stage the merge target into the state dir for publication: the import
+    # writes only the --archive-dir index, and publish_annotation_state
+    # uploads state_dir/index.db. Identical dirs are a no-op; a missing
+    # archive index falls through to the gate's standard prerequisite hint.
+    if archive_dir.resolve() != state_dir.resolve() and (archive_dir / "index.db").is_file():
+        state_dir.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(archive_dir / "index.db", state_dir / "index.db")
     missing = [
         name
         for name in ("queue.json", "observations.jsonl", "preview-ledger.json", "index.db")
@@ -1360,9 +1384,11 @@ def handle_import_local_observations(argv: list[str]) -> int:
     redaction-gated append-only merge into the ``--archive-dir`` archive
     (``_write_import_merge``), the digest-stable report
     (``_build_import_report``, carrying the per-session ``identity_summary``),
-    and the optional publish (``_publish_import_state``). The state-dir
-    ``index.db`` is never written by the import; ``--state-dir`` stays for
-    the scan artifacts, report/ledger, and ``--publish`` payload staging.
+    and the optional publish (``_publish_import_state`` — which stages the
+    merged ``--archive-dir`` index into the state dir for the payload). The
+    state-dir ``index.db`` is never written by the import; ``--state-dir``
+    stays for the scan artifacts, report/ledger, and ``--publish`` payload
+    staging.
     This handler owns only arg parsing, the fail-closed error surface, and
     output; ``--json`` prints the report and a real run writes it to
     ``--state-dir/import-report.json`` with the ledger in
@@ -1426,14 +1452,14 @@ def handle_import_local_observations(argv: list[str]) -> int:
     if args.publish:
         try:
             report["publish"] = _publish_import_state(
-                args.state_dir, args.hub_repo, args.manifest
+                args.archive_dir, args.state_dir, args.hub_repo, args.manifest
             )
         except _ImportPublishError as exc:
             print_error(
                 console, "adjudicate import-local-observations publish failed", exc.message
             )
             return 1
-        except (ValueError, HubUnavailableError, HydrationError, PublicDestinationError, FileNotFoundError) as exc:
+        except (ValueError, OSError, HubUnavailableError, HydrationError, PublicDestinationError) as exc:
             print_error(console, "adjudicate import-local-observations failed", str(exc))
             return 1
 

--- a/daydream/training/adjudication/cli.py
+++ b/daydream/training/adjudication/cli.py
@@ -1146,13 +1146,24 @@ def _hydrated_identity_index(
 
 def _projector_findings_map(
     sessions: list[dict[str, Any]],
+    runs_by_session: Mapping[str, Mapping[str, Any]] | None = None,
 ) -> dict[str, list[dict[str, Any]]]:
     """Derive the per-finding projected map from the pinned index's sessions.
 
     ``project_findings`` is the single enumeration authority; each finding
-    contributes its ``record_id``, its per-finding evidence digest (so the
-    run-level classification's exact-identity match is discriminating even
-    for multi-finding sessions), and its finding fingerprint.
+    contributes its ``record_id``, its evidence anchor, and its finding
+    fingerprint.
+
+    The anchor is the session's ``head_sha`` from the inventoried source run
+    rows when one exists: ``training/harvest.py`` stores exactly ``head_sha``
+    in ``label_observations.evidence_sha``, so the importer's exact-identity
+    match (``classify_run_level`` compares ``finding["evidence_sha"]``
+    against the imported row's ``evidence_sha`` column) can actually fire for
+    harvest-produced rows instead of always reporting ``ambiguous``. Only when
+    the session has no run anchor does the map fall back to the per-finding
+    reply digest -- a digest space no archive writer stores, so rows whose
+    anchor the pinned index cannot resolve are honestly reported ambiguous
+    (per-finding validation is informational for anchor-less sessions).
     """
     from daydream.training.corpus_v2.projector import project_findings
     from daydream.training.labeler_versions import reply_evidence_digest
@@ -1160,6 +1171,8 @@ def _projector_findings_map(
     findings_map: dict[str, list[dict[str, Any]]] = {}
     for session in sessions:
         session_id = str(session["session_id"])
+        run = (runs_by_session or {}).get(session_id) or {}
+        run_anchor = run.get("head_sha")
         rows: list[dict[str, Any]] = []
         for finding in project_findings(session):
             evidence = finding["evidence"]
@@ -1171,7 +1184,9 @@ def _projector_findings_map(
             rows.append(
                 {
                     "record_id": finding["record_id"],
-                    "evidence_sha": reply_evidence_digest(evidence),
+                    "evidence_sha": (
+                        str(run_anchor) if run_anchor else reply_evidence_digest(evidence)
+                    ),
                     "fingerprint": finding["finding_fingerprint"],
                 }
             )
@@ -1413,7 +1428,9 @@ def handle_import_local_observations(argv: list[str]) -> int:
         # projector's per-finding map for exact run-level evidence matching.
         sessions = _load_import_index_sessions(args.index_root)
         hydrated_index = _hydrated_identity_index(sessions, args.index_root)
-        projector_findings = _projector_findings_map(sessions)
+        projector_findings = _projector_findings_map(
+            sessions, inventory["runs_by_session"]
+        )
         result = run_pure_import(
             inventory["inventories"],
             hydrated_index=hydrated_index,

--- a/daydream/training/adjudication/cli.py
+++ b/daydream/training/adjudication/cli.py
@@ -36,8 +36,9 @@ deterministic adjudication queue:
   read-only inventory, identity linkage against the roots' run metadata,
   content-digest dedupe, version gate, run-level classification,
   reason-coded accounting (bucket sum == source row count), and — unless
-  ``--dry-run`` — an append-only merge into the ``--state-dir`` archive
-  followed by fail-closed redaction + secret scan. ``--json`` prints the
+  ``--dry-run`` — an append-only merge into the ``--archive-dir`` archive
+  (the hydrated stage's index.db — the single merge target) followed by
+  fail-closed redaction + secret scan. ``--json`` prints the
   digest-stable import report (also written to
   ``--state-dir/import-report.json`` on a real run, alongside
   ``import-ledger.json``). Dry-run writes nothing (S2).
@@ -358,6 +359,12 @@ def _build_adjudicate_parser() -> argparse.ArgumentParser:
     p_import.add_argument("--archive-root", type=Path, action="append", required=True,
                           metavar="PATH",
                           help="Source archive/backup root holding index.db (repeatable)")
+    p_import.add_argument("--index-root", type=Path, required=True, metavar="PATH",
+                          help="Pinned hydrated index / materialized snapshot root the "
+                               "import links session identity and finding evidence against")
+    p_import.add_argument("--archive-dir", type=Path, required=True, metavar="PATH",
+                          help="Hydrated archive directory holding the SQLite index the "
+                               "import merges into — the single merge target")
     _add_state_dir(p_import)
     p_import.add_argument("--json", action="store_true",
                           help="Print the digest-stable import report as JSON")
@@ -891,6 +898,14 @@ def _inventory_import_root(root: Path) -> dict[str, Any]:
             # precedence marker to the writer's own default ("auto") so no
             # downstream ``row["source"]`` read raises KeyError on a legacy row.
             row["source"] = "auto"
+        runs_dir = root / "runs" / str(row["session_id"])
+        if runs_dir.is_dir():
+            # Derivative content digest for identity linkage: the hydrated
+            # index side derives the same digest over its own runs/<sid>
+            # directory, so a matching pair links by session_id.
+            from daydream.archive.sanitize import _derivative_digest
+
+            row["derivative_digest"] = _derivative_digest(runs_dir)
         run = runs.get(str(row["session_id"]))
         if run is not None:
             for field in ("repo_slug", "base_sha", "head_sha", "remote_url", "source_path"):
@@ -1073,21 +1088,138 @@ def _link_imported_rows(result: dict[str, Any]) -> list[dict[str, Any]]:
     return linked_rows
 
 
+def _load_import_index_sessions(index_root: Path) -> list[dict[str, Any]]:
+    """Load the pinned index's sessions for the import identity derivation.
+
+    A materialized snapshot root carries ``sessions.jsonl`` (the hydrated
+    session shape); a hydrated staging archive carries ``index.db`` and
+    derives its sessions from the ``label_observations`` rows via the shared
+    fail-closed materialize adapter. Anything else is a derive failure —
+    no empty-literal fallback.
+    """
+    if (index_root / _SESSIONS_FILENAME).is_file():
+        return _load_sessions_for_index(index_root)
+    if (index_root / "index.db").is_file():
+        from daydream.training.adjudication.materialize import _sessions_from_hydrated_stage
+
+        sessions, _ = _sessions_from_hydrated_stage(index_root)
+        return sessions
+    raise ValueError(
+        f"import index root {index_root} has neither sessions.jsonl nor index.db; "
+        "not a hydrated index or materialized snapshot"
+    )
+
+
+def _hydrated_identity_index(
+    sessions: list[dict[str, Any]], index_root: Path
+) -> dict[str, dict[str, Any]]:
+    """Derive the ``link_session_identity`` hydrated-index map from the pinned
+    index's sessions — never an empty literal.
+
+    Each entry carries the session's derivative content digest (sha256 over
+    ``<index_root>/runs/<session_id>`` when that directory exists, else
+    ``None``) plus the identity ``record_id``.
+    """
+    from daydream.archive.sanitize import _derivative_digest
+
+    hydrated: dict[str, dict[str, Any]] = {}
+    for session in sessions:
+        session_id = str(session["session_id"])
+        runs_dir = index_root / "runs" / session_id
+        hydrated[session_id] = {
+            "derivative_digest": _derivative_digest(runs_dir) if runs_dir.is_dir() else None,
+            "record_id": session_id,
+        }
+    return hydrated
+
+
+def _projector_findings_map(
+    sessions: list[dict[str, Any]],
+) -> dict[str, list[dict[str, Any]]]:
+    """Derive the per-finding projected map from the pinned index's sessions.
+
+    ``project_findings`` is the single enumeration authority; each finding
+    contributes its ``record_id``, its per-finding evidence digest (so the
+    run-level classification's exact-identity match is discriminating even
+    for multi-finding sessions), and its finding fingerprint.
+    """
+    from daydream.training.corpus_v2.projector import project_findings
+    from daydream.training.labeler_versions import reply_evidence_digest
+
+    findings_map: dict[str, list[dict[str, Any]]] = {}
+    for session in sessions:
+        session_id = str(session["session_id"])
+        rows: list[dict[str, Any]] = []
+        for finding in project_findings(session):
+            evidence = finding["evidence"]
+            if not isinstance(evidence, list):
+                raise ValueError(
+                    f"session {session_id!r}: projected finding "
+                    f"{finding['finding_fingerprint']!r} carries malformed evidence"
+                )
+            rows.append(
+                {
+                    "record_id": finding["record_id"],
+                    "evidence_sha": reply_evidence_digest(evidence),
+                    "fingerprint": finding["finding_fingerprint"],
+                }
+            )
+        findings_map[session_id] = rows
+    return findings_map
+
+
+def _identity_summary(result: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    """Per-session identity-resolution summary for the import report.
+
+    ``matched_by`` comes from the identity link (``session_id`` /
+    ``repo_slug_sha``, or ``None`` for an unmatched session);
+    ``validation_outcome`` from the run-level classification (``matched``
+    when the evidence digest pinned exactly one projected finding,
+    ``ambiguous`` when it could not, ``run_level_only`` when the session has
+    no projected findings, and ``unmatched`` when identity itself failed).
+    Deterministic (sorted by session id) so the report stays digest-stable.
+    """
+    link = result["link"]
+    run_level = result["run_level"]
+    summary: dict[str, dict[str, Any]] = {}
+    for session_id in sorted(
+        set(link["linked"]) | set(link["unmatched"]) | set(link["identity_conflict"])
+    ):
+        if session_id in link["linked"]:
+            matched_by: str | None = link["linked"][session_id]["matched_by"]
+            if session_id in run_level["per_finding"]:
+                outcome = "matched"
+            elif session_id in run_level["ambiguous_run_mapping"]:
+                outcome = "ambiguous"
+            else:
+                outcome = "run_level_only"
+        else:
+            matched_by = None
+            outcome = "unmatched"
+        summary[session_id] = {"matched_by": matched_by, "validation_outcome": outcome}
+    return summary
+
+
 def _write_import_merge(
+    archive_dir: Path,
     state_dir: Path,
     linked_rows: list[dict[str, Any]],
     runs_by_session: dict[str, dict[str, Any]],
 ) -> dict[str, Any]:
-    """Redaction-gated merge of the linked rows into the state-dir archive.
+    """Redaction-gated merge of the linked rows into the hydrated archive.
+
+    The merge target is ``--archive-dir`` (the hydrated stage's index.db —
+    the single archive the canonical chain reads); ``--state-dir`` remains
+    scratch for the scan artifacts and publish payload staging only.
 
     Fail-closed gates first, before any state write (M9/AC6): the redaction +
     secret scan and the merge's drift / malformed-row / timestamp gate both
     run before the seed/merge, so a blocked or drifted import cannot leave
     partially seeded runs or unredacted observation rows committed in the
-    state archive (and every later run re-blocking on the same dirty payload).
-    The merge commits the scan's **redacted** payload — never the unredacted
-    originals — so credential-bearing metadata cannot reach the archive.
-    ``dry_run=True`` never touches the archive, so the gate can run
+    hydrated archive (and every later run re-blocking on the same dirty
+    payload). The merge commits the scan's **redacted** payload — never the
+    unredacted originals — so credential-bearing metadata cannot reach the
+    archive. ``dry_run=True`` never touches the archive, so the gate can run
     unconditionally.
 
     Returns:
@@ -1123,11 +1255,11 @@ def _write_import_merge(
             include_observed_at=row["source"] != "auto",
         )
     _seed_target_runs(
-        state_dir,
+        archive_dir,
         {str(row["session_id"]) for row in redacted_rows},
         runs_by_session,
     )
-    merged = merge_imported_observations(state_dir, redacted_rows, dry_run=False)
+    merged = merge_imported_observations(archive_dir, redacted_rows, dry_run=False)
     return {
         "planned": merged["planned"],
         "appended": merged["appended"],
@@ -1142,6 +1274,7 @@ def _build_import_report(
     *,
     dry_run: bool,
     merge_state: dict[str, Any],
+    identity_summary: dict[str, dict[str, Any]],
 ) -> dict[str, Any]:
     """Compose the digest-stable import report (S1).
 
@@ -1156,6 +1289,7 @@ def _build_import_report(
         "sources": sources,
         "deduped_count": result["deduped_count"],
         "accounting": dict(result["accounting"]),
+        "identity_summary": identity_summary,
         "merge": {
             "planned": len(merge_state["planned"]),
             "appended": merge_state["appended"],
@@ -1175,16 +1309,16 @@ def _publish_import_state(state_dir: Path, hub_repo: str, manifest: Path) -> dic
 
     The publish composition requires the adjudication-state payload
     (queue.json / observations.jsonl / preview-ledger.json) and the state
-    archive index (index.db — where the import's appended rows live) to
-    exist; the import itself only writes ``index.db``, so fail closed with a
-    prerequisite hint on a fresh state-dir instead of a bare
-    ``FileNotFoundError``. Reuses the existing publication: the private repo
-    hard-fail and the S1 secret scan are ``publish_annotation_state``'s own
-    fail-closed gates, so a public destination or a credential-shaped payload
-    is refused before any byte reaches the Hub. The published bundle carries
-    ``index.db`` and the checkpoint always records its digest, so a fresh-VM
-    resume restores the imported rows themselves, not just the queue/report
-    (AC5: the VM-local ``--state-dir`` is scratch only).
+    archive index (index.db — the ``--archive-dir`` merge target staged into
+    the state dir for publication) to exist; fail closed with a prerequisite
+    hint on a fresh state-dir instead of a bare ``FileNotFoundError``.
+    Reuses the existing publication: the private repo hard-fail and the S1
+    secret scan are ``publish_annotation_state``'s own fail-closed gates, so
+    a public destination or a credential-shaped payload is refused before
+    any byte reaches the Hub. The published bundle carries ``index.db`` and
+    the checkpoint always records its digest, so a fresh-VM resume restores
+    the published archive index, not just the queue/report (AC5: the
+    VM-local ``--state-dir`` is scratch only).
 
     Returns:
         ``{"prefix": ..., "uploaded": ...}``.
@@ -1218,15 +1352,21 @@ def handle_import_local_observations(argv: list[str]) -> int:
     """Handle ``corpus adjudicate import-local-observations`` (KD6, S1/S2/S3).
 
     Thin composition over the independently testable pipeline units: read-only
-    inventory (``_inventory_import_roots``), the pure import pipeline
-    (``run_pure_import``), identity linkage (``_link_imported_rows``), then —
-    unless ``--dry-run`` — the redaction-gated append-only merge
+    inventory (``_inventory_import_roots``), the pinned-index identity
+    derivation (``_load_import_index_sessions`` -> ``_hydrated_identity_index``
+    + ``_projector_findings_map`` — real identity inputs, never empty
+    literals), the pure import pipeline (``run_pure_import``), identity
+    linkage (``_link_imported_rows``), then — unless ``--dry-run`` — the
+    redaction-gated append-only merge into the ``--archive-dir`` archive
     (``_write_import_merge``), the digest-stable report
-    (``_build_import_report``), and the optional publish
-    (``_publish_import_state``). This handler owns only arg parsing, the
-    fail-closed error surface, and output; ``--json`` prints the report and a
-    real run writes it to ``--state-dir/import-report.json`` with the ledger
-    in ``--state-dir/import-ledger.json``. Dry-run writes nothing (S2).
+    (``_build_import_report``, carrying the per-session ``identity_summary``),
+    and the optional publish (``_publish_import_state``). The state-dir
+    ``index.db`` is never written by the import; ``--state-dir`` stays for
+    the scan artifacts, report/ledger, and ``--publish`` payload staging.
+    This handler owns only arg parsing, the fail-closed error surface, and
+    output; ``--json`` prints the report and a real run writes it to
+    ``--state-dir/import-report.json`` with the ledger in
+    ``--state-dir/import-ledger.json``. Dry-run writes nothing (S2).
     """
     from daydream.ui import create_console, print_error, print_success
 
@@ -1242,23 +1382,30 @@ def handle_import_local_observations(argv: list[str]) -> int:
         inventory = _inventory_import_roots(
             args.archive_root, console=None if args.json else console
         )
+        # Real identity inputs, derived from the pinned index — never empty
+        # literals: the hydrated-index map for session linkage and the
+        # projector's per-finding map for exact run-level evidence matching.
+        sessions = _load_import_index_sessions(args.index_root)
+        hydrated_index = _hydrated_identity_index(sessions, args.index_root)
+        projector_findings = _projector_findings_map(sessions)
         result = run_pure_import(
             inventory["inventories"],
-            hydrated_index={},
+            hydrated_index=hydrated_index,
             repo_slug_sha_lookup=inventory["repo_slug_sha_lookup"],
-            projector_findings={},
+            projector_findings=projector_findings,
             unmatched_identity_less=True,
         )
         linked_rows = _link_imported_rows(result)
         # Dry-run still exercises the merge's fail-closed drift gate, but the
         # planned appends are counted, never written (S2). The real path runs
         # the redaction + secret scan and the drift / malformed-row gate
-        # before any state write (M9/AC6).
+        # before any state write (M9/AC6). The merge targets --archive-dir —
+        # the hydrated stage's index.db — never the state-dir index.
         merge_state = (
-            merge_imported_observations(args.state_dir, linked_rows, dry_run=True)
+            merge_imported_observations(args.archive_dir, linked_rows, dry_run=True)
             if args.dry_run
             else _write_import_merge(
-                args.state_dir, linked_rows, inventory["runs_by_session"]
+                args.archive_dir, args.state_dir, linked_rows, inventory["runs_by_session"]
             )
         )
     except _ImportBlockedError as exc:
@@ -1268,12 +1415,13 @@ def handle_import_local_observations(argv: list[str]) -> int:
             exc.message,
         )
         return 1
-    except (ValueError, sqlite3.Error, OSError) as exc:
+    except (ValueError, sqlite3.Error, OSError, HubUnavailableError, HydrationError) as exc:
         print_error(console, "adjudicate import-local-observations failed", str(exc))
         return 1
 
     report = _build_import_report(
-        inventory["sources"], result, dry_run=bool(args.dry_run), merge_state=merge_state
+        inventory["sources"], result, dry_run=bool(args.dry_run), merge_state=merge_state,
+        identity_summary=_identity_summary(result),
     )
     if args.publish:
         try:

--- a/daydream/training/adjudication/materialize.py
+++ b/daydream/training/adjudication/materialize.py
@@ -1,8 +1,9 @@
 """Preview materialization of per-finding annotation snapshots (issue #1055).
 
-Runs the #980 semantic resolutions stored in a hydrated index through the
-shared serializer (``snapshot.build_canonical_record``) and emits a
-deterministic ``sessions.jsonl`` plus a pin-pinned ``preview-manifest.json``.
+Runs the #980 semantic resolutions stored in a hydrated index's
+``label_observations.rubric_json`` through the shared serializer
+(``snapshot.build_canonical_record``) and emits a deterministic
+``sessions.jsonl`` plus a pin-pinned ``preview-manifest.json``.
 
 Preview mode guarantees (AC 4 / M2): never appends ``label_observations``,
 never writes any resume-cache or harvest-complete marker. When the input is a
@@ -21,7 +22,11 @@ from typing import Any, cast, get_args
 from daydream.archive.hydrate import HubUnavailableError
 from daydream.training.adjudication.preview import _load_sessions
 from daydream.training.adjudication.snapshot import build_canonical_record, snapshot_id
-from daydream.training.labeler_signals import PerFindingDisposition, PerFindingResolution
+from daydream.training.labeler_signals import (
+    PerFindingDisposition,
+    PerFindingResolution,
+    resolution_from_dict,
+)
 
 __all__ = ["run_materialize"]
 
@@ -45,11 +50,22 @@ def _sessions_from_hydrated_stage(index_root: Path) -> tuple[list[dict[str, Any]
     """Build queue-consumable session records from a hydrated staging archive.
 
     A hydrated staging archive (``archive.hydrate.run_hydrate_hub``) has no
-    ``sessions.jsonl``: its sessions live in the SQLite index plus one
-    sanitized ``trajectory.json`` per run under ``runs/<session_id>/``, whose
-    ``resolutions`` carry the #980 semantic dispositions. This adapter joins
-    the two into the same session shape ``_load_sessions`` returns — read-only
-    over the index, fail-closed on any missing or adjudication-empty run.
+    ``sessions.jsonl``: its per-finding resolutions live in the SQLite
+    index's ``label_observations.rubric_json`` (the canonical dict shape
+    emitted by ``Rubric.to_dict``). This adapter joins ``query_runs`` rows
+    to their observations into the same session shape ``_load_sessions``
+    returns — the observations connection is opened read-only, fail-closed
+    on any missing or adjudication-empty run.
+
+    Latest-observation selection (deterministic): a session's rows are
+    grouped by the harvester dedup key ``(evidence_sha, labeler_policy_version,
+    reply_evidence_digest, labels, has_posterior)``; within an identical key
+    the latest ``observed_at`` wins; across distinct keys the winner follows
+    the archive's ``_PRECEDENCE_ORDER`` (human-first ``source='human'``, then
+    ``observed_at DESC``). More than one distinct dedup key means the session
+    is **conflicting**: the winner still supplies the resolutions and every
+    emitted record for that session carries ``"conflicting": true`` (surfaced
+    non-gold downstream, never merged away).
 
     The index revision is the pinned source commit (the single revision
     directory under ``downloads/``) — a full 40-hex SHA, exactly what the
@@ -64,31 +80,39 @@ def _sessions_from_hydrated_stage(index_root: Path) -> tuple[list[dict[str, Any]
     sessions: list[dict[str, Any]] = []
     for row in query_runs(index_root):
         session_id = str(row["session_id"])
-        trajectory_path = index_root / "runs" / session_id / "trajectory.json"
-        if not trajectory_path.is_file():
+        observations = _label_observations_readonly(index_root / "index.db", session_id)
+        if not observations:
             raise HubUnavailableError(
-                f"hydrated index run {session_id!r} has no trajectory at {trajectory_path}"
+                f"hydrated index session {session_id!r} has no label_observations rows "
+                "to materialize"
             )
+        winner, conflicting = _winning_observation(observations)
         try:
-            trajectory = json.loads(trajectory_path.read_text(encoding="utf-8"))
-        except (OSError, ValueError) as exc:
+            rubric = json.loads(winner["rubric_json"])
+        except (KeyError, TypeError, ValueError) as exc:
             raise HubUnavailableError(
-                f"unreadable hydrated trajectory at {trajectory_path}: {exc}"
+                f"session {session_id!r}: unreadable winning rubric_json: {exc}"
             ) from exc
-        resolutions = trajectory.get("resolutions") if isinstance(trajectory, dict) else None
+        if not isinstance(rubric, dict):
+            raise HubUnavailableError(
+                f"session {session_id!r}: winning rubric_json is not an object"
+            )
+        resolutions = rubric.get("per_finding_resolutions")
         if not isinstance(resolutions, list) or not resolutions:
             raise HubUnavailableError(
-                f"hydrated trajectory for session {session_id!r} carries no "
-                "per-finding resolutions to materialize"
+                f"session {session_id!r}: winning rubric_json carries no "
+                "per_finding_resolutions to materialize (legacy labels-only rows "
+                "are not backfilled)"
             )
-        sessions.append(
-            {
-                "session_id": session_id,
-                "trajectory_id": session_id,
-                "segment_id": session_id,
-                "resolutions": resolutions,
-            }
-        )
+        session: dict[str, Any] = {
+            "session_id": session_id,
+            "trajectory_id": session_id,
+            "segment_id": session_id,
+            "resolutions": resolutions,
+        }
+        if conflicting:
+            session["conflicting"] = True
+        sessions.append(session)
     if not sessions:
         raise HubUnavailableError(f"hydrated index at {index_root} has no runs")
     downloads = index_root / "downloads"
@@ -103,10 +127,59 @@ def _sessions_from_hydrated_stage(index_root: Path) -> tuple[list[dict[str, Any]
     return sessions, revisions[0]
 
 
-def _resolution_from_row(row: dict[str, Any]) -> PerFindingResolution:
-    """Rebuild the #980 semantic-resolution object from a stored index row.
+def _label_observations_readonly(db_path: Path, session_id: str) -> list[dict[str, Any]]:
+    """Read one session's ``label_observations`` rows over a **read-only**
+    connection (``mode=ro`` URI — never ``_get_connection``, which opens
+    read-write and runs WAL pragmas against the hydrated staging index).
+    """
+    import sqlite3
 
-    Fail-closed: a stored row missing a required field raises ``ValueError``
+    conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+    conn.row_factory = sqlite3.Row
+    try:
+        cursor = conn.execute(
+            "SELECT * FROM label_observations WHERE session_id = ?", (session_id,)
+        )
+        return [dict(r) for r in cursor.fetchall()]
+    finally:
+        conn.close()
+
+
+def _winning_observation(
+    observations: list[dict[str, Any]],
+) -> tuple[dict[str, Any], bool]:
+    """Deterministic latest-observation selection (see the module docstring for
+    the rule). Returns the winning row and whether the session is conflicting
+    (more than one distinct dedup key).
+    """
+    groups: dict[tuple[Any, ...], dict[str, Any]] = {}
+    for obs in observations:
+        key = (
+            obs.get("evidence_sha"),
+            obs.get("labeler_policy_version"),
+            obs.get("reply_evidence_digest"),
+            obs.get("labels"),
+            obs.get("has_posterior"),
+        )
+        existing = groups.get(key)
+        if existing is None or str(obs.get("observed_at", "")) > str(existing.get("observed_at", "")):
+            groups[key] = obs
+    winners = list(groups.values())
+    winner = max(
+        winners,
+        key=lambda o: (
+            1 if o.get("source") == "human" else 0,
+            str(o.get("observed_at", "")),
+        ),
+    )
+    return winner, len(groups) > 1
+
+
+def _resolution_from_row(row: dict[str, Any]) -> PerFindingResolution:
+    """Rebuild the #980 semantic-resolution object from a stored resolution entry.
+
+    Delegates to the canonical ``labeler_signals.resolution_from_dict``;
+    fail-closed: a stored entry missing a required field raises ``ValueError``
     naming the field and fingerprint — never ``None``-coerced into a record.
     """
     fingerprint = row.get("fingerprint")
@@ -128,12 +201,14 @@ def _resolution_from_row(row: dict[str, Any]) -> PerFindingResolution:
             f"disposition {disposition!r}"
         )
     typed_disposition = cast(PerFindingDisposition, disposition)
-    return PerFindingResolution(
-        fingerprint=fingerprint,
-        comment_id=row.get("comment_id"),
-        disposition=typed_disposition,
-        evidence=list(row.get("evidence") or []),
-        evidence_digest=evidence_digest,
+    return resolution_from_dict(
+        {
+            "fingerprint": fingerprint,
+            "comment_id": row.get("comment_id"),
+            "disposition": typed_disposition,
+            "evidence": list(row.get("evidence") or []),
+            "evidence_digest": evidence_digest,
+        }
     )
 
 
@@ -169,8 +244,8 @@ def run_materialize(
     if (index_root / _SESSIONS_OUT_FILENAME).is_file():
         sessions, index_revision = _load_sessions(index_root)
     else:
-        # Hydrated staging archive: derive the sessions from the SQLite index
-        # plus the sanitized per-run trajectories (read-only).
+        # Hydrated staging archive: derive the sessions from the SQLite
+        # index's label_observations (read-only).
         sessions, index_revision = _sessions_from_hydrated_stage(index_root)
 
     # Validate the pin before touching its components in the loop body:

--- a/daydream/training/adjudication/materialize.py
+++ b/daydream/training/adjudication/materialize.py
@@ -22,6 +22,7 @@ from typing import Any, cast, get_args
 from daydream.archive.hydrate import HubUnavailableError
 from daydream.training.adjudication.preview import _load_sessions
 from daydream.training.adjudication.snapshot import build_canonical_record, snapshot_id
+from daydream.training.dispositions import DECISIVE_DISPOSITIONS
 from daydream.training.labeler_signals import (
     PerFindingDisposition,
     PerFindingResolution,
@@ -32,6 +33,17 @@ __all__ = ["run_materialize"]
 
 _SESSIONS_OUT_FILENAME = "sessions.jsonl"
 _MANIFEST_FILENAME = "preview-manifest.json"
+
+# Disposition written for a conflicted generation's materialized records
+# (sessions.jsonl). The operator queue (``queue.build_queue``'s default
+# non-decisive set) and the final bundle's sessions.jsonl must route the
+# finding to task-only adjudication -- never gold -- and the archive
+# `rubric_json` keeps the real decisive disposition for provenance (the
+# canonical harvest restores it from the fresh queue). Corpus-v2's gold gate
+# (``tiers.classify_tier``) keys solely on disposition/evidence and never
+# reads the ``conflicting`` flag, so a decisive disposition here would still
+# classify gold; a non-decisive disposition forces ``task-only``.
+_CONFLICTED_DISPOSITION = "ambiguous"
 
 
 def _canonical(payload: dict[str, Any]) -> str:
@@ -63,15 +75,24 @@ def _sessions_from_hydrated_stage(index_root: Path) -> tuple[list[dict[str, Any]
     the latest ``observed_at`` wins; across distinct keys the winner follows
     the archive's ``_PRECEDENCE_ORDER`` (human-first ``source='human'``, then
     ``observed_at DESC``). The session is **conflicting** only when its
-    generations disagree in disposition-relevant content (more than one
-    distinct ``labels`` set across the dedup-key groups): the archive appends
+    generations disagree in disposition-relevant content — more than one
+    distinct decision-bearing ``labels`` set across the dedup-key groups,
+    scoped to non-human rows (``_winning_observation``): the archive appends
     fresh generations with identical labels on policy-version bumps,
     edited-reply digest changes, and label-preserving observation overlays
     (``index.append_label_observation``), so a dedup-key split alone never
-    marks a session non-gold. For a conflicted session the winner still
-    supplies the resolutions and every emitted record for that session
-    carries ``"conflicting": true`` (surfaced non-gold downstream, never
-    merged away).
+    marks a session non-gold, and neither a human override row (authoritative
+    under the archive's precedence) nor a non-decisive-only generation (a
+    pre-adjudication evolution) does. For a conflicted session the winner
+    still supplies the resolutions and every emitted record for that session
+    carries ``"conflicting": true`` with the disposition neutralized to
+    ``_CONFLICTED_DISPOSITION`` (surfaced non-gold downstream, never merged
+    away). A session whose rows carry no materializable per-finding
+    resolutions (``rubric_json`` NULL — a human ``daydream label`` row — or
+    a legacy labels-only row) and no sanitized per-run trajectory contributes
+    no records at all: such sessions are evidence-only (e.g. rows a runbook
+    step-3b import admitted from a backup root outside the curation) and must
+    not fail the whole curation.
 
     The index revision is the pinned source commit (the single revision
     directory under ``downloads/``) — a full 40-hex SHA, exactly what the
@@ -82,28 +103,38 @@ def _sessions_from_hydrated_stage(index_root: Path) -> tuple[list[dict[str, Any]
             f"hydrated index sessions file not found: {index_root / 'sessions.jsonl'}"
         )
     _raise_on_uncheckpointed_wal(index_root / "index.db")
+    rows = _query_runs_readonly(index_root / "index.db")
+    if not rows:
+        raise HubUnavailableError(f"hydrated index at {index_root} has no runs")
     sessions: list[dict[str, Any]] = []
-    for row in _query_runs_readonly(index_root / "index.db"):
+    for row in rows:
         session_id = str(row["session_id"])
         observations = _label_observations_readonly(index_root / "index.db", session_id)
-        session: dict[str, Any]
         if observations:
             winner, conflicting = _winning_observation(observations)
-            try:
-                rubric = json.loads(winner["rubric_json"])
-            except (KeyError, TypeError, ValueError) as exc:
-                raise HubUnavailableError(
-                    f"session {session_id!r}: unreadable winning rubric_json: {exc}"
-                ) from exc
-            if not isinstance(rubric, dict):
-                raise HubUnavailableError(
-                    f"session {session_id!r}: winning rubric_json is not an object"
-                )
-            resolutions = rubric.get("per_finding_resolutions")
-            if not isinstance(resolutions, list) or not resolutions:
-                # Legacy labels-only rows (pre-#1095 ``Rubric.to_dict`` emitted
-                # only ``per_finding_outcomes``) carry no per-finding semantics
-                # to materialize, and the import path (runbook step 3b) appends
+            resolutions: list[dict[str, Any]] | None = None
+            session: dict[str, Any]
+            rubric_raw = winner.get("rubric_json")
+            if rubric_raw is not None:
+                try:
+                    rubric = json.loads(rubric_raw)
+                except (KeyError, TypeError, ValueError) as exc:
+                    raise HubUnavailableError(
+                        f"session {session_id!r}: unreadable winning rubric_json: {exc}"
+                    ) from exc
+                if not isinstance(rubric, dict):
+                    raise HubUnavailableError(
+                        f"session {session_id!r}: winning rubric_json is not an object"
+                    )
+                per_finding = rubric.get("per_finding_resolutions")
+                if isinstance(per_finding, list) and per_finding:
+                    resolutions = per_finding
+            if resolutions is None:
+                # NULL rubric_json (a human-sourced ``daydream label`` row --
+                # ``index.update_labels`` appends with no rubric) or a legacy
+                # labels-only row (pre-#1095 ``Rubric.to_dict`` emitted only
+                # ``per_finding_outcomes``) carries no per-finding semantics to
+                # materialize, and the import path (runbook step 3b) appends
                 # such rows verbatim — an imported archive therefore reaches
                 # this branch with observations present, and failing closed
                 # here would brick the session for every later
@@ -111,8 +142,13 @@ def _sessions_from_hydrated_stage(index_root: Path) -> tuple[list[dict[str, Any]
                 # sanitized per-run trajectory instead (the pre-#1095
                 # materialization source), exactly like a session with no
                 # observation rows at all; a session with no trajectory either
-                # still fails closed below naming it.
+                # has no materializable content at all and contributes no
+                # records (evidence-only rows, e.g. sessions an import admitted
+                # from a backup root outside the curation), never failing the
+                # whole stage over one such session.
                 resolutions = _trajectory_resolutions_readonly(index_root, session_id)
+                if resolutions is None:
+                    continue
             session = {
                 "session_id": session_id,
                 "trajectory_id": session_id,
@@ -128,8 +164,12 @@ def _sessions_from_hydrated_stage(index_root: Path) -> tuple[list[dict[str, Any]
             # guarantees (_REQUIRED_SESSION_ARTIFACTS) -- the pre-#1095
             # materialization source -- so the first preview pass over a new
             # stage still works. Once any observation row exists for the
-            # session it wins; the two sources are never mixed.
+            # session it wins; the two sources are never mixed. A session
+            # without either contributes no records (the one-session-fails-all
+            # blast radius is reserved for corrupt data, not absence).
             resolutions = _trajectory_resolutions_readonly(index_root, session_id)
+            if resolutions is None:
+                continue
             session = {
                 "session_id": session_id,
                 "trajectory_id": session_id,
@@ -137,8 +177,6 @@ def _sessions_from_hydrated_stage(index_root: Path) -> tuple[list[dict[str, Any]
                 "resolutions": resolutions,
             }
         sessions.append(session)
-    if not sessions:
-        raise HubUnavailableError(f"hydrated index at {index_root} has no runs")
     downloads = index_root / "downloads"
     if not downloads.is_dir():
         raise HubUnavailableError(f"hydrated index at {index_root} has no downloads/ revision pin")
@@ -151,24 +189,29 @@ def _sessions_from_hydrated_stage(index_root: Path) -> tuple[list[dict[str, Any]
     return sessions, revisions[0]
 
 
-def _trajectory_resolutions_readonly(index_root: Path, session_id: str) -> list[dict[str, Any]]:
+def _trajectory_resolutions_readonly(
+    index_root: Path, session_id: str
+) -> list[dict[str, Any]] | None:
     """Read a session's per-finding resolutions from the sanitized per-run
     trajectory (the pre-#1095 materialization source). Used when the hydrated
     staging archive has no materializable ``label_observations`` history for
     the session: no observation rows yet (freshly hydrated stage; canonical
-    harvest appends the first rows) or only legacy labels-only rows whose
-    rubric_json carries no ``per_finding_resolutions`` (pre-#1095
-    ``Rubric.to_dict``; such rows are appended verbatim by the import path,
-    runbook step 3b). Fail-closed: a missing/unreadable/empty trajectory
-    raises ``HubUnavailableError`` naming the session -- never silently
-    skipped.
+    harvest appends the first rows), a NULL ``rubric_json`` (human-sourced
+    row), or only legacy labels-only rows whose rubric_json carries no
+    ``per_finding_resolutions`` (pre-#1095 ``Rubric.to_dict``; such rows are
+    appended verbatim by the import path, runbook step 3b).
+
+    Returns ``None`` when the trajectory is absent -- the session has no
+    materializable content at all (e.g. a session a runbook step-3b import
+    admitted from a backup root outside the curation: DB-only ``runs`` row,
+    evidence-only observation rows, no ``runs/<sid>`` files) and contributes
+    no records; the caller skips it. Anything *present* but unreadable,
+    malformed, or empty still raises ``HubUnavailableError`` naming the
+    session -- corrupt data is never silently skipped.
     """
     trajectory_path = index_root / "runs" / session_id / "trajectory.json"
     if not trajectory_path.is_file():
-        raise HubUnavailableError(
-            f"hydrated index session {session_id!r} has no label_observations rows "
-            f"and no trajectory at {trajectory_path}"
-        )
+        return None
     try:
         trajectory = json.loads(trajectory_path.read_text(encoding="utf-8"))
     except (OSError, ValueError) as exc:
@@ -277,7 +320,46 @@ def _winning_observation(
     # labels projection), never from the full dedup tuple: two rows agreeing
     # on the disposition but split on evidence_sha / policy version / reply
     # digest / has_posterior are agreeing generations that stay gold-eligible.
-    return winner, len({o.get("labels") for o in winners}) > 1
+    # The comparison is additionally scoped (issue #336): a human override row
+    # is authoritative under the archive's precedence (``_PRECEDENCE_ORDER``,
+    # ``index.update_labels``' human-wins contract) -- never a disagreeing
+    # generation -- so it cannot contribute a distinct label set; and only
+    # decision-bearing label sets (labels claiming a decisive
+    # ``finding-<disposition>``) count, so a pre-adjudication generation
+    # (``[]`` labels, an ``unanswered``-only snapshot) that a later decisive
+    # generation resolves is an evolution -- resolved-unanswered -> accepted --
+    # not a harvester disagreement, and stays gold-eligible after
+    # re-materialization.
+    decisive_sets = {
+        o.get("labels")
+        for o in winners
+        if o.get("source") != "human" and _labels_claim_decisive(o.get("labels"))
+    }
+    return winner, len(decisive_sets) > 1
+
+
+def _labels_claim_decisive(labels: Any) -> bool:
+    """True when the archived labels projection claims at least one decisive
+    ``finding-<disposition>`` label (e.g. ``finding-accepted``). Rows store the
+    labels column as a JSON array string; non-string / non-list / unparsable
+    values claim nothing (a session with no decisive claim cannot disagree
+    about a gold disposition). Non-decisive finding labels (``finding-unanswered``)
+    and non-finding labels (``posterior``) are not claims.
+    """
+    if isinstance(labels, str):
+        try:
+            labels = json.loads(labels)
+        except ValueError:
+            return False
+    if not isinstance(labels, list):
+        return False
+    for label in labels:
+        if not isinstance(label, str):
+            continue
+        disposition = label[len("finding-"):] if label.startswith("finding-") else None
+        if disposition in DECISIVE_DISPOSITIONS:
+            return True
+    return False
 
 
 def _resolution_from_row(row: dict[str, Any]) -> PerFindingResolution:
@@ -378,7 +460,23 @@ def run_materialize(
                 # per-finding record so downstream consumers (canonical
                 # harvest) can exclude the disposition from decisive labels
                 # while the full record — flag included — lands in rubric_json.
+                # The winner's decisive disposition is neutralized to
+                # ``_CONFLICTED_DISPOSITION``: the operator queue (build_queue's
+                # default non-decisive set) and the final bundle's sessions.jsonl
+                # then route the finding to task-only adjudication — never gold,
+                # one disposition in the bundle — while the canonical harvest
+                # restores the real decisive disposition for the archive
+                # rubric_json provenance from the freshly re-derived queue.
                 record["conflicting"] = True
+                record["disposition"] = _CONFLICTED_DISPOSITION
+                # The record embeds the session-shape view (``resolutions``)
+                # that ``project_findings``/``build_queue`` consume; neutralize
+                # its disposition too, or the operator queue would still
+                # classify the finding gold (``tiers.classify_tier`` reads the
+                # resolution, never the record's top-level disposition).
+                for nested in record.get("resolutions") or []:
+                    if isinstance(nested, dict):
+                        nested["disposition"] = _CONFLICTED_DISPOSITION
             records.append(record)
     records.sort(key=lambda r: str(r["record_id"]))
 

--- a/daydream/training/adjudication/materialize.py
+++ b/daydream/training/adjudication/materialize.py
@@ -62,10 +62,16 @@ def _sessions_from_hydrated_stage(index_root: Path) -> tuple[list[dict[str, Any]
     reply_evidence_digest, labels, has_posterior)``; within an identical key
     the latest ``observed_at`` wins; across distinct keys the winner follows
     the archive's ``_PRECEDENCE_ORDER`` (human-first ``source='human'``, then
-    ``observed_at DESC``). More than one distinct dedup key means the session
-    is **conflicting**: the winner still supplies the resolutions and every
-    emitted record for that session carries ``"conflicting": true`` (surfaced
-    non-gold downstream, never merged away).
+    ``observed_at DESC``). The session is **conflicting** only when its
+    generations disagree in disposition-relevant content (more than one
+    distinct ``labels`` set across the dedup-key groups): the archive appends
+    fresh generations with identical labels on policy-version bumps,
+    edited-reply digest changes, and label-preserving observation overlays
+    (``index.append_label_observation``), so a dedup-key split alone never
+    marks a session non-gold. For a conflicted session the winner still
+    supplies the resolutions and every emitted record for that session
+    carries ``"conflicting": true`` (surfaced non-gold downstream, never
+    merged away).
 
     The index revision is the pinned source commit (the single revision
     directory under ``downloads/``) — a full 40-hex SHA, exactly what the
@@ -75,6 +81,7 @@ def _sessions_from_hydrated_stage(index_root: Path) -> tuple[list[dict[str, Any]
         raise HubUnavailableError(
             f"hydrated index sessions file not found: {index_root / 'sessions.jsonl'}"
         )
+    _raise_on_uncheckpointed_wal(index_root / "index.db")
     sessions: list[dict[str, Any]] = []
     for row in _query_runs_readonly(index_root / "index.db"):
         session_id = str(row["session_id"])
@@ -94,11 +101,18 @@ def _sessions_from_hydrated_stage(index_root: Path) -> tuple[list[dict[str, Any]
                 )
             resolutions = rubric.get("per_finding_resolutions")
             if not isinstance(resolutions, list) or not resolutions:
-                raise HubUnavailableError(
-                    f"session {session_id!r}: winning rubric_json carries no "
-                    "per_finding_resolutions to materialize (legacy labels-only rows "
-                    "are not backfilled)"
-                )
+                # Legacy labels-only rows (pre-#1095 ``Rubric.to_dict`` emitted
+                # only ``per_finding_outcomes``) carry no per-finding semantics
+                # to materialize, and the import path (runbook step 3b) appends
+                # such rows verbatim — an imported archive therefore reaches
+                # this branch with observations present, and failing closed
+                # here would brick the session for every later
+                # preview/materialize/harvest. Serve the session from the
+                # sanitized per-run trajectory instead (the pre-#1095
+                # materialization source), exactly like a session with no
+                # observation rows at all; a session with no trajectory either
+                # still fails closed below naming it.
+                resolutions = _trajectory_resolutions_readonly(index_root, session_id)
             session = {
                 "session_id": session_id,
                 "trajectory_id": session_id,
@@ -139,11 +153,15 @@ def _sessions_from_hydrated_stage(index_root: Path) -> tuple[list[dict[str, Any]
 
 def _trajectory_resolutions_readonly(index_root: Path, session_id: str) -> list[dict[str, Any]]:
     """Read a session's per-finding resolutions from the sanitized per-run
-    trajectory (the pre-#1095 materialization source). Used only when the
-    hydrated staging archive carries no ``label_observations`` history for
-    the session yet (freshly hydrated stage; canonical harvest appends the
-    first rows). Fail-closed: a missing/unreadable/empty trajectory raises
-    ``HubUnavailableError`` naming the session -- never silently skipped.
+    trajectory (the pre-#1095 materialization source). Used when the hydrated
+    staging archive has no materializable ``label_observations`` history for
+    the session: no observation rows yet (freshly hydrated stage; canonical
+    harvest appends the first rows) or only legacy labels-only rows whose
+    rubric_json carries no ``per_finding_resolutions`` (pre-#1095
+    ``Rubric.to_dict``; such rows are appended verbatim by the import path,
+    runbook step 3b). Fail-closed: a missing/unreadable/empty trajectory
+    raises ``HubUnavailableError`` naming the session -- never silently
+    skipped.
     """
     trajectory_path = index_root / "runs" / session_id / "trajectory.json"
     if not trajectory_path.is_file():
@@ -166,11 +184,33 @@ def _trajectory_resolutions_readonly(index_root: Path, session_id: str) -> list[
     return resolutions
 
 
+def _raise_on_uncheckpointed_wal(db_path: Path) -> None:
+    """Fail loudly when the hydrated index has an uncheckpointed WAL.
+
+    The archive's writer (``index._get_connection``) runs in persistent WAL
+    mode, so a crashed/interrupted writer between commit and close leaves
+    committed rows in ``index.db-wal``. The read-only adapters below open with
+    ``immutable=1``, which by design skips ``-wal``/``-shm`` entirely — such
+    rows would then be silently dropped and preview/materialize would serve
+    fewer sessions with no error and no sidecar. A surviving ``index.db-wal``
+    is therefore a loud error: the operator must checkpoint/recover the index
+    (or let an active writer finish) before the read-only guarantee holds.
+    """
+    if (db_path.with_name(db_path.name + "-wal")).is_file():
+        raise HubUnavailableError(
+            f"hydrated index {db_path} has an uncheckpointed WAL "
+            f"({db_path.name}-wal): committed rows may live only in the WAL; "
+            "checkpoint or recover the index before previewing/materializing"
+        )
+
+
 def _query_runs_readonly(db_path: Path) -> list[dict[str, Any]]:
     """Read all ``runs`` rows over a **read-only** connection (``mode=ro``
     URI — ``query_runs`` goes through ``_get_connection``, which opens
     read-write, runs ``PRAGMA journal_mode=WAL`` against the hydrated
-    staging index, and leaves ``-wal``/``-shm`` sidecars behind).
+    staging index, and leaves ``-wal``/``-shm`` sidecars behind). Callers
+    must reject an uncheckpointed ``index.db-wal`` first
+    (``_raise_on_uncheckpointed_wal``): ``immutable=1`` skips it entirely.
     """
     import sqlite3
 
@@ -207,7 +247,11 @@ def _winning_observation(
 ) -> tuple[dict[str, Any], bool]:
     """Deterministic latest-observation selection (see the module docstring for
     the rule). Returns the winning row and whether the session is conflicting
-    (more than one distinct dedup key).
+    (more than one distinct disposition-relevant ``labels`` set across the
+    dedup-key groups — see ``index.append_label_observation``; a dedup-key
+    split that preserves the labels — policy-version bump, edited-reply
+    digest change, label-preserving overlay — is agreeing generations, not a
+    conflict).
     """
     groups: dict[tuple[Any, ...], dict[str, Any]] = {}
     for obs in observations:
@@ -229,7 +273,11 @@ def _winning_observation(
             str(o.get("observed_at", "")),
         ),
     )
-    return winner, len(groups) > 1
+    # Conflict is decided from disposition-relevant content (the archived
+    # labels projection), never from the full dedup tuple: two rows agreeing
+    # on the disposition but split on evidence_sha / policy version / reply
+    # digest / has_posterior are agreeing generations that stay gold-eligible.
+    return winner, len({o.get("labels") for o in winners}) > 1
 
 
 def _resolution_from_row(row: dict[str, Any]) -> PerFindingResolution:

--- a/daydream/training/adjudication/materialize.py
+++ b/daydream/training/adjudication/materialize.py
@@ -79,37 +79,49 @@ def _sessions_from_hydrated_stage(index_root: Path) -> tuple[list[dict[str, Any]
     for row in _query_runs_readonly(index_root / "index.db"):
         session_id = str(row["session_id"])
         observations = _label_observations_readonly(index_root / "index.db", session_id)
-        if not observations:
-            raise HubUnavailableError(
-                f"hydrated index session {session_id!r} has no label_observations rows "
-                "to materialize"
-            )
-        winner, conflicting = _winning_observation(observations)
-        try:
-            rubric = json.loads(winner["rubric_json"])
-        except (KeyError, TypeError, ValueError) as exc:
-            raise HubUnavailableError(
-                f"session {session_id!r}: unreadable winning rubric_json: {exc}"
-            ) from exc
-        if not isinstance(rubric, dict):
-            raise HubUnavailableError(
-                f"session {session_id!r}: winning rubric_json is not an object"
-            )
-        resolutions = rubric.get("per_finding_resolutions")
-        if not isinstance(resolutions, list) or not resolutions:
-            raise HubUnavailableError(
-                f"session {session_id!r}: winning rubric_json carries no "
-                "per_finding_resolutions to materialize (legacy labels-only rows "
-                "are not backfilled)"
-            )
-        session: dict[str, Any] = {
-            "session_id": session_id,
-            "trajectory_id": session_id,
-            "segment_id": session_id,
-            "resolutions": resolutions,
-        }
-        if conflicting:
-            session["conflicting"] = True
+        session: dict[str, Any]
+        if observations:
+            winner, conflicting = _winning_observation(observations)
+            try:
+                rubric = json.loads(winner["rubric_json"])
+            except (KeyError, TypeError, ValueError) as exc:
+                raise HubUnavailableError(
+                    f"session {session_id!r}: unreadable winning rubric_json: {exc}"
+                ) from exc
+            if not isinstance(rubric, dict):
+                raise HubUnavailableError(
+                    f"session {session_id!r}: winning rubric_json is not an object"
+                )
+            resolutions = rubric.get("per_finding_resolutions")
+            if not isinstance(resolutions, list) or not resolutions:
+                raise HubUnavailableError(
+                    f"session {session_id!r}: winning rubric_json carries no "
+                    "per_finding_resolutions to materialize (legacy labels-only rows "
+                    "are not backfilled)"
+                )
+            session = {
+                "session_id": session_id,
+                "trajectory_id": session_id,
+                "segment_id": session_id,
+                "resolutions": resolutions,
+            }
+            if conflicting:
+                session["conflicting"] = True
+        else:
+            # Freshly hydrated staging archive: no label_observations history
+            # yet (canonical harvest appends the first rows, runbook step 5).
+            # Fall back to the sanitized per-run trajectory the hydration gate
+            # guarantees (_REQUIRED_SESSION_ARTIFACTS) -- the pre-#1095
+            # materialization source -- so the first preview pass over a new
+            # stage still works. Once any observation row exists for the
+            # session it wins; the two sources are never mixed.
+            resolutions = _trajectory_resolutions_readonly(index_root, session_id)
+            session = {
+                "session_id": session_id,
+                "trajectory_id": session_id,
+                "segment_id": session_id,
+                "resolutions": resolutions,
+            }
         sessions.append(session)
     if not sessions:
         raise HubUnavailableError(f"hydrated index at {index_root} has no runs")
@@ -123,6 +135,35 @@ def _sessions_from_hydrated_stage(index_root: Path) -> tuple[list[dict[str, Any]
             "expected exactly one pinned source commit"
         )
     return sessions, revisions[0]
+
+
+def _trajectory_resolutions_readonly(index_root: Path, session_id: str) -> list[dict[str, Any]]:
+    """Read a session's per-finding resolutions from the sanitized per-run
+    trajectory (the pre-#1095 materialization source). Used only when the
+    hydrated staging archive carries no ``label_observations`` history for
+    the session yet (freshly hydrated stage; canonical harvest appends the
+    first rows). Fail-closed: a missing/unreadable/empty trajectory raises
+    ``HubUnavailableError`` naming the session -- never silently skipped.
+    """
+    trajectory_path = index_root / "runs" / session_id / "trajectory.json"
+    if not trajectory_path.is_file():
+        raise HubUnavailableError(
+            f"hydrated index session {session_id!r} has no label_observations rows "
+            f"and no trajectory at {trajectory_path}"
+        )
+    try:
+        trajectory = json.loads(trajectory_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:
+        raise HubUnavailableError(
+            f"unreadable hydrated trajectory at {trajectory_path}: {exc}"
+        ) from exc
+    resolutions = trajectory.get("resolutions") if isinstance(trajectory, dict) else None
+    if not isinstance(resolutions, list) or not resolutions:
+        raise HubUnavailableError(
+            f"hydrated trajectory for session {session_id!r} carries no "
+            "per-finding resolutions to materialize"
+        )
+    return resolutions
 
 
 def _query_runs_readonly(db_path: Path) -> list[dict[str, Any]]:

--- a/daydream/training/adjudication/materialize.py
+++ b/daydream/training/adjudication/materialize.py
@@ -75,10 +75,8 @@ def _sessions_from_hydrated_stage(index_root: Path) -> tuple[list[dict[str, Any]
         raise HubUnavailableError(
             f"hydrated index sessions file not found: {index_root / 'sessions.jsonl'}"
         )
-    from daydream.archive.index import query_runs
-
     sessions: list[dict[str, Any]] = []
-    for row in query_runs(index_root):
+    for row in _query_runs_readonly(index_root / "index.db"):
         session_id = str(row["session_id"])
         observations = _label_observations_readonly(index_root / "index.db", session_id)
         if not observations:
@@ -127,14 +125,32 @@ def _sessions_from_hydrated_stage(index_root: Path) -> tuple[list[dict[str, Any]
     return sessions, revisions[0]
 
 
-def _label_observations_readonly(db_path: Path, session_id: str) -> list[dict[str, Any]]:
-    """Read one session's ``label_observations`` rows over a **read-only**
-    connection (``mode=ro`` URI — never ``_get_connection``, which opens
-    read-write and runs WAL pragmas against the hydrated staging index).
+def _query_runs_readonly(db_path: Path) -> list[dict[str, Any]]:
+    """Read all ``runs`` rows over a **read-only** connection (``mode=ro``
+    URI — ``query_runs`` goes through ``_get_connection``, which opens
+    read-write, runs ``PRAGMA journal_mode=WAL`` against the hydrated
+    staging index, and leaves ``-wal``/``-shm`` sidecars behind).
     """
     import sqlite3
 
-    conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+    conn = sqlite3.connect(f"file:{db_path}?mode=ro&immutable=1", uri=True)
+    conn.row_factory = sqlite3.Row
+    try:
+        return [dict(r) for r in conn.execute("SELECT * FROM runs").fetchall()]
+    finally:
+        conn.close()
+
+
+def _label_observations_readonly(db_path: Path, session_id: str) -> list[dict[str, Any]]:
+    """Read one session's ``label_observations`` rows over a **read-only**
+    connection (``mode=ro&immutable=1`` URI — never ``_get_connection``,
+    which opens read-write and runs WAL pragmas against the hydrated
+    staging index; ``immutable=1`` also keeps a WAL-mode db from
+    materializing ``-shm``/``-wal`` sidecars on read).
+    """
+    import sqlite3
+
+    conn = sqlite3.connect(f"file:{db_path}?mode=ro&immutable=1", uri=True)
     conn.row_factory = sqlite3.Row
     try:
         cursor = conn.execute(

--- a/daydream/training/adjudication/materialize.py
+++ b/daydream/training/adjudication/materialize.py
@@ -262,14 +262,19 @@ def run_materialize(
             if not isinstance(row, dict):
                 raise ValueError(f"materialize: non-object resolution row in session data: {row!r}")
             resolution = _resolution_from_row(row)
-            records.append(
-                build_canonical_record(
-                    session,
-                    resolution,
-                    evidence_observed_at=pin["evidence_observed_at"],
-                    as_of=pin.get("as_of"),
-                )
+            record = build_canonical_record(
+                session,
+                resolution,
+                evidence_observed_at=pin["evidence_observed_at"],
+                as_of=pin.get("as_of"),
             )
+            if session.get("conflicting"):
+                # The session-level conflict flag rides on every emitted
+                # per-finding record so downstream consumers (canonical
+                # harvest) can exclude the disposition from decisive labels
+                # while the full record — flag included — lands in rubric_json.
+                record["conflicting"] = True
+            records.append(record)
     records.sort(key=lambda r: str(r["record_id"]))
 
     id_digest = hashlib.sha256(

--- a/daydream/training/adjudication/preview.py
+++ b/daydream/training/adjudication/preview.py
@@ -2,7 +2,10 @@
 
 Builds the adjudication queue over a hydrated index and writes a
 digest-pinned, canonical-JSON ledger so an operator can inspect exactly what a
-subsequent canonical harvest would adjudicate *before* running it. The ledger
+subsequent canonical harvest would adjudicate *before* running it. A
+hydrated staging archive with no ``sessions.jsonl`` is served through the
+same read-only SQLite adapter materialize uses (never the read-write
+``_get_connection``); preview never mutates the index. The ledger
 pins per-finding evidence digests (delta on
 ``corpus_v2.bundle``'s bundle-digest SHA256SUMS verification and
 the projector's two-bundle verification), and a re-preview against an
@@ -113,7 +116,18 @@ def run_preview(index_root: Path, ledger_path: Path) -> dict[str, Any]:
     ``resolve_source_revision``; malformed evidence raises ``ValueError``
     from the queue builder naming the offending fingerprint.
     """
-    sessions, index_revision = _load_sessions(index_root)
+    if (index_root / _SESSIONS_FILENAME).is_file():
+        sessions, index_revision = _load_sessions(index_root)
+    else:
+        # Hydrated staging archive: derive the sessions from the SQLite
+        # index's label_observations via the shared materialize adapter
+        # (read-only; lazy import — materialize imports this module's
+        # ``_load_sessions``).
+        from daydream.training.adjudication.materialize import (
+            _sessions_from_hydrated_stage,
+        )
+
+        sessions, index_revision = _sessions_from_hydrated_stage(index_root)
     items = [
         {k: item[k] for k in _ITEM_KEYS} for item in build_queue(sessions)
     ]

--- a/daydream/training/adjudication/queue.py
+++ b/daydream/training/adjudication/queue.py
@@ -34,12 +34,21 @@ def _profile_label(
     Uses the same authority as the projector: ``extract_provenance`` derives
     the profile from the canonical ``profile_*`` fields, and the label is the
     canonical ``profile_name`` when present, else the legacy flat ``profile``
-    string a resolution may carry. Never ``str(None)``-coerced in the export.
+    string a resolution may carry. A nested ``profile`` block (canonical
+    annotation records carry one — ``extract_provenance``'s shape) contributes
+    its ``profile_name`` too, so a resolution row stored after the #1095
+    canonical serialization resolves to the same label its provenance would.
+    Never ``str(None)``-coerced and never ``str(dict)``-coerced in the export.
     """
     profile_name = provenance["profile"].get("profile_name")
     if profile_name is not None:
         return str(profile_name)
     flat = resolution.get("profile")
+    if isinstance(flat, Mapping):
+        nested_name = flat.get("profile_name")
+        if nested_name is not None:
+            return str(nested_name)
+        return None
     return str(flat) if flat is not None else None
 
 _ITEM_KEYS = (

--- a/daydream/training/labeler_signals.py
+++ b/daydream/training/labeler_signals.py
@@ -28,7 +28,7 @@ import json
 import re
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Callable, Literal, cast
+from typing import Any, Callable, Literal, Mapping, cast, get_args
 
 from daydream.pr_review import parse_finding_markers
 from daydream.training.labeler_versions import reply_evidence_digest
@@ -236,6 +236,46 @@ class PerFindingResolution:
     disposition: PerFindingDisposition
     evidence: list[dict[str, Any]] = field(default_factory=list)
     evidence_digest: str = ""
+
+
+def resolution_to_dict(r: PerFindingResolution) -> dict[str, Any]:
+    """Serialize a ``PerFindingResolution`` to the canonical dict shape.
+
+    Emits exactly the canonical keys; ``evidence`` is copied, never aliased.
+    """
+
+    return {
+        "fingerprint": r.fingerprint,
+        "comment_id": r.comment_id,
+        "disposition": r.disposition,
+        "evidence": list(r.evidence),
+        "evidence_digest": r.evidence_digest,
+    }
+
+
+def resolution_from_dict(payload: Mapping[str, Any]) -> PerFindingResolution:
+    """Rebuild a ``PerFindingResolution`` from the canonical dict shape.
+
+    Fail-closed: missing required fields raise ``ValueError`` naming the
+    field; never ``None``-coerced, no fallback substitution.
+    """
+
+    fingerprint = payload.get("fingerprint")
+    if not fingerprint:
+        raise ValueError("missing or empty fingerprint")
+    disposition = payload.get("disposition")
+    if disposition not in get_args(PerFindingDisposition):
+        raise ValueError(f"invalid disposition: {disposition!r}")
+    evidence_digest = payload.get("evidence_digest")
+    if not evidence_digest:
+        raise ValueError("missing or empty evidence_digest")
+    return PerFindingResolution(
+        fingerprint=fingerprint,
+        comment_id=payload.get("comment_id"),
+        disposition=cast(PerFindingDisposition, disposition),
+        evidence=list(payload.get("evidence") or []),
+        evidence_digest=evidence_digest,
+    )
 
 
 @dataclass(frozen=True)

--- a/daydream/training/rubric.py
+++ b/daydream/training/rubric.py
@@ -30,6 +30,7 @@ from daydream.training.labeler_signals import (
     LocalCommitAppliedSignal,
     PerFindingResolution,
     PRMergeSignal,
+    resolution_to_dict,
 )
 
 PosteriorSource = Literal["pr_review", "local_branch", "none"]
@@ -56,7 +57,10 @@ class Rubric:
             carries the authoritative outcome label.
         per_finding_resolutions: Per-finding dispositions joined by
             fingerprint, or ``None`` when no per-finding join was
-            performed. Serialized as ``per_finding_outcomes``.
+            performed. Serialized two ways: the full resolution objects
+            (fingerprint, disposition, evidence, evidence digest) under
+            ``per_finding_resolutions``, and the derived labels-only view
+            under ``per_finding_outcomes`` for existing consumers.
     """
 
     pr_merge: PRMergeSignal
@@ -95,6 +99,7 @@ class Rubric:
         if self.local_commit_applied is not None:
             out["local_commit_applied"] = {"verdict": self.local_commit_applied.verdict}
         if self.per_finding_resolutions is not None:
+            out["per_finding_resolutions"] = [resolution_to_dict(r) for r in self.per_finding_resolutions]
             out["per_finding_outcomes"] = derive_per_finding_labels(self, self.per_finding_resolutions)
         return out
 

--- a/docs/runbooks/annotation-final-publish.md
+++ b/docs/runbooks/annotation-final-publish.md
@@ -154,9 +154,11 @@ The real run is read-only over the sources: it appends the surviving
 the `--archive-dir` archive and writes the digest-stable import report and
 ledger beside the scan artifacts in `--state-dir`. The import never writes
 the state-dir `index.db`; the hydrated archive is the single merge target.
-To checkpoint the merged state for fresh-VM resume, add
+To checkpoint the merged state for fresh-VM resume, re-run the command with
 `--publish --manifest /tmp/snapshot/preview-manifest.json` (mutually
-exclusive with `--dry-run`) after the real run has succeeded once.
+exclusive with `--dry-run`) — the publish payload also needs the queue and
+observations that step 4's `build`/`label` produce, so run that publish
+re-run after step 4 (see the checkpoint note there).
 
 ## 4. Build, label, and publish the human queue
 
@@ -180,6 +182,17 @@ daydream corpus adjudicate publish-state --state-dir /tmp/state --manifest /tmp/
 decisive records — those are adjudicated automatically.
 `label` records provenance (who, why, when) that the final bundle carries
 forward. `publish-state` uploads additively, so it is safe to re-run.
+
+To checkpoint the step-3b import's merged history for fresh-VM resume, re-run
+the step-3b import with `--publish --manifest
+/tmp/snapshot/preview-manifest.json` (mutually exclusive with `--dry-run`);
+`build` above supplies the queue the publish payload requires, and the import
+stages the merged `--archive-dir` index into the state dir for the
+publication:
+
+```bash
+daydream corpus adjudicate import-local-observations --archive-root /tmp/local-archive --index-root /tmp/snapshot --archive-dir /tmp/daydream-hydrate --state-dir /tmp/state --publish --manifest /tmp/snapshot/preview-manifest.json
+```
 
 ## 5. Canonical harvest with the drift gate
 

--- a/docs/runbooks/annotation-final-publish.md
+++ b/docs/runbooks/annotation-final-publish.md
@@ -20,7 +20,8 @@ Two operator-safety constraints frame every step:
   published adjudication state from the Hub after VM loss. Re-run it any time
   you are unsure the local state is intact.
 
-Every `daydream corpus adjudicate` command below (steps 1–8) is a literal, single-line CLI invocation that parses against the real parser (enforced by
+Every `daydream corpus adjudicate` command below (steps 1–8, including the
+lettered sub-steps 3a–3b) is a literal, single-line CLI invocation that parses against the real parser (enforced by
 `tests/test_cli_adjudicate.py::test_runbook_commands_parse_against_real_parser`). The step 9 (`corpus build-v2`) and step 10 (`train --corpus-v2`) commands are not covered by that parser check — `tests/test_training_docs_v2.py` only asserts their presence.
 
 ---
@@ -102,6 +103,60 @@ curation manifest), and `--sanitized-hub-commit` is the same pinned revision.
 `/tmp/snapshot` receives `sessions.jsonl` and the `preview-manifest.json` that
 pins it. This snapshot is the input to both the canonical harvest (step 5) and
 the final bundle (steps 6–7).
+
+## 3a. Preview the ledger — the pre-harvest drift check
+
+Before labeling (or re-harvesting on a resume), build the digest-pinned preview
+ledger over the materialized snapshot and validate the export rows it feeds —
+without writing anything:
+
+```bash
+daydream corpus adjudicate export --index-root /tmp/snapshot --state-dir /tmp/state --dry-run
+```
+
+This runs the read-only preview over the snapshot's `sessions.jsonl` and pins
+`preview-ledger.json` (canonical JSON, byte-identical for an identical index)
+in `/tmp/state`. The ledger is the drift reference the canonical harvest's
+drift gate (step 5) adjudicates the queue against — a re-run of this command
+against a changed snapshot reports any drifted record ids instead of silently
+merging them, which is exactly what you want to catch before labeling or
+harvesting. Re-run it any time the snapshot or the observations change.
+
+## 3b. Import surviving local history into the hydrated archive
+
+Before the canonical harvest, merge any surviving local archive/backup roots'
+immutable `label_observations` histories into the hydrated stage's archive
+index — the same `index.db` (under `INDEX_ROOT`, i.e. `/tmp/daydream-hydrate`)
+that step 5 appends the harvest's observations into, so imported and
+harvested resolutions meet in one place. First plan the import without
+writing anything:
+
+```bash
+daydream corpus adjudicate import-local-observations --archive-root /tmp/local-archive --index-root /tmp/snapshot --archive-dir /tmp/daydream-hydrate --state-dir /tmp/state --dry-run
+```
+
+`--archive-root` (repeatable) is each local archive/backup root holding an
+`index.db` with a `label_observations` history; `--index-root` is the pinned
+materialized snapshot the import links session identity and per-finding
+evidence against. The dry run inventories the sources, runs the identity
+linkage and content-digest dedupe against the pinned index, and reports the
+reason-coded per-session accounting (the buckets always sum to the source row
+count) while writing nothing.
+
+Proceed with the real run only after the planned accounting looks right:
+
+```bash
+daydream corpus adjudicate import-local-observations --archive-root /tmp/local-archive --index-root /tmp/snapshot --archive-dir /tmp/daydream-hydrate --state-dir /tmp/state
+```
+
+The real run is read-only over the sources: it appends the surviving
+(survived-dedupe) rows — after a fail-closed redaction + secret scan — into
+the `--archive-dir` archive and writes the digest-stable import report and
+ledger beside the scan artifacts in `--state-dir`. The import never writes
+the state-dir `index.db`; the hydrated archive is the single merge target.
+To checkpoint the merged state for fresh-VM resume, add
+`--publish --manifest /tmp/snapshot/preview-manifest.json` (mutually
+exclusive with `--dry-run`) after the real run has succeeded once.
 
 ## 4. Build, label, and publish the human queue
 

--- a/docs/runbooks/annotation-final-publish.md
+++ b/docs/runbooks/annotation-final-publish.md
@@ -108,7 +108,8 @@ the final bundle (steps 6–7).
 
 Before labeling (or re-harvesting on a resume), build the digest-pinned preview
 ledger over the materialized snapshot and validate the export rows it feeds —
-without writing anything:
+`--dry-run` skips only the `--out` export rows file; the ledger pin below is
+written either way:
 
 ```bash
 daydream corpus adjudicate export --index-root /tmp/snapshot --state-dir /tmp/state --dry-run
@@ -116,11 +117,13 @@ daydream corpus adjudicate export --index-root /tmp/snapshot --state-dir /tmp/st
 
 This runs the read-only preview over the snapshot's `sessions.jsonl` and pins
 `preview-ledger.json` (canonical JSON, byte-identical for an identical index)
-in `/tmp/state`. The ledger is the drift reference the canonical harvest's
-drift gate (step 5) adjudicates the queue against — a re-run of this command
-against a changed snapshot reports any drifted record ids instead of silently
-merging them, which is exactly what you want to catch before labeling or
-harvesting. Re-run it any time the snapshot or the observations change.
+in `/tmp/state` — the ledger feeds the export rows and the publish payload. The
+canonical harvest's drift gate (step 5) does not read it: it re-derives the
+fresh queue over the snapshot and compares materialized evidence digests
+against that queue directly. A re-run of this command against a changed
+snapshot reports any drifted record ids instead of silently merging them,
+which is exactly what you want to catch before labeling or harvesting. Re-run
+it any time the snapshot or the observations change.
 
 ## 3b. Import surviving local history into the hydrated archive
 

--- a/tests/test_cli_corpus_namespace.py
+++ b/tests/test_cli_corpus_namespace.py
@@ -36,6 +36,32 @@ def _run_main(argv: list[str]) -> int:
     return 0
 
 
+def test_corpus_harvest_exits_nonzero_on_aborted_summary(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _fake_run_harvest(_config: Any) -> dict[str, Any]:
+        return {"considered": 3, "annotated": 1, "skipped": 0, "errors": 0, "aborted": 1}
+
+    monkeypatch.setattr("daydream.training.harvest.run_harvest", _fake_run_harvest)
+    assert _run_main(["corpus", "harvest", "--dry-run"]) == 1
+
+
+def test_corpus_harvest_exits_nonzero_on_row_errors(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _fake_run_harvest(_config: Any) -> dict[str, Any]:
+        return {"considered": 3, "annotated": 1, "skipped": 0, "errors": 2, "aborted": 0}
+
+    monkeypatch.setattr("daydream.training.harvest.run_harvest", _fake_run_harvest)
+    assert _run_main(["corpus", "harvest", "--dry-run"]) == 1
+
+
+def test_corpus_harvest_still_exits_zero_on_clean_partial(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Unresolved findings in the data are not process failure (spec KD)."""
+
+    def _fake_run_harvest(_config: Any) -> dict[str, Any]:
+        return {"considered": 3, "annotated": 1, "skipped": 2, "errors": 0, "aborted": 0}
+
+    monkeypatch.setattr("daydream.training.harvest.run_harvest", _fake_run_harvest)
+    assert _run_main(["corpus", "harvest", "--dry-run"]) == 0
+
+
 def test_corpus_harvest_routes(monkeypatch: pytest.MonkeyPatch) -> None:
     called = {}
 

--- a/tests/test_training_adjudication_canonical.py
+++ b/tests/test_training_adjudication_canonical.py
@@ -559,3 +559,39 @@ def test_conflicted_session_yields_no_decisive_label(tmp_path: Path) -> None:
     assert rubric["per_finding_resolutions"][0]["conflicting"] is True
     # and no decisive label was projected from the conflicted disposition
     assert "finding-accepted" not in history[0]["labels"]
+
+
+def test_conflicted_session_never_projects_gold(tmp_path: Path) -> None:
+    """The non-gold guarantee extends to the corpus-v2 projection: a
+    conflicted session's annotations.jsonl row (full record, ``conflicting``
+    flag intact) must never classify gold with ``outcome_label`` set even
+    with a decisive disposition + evidence -- the same gate canonical.py
+    applies to the archive labels column, enforced where ``classify_tier``
+    flows into the projected record."""
+    from daydream.training.corpus_v2.projector import project_findings
+
+    root = _hydrated_sqlite_index_with_conflict(tmp_path)  # two distinct dedup keys, s1
+    mat = tmp_path / "mat"
+    run_materialize(root, mat, pin=_PIN)
+    archive = tmp_path / "archive"
+    _seed_archive(archive)
+    run_canonical_harvest(index_root=root, materialize_dir=mat, archive_dir=archive)
+    rows = [
+        json.loads(line)
+        for line in (mat / "annotations.jsonl").read_text().splitlines()
+        if line
+    ]
+    # the flag rides through the harvest into the projection input verbatim
+    assert any(row.get("conflicting") is True for row in rows)
+    # run_build_corpus_v2's snapshot assembly (session-scoped resolutions) --
+    # the boundary classify_tier reaches the corpus-v2 gold label through.
+    session = {
+        "session_id": "s1",
+        "trajectory_id": "s1",
+        "segment_id": "s1",
+        "resolutions": [row for row in rows if row.get("session_id") == "s1"],
+    }
+    records = project_findings(session)
+    assert records  # the finding is still projected -- provenance preserved
+    assert all(r["tier"] != "gold" for r in records)
+    assert all(r["outcome_label"] is None for r in records)

--- a/tests/test_training_adjudication_canonical.py
+++ b/tests/test_training_adjudication_canonical.py
@@ -548,6 +548,11 @@ def test_conflicted_session_yields_no_decisive_label(tmp_path: Path) -> None:
     run_materialize(root, mat, pin=_PIN)
     record = json.loads((tmp_path / "mat" / "sessions.jsonl").read_text().splitlines()[0])
     assert record["conflicting"] is True  # surfaced, never silently merged
+    # The conflicted disposition is neutralized so the operator queue routes
+    # the finding to task-only adjudication and the bundle carries one
+    # disposition (issue #336 item 7) -- the archive rubric_json restores the
+    # real decisive disposition for provenance in the harvest below.
+    assert record["disposition"] == "ambiguous"
     archive = tmp_path / "archive"
     _seed_archive(archive)
     out = run_canonical_harvest(
@@ -559,6 +564,112 @@ def test_conflicted_session_yields_no_decisive_label(tmp_path: Path) -> None:
     assert rubric["per_finding_resolutions"][0]["conflicting"] is True
     # and no decisive label was projected from the conflicted disposition
     assert "finding-accepted" not in history[0]["labels"]
+
+
+def test_canonical_harvest_re_derives_conflict_after_materialize(tmp_path: Path) -> None:
+    """A session that becomes conflicting *after* materialize (runbook step-3b
+    import appends a disagreeing generation to the same index.db) passes the
+    evidence-digest drift gate but must not emit decisive labels: the conflict
+    verdict is re-derived from the fresh sessions at harvest time, never
+    trusted from the materialized snapshot's flags (issue #336 item 2)."""
+    from daydream.archive.index import _get_connection
+
+    root = tmp_path / "hydrated"
+    conn = _get_connection(root)
+    conn.execute(
+        "INSERT INTO runs (session_id, archived_at, run_flow, archive_path) "
+        "VALUES ('s1', '2026-01-01T00:00:00+00:00', 'deep', 'archive/s1')"
+    )
+    rubric = {"posterior_source": "pr_review",
+              "per_finding_resolutions": [{
+                  "fingerprint": "fp-1", "comment_id": 7, "disposition": "accepted",
+                  "evidence": [{"reply_id": 1, "body_sha256": "abc"}],
+                  "evidence_digest": "d" * 32}]}
+    rubric_json = json.dumps(rubric)
+    conn.execute(
+        "INSERT INTO label_observations (session_id, observed_at, labels, labeler_version, "
+        "evidence_sha, rubric_json, has_posterior, source, labeler_policy_version) "
+        "VALUES ('s1', '2026-01-02T00:00:00+00:00', '[\"finding-accepted\"]', 'v1', "
+        "'e' * 64, ?, 0, 'auto', '980-rubric-r2')",
+        (rubric_json,),
+    )
+    conn.commit()
+    conn.close()
+    (root / "downloads" / ("a" * 40)).mkdir(parents=True)
+    mat = tmp_path / "mat"
+    run_materialize(root, mat, pin=_PIN)
+    record = json.loads((tmp_path / "mat" / "sessions.jsonl").read_text().splitlines()[0])
+    assert record.get("conflicting") is None  # not conflicting at materialize time
+    # Step-3b import: an older disagreeing generation lands in the same
+    # index.db -- the winning row (and its evidence digest) is unchanged.
+    conn = _get_connection(root)
+    conn.execute(
+        "INSERT INTO label_observations (session_id, observed_at, labels, labeler_version, "
+        "evidence_sha, rubric_json, has_posterior, source, labeler_policy_version) "
+        "VALUES ('s1', '2026-01-01T00:00:00+00:00', '[\"finding-rejected\"]', 'v1', "
+        "'d' * 64, ?, 0, 'auto', '980-rubric-r2')",
+        (rubric_json,),
+    )
+    conn.commit()
+    conn.close()
+    archive = tmp_path / "archive"
+    _seed_archive(archive)
+    out = run_canonical_harvest(index_root=root, materialize_dir=mat, archive_dir=archive)
+    assert out["appended_sessions"] == 1
+    history = label_observation_history(archive, "s1")
+    # The freshly re-derived conflict suppressed the decisive label even
+    # though the materialized snapshot had no conflicting flag.
+    assert "finding-accepted" not in history[0]["labels"]
+    rows = [
+        json.loads(line)
+        for line in (mat / "annotations.jsonl").read_text().splitlines()
+        if line
+    ]
+    assert rows[0]["disposition"] == "ambiguous"
+    assert rows[0]["conflicting"] is True
+
+
+def test_canonical_harvest_human_resolution_clears_session_conflict(
+    tmp_path: Path,
+) -> None:
+    """A decisive human adjudication on a conflicted finding resolves the
+    conflict: the precedence merge clears the ``conflicting`` flag so the
+    resolution is not suppressed to non-gold, and the archive row projects the
+    decisive label (issue #336 item 7 -- a human override is never ignored)."""
+    from daydream.training.corpus_v2.identity import record_id
+
+    root = _hydrated_sqlite_index_with_conflict(tmp_path)  # two distinct dedup keys, s1
+    mat = tmp_path / "mat"
+    run_materialize(root, mat, pin=_PIN)
+    archive = tmp_path / "archive"
+    _seed_archive(archive)
+    rid = record_id("s1", "s1", "s1", "fp-1")
+    obs = tmp_path / "observations.jsonl"
+    obs.write_text(json.dumps({
+        "record_id": rid, "disposition": "accepted", "evidence_digest": "d" * 32,
+        "evidence": [], "labeler": "alice", "role": "adjudicator",
+        "rationale": "operator resolved the disagreeing generations",
+        "valid_at": "2026-01-02T00:00:00+00:00",
+        "observed_at": "2026-01-02T01:00:00+00:00", "rubric_version": "v1",
+    }) + "\n", encoding="utf-8")
+    out = run_canonical_harvest(
+        index_root=root, materialize_dir=mat, archive_dir=archive,
+        observations_path=obs,
+    )
+    assert out["human_adjudicated"] == 1
+    history = label_observation_history(archive, "s1")
+    rubric = json.loads(history[0]["rubric_json"])
+    record = rubric["per_finding_resolutions"][0]
+    assert record.get("conflicting") is not True  # cleared by the human resolution
+    assert record["disposition"] == "accepted"
+    assert "finding-accepted" in history[0]["labels"]
+    rows = [
+        json.loads(line)
+        for line in (mat / "annotations.jsonl").read_text().splitlines()
+        if line
+    ]
+    assert rows[0]["disposition"] == "accepted"
+    assert rows[0].get("conflicting") is not True
 
 
 def test_conflicted_session_never_projects_gold(tmp_path: Path) -> None:

--- a/tests/test_training_adjudication_canonical.py
+++ b/tests/test_training_adjudication_canonical.py
@@ -502,3 +502,60 @@ def test_canonical_harvest_complete_set_is_idempotent_and_exactly_once(
     assert (mat / "annotations.jsonl").read_bytes() == first
     assert summary2["appended_sessions"] == 0
     assert summary2["skipped_sessions"] == 3
+
+
+def _hydrated_sqlite_index_with_conflict(tmp_path: Path) -> Path:
+    """Task 3's ``_hydrated_sqlite_index`` shape, extended with a second,
+    distinct-dedup-key ``label_observations`` row for the same session — two
+    harvester generations disagreeing (labels differ ⇒ dedup keys differ) on
+    one ``s1``. The latest-observed auto row wins; the session is conflicting."""
+    from daydream.archive.index import _get_connection
+
+    root = tmp_path / "hydrated"
+    conn = _get_connection(root)
+    conn.execute(
+        "INSERT INTO runs (session_id, archived_at, run_flow, archive_path) "
+        "VALUES ('s1', '2026-01-01T00:00:00+00:00', 'deep', 'archive/s1')"
+    )
+    rubric = {"posterior_source": "pr_review",
+              "per_finding_resolutions": [{
+                  "fingerprint": "fp-1", "comment_id": 7, "disposition": "accepted",
+                  "evidence": [{"reply_id": 1, "body_sha256": "abc"}],
+                  "evidence_digest": "d" * 32}]}
+    rubric_json = json.dumps(rubric)
+    for observed_at, labels, evidence_sha in (
+        ("2026-01-02T00:00:00+00:00", '["finding-accepted"]', "e" * 64),
+        ("2026-01-03T00:00:00+00:00", '["finding-rejected"]', "f" * 64),
+    ):
+        conn.execute(
+            "INSERT INTO label_observations (session_id, observed_at, labels, labeler_version, "
+            "evidence_sha, rubric_json, has_posterior, source, labeler_policy_version) "
+            "VALUES ('s1', ?, ?, 'v1', ?, ?, 0, 'auto', '980-rubric-r2')",
+            (observed_at, labels, evidence_sha, rubric_json),
+        )
+    conn.commit()
+    conn.close()
+    (root / "downloads" / ("a" * 40)).mkdir(parents=True)
+    return root
+
+
+def test_conflicted_session_yields_no_decisive_label(tmp_path: Path) -> None:
+    """Two distinct harvester dedup keys on one session = conflicting
+    observations: the winner's resolutions still materialize, but the
+    canonical harvest must not emit a decisive finding label for it."""
+    root = _hydrated_sqlite_index_with_conflict(tmp_path)  # two distinct dedup keys, s1
+    mat = tmp_path / "mat"
+    run_materialize(root, mat, pin=_PIN)
+    record = json.loads((tmp_path / "mat" / "sessions.jsonl").read_text().splitlines()[0])
+    assert record["conflicting"] is True  # surfaced, never silently merged
+    archive = tmp_path / "archive"
+    _seed_archive(archive)
+    out = run_canonical_harvest(
+        index_root=root, materialize_dir=mat, archive_dir=archive,
+    )
+    assert out["appended_sessions"] == 1
+    history = label_observation_history(archive, "s1")
+    rubric = json.loads(history[0]["rubric_json"])
+    assert rubric["per_finding_resolutions"][0]["conflicting"] is True
+    # and no decisive label was projected from the conflicted disposition
+    assert "finding-accepted" not in history[0]["labels"]

--- a/tests/test_training_adjudication_e2e_issue1095.py
+++ b/tests/test_training_adjudication_e2e_issue1095.py
@@ -30,7 +30,7 @@ _OBSERVED = "2026-01-02T00:00:00+00:00"
 _EVIDENCE = [{"reply_id": 1, "body_sha256": "abc", "created_at": "2026-01-01T00:00:00+00:00"}]
 
 
-def _resolution(fingerprint: str, disposition: str, digest: str) -> dict:
+def _resolution(fingerprint: str, disposition: str, digest: str) -> dict[str, object]:
     return {
         "fingerprint": fingerprint, "disposition": disposition,
         "evidence": _EVIDENCE, "evidence_digest": digest,

--- a/tests/test_training_adjudication_e2e_issue1095.py
+++ b/tests/test_training_adjudication_e2e_issue1095.py
@@ -1,0 +1,159 @@
+"""Issue #1095 acceptance: hydrated archive -> preview -> imported local
+history -> queue -> canonical drift-checked harvest, every finding exactly once.
+
+Real-path fixture: real SQLite ``index.db`` files written through the
+production archive writers (``upsert_run`` / ``append_label_observation``),
+the real CLI entrypoint for the local-history import, and the real
+materialize/preview/canonical pipeline. No mocking anywhere — Task 10 owns
+the publish wiring.
+"""
+
+import json
+from pathlib import Path
+
+from daydream.archive.index import append_label_observation, label_observation_history, upsert_run
+from daydream.training.adjudication.canonical import run_canonical_harvest
+from daydream.training.adjudication.cli import handle_adjudicate
+from daydream.training.adjudication.materialize import run_materialize
+from daydream.training.adjudication.preview import run_preview
+from tests.harness.trajectory import make_manifest
+
+_PIN = {  # same shape as tests/test_training_adjudication_canonical.py
+    "curation_id": "cur-e2e", "sanitized_hub_commit": "a" * 40,
+    "source_hub_commit": "b" * 40, "archive_index_digest": "c" * 64,
+    "evidence_observed_at": "2026-01-01T00:00:00+00:00",
+    "as_of": "2026-02-01T00:00:00+00:00",
+    "labeler_version": "v1", "rubric_version": "v1", "classifier_version": "v1",
+}
+
+_OBSERVED = "2026-01-02T00:00:00+00:00"
+_EVIDENCE = [{"reply_id": 1, "body_sha256": "abc", "created_at": "2026-01-01T00:00:00+00:00"}]
+
+
+def _resolution(fingerprint: str, disposition: str, digest: str) -> dict:
+    return {
+        "fingerprint": fingerprint, "disposition": disposition,
+        "evidence": _EVIDENCE, "evidence_digest": digest,
+        "profile": "pr_review", "stack": "python", "comment_id": 7,
+    }
+
+
+def _seed_observation(
+    root: Path, session_id: str, fingerprint: str, disposition: str, digest: str,
+    *, labels: list[str], observed_at: str = _OBSERVED,
+) -> None:
+    append_label_observation(
+        root,
+        session_id,
+        labels=labels,
+        pr_state=None,
+        labeler_version="980-rubric-r2",
+        evidence_sha=digest,
+        rubric_json=json.dumps({
+            "posterior_source": "pr_review",
+            "per_finding_resolutions": [_resolution(fingerprint, disposition, digest)],
+        }),
+        valid_at=_OBSERVED,
+        reply_evidence_digest=None,
+        reward_version=None,
+        has_posterior=False,
+        source="auto",
+        observed_at=observed_at,
+    )
+
+
+def _seed_run(root: Path, session_id: str) -> tuple[str, str]:
+    head = "h" + session_id.encode().hex()
+    base = "b" + session_id.encode().hex()
+    upsert_run(root, make_manifest(session_id=session_id, repo_slug="org/repo",
+                                   head_sha=head, base_sha=base))
+    return base, head
+
+
+def _seed_hydrated_archive(tmp_path: Path) -> Path:
+    """Four sessions: accepted, rejected, conflicted (two distinct dedup keys),
+    unresolved (unanswered) — each through the real archive writers, with
+    ``rubric_json`` carrying the full ``per_finding_resolutions`` (Task 2
+    shape) so the SQLite materialization path can consume the index."""
+    root = tmp_path / "hydrated"
+    _seed_run(root, "s-acc")
+    _seed_observation(root, "s-acc", "fp-acc", "accepted", "d0" * 32,
+                      labels=["finding-accepted"])
+    _seed_run(root, "s-rej")
+    _seed_observation(root, "s-rej", "fp-rej", "rejected", "d1" * 32,
+                      labels=["finding-rejected"])
+    _seed_run(root, "s-unres")
+    _seed_observation(root, "s-unres", "fp-unres", "unanswered", "d2" * 32,
+                      labels=["finding-unanswered"])
+    # Conflicted: two observations with distinct dedup keys (different labels)
+    # for the same session — the materializer must surface the session
+    # non-gold (``conflicting: true``), never merge the generations away.
+    _seed_run(root, "s-conf")
+    _seed_observation(root, "s-conf", "fp-conf", "accepted", "d3" * 32,
+                      labels=["finding-accepted"], observed_at="2026-01-02T00:00:00+00:00")
+    _seed_observation(root, "s-conf", "fp-conf", "accepted", "d3" * 32,
+                      labels=["finding-accepted", "posterior"],
+                      observed_at="2026-01-03T00:00:00+00:00")
+    (root / "downloads" / ("a" * 40)).mkdir(parents=True)
+    return root
+
+
+def _seed_local_backup(tmp_path: Path, base: str, head: str) -> Path:
+    """A local backup archive carrying a byte-identical copy of s-acc's
+    observation — the merge must dedupe it (no new generation, s-acc stays
+    non-conflicting at harvest time)."""
+    backup = tmp_path / "backup"
+    upsert_run(backup, make_manifest(session_id="s-acc", repo_slug="org/repo",
+                                     head_sha=head, base_sha=base))
+    _seed_observation(backup, "s-acc", "fp-acc", "accepted", "d0" * 32,
+                      labels=["finding-accepted"])
+    return backup
+
+
+def test_hydrated_to_canonical_harvest_end_to_end(tmp_path: Path) -> None:
+    root = _seed_hydrated_archive(tmp_path)
+    # 1. preview is read-only over the hydrated index and pins the operator
+    #    queue (only the non-decisive finding enters it; the decisive ones are
+    #    enumerated by materialize + the complete-set drift gate).
+    summary = run_preview(root, tmp_path / "ledger.json")
+    assert summary["item_count"] == 1
+    # 2. materialize from SQLite: one record per finding, all four classes.
+    mat = run_materialize(root, tmp_path / "snapshot", pin=_PIN)
+    assert mat["record_count"] == 4
+    # 3. import a local backup history for one session (CLI path, dry-run
+    #    then real) — identical content, so the merge dedupes and the
+    #    session stays non-conflicting.
+    base, head = "b" + b"s-acc".hex(), "h" + b"s-acc".hex()
+    backup = _seed_local_backup(tmp_path, base, head)
+    rc = handle_adjudicate([
+        "import-local-observations", "--archive-root", str(backup),
+        "--index-root", str(root), "--archive-dir", str(root),
+        "--state-dir", str(tmp_path / "state"), "--dry-run", "--json",
+    ])
+    assert rc == 0
+    rc = handle_adjudicate([
+        "import-local-observations", "--archive-root", str(backup),
+        "--index-root", str(root), "--archive-dir", str(root),
+        "--state-dir", str(tmp_path / "state"),
+    ])
+    assert rc == 0
+    # 4. canonical drift-checked harvest over the same hydrated archive
+    out = run_canonical_harvest(
+        index_root=root, materialize_dir=tmp_path / "snapshot", archive_dir=root,
+    )
+    # exactly-once accounting: 4 sessions in, 4 session rows out
+    assert out["record_count"] == 4
+    rows = [r for sid in ("s-acc", "s-rej", "s-conf", "s-unres")
+            for r in label_observation_history(root, sid)]
+    assert len(rows) >= 4  # one per session at minimum (import may add generations)
+    dispositions = set()
+    for row in rows:
+        rubric = json.loads(row["rubric_json"])
+        for rec in rubric["per_finding_resolutions"]:
+            dispositions.add((rec["fingerprint"], rec["disposition"], rec.get("conflicting", False)))
+    # accepted, rejected, unresolved each exactly once; conflicted surfaced non-gold
+    assert ("fp-acc", "accepted", False) in dispositions
+    assert ("fp-rej", "rejected", False) in dispositions
+    assert ("fp-unres", "unanswered", False) in dispositions
+    assert ("fp-conf", "accepted", True) in dispositions
+    assert len([d for d in dispositions if d[0] == "fp-acc"]) == 1

--- a/tests/test_training_adjudication_e2e_issue1095.py
+++ b/tests/test_training_adjudication_e2e_issue1095.py
@@ -71,8 +71,10 @@ def _seed_run(root: Path, session_id: str) -> tuple[str, str]:
 
 
 def _seed_hydrated_archive(tmp_path: Path) -> Path:
-    """Four sessions: accepted, rejected, conflicted (two distinct dedup keys),
-    unresolved (unanswered) — each through the real archive writers, with
+    """Five sessions: accepted, rejected, conflicted (two distinct dedup keys),
+    unresolved (unanswered), and legacy (labels-only row with no trajectory
+    artifact — the state a step-3b import of a backup-root session outside the
+    curation leaves behind) — each through the real archive writers, with
     ``rubric_json`` carrying the full ``per_finding_resolutions`` (Task 2
     shape) so the SQLite materialization path can consume the index."""
     root = tmp_path / "hydrated"
@@ -94,6 +96,21 @@ def _seed_hydrated_archive(tmp_path: Path) -> Path:
     _seed_observation(root, "s-conf", "fp-conf", "accepted", "d3" * 32,
                       labels=["finding-accepted", "posterior"],
                       observed_at="2026-01-03T00:00:00+00:00")
+    # Legacy labels-only session with no trajectory anywhere (DB-only runs
+    # row, no runs/<sid> files): the exact state a step-3b import of a backup
+    # root session outside the curation leaves behind. It has no per-finding
+    # resolutions to materialize and must not brick any later
+    # preview/materialize/harvest derivation (issue #336 item 5).
+    _seed_run(root, "s-legacy")
+    append_label_observation(
+        root, "s-legacy",
+        labels=["finding-accepted"], pr_state=None,
+        labeler_version="980-rubric-r2", evidence_sha=None,
+        rubric_json=json.dumps({"per_finding_outcomes": ["accepted"]}),
+        valid_at=_OBSERVED, reply_evidence_digest=None,
+        reward_version=None, has_posterior=False, source="auto",
+        observed_at="2026-01-02T00:00:00+00:00",
+    )
     (root / "downloads" / ("a" * 40)).mkdir(parents=True)
     return root
 
@@ -117,9 +134,34 @@ def test_hydrated_to_canonical_harvest_end_to_end(tmp_path: Path) -> None:
     #    enumerated by materialize + the complete-set drift gate).
     summary = run_preview(root, tmp_path / "ledger.json")
     assert summary["item_count"] == 1
-    # 2. materialize from SQLite: one record per finding, all four classes.
+    # 2. materialize from SQLite: one record per finding across the
+    # materializable classes; the legacy labels-only session contributes
+    # nothing (record_count stays 4) instead of bricking the derivation.
     mat = run_materialize(root, tmp_path / "snapshot", pin=_PIN)
     assert mat["record_count"] == 4
+    # 2a. the conflicted finding is routed to task-only adjudication: the
+    # materialized record carries the neutralized disposition (one disposition
+    # in the bundle, never gold) while the operator queue enumerates it
+    # (issue #336 item 7).
+    from daydream.training.adjudication.queue import build_queue
+
+    snapshot_records = {
+        json.loads(line)["fingerprint"]: json.loads(line)
+        for line in (tmp_path / "snapshot" / "sessions.jsonl").read_text().splitlines()
+        if line
+    }
+    assert snapshot_records["fp-conf"]["conflicting"] is True
+    assert snapshot_records["fp-conf"]["disposition"] == "ambiguous"
+    queue = build_queue(
+        [
+            json.loads(line)
+            for line in (tmp_path / "snapshot" / "sessions.jsonl").read_text().splitlines()
+            if line
+        ]
+    )
+    assert snapshot_records["fp-conf"]["record_id"] in {
+        str(item["record_id"]) for item in queue
+    }
     # 3. import a local backup history for one session (CLI path, dry-run
     #    then real) — identical content, so the merge dedupes and the
     #    session stays non-conflicting.
@@ -141,7 +183,9 @@ def test_hydrated_to_canonical_harvest_end_to_end(tmp_path: Path) -> None:
     out = run_canonical_harvest(
         index_root=root, materialize_dir=tmp_path / "snapshot", archive_dir=root,
     )
-    # exactly-once accounting: 4 sessions in, 4 session rows out
+    # exactly-once accounting: 4 sessions in, 4 session rows out (the legacy
+    # labels-only session is evidence-only and contributes no records, and the
+    # harvest does not brick over it)
     assert out["record_count"] == 4
     rows = [r for sid in ("s-acc", "s-rej", "s-conf", "s-unres")
             for r in label_observation_history(root, sid)]

--- a/tests/test_training_adjudication_import_cli.py
+++ b/tests/test_training_adjudication_import_cli.py
@@ -72,12 +72,50 @@ def _digest(path: Path) -> str:
     return hashlib.sha256(path.read_bytes()).hexdigest()
 
 
-def _import_args(*roots: Path, state_dir: Path, extra: list[str]) -> list[str]:
+def _import_args(
+    *roots: Path,
+    state_dir: Path,
+    extra: list[str],
+    index_root: Path | None = None,
+    archive_dir: Path | None = None,
+) -> list[str]:
     argv: list[str] = ["import-local-observations"]
     for root in roots:
         argv += ["--archive-root", str(root)]
-    argv += ["--state-dir", str(state_dir), *extra]
+    if index_root is None:
+        index_root = state_dir.parent / "idx"
+        index_root.mkdir(exist_ok=True)
+        (index_root / "sessions.jsonl").write_text("", encoding="utf-8")
+    if archive_dir is None:
+        archive_dir = state_dir.parent / "archive"
+    argv += [
+        "--index-root", str(index_root),
+        "--archive-dir", str(archive_dir),
+        "--state-dir", str(state_dir),
+        *extra,
+    ]
     return argv
+
+
+def _materialized_snapshot(root: Path, session: str, fingerprint: str) -> Path:
+    """A materialized snapshot root (``sessions.jsonl`` in the hydrated-index
+    session shape) with one projected finding for *session* — the projector
+    shape the import links per-finding evidence against."""
+    root.mkdir(parents=True, exist_ok=True)
+    sessions = [{
+        "session_id": session, "trajectory_id": session, "segment_id": session,
+        "resolutions": [{
+            "fingerprint": fingerprint, "disposition": "unanswered",
+            "evidence": [{"reply_id": 1, "body_sha256": "abc",
+                          "created_at": "2026-01-01T00:00:00+00:00"}],
+            "evidence_digest": "d" * 32, "profile": "pr_review", "stack": "python",
+            "comment_id": 7,
+        }],
+    }]
+    (root / "sessions.jsonl").write_text(
+        "".join(json.dumps(s, sort_keys=True) + "\n" for s in sessions), encoding="utf-8"
+    )
+    return root
 
 
 def test_cli_import_writes_report_dry_run(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
@@ -115,8 +153,9 @@ def test_cli_real_path_real_archive(tmp_path: Path, capsys: pytest.CaptureFixtur
     before = (src / "index.db").read_bytes()
 
     state = tmp_path / "state"
+    archive = tmp_path / "archive"
     rc = cli._handle_corpus_command(
-        ["adjudicate", *_import_args(src, state_dir=state, extra=[])]
+        ["adjudicate", *_import_args(src, state_dir=state, archive_dir=archive, extra=[])]
     )
     assert rc == 0
     capsys.readouterr()  # drain the human-readable run before the --json re-run
@@ -127,12 +166,18 @@ def test_cli_real_path_real_archive(tmp_path: Path, capsys: pytest.CaptureFixtur
     report = json.loads((state / "import-report.json").read_text(encoding="utf-8"))
     assert report["dry_run"] is False
     assert sum(report["accounting"].values()) == 2
+    assert report["identity_summary"]["sess-1"]["matched_by"] == "repo_slug_sha"
+    assert report["identity_summary"]["sess-2"]["matched_by"] == "repo_slug_sha"
+    report = json.loads((state / "import-report.json").read_text(encoding="utf-8"))
+    assert report["dry_run"] is False
+    assert sum(report["accounting"].values()) == 2
     ledger = json.loads((state / "import-ledger.json").read_text(encoding="utf-8"))
     assert ledger["accounting"] == report["accounting"]
     assert {entry["session_id"] for entry in ledger["observations"]} == {"sess-1", "sess-2"}
 
-    # The merge appended the imported observations into the state archive.
-    conn = sqlite3.connect(f"file:{state / 'index.db'}?mode=ro", uri=True)
+    # The merge appended the imported observations into the hydrated
+    # --archive-dir archive; the state-dir index.db is never written.
+    conn = sqlite3.connect(f"file:{archive / 'index.db'}?mode=ro", uri=True)
     try:
         rows = conn.execute(
             "SELECT session_id, evidence_sha FROM label_observations ORDER BY session_id"
@@ -140,11 +185,12 @@ def test_cli_real_path_real_archive(tmp_path: Path, capsys: pytest.CaptureFixtur
     finally:
         conn.close()
     assert rows == [("sess-1", "e" * 64), ("sess-2", "f" * 64)]
+    assert not (state / "index.db").exists()
 
     # Idempotent re-import (M4): identical sources, nothing new appended,
     # byte-identical report.
     rc = cli._handle_corpus_command(
-        ["adjudicate", *_import_args(src, state_dir=state, extra=["--json"])]
+        ["adjudicate", *_import_args(src, state_dir=state, archive_dir=archive, extra=["--json"])]
     )
     assert rc == 0
     assert json.loads(capsys.readouterr().out)["merge"]["appended"] == 0
@@ -152,7 +198,7 @@ def test_cli_real_path_real_archive(tmp_path: Path, capsys: pytest.CaptureFixtur
     # identical re-import produces a byte-identical report.
     report_bytes = (state / "import-report.json").read_bytes()
     rc = cli._handle_corpus_command(
-        ["adjudicate", *_import_args(src, state_dir=state, extra=[])]
+        ["adjudicate", *_import_args(src, state_dir=state, archive_dir=archive, extra=[])]
     )
     assert rc == 0
     assert (state / "import-report.json").read_bytes() == report_bytes
@@ -169,8 +215,9 @@ def test_cli_reimport_does_not_displace_newer_target_runs_state(
     src = tmp_path / "src"
     _seed_session(src, "sess-1", evidence_sha="e" * 64, labels=["accepted"])
     state = tmp_path / "state"
+    archive = tmp_path / "archive"
     assert cli._handle_corpus_command(
-        ["adjudicate", *_import_args(src, state_dir=state, extra=[])]
+        ["adjudicate", *_import_args(src, state_dir=state, archive_dir=archive, extra=[])]
     ) == 0
 
     # Newer target state: a later archive refresh rewrites the same session
@@ -178,7 +225,7 @@ def test_cli_reimport_does_not_displace_newer_target_runs_state(
     head = hashlib.sha256("sess-1".encode()).hexdigest()
     base = hashlib.sha256(("base-" + "sess-1").encode()).hexdigest()
     upsert_run(
-        state,
+        archive,
         make_manifest(
             session_id="sess-1",
             repo_slug="org/repo",
@@ -190,7 +237,7 @@ def test_cli_reimport_does_not_displace_newer_target_runs_state(
             total_cost_usd=99.5,
         ),
     )
-    conn = sqlite3.connect(f"file:{state / 'index.db'}?mode=ro", uri=True)
+    conn = sqlite3.connect(f"file:{archive / 'index.db'}?mode=ro", uri=True)
     conn.row_factory = sqlite3.Row
     try:
         newer = dict(
@@ -206,10 +253,10 @@ def test_cli_reimport_does_not_displace_newer_target_runs_state(
     # populated target column must survive untouched (only NULL columns may be
     # filled from the source snapshot).
     assert cli._handle_corpus_command(
-        ["adjudicate", *_import_args(src, state_dir=state, extra=["--json"])]
+        ["adjudicate", *_import_args(src, state_dir=state, archive_dir=archive, extra=["--json"])]
     ) == 0
     capsys.readouterr()
-    conn = sqlite3.connect(f"file:{state / 'index.db'}?mode=ro", uri=True)
+    conn = sqlite3.connect(f"file:{archive / 'index.db'}?mode=ro", uri=True)
     conn.row_factory = sqlite3.Row
     try:
         after = dict(
@@ -301,6 +348,8 @@ def test_publish_then_resume_reproduces_queue_and_report(
             *_import_args(
                 src,
                 state_dir=state,
+                index_root=index_root,
+                archive_dir=state,  # publish stages the merged index from --archive-dir
                 extra=[
                     "--json",
                     "--publish",
@@ -373,8 +422,7 @@ def test_publish_refuses_non_private_before_any_write(
 
     src = tmp_path / "src"
     _seed_session(src, "sess-1", evidence_sha="e" * 64, labels=["accepted"])
-    _seed_publishable_state(tmp_path)
-    state = tmp_path / "state"
+    index_root, state = _seed_publishable_state(tmp_path)
     manifest = _write_manifest(tmp_path)
 
     hub = build_annotations_hub(curation_id="cur-import", snapshot_id="e" * 64, private=False)
@@ -387,6 +435,8 @@ def test_publish_refuses_non_private_before_any_write(
             *_import_args(
                 src,
                 state_dir=state,
+                index_root=index_root,
+                archive_dir=state,  # publish stages the merged index from --archive-dir
                 extra=["--publish", "--manifest", str(manifest), "--hub-repo", "org/public-ds"],
             ),
         ]
@@ -452,12 +502,13 @@ def test_cli_import_persists_redacted_rows(tmp_path: Path, capsys: pytest.Captur
     )
 
     state = tmp_path / "state"
+    archive = tmp_path / "archive"
     rc = cli._handle_corpus_command(
-        ["adjudicate", *_import_args(src, state_dir=state, extra=[])]
+        ["adjudicate", *_import_args(src, state_dir=state, archive_dir=archive, extra=[])]
     )
     assert rc == 0
     capsys.readouterr()
-    conn = sqlite3.connect(f"file:{state / 'index.db'}?mode=ro", uri=True)
+    conn = sqlite3.connect(f"file:{archive / 'index.db'}?mode=ro", uri=True)
     try:
         rows = conn.execute("SELECT rubric_json FROM label_observations").fetchall()
     finally:
@@ -535,6 +586,7 @@ def test_cli_import_non_iso_stamp_fails_closed(tmp_path: Path, capsys: pytest.Ca
     # Fail-closed before any state write: no archive, no seeded runs, no
     # partial appends, no placeholder success report.
     assert (state / "index.db").exists() is False
+    assert not (tmp_path / "archive" / "index.db").exists()
 
 
 def test_cli_missing_archive_root_exits_2() -> None:
@@ -568,3 +620,110 @@ def test_cli_inventory_failure_exits_1(tmp_path: Path, capsys: pytest.CaptureFix
     # split the reason on an 80-col non-TTY console.
     assert "index.db" in captured.out + captured.err
     assert not state.exists()  # no placeholder success
+    assert not (tmp_path / "archive" / "index.db").exists()  # no archive write either
+
+
+def test_cli_import_links_against_hydrated_index_and_merges_into_archive_dir(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Empty-literal identity maps are gone: the importer links sessions
+    against the pinned hydrated index, validates exact finding identity
+    against the projected findings, and appends into the hydrated
+    --archive-dir index.db — never the state-dir index."""
+    from daydream.archive.index import _get_connection
+
+    src = tmp_path / "backup"
+    _seed_session(src, "sess-1", evidence_sha="e" * 64, labels=["accepted"])
+    index = tmp_path / "hydrated"
+    conn = _get_connection(index)
+    conn.execute(
+        "INSERT INTO runs (session_id, archived_at, run_flow, archive_path) "
+        "VALUES ('sess-1', '2026-01-01T00:00:00+00:00', 'deep', 'archive/sess-1')"
+    )
+    conn.commit()
+    conn.close()
+    # a materialized snapshot with one finding for sess-1 (project_findings shape)
+    mat = _materialized_snapshot(tmp_path / "mat", session="sess-1", fingerprint="fp-1")
+
+    state = tmp_path / "state"
+    rc = cli._handle_corpus_command(
+        ["adjudicate", *_import_args(src, state_dir=state, index_root=mat, archive_dir=index,
+                                     extra=[])]
+    )
+    assert rc == 0
+    # row landed in the hydrated archive, keyed to the Hub session id
+    conn = _get_connection(index)
+    rows = conn.execute(
+        "SELECT session_id, source FROM label_observations"
+    ).fetchall()
+    conn.close()
+    # Provenance survives the merge verbatim (source stays the source row's
+    # own 'auto', never rewritten).
+    assert [tuple(r) for r in rows] == [("sess-1", "auto")]
+    # state-dir index.db was never created
+    assert not (state / "index.db").exists()
+
+
+def test_cli_import_report_shows_mapping_summary(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The import report carries a per-session mapping summary (matched_by,
+    validation outcome) so operators can audit identity resolution."""
+    src = tmp_path / "backup"
+    _seed_session(src, "sess-1", evidence_sha="e" * 64, labels=["accepted"])
+    # identical derivative content on both sides -> links by session_id
+    (src / "runs" / "sess-1").mkdir(parents=True)
+    (src / "runs" / "sess-1" / "trajectory.json").write_text("{}", encoding="utf-8")
+    mat = _materialized_snapshot(tmp_path / "mat", session="sess-1", fingerprint="fp-1")
+    (mat / "runs" / "sess-1").mkdir(parents=True)
+    (mat / "runs" / "sess-1" / "trajectory.json").write_text("{}", encoding="utf-8")
+
+    state = tmp_path / "state"
+    index = tmp_path / "hydrated"
+    rc = cli._handle_corpus_command(
+        ["adjudicate", *_import_args(src, state_dir=state, index_root=mat, archive_dir=index,
+                                     extra=["--json"])]
+    )
+    assert rc == 0
+    report = json.loads(capsys.readouterr().out)
+    summary = report["identity_summary"]["sess-1"]
+    assert summary["matched_by"] == "session_id"
+    # The run-level evidence digest does not match the projected finding's
+    # per-finding digest, so the session routes to the ambiguous bucket.
+    assert summary["validation_outcome"] == "ambiguous"
+
+
+def test_cli_import_missing_identity_flags_exit_2() -> None:
+    from daydream.training.adjudication.cli import handle_adjudicate
+
+    with pytest.raises(SystemExit) as exc:
+        handle_adjudicate(
+            ["import-local-observations", "--archive-root", "/tmp", "--state-dir", "/tmp/s"]
+        )
+    assert exc.value.code == 2
+    with pytest.raises(SystemExit) as exc:
+        handle_adjudicate(
+            ["import-local-observations", "--archive-root", "/tmp",
+             "--index-root", "/tmp/idx", "--state-dir", "/tmp/s"]
+        )
+    assert exc.value.code == 2
+
+
+def test_cli_import_unreadable_index_root_exits_1(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A missing --index-root index fails closed: exit 1 via the derive
+    failure path, no empty-literal fallback anywhere."""
+    src = tmp_path / "backup"
+    _seed_session(src, "sess-1", evidence_sha="e" * 64, labels=["accepted"])
+    state = tmp_path / "state"
+    missing = tmp_path / "no-such-index"
+    rc = cli._handle_corpus_command(
+        ["adjudicate", *_import_args(src, state_dir=state, index_root=missing,
+                                     archive_dir=tmp_path / "archive", extra=[])]
+    )
+    assert rc == 1
+    captured = capsys.readouterr()
+    assert "no-such-index" in (captured.out + captured.err).replace("\n", " ") or \
+        "index" in (captured.out + captured.err)
+    assert not state.exists()

--- a/tests/test_training_adjudication_import_cli.py
+++ b/tests/test_training_adjudication_import_cli.py
@@ -668,9 +668,13 @@ def test_cli_import_report_shows_mapping_summary(
     tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
     """The import report carries a per-session mapping summary (matched_by,
-    validation outcome) so operators can audit identity resolution."""
+    validation outcome) so operators can audit identity resolution. A
+    harvest-produced row's evidence anchor is the run's ``head_sha`` (what
+    ``training/harvest.py`` stores in ``label_observations.evidence_sha``), so
+    the per-finding identity match actually fires for it (issue #336 item 4)."""
     src = tmp_path / "backup"
-    _seed_session(src, "sess-1", evidence_sha="e" * 64, labels=["accepted"])
+    head = hashlib.sha256("sess-1".encode()).hexdigest()
+    _seed_session(src, "sess-1", evidence_sha=head, labels=["accepted"])
     # identical derivative content on both sides -> links by session_id
     (src / "runs" / "sess-1").mkdir(parents=True)
     (src / "runs" / "sess-1" / "trajectory.json").write_text("{}", encoding="utf-8")
@@ -688,9 +692,11 @@ def test_cli_import_report_shows_mapping_summary(
     report = json.loads(capsys.readouterr().out)
     summary = report["identity_summary"]["sess-1"]
     assert summary["matched_by"] == "session_id"
-    # The run-level evidence digest does not match the projected finding's
-    # per-finding digest, so the session routes to the ambiguous bucket.
-    assert summary["validation_outcome"] == "ambiguous"
+    # The row's evidence anchor (head_sha) matches the pinned session's run
+    # anchor exactly, so the exact-identity match fires and the run-level row
+    # routes to the per-finding bucket -- ``matched``, never the stale/
+    # ambiguous fallback.
+    assert summary["validation_outcome"] == "matched"
 
 
 def test_cli_import_missing_identity_flags_exit_2() -> None:

--- a/tests/test_training_adjudication_import_cli.py
+++ b/tests/test_training_adjudication_import_cli.py
@@ -349,7 +349,7 @@ def test_publish_then_resume_reproduces_queue_and_report(
                 src,
                 state_dir=state,
                 index_root=index_root,
-                archive_dir=state,  # publish stages the merged index from --archive-dir
+                archive_dir=tmp_path / "archive",  # distinct dir: publish stages the merged --archive-dir index
                 extra=[
                     "--json",
                     "--publish",
@@ -436,7 +436,7 @@ def test_publish_refuses_non_private_before_any_write(
                 src,
                 state_dir=state,
                 index_root=index_root,
-                archive_dir=state,  # publish stages the merged index from --archive-dir
+                archive_dir=tmp_path / "archive",  # distinct dir: publish stages the merged --archive-dir index
                 extra=["--publish", "--manifest", str(manifest), "--hub-repo", "org/public-ds"],
             ),
         ]

--- a/tests/test_training_adjudication_materialize.py
+++ b/tests/test_training_adjudication_materialize.py
@@ -219,16 +219,23 @@ def test_materialize_serves_legacy_labels_only_rows_from_trajectory(tmp_path: Pa
     assert record["evidence_digest"] == "d" * 32
 
 
-def test_materialize_fails_closed_when_legacy_labels_only_rows_have_no_trajectory(
+def test_materialize_skips_legacy_labels_only_sessions_without_trajectory(
     tmp_path: Path,
 ) -> None:
     """A legacy labels-only session with no trajectory anywhere has no
-    materializable resolutions: fail closed naming the session — never
-    silently skipped, never a partial snapshot."""
+    materializable resolutions: it contributes no records instead of failing
+    the whole curation -- the row is evidence-only (e.g. a session a runbook
+    step-3b import admitted from a backup root outside the curation: DB-only
+    runs row, labels-only observations, no runs/<sid> files), and one such
+    session must not brick every later preview/materialize/harvest pass."""
     root = _hydrated_sqlite_index(tmp_path)
     _make_labels_only_rubric(root)
-    with pytest.raises(Exception, match="s1"):
-        run_materialize(root, tmp_path / "out", pin=_PIN)
+    summary = run_materialize(root, tmp_path / "out", pin=_PIN)
+    assert summary["record_count"] == 0
+    lines = [
+        ln for ln in (tmp_path / "out" / "sessions.jsonl").read_text().splitlines() if ln
+    ]
+    assert lines == []  # the session is served nothing, never fabricated
 
 
 def _hydrated_sqlite_index_agreeing_generations(tmp_path: Path) -> Path:
@@ -267,6 +274,34 @@ def _hydrated_sqlite_index_agreeing_generations(tmp_path: Path) -> Path:
     return root
 
 
+def test_materialize_serves_human_labeled_session_from_trajectory(tmp_path: Path) -> None:
+    """A human-sourced row (``daydream label`` / ``index.update_labels``
+    appends ``source='human'`` with a NULL ``rubric_json``) wins precedence but
+    must not brick the derivation: the NULL rubric falls back to the sanitized
+    trajectory like a legacy labels-only row (issue #336 item 1), and the
+    human row -- authoritative under the archive's human-wins precedence --
+    never flags the session conflicting (issue #336 item 3)."""
+    root = _hydrated_sqlite_index(tmp_path)
+    _seed_legacy_trajectory(root)
+    from daydream.archive.index import append_label_observation
+
+    append_label_observation(
+        root,
+        "s1",
+        labels=["finding-rejected"],
+        pr_state=None,
+        labeler_version="human",
+        evidence_sha=None,
+        source="human",
+        observed_at="2026-01-04T00:00:00+00:00",
+    )
+    summary = run_materialize(root, tmp_path / "out", pin=_PIN)
+    assert summary["record_count"] == 1
+    record = json.loads((tmp_path / "out" / "sessions.jsonl").read_text().splitlines()[0])
+    assert record["disposition"] == "accepted"  # served from the trajectory
+    assert record.get("conflicting") is None  # human override is not a disagreement
+
+
 def test_agreeing_generations_are_not_conflicting(tmp_path: Path) -> None:
     """Two generations with identical dispositions (same labels) split only on
     non-disposition dedup members (evidence_sha, policy version) are agreeing
@@ -274,6 +309,56 @@ def test_agreeing_generations_are_not_conflicting(tmp_path: Path) -> None:
     canonical harvest keeps projecting its decisive finding-accepted label
     instead of suppressing it."""
     root = _hydrated_sqlite_index_agreeing_generations(tmp_path)
+    mat = tmp_path / "mat"
+    run_materialize(root, mat, pin=_PIN)
+    record = json.loads((tmp_path / "mat" / "sessions.jsonl").read_text().splitlines()[0])
+    assert record.get("conflicting") is None
+    assert record["disposition"] == "accepted"
+
+
+def _hydrated_sqlite_index_evolving(tmp_path: Path) -> Path:
+    """Two auto generations for ``s1``: a pre-adjudication generation whose
+    labels carry no decisive finding- label, resolved by a later decisive
+    accepted generation — distinct dedup keys, distinct label sets, but an
+    evolution (resolved-unanswered -> accepted), not a harvester
+    disagreement (issue #336 item 3)."""
+    from daydream.archive.index import _get_connection
+
+    root = tmp_path / "hydrated"
+    conn = _get_connection(root)
+    conn.execute(
+        "INSERT INTO runs (session_id, archived_at, run_flow, archive_path) "
+        "VALUES ('s1', '2026-01-01T00:00:00+00:00', 'deep', 'archive/s1')"
+    )
+    for observed_at, labels, evidence_sha, disposition in (
+        ("2026-01-02T00:00:00+00:00", '["finding-unanswered"]', "e" * 64, "unanswered"),
+        ("2026-01-03T00:00:00+00:00", '["finding-accepted"]', "f" * 64, "accepted"),
+    ):
+        rubric = {"posterior_source": "pr_review",
+                  "per_finding_resolutions": [{
+                      "fingerprint": "fp-1", "comment_id": 7, "disposition": disposition,
+                      "evidence": [{"reply_id": 1, "body_sha256": "abc"}],
+                      "evidence_digest": "d" * 32}]}
+        conn.execute(
+            "INSERT INTO label_observations (session_id, observed_at, labels, labeler_version, "
+            "evidence_sha, rubric_json, has_posterior, source, labeler_policy_version) "
+            "VALUES ('s1', ?, ?, 'v1', ?, ?, 0, 'auto', '980-rubric-r2')",
+            (observed_at, labels, evidence_sha, json.dumps(rubric)),
+        )
+    conn.commit()
+    conn.close()
+    (root / "downloads" / ("a" * 40)).mkdir(parents=True)
+    return root
+
+
+def test_resolved_unanswered_to_accepted_evolution_is_not_conflicting(
+    tmp_path: Path,
+) -> None:
+    """A pre-adjudication generation (no decisive finding- label) resolved by a
+    later decisive generation is an evolution, never a harvester disagreement:
+    the session stays gold-eligible after re-materialization (issue #336
+    item 3)."""
+    root = _hydrated_sqlite_index_evolving(tmp_path)
     mat = tmp_path / "mat"
     run_materialize(root, mat, pin=_PIN)
     record = json.loads((tmp_path / "mat" / "sessions.jsonl").read_text().splitlines()[0])

--- a/tests/test_training_adjudication_materialize.py
+++ b/tests/test_training_adjudication_materialize.py
@@ -130,3 +130,55 @@ def test_materialize_emits_every_disposition(tmp_path: Path) -> None:
     assert {r["disposition"] for r in rows} == {
         "accepted", "rejected", "ambiguous", "unanswered", "missing"}
     assert len({r["record_id"] for r in rows}) == 5  # no silent dedup across classes
+
+
+def _hydrated_sqlite_index(tmp_path: Path) -> Path:
+    """Hydrated staging archive whose per-finding data lives ONLY in
+    label_observations.rubric_json — no trajectory.json resolutions key."""
+    from daydream.archive.index import _get_connection
+    root = tmp_path / "hydrated"
+    conn = _get_connection(root)
+    conn.execute(
+        "INSERT INTO runs (session_id, archived_at, run_flow, archive_path) "
+        "VALUES ('s1', '2026-01-01T00:00:00+00:00', 'deep', 'archive/s1')"
+    )
+    rubric = {"posterior_source": "pr_review",
+              "per_finding_resolutions": [{
+                  "fingerprint": "fp-1", "comment_id": 7, "disposition": "accepted",
+                  "evidence": [{"reply_id": 1, "body_sha256": "abc"}],
+                  "evidence_digest": "d" * 32}]}
+    conn.execute(
+        "INSERT INTO label_observations (session_id, observed_at, labels, labeler_version, "
+        "evidence_sha, rubric_json, has_posterior, source, labeler_policy_version) "
+        "VALUES ('s1', '2026-01-02T00:00:00+00:00', '[\"finding-accepted\"]', 'v1', "
+        "'e' * 64, ?, 0, 'auto', '980-rubric-r2')",
+        (json.dumps(rubric),),
+    )
+    conn.commit()
+    conn.close()
+    (root / "downloads" / ("a" * 40)).mkdir(parents=True)
+    return root
+
+
+def test_materialize_reads_resolutions_from_sqlite_not_trajectory(tmp_path: Path) -> None:
+    root = _hydrated_sqlite_index(tmp_path)
+    assert not (root / "runs").exists()  # no trajectory anywhere
+    summary = run_materialize(root, tmp_path / "out", pin=_PIN)
+    assert summary["record_count"] == 1
+    record = json.loads((tmp_path / "out" / "sessions.jsonl").read_text().splitlines()[0])
+    assert record["fingerprint"] == "fp-1"
+    assert record["disposition"] == "accepted"
+    assert record["evidence_digest"] == "d" * 32
+
+
+def test_materialize_fails_closed_on_labels_only_rubric(tmp_path: Path) -> None:
+    """Legacy labels-only rubric_json (no per_finding_resolutions) is a reviewable
+    structural gap — never backfilled, never silently skipped."""
+    root = _hydrated_sqlite_index(tmp_path)
+    import sqlite3
+    conn = sqlite3.connect(str(root / "index.db"))
+    conn.execute("UPDATE label_observations SET rubric_json = '{\"per_finding_outcomes\": [\"accepted\"]}'")
+    conn.commit()
+    conn.close()
+    with pytest.raises(Exception, match="s1"):
+        run_materialize(root, tmp_path / "out", pin=_PIN)

--- a/tests/test_training_adjudication_materialize.py
+++ b/tests/test_training_adjudication_materialize.py
@@ -171,14 +171,135 @@ def test_materialize_reads_resolutions_from_sqlite_not_trajectory(tmp_path: Path
     assert record["evidence_digest"] == "d" * 32
 
 
-def test_materialize_fails_closed_on_labels_only_rubric(tmp_path: Path) -> None:
-    """Legacy labels-only rubric_json (no per_finding_resolutions) is a reviewable
-    structural gap — never backfilled, never silently skipped."""
-    root = _hydrated_sqlite_index(tmp_path)
+def _make_labels_only_rubric(root: Path) -> None:
+    """Rewrite the session's winning rubric_json to the pre-#1095 labels-only
+    shape (only ``per_finding_outcomes``, no ``per_finding_resolutions``) —
+    exactly what the import path appends verbatim from a surviving old archive
+    (``Rubric.to_dict`` before 7a2b580, ``docs`` commit 23c02d4)."""
     import sqlite3
+
+    labels_only = json.dumps({"per_finding_outcomes": ["accepted"]})
     conn = sqlite3.connect(str(root / "index.db"))
-    conn.execute("UPDATE label_observations SET rubric_json = '{\"per_finding_outcomes\": [\"accepted\"]}'")
+    conn.execute("UPDATE label_observations SET rubric_json = ?", (labels_only,))
     conn.commit()
     conn.close()
+
+
+def _seed_legacy_trajectory(root: Path, session_id: str = "s1") -> None:
+    """Legacy hydrated trajectory: ``runs/<session_id>/trajectory.json`` with a
+    ``resolutions`` key — the pre-#1095 materialization source."""
+    trajectory_dir = root / "runs" / session_id
+    trajectory_dir.mkdir(parents=True)
+    trajectory_dir.joinpath("trajectory.json").write_text(json.dumps({
+        "session_id": session_id,
+        "trajectory_id": session_id,
+        "segment_id": session_id,
+        "resolutions": [{
+            "fingerprint": "fp-1", "disposition": "accepted",
+            "evidence": [{"reply_id": 1, "body_sha256": "abc"}],
+            "evidence_digest": "d" * 32,
+        }],
+    }), encoding="utf-8")
+
+
+def test_materialize_serves_legacy_labels_only_rows_from_trajectory(tmp_path: Path) -> None:
+    """A pre-#1095 labels-only row (imported verbatim from a surviving old
+    archive) must not brick the session: materialize serves it from the
+    sanitized per-run trajectory — the pre-#1095 materialization source —
+    instead of failing closed, so preview/materialize/harvest keep working
+    after an import."""
+    root = _hydrated_sqlite_index(tmp_path)
+    _make_labels_only_rubric(root)
+    _seed_legacy_trajectory(root)
+    summary = run_materialize(root, tmp_path / "out", pin=_PIN)
+    assert summary["record_count"] == 1
+    record = json.loads((tmp_path / "out" / "sessions.jsonl").read_text().splitlines()[0])
+    assert record["fingerprint"] == "fp-1"
+    assert record["disposition"] == "accepted"
+    assert record["evidence_digest"] == "d" * 32
+
+
+def test_materialize_fails_closed_when_legacy_labels_only_rows_have_no_trajectory(
+    tmp_path: Path,
+) -> None:
+    """A legacy labels-only session with no trajectory anywhere has no
+    materializable resolutions: fail closed naming the session — never
+    silently skipped, never a partial snapshot."""
+    root = _hydrated_sqlite_index(tmp_path)
+    _make_labels_only_rubric(root)
     with pytest.raises(Exception, match="s1"):
         run_materialize(root, tmp_path / "out", pin=_PIN)
+
+
+def _hydrated_sqlite_index_agreeing_generations(tmp_path: Path) -> Path:
+    """Task 3's ``_hydrated_sqlite_index`` shape, extended with a second
+    generation for ``s1`` that agrees on the disposition (identical labels)
+    but splits the dedup tuple on non-disposition members (evidence_sha and
+    policy version) — exactly what ``append_label_observation`` produces on a
+    policy-version bump or an edited-reply digest change."""
+    from daydream.archive.index import _get_connection
+
+    root = tmp_path / "hydrated"
+    conn = _get_connection(root)
+    conn.execute(
+        "INSERT INTO runs (session_id, archived_at, run_flow, archive_path) "
+        "VALUES ('s1', '2026-01-01T00:00:00+00:00', 'deep', 'archive/s1')"
+    )
+    rubric = {"posterior_source": "pr_review",
+              "per_finding_resolutions": [{
+                  "fingerprint": "fp-1", "comment_id": 7, "disposition": "accepted",
+                  "evidence": [{"reply_id": 1, "body_sha256": "abc"}],
+                  "evidence_digest": "d" * 32}]}
+    rubric_json = json.dumps(rubric)
+    for observed_at, policy_version, evidence_sha in (
+        ("2026-01-02T00:00:00+00:00", "980-rubric-r1", "e" * 64),
+        ("2026-01-03T00:00:00+00:00", "980-rubric-r2", "f" * 64),
+    ):
+        conn.execute(
+            "INSERT INTO label_observations (session_id, observed_at, labels, labeler_version, "
+            "evidence_sha, rubric_json, has_posterior, source, labeler_policy_version) "
+            "VALUES ('s1', ?, '[\"finding-accepted\"]', 'v1', ?, ?, 0, 'auto', ?)",
+            (observed_at, evidence_sha, rubric_json, policy_version),
+        )
+    conn.commit()
+    conn.close()
+    (root / "downloads" / ("a" * 40)).mkdir(parents=True)
+    return root
+
+
+def test_agreeing_generations_are_not_conflicting(tmp_path: Path) -> None:
+    """Two generations with identical dispositions (same labels) split only on
+    non-disposition dedup members (evidence_sha, policy version) are agreeing
+    generations: the session must not be flagged conflicting so the next
+    canonical harvest keeps projecting its decisive finding-accepted label
+    instead of suppressing it."""
+    root = _hydrated_sqlite_index_agreeing_generations(tmp_path)
+    mat = tmp_path / "mat"
+    run_materialize(root, mat, pin=_PIN)
+    record = json.loads((tmp_path / "mat" / "sessions.jsonl").read_text().splitlines()[0])
+    assert record.get("conflicting") is None
+    assert record["disposition"] == "accepted"
+
+
+def test_materialize_fails_loudly_on_uncheckpointed_wal(tmp_path: Path) -> None:
+    """A crashed/interrupted writer between commit and close leaves committed
+    rows in ``index.db-wal``; the ``immutable=1`` read-only adapters would
+    silently skip them and serve fewer sessions with no error — the guard must
+    fail loudly instead of serving a partial snapshot."""
+    root = _hydrated_sqlite_index(tmp_path)
+    import sqlite3
+    # Simulate the crash window: a fresh writer commits rows into the WAL but
+    # has not closed (checkpointed) yet.
+    conn = sqlite3.connect(str(root / "index.db"))
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute(
+        "INSERT INTO runs (session_id, archived_at, run_flow, archive_path) "
+        "VALUES ('s2', '2026-01-01T00:00:00+00:00', 'deep', 'archive/s2')"
+    )
+    conn.commit()
+    try:
+        assert (root / "index.db-wal").is_file()  # committed but uncheckpointed
+        with pytest.raises(HubUnavailableError, match="uncheckpointed WAL"):
+            run_materialize(root, tmp_path / "out", pin=_PIN)
+    finally:
+        conn.close()

--- a/tests/test_training_adjudication_preview_harvest.py
+++ b/tests/test_training_adjudication_preview_harvest.py
@@ -193,6 +193,25 @@ def test_preview_and_harvest_identity_digest_stability_gate(tmp_path: Path) -> N
         assert e["record_id"] == rid(e["session_id"], e["trajectory_id"], e["segment_id"], e["fingerprint"])
 
 
+def test_preview_never_mutates_the_hydrated_index(tmp_path: Path) -> None:
+    """Req 5: preview opens the SQLite index read-only, never appends
+    label_observations, never writes resume-cache/complete markers."""
+    import hashlib
+
+    from tests.test_training_adjudication_materialize import _hydrated_sqlite_index
+
+    root = _hydrated_sqlite_index(tmp_path)
+    before = hashlib.sha256((root / "index.db").read_bytes()).hexdigest()
+    before_tree = sorted(p.relative_to(root).as_posix() for p in root.rglob("*") if p.is_file())
+
+    run_preview(root, tmp_path / "ledger.json")
+
+    after = hashlib.sha256((root / "index.db").read_bytes()).hexdigest()
+    after_tree = sorted(p.relative_to(root).as_posix() for p in root.rglob("*") if p.is_file())
+    assert after == before  # index.db bytes untouched (no WAL checkpoint either)
+    assert after_tree == before_tree  # no marker/cache files added anywhere
+
+
 def test_posterior_feed_is_pr_review_only(tmp_path: Path) -> None:
     root = _hydrated_index(tmp_path, profiles=["pr_review", "task"])
     ledger = tmp_path / "ledger.json"

--- a/tests/test_training_harvest.py
+++ b/tests/test_training_harvest.py
@@ -2007,3 +2007,33 @@ def test_per_finding_resolution_from_dict_fails_closed() -> None:
         resolution_from_dict({"fingerprint": "fp-1", "disposition": "banana"})
     with pytest.raises(ValueError, match="evidence_digest"):
         resolution_from_dict({"fingerprint": "fp-1", "disposition": "accepted"})
+
+
+def test_rubric_to_dict_carries_full_per_finding_resolutions() -> None:
+    """Req 1/3: the SQLite blob must carry fingerprints + evidence + digests,
+    not labels only — the materializer's sole per-finding source."""
+    from daydream.training.labeler_signals import (
+        CommentResolutionSignal,
+        FixAppliedSignal,
+        PerFindingResolution,
+        PRMergeSignal,
+    )
+    from daydream.training.rubric import Rubric
+
+    r = PerFindingResolution(fingerprint="fp-1", comment_id=7, disposition="accepted",
+                             evidence=[{"reply_id": 1}], evidence_digest="d" * 32)
+    rubric = Rubric(
+        pr_merge=PRMergeSignal(True, None, "closed", False),
+        fix_applied=FixAppliedSignal("applied", 1, 1, []),
+        comment_resolution=CommentResolutionSignal(1, 1, 0),
+        local_commit_applied=None, posterior_source="pr_review",
+        per_finding_resolutions=[r],
+    )
+    d = rubric.to_dict()
+    stored = d["per_finding_resolutions"]
+    assert stored[0]["fingerprint"] == "fp-1"
+    assert stored[0]["disposition"] == "accepted"
+    assert stored[0]["evidence_digest"] == "d" * 32
+    assert stored[0]["evidence"] == [{"reply_id": 1}]
+    # backward-compat consumers keep their labels-only view
+    assert d["per_finding_outcomes"] == ["accepted"]

--- a/tests/test_training_harvest.py
+++ b/tests/test_training_harvest.py
@@ -1982,3 +1982,28 @@ def test_hub_import_accepts_clean_bundle_in_place(tmp_path: Path) -> None:
     assert result.imported is True
     assert result.quarantined is False
     assert incoming.exists()
+
+
+def test_per_finding_resolution_round_trips_through_canonical_dict() -> None:
+    from daydream.training.labeler_signals import (
+        PerFindingResolution,
+        resolution_from_dict,
+        resolution_to_dict,
+    )
+
+    r = PerFindingResolution(
+        fingerprint="fp-1", comment_id=7, disposition="accepted",
+        evidence=[{"reply_id": 1, "body_sha256": "abc"}], evidence_digest="d" * 32,
+    )
+    restored = resolution_from_dict(resolution_to_dict(r))
+    assert restored == r  # canonical dict is the one round-trip shape
+
+def test_per_finding_resolution_from_dict_fails_closed() -> None:
+    from daydream.training.labeler_signals import resolution_from_dict
+
+    with pytest.raises(ValueError, match="fingerprint"):
+        resolution_from_dict({"disposition": "accepted", "evidence_digest": "d" * 32})
+    with pytest.raises(ValueError, match="disposition"):
+        resolution_from_dict({"fingerprint": "fp-1", "disposition": "banana"})
+    with pytest.raises(ValueError, match="evidence_digest"):
+        resolution_from_dict({"fingerprint": "fp-1", "disposition": "accepted"})


### PR DESCRIPTION
## Summary
- Hydrated-stage materialization for annotation adjudication: trajectory fallback + nested-profile label (issue #1095)
- Hardened gold gate and import materialization; re-derive conflicts with neutralized dispositions
- New end-to-end hydrated→preview→import→harvest fixture and unit tests
- Runbook updated with preview + import steps for the annotation final-publish flow

## Test Plan
- [x] Full `make check` gate green at review commit 27472e8 (integration 194 passed / 2 skipped)
- [x] Two daydream deep-precision review rounds passed (round-2 fixes in 27472e8)

Closes #1095