### PR TITLE
fix(codex): parse current file_change contract (Closes #1125)

### DIFF
--- a/daydream/backends/codex.py
+++ b/daydream/backends/codex.py
@@ -571,18 +571,67 @@ class CodexBackend:
                     elif item_type == "file_change":
                         # file_change has no item.started — emit a synthetic pair.
                         item_id = item.get("id", str(uuid.uuid4()))
-                        file_path = item.get("file_path", "unknown")
-                        action = item.get("action", "modified")
-                        yield ToolStartEvent(
-                            id=item_id,
-                            name="patch",
-                            input={"file": file_path, "action": action},
-                        )
-                        yield ToolResultEvent(
-                            id=item_id,
-                            output=f"{action}: {file_path}",
-                            is_error=False,
-                        )
+                        changes = item.get("changes")
+                        if isinstance(changes, dict) and changes:
+                            # Current CLI shape: a map of path -> {type, ...}.
+                            # Normalize each path against execution_cwd; keep
+                            # absolute paths that fall outside it.
+                            parsed = []
+                            for raw_path, entry in changes.items():
+                                kind = entry.get("type", "unknown") if isinstance(entry, dict) else "unknown"
+                                path = str(raw_path)
+                                try:
+                                    if os.path.isabs(path) and os.path.commonpath([
+                                        path,
+                                        str(execution_cwd),
+                                    ]) == str(execution_cwd):
+                                        path = os.path.relpath(path, execution_cwd)
+                                except ValueError:
+                                    pass  # disjoint drives etc. — keep absolute
+                                parsed.append({"path": path, "kind": kind})
+                            yield ToolStartEvent(
+                                id=item_id,
+                                name="patch",
+                                input={"changes": parsed},
+                            )
+                            status = item.get("status", "")
+                            if status == "declined":
+                                output = "File change declined by sandbox"
+                            else:
+                                output = ", ".join(
+                                    f"{c['kind']}: {c['path']}" for c in parsed
+                                )
+                                if status in ("failed", "declined"):
+                                    for stream in ("stdout", "stderr"):
+                                        excerpt = item.get(stream, "")
+                                        if excerpt:
+                                            output += f"\n{stream}: {excerpt[:500]}"
+                            yield ToolResultEvent(
+                                id=item_id,
+                                output=output,
+                                is_error=status != "completed",
+                                status=status or None,
+                            )
+                        elif "file_path" in item:
+                            # Legacy scalar shape (older CLI): keep as-is.
+                            file_path = item.get("file_path", "unknown")
+                            action = item.get("action", "modified")
+                            yield ToolStartEvent(
+                                id=item_id,
+                                name="patch",
+                                input={"file": file_path, "action": action},
+                            )
+                            yield ToolResultEvent(
+                                id=item_id,
+                                output=f"{action}: {file_path}",
+                                is_error=False,
+                            )
+                        else:
+                            _warn(
+                                "file_change item without paths",
+                                item_id=item_id,
+                                status=item.get("status", ""),
+                            )
 
                     elif item_type == "mcp_tool_call":
                         item_id = item.get("id")

--- a/daydream/backends/codex.py
+++ b/daydream/backends/codex.py
@@ -571,11 +571,23 @@ class CodexBackend:
                     elif item_type == "file_change":
                         # file_change has no item.started — emit a synthetic pair.
                         changes = item.get("changes")
-                        if isinstance(changes, dict) and changes:
-                            item_id = item.get("id", str(uuid.uuid4()))
+                        if isinstance(changes, dict) or isinstance(changes, list):
                             # Current CLI shape: a map of path -> {type, ...}.
                             # Normalize each path against execution_cwd; keep
-                            # absolute paths that fall outside it.
+                            # absolute paths that fall outside it. A
+                            # list-shaped `changes` (plausible alternate CLI
+                            # layout) is folded to the same path-keyed map;
+                            # entries without a path-ish key carry no usable
+                            # path and are dropped. An empty map is a no-op,
+                            # never an error — the old code always recorded
+                            # success for it.
+                            if isinstance(changes, list):
+                                changes = {
+                                    str(c.get("path") or c.get("file_path")): c
+                                    for c in changes
+                                    if isinstance(c, dict) and (c.get("path") or c.get("file_path"))
+                                }
+                            item_id = item.get("id", str(uuid.uuid4()))
                             parsed = []
                             for raw_path, entry in changes.items():
                                 kind = entry.get("type", "unknown") if isinstance(entry, dict) else "unknown"
@@ -589,23 +601,43 @@ class CodexBackend:
                                 except ValueError:
                                     pass  # disjoint drives etc. — keep absolute
                                 parsed.append({"path": path, "kind": kind})
+                            # A missing `status` means "completed": the old
+                            # code always recorded success, so an absent status
+                            # must never be archived as an error.
+                            status = item.get("status", "completed")
+                            # Cap the joined path listing with the same limit
+                            # as the stdout/stderr excerpts so a large
+                            # multi-file apply or a giant path cannot produce
+                            # an unbounded ToolResult output.
+                            joined = ", ".join(
+                                f"{c['kind']}: {c['path']}" for c in parsed
+                            )[:500]
+                            if status == "declined":
+                                # Name the affected paths and keep any
+                                # stdout/stderr so a declined change is not
+                                # silently path-free.
+                                output = f"File change declined by sandbox: {joined}"
+                            else:
+                                output = joined
+                            if status in ("failed", "declined"):
+                                for stream in ("stdout", "stderr"):
+                                    excerpt = item.get(stream, "")
+                                    if excerpt:
+                                        output += f"\n{stream}: {excerpt[:500]}"
+                            # Preserve the legacy patch-input keys for
+                            # extension tool supervisors keyed on
+                            # {"file", "action"} — exact only for single-file
+                            # changes; multi-file stays namespaced under
+                            # `changes`.
+                            start_input: dict[str, Any] = {"changes": parsed}
+                            if len(parsed) == 1:
+                                start_input["file"] = parsed[0]["path"]
+                                start_input["action"] = parsed[0]["kind"]
                             yield ToolStartEvent(
                                 id=item_id,
                                 name="patch",
-                                input={"changes": parsed},
+                                input=start_input,
                             )
-                            status = item.get("status", "")
-                            if status == "declined":
-                                output = "File change declined by sandbox"
-                            else:
-                                output = ", ".join(
-                                    f"{c['kind']}: {c['path']}" for c in parsed
-                                )
-                                if status in ("failed", "declined"):
-                                    for stream in ("stdout", "stderr"):
-                                        excerpt = item.get(stream, "")
-                                        if excerpt:
-                                            output += f"\n{stream}: {excerpt[:500]}"
                             yield ToolResultEvent(
                                 id=item_id,
                                 output=output,
@@ -632,10 +664,12 @@ class CodexBackend:
                             # Never silently archive (the old behavior recorded
                             # "modified: unknown"): emit a synthetic pair whose
                             # ToolResult is an observable error echoing the
-                            # item's available fields.
-                            item_id = item.get("id")
-                            if not item_id:
-                                item_id = _claim_tool_id("file_change", "file_change:pathless", "")
+                            # item's available fields. Fall back to a plain
+                            # uuid, not `_claim_tool_id` — file_change never
+                            # populates the FIFO/content-key maps, so that call
+                            # could only fire a spurious "unmatched tool result"
+                            # warning for an item that is not unmatched.
+                            item_id = item.get("id", str(uuid.uuid4()))
                             fields = {
                                 k: v for k, v in item.items()
                                 if k != "type" and v != "unknown"

--- a/daydream/backends/codex.py
+++ b/daydream/backends/codex.py
@@ -603,8 +603,9 @@ class CodexBackend:
                                 parsed.append({"path": path, "kind": kind})
                             # A missing `status` means "completed": the old
                             # code always recorded success, so an absent status
-                            # must never be archived as an error.
-                            status = item.get("status", "completed")
+                            # (or an explicit `null`) must never be archived as
+                            # an error.
+                            status = item.get("status") or "completed"
                             # Cap the joined path listing with the same limit
                             # as the stdout/stderr excerpts so a large
                             # multi-file apply or a giant path cannot produce
@@ -626,13 +627,19 @@ class CodexBackend:
                                         output += f"\n{stream}: {excerpt[:500]}"
                             # Preserve the legacy patch-input keys for
                             # extension tool supervisors keyed on
-                            # {"file", "action"} — exact only for single-file
-                            # changes; multi-file stays namespaced under
-                            # `changes`.
+                            # {"file", "action"}: exact path/kind for
+                            # single-file changes; multi-file (or empty)
+                            # keeps the pre-diff scalar fallback
+                            # ("unknown"/"modified") so the documented keys
+                            # never go silent, with the full detail
+                            # namespaced under `changes`.
                             start_input: dict[str, Any] = {"changes": parsed}
                             if len(parsed) == 1:
                                 start_input["file"] = parsed[0]["path"]
                                 start_input["action"] = parsed[0]["kind"]
+                            else:
+                                start_input["file"] = "unknown"
+                                start_input["action"] = "modified"
                             yield ToolStartEvent(
                                 id=item_id,
                                 name="patch",
@@ -674,7 +681,11 @@ class CodexBackend:
                                 k: v for k, v in item.items()
                                 if k != "type" and v != "unknown"
                             }
-                            echo = json.dumps(fields)
+                            # Cap the diagnostic echo with the same limit as the
+                            # stdout/stderr excerpts so a degenerate pathless item
+                            # carrying a large field cannot produce an unbounded
+                            # ToolResult output.
+                            echo = json.dumps(fields)[:500]
                             yield ToolStartEvent(
                                 id=item_id,
                                 name="patch",

--- a/daydream/backends/codex.py
+++ b/daydream/backends/codex.py
@@ -570,9 +570,9 @@ class CodexBackend:
 
                     elif item_type == "file_change":
                         # file_change has no item.started — emit a synthetic pair.
-                        item_id = item.get("id", str(uuid.uuid4()))
                         changes = item.get("changes")
                         if isinstance(changes, dict) and changes:
+                            item_id = item.get("id", str(uuid.uuid4()))
                             # Current CLI shape: a map of path -> {type, ...}.
                             # Normalize each path against execution_cwd; keep
                             # absolute paths that fall outside it.
@@ -614,6 +614,7 @@ class CodexBackend:
                             )
                         elif "file_path" in item:
                             # Legacy scalar shape (older CLI): keep as-is.
+                            item_id = item.get("id", str(uuid.uuid4()))
                             file_path = item.get("file_path", "unknown")
                             action = item.get("action", "modified")
                             yield ToolStartEvent(
@@ -627,10 +628,29 @@ class CodexBackend:
                                 is_error=False,
                             )
                         else:
-                            _warn(
-                                "file_change item without paths",
-                                item_id=item_id,
-                                status=item.get("status", ""),
+                            # Pathless payload — neither `changes` nor `file_path`.
+                            # Never silently archive (the old behavior recorded
+                            # "modified: unknown"): emit a synthetic pair whose
+                            # ToolResult is an observable error echoing the
+                            # item's available fields.
+                            item_id = item.get("id")
+                            if not item_id:
+                                item_id = _claim_tool_id("file_change", "file_change:pathless", "")
+                            fields = {
+                                k: v for k, v in item.items()
+                                if k != "type" and v != "unknown"
+                            }
+                            echo = json.dumps(fields)
+                            yield ToolStartEvent(
+                                id=item_id,
+                                name="patch",
+                                input={"file_change": fields},
+                            )
+                            yield ToolResultEvent(
+                                id=item_id,
+                                output=f"unparseable file_change item: {echo}",
+                                is_error=True,
+                                status=item.get("status") or None,
                             )
 
                     elif item_type == "mcp_tool_call":

--- a/tests/fixtures/codex_jsonl/file_change_add.jsonl
+++ b/tests/fixtures/codex_jsonl/file_change_add.jsonl
@@ -1,0 +1,3 @@
+{"type":"thread.started","thread_id":"th_fc_add"}
+{"type":"item.completed","item":{"type":"file_change","id":"fc_add_1","status":"completed","changes":{"/tmp/spike-repo/a.py":{"type":"add"}}}}
+{"type":"turn.completed","usage":{"input_tokens":100,"output_tokens":50}}

--- a/tests/fixtures/codex_jsonl/file_change_declined.jsonl
+++ b/tests/fixtures/codex_jsonl/file_change_declined.jsonl
@@ -1,0 +1,3 @@
+{"type":"thread.started","thread_id":"th_fc_declined"}
+{"type":"item.completed","item":{"type":"file_change","id":"fc_declined_1","status":"declined","changes":{"/tmp/spike-repo/e.py":{"type":"update"}}}}
+{"type":"turn.completed","usage":{"input_tokens":100,"output_tokens":50}}

--- a/tests/fixtures/codex_jsonl/file_change_failed.jsonl
+++ b/tests/fixtures/codex_jsonl/file_change_failed.jsonl
@@ -1,0 +1,3 @@
+{"type":"thread.started","thread_id":"th_fc_failed"}
+{"type":"item.completed","item":{"type":"file_change","id":"fc_failed_1","status":"failed","stderr":"patch: failed to apply hunk at main.py:12","changes":{"/tmp/spike-repo/main.py":{"type":"update"}}}}
+{"type":"turn.completed","usage":{"input_tokens":100,"output_tokens":50}}

--- a/tests/fixtures/codex_jsonl/file_change_multi.jsonl
+++ b/tests/fixtures/codex_jsonl/file_change_multi.jsonl
@@ -1,0 +1,3 @@
+{"type":"thread.started","thread_id":"th_fc_multi"}
+{"type":"item.completed","item":{"type":"file_change","id":"fc_multi_1","status":"completed","changes":{"/tmp/spike-repo/a.py":{"type":"add"},"/tmp/spike-repo/b.py":{"type":"update"},"/tmp/spike-repo/c.py":{"type":"delete"},"/tmp/spike-repo/d.py":{"type":"move"}}}}
+{"type":"turn.completed","usage":{"input_tokens":100,"output_tokens":50}}

--- a/tests/fixtures/codex_jsonl/file_change_pathless.jsonl
+++ b/tests/fixtures/codex_jsonl/file_change_pathless.jsonl
@@ -1,0 +1,3 @@
+{"type":"thread.started","thread_id":"th_fc_pathless"}
+{"type":"item.completed","item":{"type":"file_change","id":"fc_x"}}
+{"type":"turn.completed","usage":{"input_tokens":100,"output_tokens":50}}

--- a/tests/test_backend_codex.py
+++ b/tests/test_backend_codex.py
@@ -155,6 +155,18 @@ async def test_file_change_changes_map_failed_is_error_with_stderr() -> None:
     assert "failed to apply hunk" in results[0].output
 
 
+@pytest.mark.asyncio
+async def test_file_change_pathless_payload_diagnostic() -> None:
+    backend = CodexBackend(model="fixture-model")
+    events = await _run_fixture(backend, "Edit", "file_change_pathless.jsonl")
+    results = [e for e in events if isinstance(e, ToolResultEvent)]
+    assert len(results) == 1
+    assert results[0].is_error is True
+    assert "unparseable" in results[0].output
+    assert "file_change" in results[0].output  # echoes available fields
+    assert "unknown" not in results[0].output
+
+
 @pytest.mark.parametrize(
     ("fixture", "expected_output", "expected_text_count"),
     [

--- a/tests/test_backend_codex.py
+++ b/tests/test_backend_codex.py
@@ -1263,3 +1263,13 @@ async def test_codex_preserves_exit_code_and_status_on_results() -> None:
     assert ok.is_error is False
     assert ok.exit_code == 0
     assert ok.status == "completed"
+
+
+@pytest.mark.asyncio
+async def test_file_change_output_names_every_path() -> None:
+    backend = CodexBackend(model="fixture-model")
+    events = await _run_fixture(backend, "Edit", "file_change_multi.jsonl")
+    results = [e for e in events if isinstance(e, ToolResultEvent)]
+    assert "a.py" in results[0].output and "b.py" in results[0].output
+    assert "c.py" in results[0].output and "d.py" in results[0].output
+    assert "unknown" not in results[0].output

--- a/tests/test_backend_codex.py
+++ b/tests/test_backend_codex.py
@@ -167,6 +167,91 @@ async def test_file_change_pathless_payload_diagnostic() -> None:
     assert "unknown" not in results[0].output
 
 
+async def _run_inline_lines(backend: Any, prompt: Any, lines: list[str]) -> list[Any]:
+    """Drive ``execute`` over inline JSONL lines (no fixture file needed)."""
+    mock_proc = make_mock_process(lines)
+    with patch("daydream.backends._transport.asyncio.create_subprocess_exec", return_value=mock_proc):
+        return [event async for event in backend.execute(Path("/tmp"), prompt)]
+
+
+@pytest.mark.asyncio
+async def test_file_change_missing_status_is_success() -> None:
+    # A changes-map item with no `status` key must record success (the old
+    # code always did) instead of being archived as an error.
+    backend = CodexBackend(model="fixture-model")
+    events = await _run_inline_lines(backend, "Edit", [
+        '{"type":"thread.started","thread_id":"t"}',
+        '{"type":"item.completed","item":{"type":"file_change","id":"x1",'
+        '"changes":{"/tmp/spike-repo/a.py":{"type":"add"}}}}',
+        '{"type":"turn.completed","usage":{"input_tokens":100,"output_tokens":50}}',
+    ])
+    results = [e for e in events if isinstance(e, ToolResultEvent)]
+    assert len(results) == 1
+    assert results[0].is_error is False
+    assert results[0].status == "completed"
+
+
+@pytest.mark.asyncio
+async def test_file_change_declined_output_names_paths() -> None:
+    # A declined change must not lose its affected paths (or any stderr).
+    backend = CodexBackend(model="fixture-model")
+    events = await _run_inline_lines(backend, "Edit", [
+        '{"type":"thread.started","thread_id":"t"}',
+        '{"type":"item.completed","item":{"type":"file_change","id":"x1",'
+        '"status":"declined","stderr":"sandbox denied write",'
+        '"changes":{"/tmp/spike-repo/b.py":{"type":"update"}}}}',
+        '{"type":"turn.completed","usage":{"input_tokens":100,"output_tokens":50}}',
+    ])
+    results = [e for e in events if isinstance(e, ToolResultEvent)]
+    assert len(results) == 1
+    assert results[0].is_error is True
+    assert results[0].status == "declined"
+    assert "File change declined by sandbox" in results[0].output
+    assert "b.py" in results[0].output  # names the affected path
+    assert "sandbox denied write" in results[0].output  # keeps stderr
+
+
+@pytest.mark.asyncio
+async def test_file_change_list_changes_parsed() -> None:
+    # A list-shaped `changes` payload is folded to the path-keyed map;
+    # an empty list is a no-op success, never an "unparseable" error.
+    backend = CodexBackend(model="fixture-model")
+    events = await _run_inline_lines(backend, "Edit", [
+        '{"type":"thread.started","thread_id":"t"}',
+        '{"type":"item.completed","item":{"type":"file_change","id":"x1",'
+        '"status":"completed","changes":[{"path":"/tmp/spike-repo/a.py","type":"add"}]}}',
+        '{"type":"item.completed","item":{"type":"file_change","id":"x2",'
+        '"status":"completed","changes":[]}}',
+        '{"type":"turn.completed","usage":{"input_tokens":100,"output_tokens":50}}',
+    ])
+    starts = [e for e in events if isinstance(e, ToolStartEvent) and e.name == "patch"]
+    assert len(starts) == 2
+    assert starts[0].input["changes"] == [{"path": "spike-repo/a.py", "kind": "add"}]
+    assert starts[1].input["changes"] == []
+    results = [e for e in events if isinstance(e, ToolResultEvent)]
+    assert all(r.is_error is False for r in results)
+
+
+@pytest.mark.asyncio
+async def test_file_change_idless_pathless_no_unmatched_warning(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    # An id-less pathless item falls back to a plain uuid without the
+    # spurious "unmatched tool result" warning (_claim_tool_id can never
+    # match for file_change).
+    backend = CodexBackend(model="fixture-model")
+    with caplog.at_level("WARNING"):
+        events = await _run_inline_lines(backend, "Edit", [
+            '{"type":"thread.started","thread_id":"t"}',
+            '{"type":"item.completed","item":{"type":"file_change"}}',
+            '{"type":"turn.completed","usage":{"input_tokens":100,"output_tokens":50}}',
+        ])
+    results = [e for e in events if isinstance(e, ToolResultEvent)]
+    assert len(results) == 1
+    assert "unparseable" in results[0].output
+    assert "unmatched tool result" not in caplog.text
+
+
 @pytest.mark.parametrize(
     ("fixture", "expected_output", "expected_text_count"),
     [

--- a/tests/test_backend_codex.py
+++ b/tests/test_backend_codex.py
@@ -111,7 +111,7 @@ async def test_file_change_changes_map_single_path() -> None:
     events = await _run_fixture(backend, "Edit", "file_change_add.jsonl")
     starts = [e for e in events if isinstance(e, ToolStartEvent) and e.name == "patch"]
     assert len(starts) == 1
-    assert starts[0].input["changes"] == [("/tmp/spike-repo/a.py", "add")]
+    assert starts[0].input["changes"] == [{"path": "spike-repo/a.py", "kind": "add"}]
     results = [e for e in events if isinstance(e, ToolResultEvent)]
     assert len(results) == 1 and not results[0].is_error
 
@@ -125,10 +125,10 @@ async def test_file_change_changes_map_multi_path() -> None:
     assert sorted(
         (c["path"], c["kind"]) for c in starts[0].input["changes"]
     ) == [
-        ("/tmp/spike-repo/a.py", "add"),
-        ("/tmp/spike-repo/b.py", "update"),
-        ("/tmp/spike-repo/c.py", "delete"),
-        ("/tmp/spike-repo/d.py", "move"),
+        ("spike-repo/a.py", "add"),
+        ("spike-repo/b.py", "update"),
+        ("spike-repo/c.py", "delete"),
+        ("spike-repo/d.py", "move"),
     ]
     results = [e for e in events if isinstance(e, ToolResultEvent)]
     assert len(results) == 1 and not results[0].is_error

--- a/tests/test_backend_codex.py
+++ b/tests/test_backend_codex.py
@@ -96,6 +96,15 @@ async def test_tool_use_events() -> None:
     assert any(t.text == "Done!" for t in texts)
 
 
+@pytest.mark.asyncio
+async def test_file_change_legacy_scalar_payload_unchanged() -> None:
+    backend = CodexBackend(model="fixture-model")
+    events = await _run_fixture(backend, "Run ls", "tool_use.jsonl")
+    starts = [e for e in events if isinstance(e, ToolStartEvent) and e.name == "patch"]
+    assert len(starts) == 1
+    assert starts[0].input == {"file": "main.py", "action": "modified"}
+
+
 @pytest.mark.parametrize(
     ("fixture", "expected_output", "expected_text_count"),
     [

--- a/tests/test_backend_codex.py
+++ b/tests/test_backend_codex.py
@@ -105,6 +105,56 @@ async def test_file_change_legacy_scalar_payload_unchanged() -> None:
     assert starts[0].input == {"file": "main.py", "action": "modified"}
 
 
+@pytest.mark.asyncio
+async def test_file_change_changes_map_single_path() -> None:
+    backend = CodexBackend(model="fixture-model")
+    events = await _run_fixture(backend, "Edit", "file_change_add.jsonl")
+    starts = [e for e in events if isinstance(e, ToolStartEvent) and e.name == "patch"]
+    assert len(starts) == 1
+    assert starts[0].input["changes"] == [("/tmp/spike-repo/a.py", "add")]
+    results = [e for e in events if isinstance(e, ToolResultEvent)]
+    assert len(results) == 1 and not results[0].is_error
+
+
+@pytest.mark.asyncio
+async def test_file_change_changes_map_multi_path() -> None:
+    backend = CodexBackend(model="fixture-model")
+    events = await _run_fixture(backend, "Edit", "file_change_multi.jsonl")
+    starts = [e for e in events if isinstance(e, ToolStartEvent) and e.name == "patch"]
+    assert len(starts) == 1  # exactly ONE pair for the item — no id collisions
+    assert sorted(
+        (c["path"], c["kind"]) for c in starts[0].input["changes"]
+    ) == [
+        ("/tmp/spike-repo/a.py", "add"),
+        ("/tmp/spike-repo/b.py", "update"),
+        ("/tmp/spike-repo/c.py", "delete"),
+        ("/tmp/spike-repo/d.py", "move"),
+    ]
+    results = [e for e in events if isinstance(e, ToolResultEvent)]
+    assert len(results) == 1 and not results[0].is_error
+
+
+@pytest.mark.asyncio
+async def test_file_change_changes_map_declined_is_error() -> None:
+    backend = CodexBackend(model="fixture-model")
+    events = await _run_fixture(backend, "Edit", "file_change_declined.jsonl")
+    results = [e for e in events if isinstance(e, ToolResultEvent)]
+    assert len(results) == 1
+    assert results[0].is_error is True
+    assert results[0].status == "declined"
+
+
+@pytest.mark.asyncio
+async def test_file_change_changes_map_failed_is_error_with_stderr() -> None:
+    backend = CodexBackend(model="fixture-model")
+    events = await _run_fixture(backend, "Edit", "file_change_failed.jsonl")
+    results = [e for e in events if isinstance(e, ToolResultEvent)]
+    assert len(results) == 1
+    assert results[0].is_error is True
+    assert results[0].status == "failed"
+    assert "failed to apply hunk" in results[0].output
+
+
 @pytest.mark.parametrize(
     ("fixture", "expected_output", "expected_text_count"),
     [

--- a/tests/test_backend_codex.py
+++ b/tests/test_backend_codex.py
@@ -122,6 +122,10 @@ async def test_file_change_changes_map_multi_path() -> None:
     events = await _run_fixture(backend, "Edit", "file_change_multi.jsonl")
     starts = [e for e in events if isinstance(e, ToolStartEvent) and e.name == "patch"]
     assert len(starts) == 1  # exactly ONE pair for the item — no id collisions
+    # Legacy {"file", "action"} keys stay present for multi-file too (pre-diff
+    # fallback values), so tool supervisors keyed on them still see the event.
+    assert starts[0].input["file"] == "unknown"
+    assert starts[0].input["action"] == "modified"
     assert sorted(
         (c["path"], c["kind"]) for c in starts[0].input["changes"]
     ) == [
@@ -175,20 +179,46 @@ async def _run_inline_lines(backend: Any, prompt: Any, lines: list[str]) -> list
 
 
 @pytest.mark.asyncio
+async def test_file_change_pathless_echo_is_bounded() -> None:
+    # A degenerate pathless item carrying a huge field must not produce an
+    # unbounded ToolResult: the diagnostic echo is capped like every other
+    # derived string in the file_change branch.
+    backend = CodexBackend(model="fixture-model")
+    big_field = "x" * 100_000
+    pathless_line = (
+        '{"type":"item.completed","item":{"type":"file_change",'
+        '"id":"x1","stderr":"%s"}}' % big_field
+    )
+    events = await _run_inline_lines(backend, "Edit", [
+        '{"type":"thread.started","thread_id":"t"}',
+        pathless_line,
+        '{"type":"turn.completed","usage":{"input_tokens":100,"output_tokens":50}}',
+    ])
+    results = [e for e in events if isinstance(e, ToolResultEvent)]
+    assert len(results) == 1
+    assert results[0].is_error is True
+    assert "unparseable" in results[0].output
+    assert len(results[0].output) < 600
+
+
+@pytest.mark.asyncio
 async def test_file_change_missing_status_is_success() -> None:
-    # A changes-map item with no `status` key must record success (the old
-    # code always did) instead of being archived as an error.
+    # A changes-map item with no `status` key — or an explicit `"status":
+    # null` — must record success (the old code always did) instead of
+    # being archived as an error.
     backend = CodexBackend(model="fixture-model")
     events = await _run_inline_lines(backend, "Edit", [
         '{"type":"thread.started","thread_id":"t"}',
         '{"type":"item.completed","item":{"type":"file_change","id":"x1",'
         '"changes":{"/tmp/spike-repo/a.py":{"type":"add"}}}}',
+        '{"type":"item.completed","item":{"type":"file_change","id":"x2",'
+        '"status":null,"changes":{"/tmp/spike-repo/b.py":{"type":"update"}}}}',
         '{"type":"turn.completed","usage":{"input_tokens":100,"output_tokens":50}}',
     ])
     results = [e for e in events if isinstance(e, ToolResultEvent)]
-    assert len(results) == 1
-    assert results[0].is_error is False
-    assert results[0].status == "completed"
+    assert len(results) == 2
+    assert all(r.is_error is False for r in results)
+    assert all(r.status == "completed" for r in results)
 
 
 @pytest.mark.asyncio
@@ -1348,13 +1378,3 @@ async def test_codex_preserves_exit_code_and_status_on_results() -> None:
     assert ok.is_error is False
     assert ok.exit_code == 0
     assert ok.status == "completed"
-
-
-@pytest.mark.asyncio
-async def test_file_change_output_names_every_path() -> None:
-    backend = CodexBackend(model="fixture-model")
-    events = await _run_fixture(backend, "Edit", "file_change_multi.jsonl")
-    results = [e for e in events if isinstance(e, ToolResultEvent)]
-    assert "a.py" in results[0].output and "b.py" in results[0].output
-    assert "c.py" in results[0].output and "d.py" in results[0].output
-    assert "unknown" not in results[0].output

--- a/tests/test_codex_real_cli_contract.py
+++ b/tests/test_codex_real_cli_contract.py
@@ -174,6 +174,22 @@ async def test_real_file_change_parses_to_expected_events() -> None:
             changes_keys.extend(changes.keys())
     assert changes_keys, "fixture has a file_change item with no changes keys"
 
+    # The parser normalizes absolute paths under execution_cwd to repo-relative
+    # (codex.py file_change branch: commonpath/relpath), so the fixture's raw
+    # changes keys must undergo the same transform before comparison. Mirror the
+    # parser's guards: keys outside the cwd stay absolute, disjoint-drive
+    # ValueError keeps them absolute too.
+    execution_cwd = "/tmp"
+    normalized_keys: list[str] = []
+    for key in changes_keys:
+        try:
+            if os.path.isabs(key) and os.path.commonpath([key, execution_cwd]) == execution_cwd:
+                normalized_keys.append(os.path.relpath(key, execution_cwd))
+            else:
+                normalized_keys.append(key)
+        except ValueError:
+            normalized_keys.append(key)
+
     backend = CodexBackend(model="gpt-5.5")
     mock_proc = make_mock_process_from_fixture(REAL_FILE_CHANGE)
 
@@ -187,8 +203,10 @@ async def test_real_file_change_parses_to_expected_events() -> None:
     parsed_paths = [
         c["path"] for start in patch_starts for c in start.input.get("changes", [])
     ]
-    assert sorted(parsed_paths) == sorted(changes_keys), (
-        f"parsed patch paths {parsed_paths} != fixture changes keys {changes_keys}"
+    # Compare against the cwd-normalized keys (parser output is relativized).
+    assert sorted(parsed_paths) == sorted(normalized_keys), (
+        f"parsed patch paths {parsed_paths} != fixture changes keys "
+        f"(normalized) {normalized_keys}"
     )
 
     patch_ids = {e.id for e in patch_starts}

--- a/tests/test_codex_real_cli_contract.py
+++ b/tests/test_codex_real_cli_contract.py
@@ -47,6 +47,7 @@ from daydream.backends.codex import CodexBackend
 from tests.harness.codex_replay import FIXTURES_DIR, make_mock_process_from_fixture
 
 REAL_GOLDEN = "real/golden.jsonl"
+REAL_FILE_CHANGE = "real/file-change.jsonl"
 
 _logger = logging.getLogger(__name__)
 
@@ -131,6 +132,71 @@ async def test_real_golden_parses_to_expected_events() -> None:
     # Result event present (turn.completed → ResultEvent with continuation).
     result_events = [e for e in events if isinstance(e, ResultEvent)]
     assert result_events, "real golden produced no ResultEvent"
+
+
+@pytest.mark.asyncio
+async def test_real_file_change_parses_to_expected_events() -> None:
+    """The committed REAL file_change capture parses to the new-shape event stream.
+
+    Mirrors ``test_real_golden_parses_to_expected_events`` but for a ``patch``
+    (file_change) item: the parser must emit a ToolStart("patch") whose
+    ``input["changes"]`` paths match the fixture's ``changes`` keys
+    (repo-relative) and a ToolResult with ``status == "completed"``.
+
+    **Blocked on a real capture** (issue #1125 Task 0 spike): the sandbox
+    environment has no OpenAI credentials, so ``codex exec`` could not
+    authenticate and no real ``file_change`` JSONL was captured. Per the plan
+    contract, a "real" fixture must never be synthesized — so the fixture is
+    simply absent and this test skips until a genuine capture lands at
+    ``tests/fixtures/codex_jsonl/real/file-change.jsonl`` (re-capture via
+    ``scripts/capture-codex-golden.sh``-style flow against an authenticated
+    CLI). The assertions below run unmodified once the fixture exists.
+    """
+    fixture_path = FIXTURES_DIR / REAL_FILE_CHANGE
+    if not fixture_path.exists():
+        pytest.skip(
+            "real file_change capture not yet available "
+            f"({fixture_path}); Task 0 spike could not capture (no OpenAI auth)"
+        )
+
+    # The fixture is genuine codex output: extract the changes keys the CLI
+    # reported so the assertion compares parser output against ground truth.
+    changes_keys: list[str] = []
+    for line in fixture_path.read_text().splitlines():
+        if not line.strip():
+            continue
+        evt = json.loads(line)
+        item = evt.get("item") or {}
+        if item.get("type") == "file_change" or (
+            evt.get("type") == "item.completed" and item.get("item_type") == "file_change"
+        ):
+            changes = item.get("changes") or {}
+            changes_keys.extend(changes.keys())
+    assert changes_keys, "fixture has a file_change item with no changes keys"
+
+    backend = CodexBackend(model="gpt-5.5")
+    mock_proc = make_mock_process_from_fixture(REAL_FILE_CHANGE)
+
+    with patch("daydream.backends._transport.asyncio.create_subprocess_exec", return_value=mock_proc):
+        events: list[Any] = []
+        async for event in backend.execute(Path("/tmp"), "apply the patch"):
+            events.append(event)
+
+    patch_starts = [e for e in events if isinstance(e, ToolStartEvent) and e.name == "patch"]
+    assert patch_starts, "real file_change fixture produced no patch ToolStart"
+    parsed_paths = [
+        c["path"] for start in patch_starts for c in start.input.get("changes", [])
+    ]
+    assert sorted(parsed_paths) == sorted(changes_keys), (
+        f"parsed patch paths {parsed_paths} != fixture changes keys {changes_keys}"
+    )
+
+    patch_ids = {e.id for e in patch_starts}
+    patch_results = [e for e in events if isinstance(e, ToolResultEvent) and e.id in patch_ids]
+    assert patch_results, "real file_change fixture produced no patch ToolResult"
+    assert any(r.status == "completed" for r in patch_results), (
+        f"no patch ToolResult with status 'completed': {[r.status for r in patch_results]}"
+    )
 
 
 @pytest.mark.live_codex


### PR DESCRIPTION
## Summary
- Reworks the codex backend `file_change` event parsing to handle the current shape (changes map with status-derived errors), with an observable diagnostic for pathless payloads
- `file_change` result output now names every changed path
- Pins the legacy scalar contract with fixtures/tests before the parser rework; adds current-shape fixtures and contract-test wiring for the real CLI
- Round-1 + round-2 daydream review fixes: hardened codex file_change event edge cases

## Test Plan
- [x] New fixtures + contract tests (tests/test_backend_codex.py, tests/test_codex_real_cli_contract.py)
- [x] Two sequential daydream deep-precision reviews passed (round 2: 5/5 findings resolved, commit 4717884)

Closes #1125