### PR TITLE
fix(harbor): render_job_config requires credentials the selected provider/backend never uses

### DIFF
--- a/daydream/benchmark/harbor/entrypoint.py
+++ b/daydream/benchmark/harbor/entrypoint.py
@@ -187,6 +187,10 @@ def apply_reviewer_env(env: Mapping[str, str] | None = None, *, backend: str = "
         return
     api_key = (source.get(_API_KEY_ENV) or "").strip()
     base_url = (source.get(_BASE_URL_ENV) or "").strip()
+    if not base_url:
+        raise EntrypointError(
+            "missing required environment variable 'DAYDREAM_REVIEW_BASE_URL'"
+        )
     parsed = urllib.parse.urlsplit(base_url)
     if (
         parsed.scheme.lower() != "https"

--- a/daydream/benchmark/harbor/package.py
+++ b/daydream/benchmark/harbor/package.py
@@ -406,9 +406,13 @@ def render_job_config(*, oracle: bool) -> bytes:
         # supported values are validated downstream by the agent/entrypoint allowlist.
         "env": {
             "DAYDREAM_REVIEW_BACKEND": "${DAYDREAM_REVIEW_BACKEND:-pi}",
+            # Mutually exclusive credentials get empty fallbacks so an unset
+            # alternative never aborts rendering: the selected provider's
+            # credential is present and the unused one resolves to "", which
+            # downstream fail-closed checks treat as missing.
             "DAYDREAM_REVIEW_MODEL": "${DAYDREAM_REVIEW_MODEL}",
-            "DAYDREAM_REVIEW_API_KEY": "${DAYDREAM_REVIEW_API_KEY}",
-            "DAYDREAM_REVIEW_BASE_URL": "${DAYDREAM_REVIEW_BASE_URL}",
+            "DAYDREAM_REVIEW_API_KEY": "${DAYDREAM_REVIEW_API_KEY:-}",
+            "DAYDREAM_REVIEW_BASE_URL": "${DAYDREAM_REVIEW_BASE_URL:-}",
             "DAYDREAM_REVIEW_PROFILE_CANDIDATE": "${DAYDREAM_REVIEW_PROFILE_CANDIDATE:-}",
             # ANTHROPIC_* carries claude-backend credentials into the container
             # (agent.build_child_env keep-set, entrypoint claude branch); the
@@ -427,11 +431,14 @@ def render_job_config(*, oracle: bool) -> bytes:
         "verifier": {"env": {
             "DAYDREAM_JUDGE_PROVIDER": "${DAYDREAM_JUDGE_PROVIDER}",
             "DAYDREAM_JUDGE_MODEL": "${DAYDREAM_JUDGE_MODEL}",
-            "DAYDREAM_JUDGE_API_KEY": "${DAYDREAM_JUDGE_API_KEY}",
-            "DAYDREAM_JUDGE_BASE_URL": "${DAYDREAM_JUDGE_BASE_URL}",
+            "DAYDREAM_JUDGE_API_KEY": "${DAYDREAM_JUDGE_API_KEY:-}",
+            "DAYDREAM_JUDGE_BASE_URL": "${DAYDREAM_JUDGE_BASE_URL:-}",
             # CLAUDE_CODE_* feeds the keyless claude-cli judge client; the
             # nonessential-traffic gate defaults on (fail-safe direction).
-            "CLAUDE_CODE_OAUTH_TOKEN": "${CLAUDE_CODE_OAUTH_TOKEN}",
+            # The oauth token is an alternative to DAYDREAM_JUDGE_API_KEY, so
+            # it gets the same empty fallback; downstream fail-closed checks
+            # treat "" as missing.
+            "CLAUDE_CODE_OAUTH_TOKEN": "${CLAUDE_CODE_OAUTH_TOKEN:-}",
             "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": (
                 "${CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC:-1}"
             ),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,7 @@ ignore_errors = true
 [[tool.mypy.overrides]]
 # Harbor ships without py.typed; no stub package exists. Narrow per-module,
 # not blanket-library, so future typed releases are picked up automatically.
-module = ["harbor.models.*", "harbor.agents.base", "harbor.environments.docker.*", "harbor.environments.base"]
+module = ["harbor.models.*", "harbor.agents.base", "harbor.utils.env", "harbor.environments.docker.*", "harbor.environments.base"]
 ignore_missing_imports = true
 
 [[tool.mypy.overrides]]

--- a/tests/test_benchmark_harbor_package.py
+++ b/tests/test_benchmark_harbor_package.py
@@ -311,6 +311,9 @@ def test_render_job_config_resolves_with_only_selected_provider_credential(
 ) -> None:
     """An unset *alternative* credential never aborts rendering (issue #979)."""
     import yaml
+
+    pytest.importorskip("harbor")
+
     from harbor.utils.env import resolve_env_vars
 
     from daydream.benchmark.harbor import package as pkg
@@ -319,7 +322,7 @@ def test_render_job_config_resolves_with_only_selected_provider_credential(
     for var in (
         "DAYDREAM_JUDGE_API_KEY", "DAYDREAM_JUDGE_BASE_URL",
         "CLAUDE_CODE_OAUTH_TOKEN", "DAYDREAM_REVIEW_API_KEY",
-        "DAYDREAM_REVIEW_BASE_URL",
+        "DAYDREAM_REVIEW_BASE_URL", "ANTHROPIC_API_KEY",
     ):
         monkeypatch.delenv(var, raising=False)
     monkeypatch.setenv("DAYDREAM_JUDGE_PROVIDER", "anthropic")
@@ -344,6 +347,9 @@ def test_render_job_config_still_requires_selection_vars(
 ) -> None:
     """Selection vars stay bare: unset provider/model still abort rendering."""
     import yaml
+
+    pytest.importorskip("harbor")
+
     from harbor.utils.env import resolve_env_vars
 
     from daydream.benchmark.harbor import package as pkg

--- a/tests/test_benchmark_harbor_package.py
+++ b/tests/test_benchmark_harbor_package.py
@@ -283,15 +283,19 @@ def test_render_job_config_matches_plan_s8_and_oracle_differs() -> None:
     agent = job["agents"][0]
     assert agent["import_path"] == "daydream.benchmark.harbor.agent:DaydreamReviewAgent"
     assert agent["env"]["DAYDREAM_REVIEW_BACKEND"] == "${DAYDREAM_REVIEW_BACKEND:-pi}"
-    assert "DAYDREAM_REVIEW_API_KEY" in agent["env"]
+    assert agent["env"]["DAYDREAM_REVIEW_API_KEY"] == "${DAYDREAM_REVIEW_API_KEY:-}"
+    assert agent["env"]["DAYDREAM_REVIEW_BASE_URL"] == "${DAYDREAM_REVIEW_BASE_URL:-}"
+    assert agent["env"]["DAYDREAM_REVIEW_MODEL"] == "${DAYDREAM_REVIEW_MODEL}"
     assert agent["env"]["DAYDREAM_REVIEW_PROFILE_CANDIDATE"] == (
         "${DAYDREAM_REVIEW_PROFILE_CANDIDATE:-}"
     )
     assert job["datasets"] == [{"path": "."}]
     assert job["metrics"] == [{"type": "uv-script", "kwargs": {"script_path": "metric.py"}}]
-    assert "DAYDREAM_JUDGE_API_KEY" in job["verifier"]["env"]
+    assert job["verifier"]["env"]["DAYDREAM_JUDGE_API_KEY"] == "${DAYDREAM_JUDGE_API_KEY:-}"
+    assert job["verifier"]["env"]["DAYDREAM_JUDGE_BASE_URL"] == "${DAYDREAM_JUDGE_BASE_URL:-}"
     assert job["verifier"]["env"]["DAYDREAM_JUDGE_PROVIDER"] == "${DAYDREAM_JUDGE_PROVIDER}"
-    assert job["verifier"]["env"]["CLAUDE_CODE_OAUTH_TOKEN"] == "${CLAUDE_CODE_OAUTH_TOKEN}"
+    assert job["verifier"]["env"]["DAYDREAM_JUDGE_MODEL"] == "${DAYDREAM_JUDGE_MODEL}"
+    assert job["verifier"]["env"]["CLAUDE_CODE_OAUTH_TOKEN"] == "${CLAUDE_CODE_OAUTH_TOKEN:-}"
     assert job["verifier"]["env"]["CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC"] == (
         "${CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC:-1}"
     )

--- a/tests/test_benchmark_harbor_package.py
+++ b/tests/test_benchmark_harbor_package.py
@@ -302,6 +302,55 @@ def test_render_job_config_matches_plan_s8_and_oracle_differs() -> None:
     assert oracle["metrics"] == job["metrics"]
 
 
+def test_render_job_config_resolves_with_only_selected_provider_credential(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unset *alternative* credential never aborts rendering (issue #979)."""
+    import yaml
+
+    from daydream.benchmark.harbor import package as pkg
+    from harbor.utils.env import resolve_env_vars
+
+    # Judge: anthropic selected -> CLAUDE_CODE_OAUTH_TOKEN must be optional.
+    for var in (
+        "DAYDREAM_JUDGE_API_KEY", "DAYDREAM_JUDGE_BASE_URL",
+        "CLAUDE_CODE_OAUTH_TOKEN", "DAYDREAM_REVIEW_API_KEY",
+        "DAYDREAM_REVIEW_BASE_URL",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv("DAYDREAM_JUDGE_PROVIDER", "anthropic")
+    monkeypatch.setenv("DAYDREAM_JUDGE_MODEL", "claude-x")
+    monkeypatch.setenv("DAYDREAM_JUDGE_API_KEY", "sk-judge")
+    monkeypatch.setenv("DAYDREAM_REVIEW_BACKEND", "pi")
+    monkeypatch.setenv("DAYDREAM_REVIEW_MODEL", "pi-model")
+    monkeypatch.setenv("DAYDREAM_REVIEW_API_KEY", "sk-review")
+
+    job = yaml.safe_load(pkg.render_job_config(oracle=False))
+    agent_env = resolve_env_vars(dict(job["agents"][0]["env"]))
+    verifier_env = resolve_env_vars(dict(job["verifier"]["env"]))
+    assert agent_env["DAYDREAM_REVIEW_API_KEY"] == "sk-review"
+    assert agent_env["ANTHROPIC_API_KEY"] == ""          # claude alternative, unused, unset
+    assert verifier_env["DAYDREAM_JUDGE_API_KEY"] == "sk-judge"
+    assert verifier_env["CLAUDE_CODE_OAUTH_TOKEN"] == ""  # alternative, unused, unset
+    assert verifier_env["DAYDREAM_JUDGE_MODEL"] == "claude-x"
+
+
+def test_render_job_config_still_requires_selection_vars(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Selection vars stay bare: unset provider/model still abort rendering."""
+    import yaml
+
+    from daydream.benchmark.harbor import package as pkg
+    from harbor.utils.env import resolve_env_vars
+
+    monkeypatch.delenv("DAYDREAM_JUDGE_PROVIDER", raising=False)
+    monkeypatch.setenv("DAYDREAM_JUDGE_MODEL", "m")
+    job = yaml.safe_load(pkg.render_job_config(oracle=False))
+    with pytest.raises(ValueError, match="DAYDREAM_JUDGE_PROVIDER"):
+        resolve_env_vars(dict(job["verifier"]["env"]))
+
+
 def test_compile_with_wheel_emits_full_packaged_tree(tmp_path: Path, fake_gh: FakeGh) -> None:
     import importlib.metadata
 

--- a/tests/test_benchmark_harbor_package.py
+++ b/tests/test_benchmark_harbor_package.py
@@ -311,9 +311,9 @@ def test_render_job_config_resolves_with_only_selected_provider_credential(
 ) -> None:
     """An unset *alternative* credential never aborts rendering (issue #979)."""
     import yaml
+    from harbor.utils.env import resolve_env_vars
 
     from daydream.benchmark.harbor import package as pkg
-    from harbor.utils.env import resolve_env_vars
 
     # Judge: anthropic selected -> CLAUDE_CODE_OAUTH_TOKEN must be optional.
     for var in (
@@ -344,9 +344,9 @@ def test_render_job_config_still_requires_selection_vars(
 ) -> None:
     """Selection vars stay bare: unset provider/model still abort rendering."""
     import yaml
+    from harbor.utils.env import resolve_env_vars
 
     from daydream.benchmark.harbor import package as pkg
-    from harbor.utils.env import resolve_env_vars
 
     monkeypatch.delenv("DAYDREAM_JUDGE_PROVIDER", raising=False)
     monkeypatch.setenv("DAYDREAM_JUDGE_MODEL", "m")

--- a/tests/test_benchmark_verifier_judge.py
+++ b/tests/test_benchmark_verifier_judge.py
@@ -1818,3 +1818,15 @@ async def test_claude_cli_communicate_only_fallback(sr_module: Any) -> None:
     assert raw == {"match": True, "confidence": 0.9, "reasoning": "same"}
     assert len(seen) == 1
     assert seen[0][1] == b""  # stderr is drained by communicate, never blocks
+
+
+def test_build_client_empty_string_api_key_fails_closed(sr_module: Any) -> None:
+    """The template's `${VAR:-}` fallback resolves to "" — still fail-closed (#979)."""
+    sr = sr_module
+    env = {
+        sr._ENV_PROVIDER: "anthropic",
+        sr._ENV_MODEL: "claude-x",
+        sr._ENV_API_KEY: "",  # exactly what resolve_env_vars emits for unset ${VAR:-}
+    }
+    with pytest.raises(sr.VerifierError, match="DAYDREAM_JUDGE_API_KEY"):
+        sr._build_client(env)


### PR DESCRIPTION
## Summary
- Fixes empty :- fallbacks for mutually exclusive credentials in `render_job_config` so Harbor no longer requires credentials the selected provider/backend never uses
- Empty-string judge API key fails closed, verified by new verifier tests
- Accurate missing-DAYDREAM_REVIEW_BASE_URL diagnostic for unset pi reviewer base URL (round-2 review remediation)

Closes #979

## Test Plan
- [x] Full suite green on review VM: 6189 passed, 6 skipped
- [x] Two sequential daydream deep-precision reviews completed (rounds 1 & 2), findings applied and pushed
- [x] All 7 commits authored anderskev@gmail.com (Kevin Anderson)