### PR TITLE
fix(observability): handle stale tracing dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ sufficient for a code change. Install the command again after a pull that change
 
 ```bash
 git pull
-uv tool install --editable .    # necessary only for a dependency change
+uv tool install --reinstall --editable .    # necessary only for a dependency change
 ```
 
 ### Run without an installed command

--- a/daydream/extensions/builtins.py
+++ b/daydream/extensions/builtins.py
@@ -14,7 +14,10 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from opentelemetry.sdk.trace.export import SpanExporter
+
     from daydream.extensions.registry import FlowEntry, Registry
+    from daydream.observability.config import ObservabilityConfig
 
 
 def register_builtins(registry: Registry) -> None:
@@ -28,11 +31,24 @@ def register_builtins(registry: Registry) -> None:
 
 def _register_trace_exporters(registry: Registry) -> None:
     """Register lazy factories; merely validating extensions never initializes tracing."""
-    from daydream.observability.exporters import honeyhive_exporter, langsmith_exporter, otlp_exporter
+    def langsmith(config: ObservabilityConfig) -> SpanExporter:
+        from daydream.observability.exporters import langsmith_exporter
 
-    registry.register_trace_exporter("langsmith", langsmith_exporter)
-    registry.register_trace_exporter("honeyhive", honeyhive_exporter)
-    registry.register_trace_exporter("otlp", otlp_exporter)
+        return langsmith_exporter(config)
+
+    def honeyhive(config: ObservabilityConfig) -> SpanExporter:
+        from daydream.observability.exporters import honeyhive_exporter
+
+        return honeyhive_exporter(config)
+
+    def otlp(config: ObservabilityConfig) -> SpanExporter:
+        from daydream.observability.exporters import otlp_exporter
+
+        return otlp_exporter(config)
+
+    registry.register_trace_exporter("langsmith", langsmith)
+    registry.register_trace_exporter("honeyhive", honeyhive)
+    registry.register_trace_exporter("otlp", otlp)
 
 
 def _register_improve_builtins(registry: Registry) -> None:

--- a/daydream/observability/runtime.py
+++ b/daydream/observability/runtime.py
@@ -120,7 +120,15 @@ class TraceSession:
             except Exception:
                 raise ObservabilityError(f"Unknown trace exporter '{name}'") from None
         with diagnostic_scope(self.policy):
-            from traceloop.sdk import Traceloop
+            try:
+                from traceloop.sdk import Traceloop
+            except ImportError:
+                raise ObservabilityError(
+                    "Tracing dependencies are missing or incompatible. From the Daydream clone, run "
+                    "'uv tool install --reinstall --editable .' to refresh the installed command, "
+                    "or use 'uv run daydream ...' to run with the project's dependencies. "
+                    "If the error persists, check 'command -v daydream' for an older installation on PATH."
+                ) from None
 
             for name, factory in factories:
                 try:

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -61,6 +61,37 @@ Endpoint and field mappings follow the
 Usage details use the `langsmith.usage_metadata` format emitted by
 [LangSmith's own OTLP exporter](https://github.com/langchain-ai/langsmith-sdk/blob/4792a53f807e9129fd4f5c243056d1976e2cff80/js/src/experimental/otel/exporter.ts#L219).
 
+## Missing tracing dependencies
+
+If tracing reports `No module named 'opentelemetry.exporter.otlp.proto.grpc'`,
+`No module named 'traceloop'`, or missing/incompatible tracing dependencies, refresh
+the installation. This can happen after pulling changes into an editable install:
+the command reads the new source, but its Python environment still has the old
+dependencies. It affects LangSmith and HoneyHive even though both send HTTP,
+because OpenLLMetry imports both OTLP transports.
+
+From the Daydream clone, reinstall the command and its dependencies:
+
+```bash
+uv tool install --reinstall --editable .
+command -v daydream
+```
+
+The command should resolve to the uv tool executable directory (`uv tool dir --bin`),
+usually `~/.local/bin`. If it resolves to a pyenv shim or another installation,
+remove that stale Daydream installation or put the uv tool directory first on
+`PATH`. The install requires Python 3.12.13 or newer.
+
+To run directly from the clone with its synchronized dependencies:
+
+```bash
+uv run daydream /path/to/project --trace-to langsmith
+uv run daydream /path/to/project --trace-to honeyhive
+```
+
+`uv sync` updates the clone's `.venv`; it does not update a separately installed
+`daydream` command. See [uv's tool management documentation](https://docs.astral.sh/uv/concepts/tools/).
+
 ## HoneyHive
 
 Use the deployment API base for your HoneyHive organization and region:

--- a/tests/test_observability_dependencies.py
+++ b/tests/test_observability_dependencies.py
@@ -1,0 +1,71 @@
+"""Stale editable installs must fail tracing actionably without breaking the off path."""
+
+import os
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    "missing",
+    ["opentelemetry.exporter.otlp.proto.grpc", "opentelemetry.exporter.otlp.proto.http", "traceloop"],
+)
+@pytest.mark.parametrize("destination", ["off", "langsmith", "honeyhive", "otlp"])
+def test_missing_tracing_dependency(missing: str, destination: str) -> None:
+    # A fresh interpreter avoids SDK imports cached by other tests. Blocking one
+    # package reproduces an editable checkout whose dependencies were not refreshed.
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            textwrap.dedent("""\
+                import importlib.abc
+                import sys
+
+                missing, destination = sys.argv[1:]
+
+                class MissingDependency(importlib.abc.MetaPathFinder):
+                    def find_spec(self, fullname, path, target=None):
+                        if fullname == missing or fullname.startswith(missing + "."):
+                            raise ModuleNotFoundError("private import diagnostic", name=fullname)
+
+                sys.meta_path.insert(0, MissingDependency())
+
+                import anyio
+                from daydream.extensions import build_registry
+                from daydream.observability.config import ObservabilityConfig, ObservabilityError
+                from daydream.observability.runtime import current_session, trace_run
+
+                registry = build_registry()
+                assert set(registry.trace_exporter_names()) >= {"langsmith", "honeyhive", "otlp"}
+
+                async def run():
+                    config = ObservabilityConfig(destinations=() if destination == "off" else (destination,))
+                    try:
+                        async with trace_run(config, registry, flow="review"):
+                            assert destination == "off", "agent work must not start with missing dependencies"
+                    except ObservabilityError as exc:
+                        assert destination != "off"
+                        message = str(exc)
+                        assert "tracing dependencies" in message.lower(), message
+                        assert "uv tool install --reinstall --editable ." in message, message
+                        assert "uv run daydream" in message, message
+                        assert "private import diagnostic" not in message, message
+                    else:
+                        assert destination == "off"
+                    assert current_session() is None
+
+                anyio.run(run)
+                """),
+            missing,
+            destination,
+        ],
+        env={key: value for key, value in os.environ.items() if not key.startswith(("OTEL_", "_OTEL_"))},
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr


### PR DESCRIPTION
## Summary

Keep tracing exporter imports lazy so stale editable installs can start with tracing disabled. When LangSmith, HoneyHive, or generic OTLP tracing is enabled, missing or incompatible OpenLLMetry dependencies now produce instructions to refresh the installation instead of a raw import error.

## Motivation

An older editable installation picks up new source after a pull without installing newly declared dependencies. This reproduced `No module named 'opentelemetry.exporter.otlp.proto.grpc'` during registry construction, before tracing initialization could handle it. Both HTTP presets are affected because OpenLLMetry imports both OTLP transports. The required packages are already declared in `pyproject.toml` and `uv.lock`.

The installation guide now explains dependency refreshes and older commands shadowing the uv installation on PATH.

## Test Plan

- [x] `make check` passed through the normal pre-push hook: 6,334 root tests passed, 9 skipped; 194 standalone RL tests passed, 2 skipped; 88.92% coverage. Lint, type checks, dead-code checks, lock checks, and Docker workflow linting passed.
- [x] Added 12 fresh-process regression cases covering unavailable gRPC, HTTP, and Traceloop packages with tracing disabled and with each built-in destination enabled. Confirmed the failures before implementing the fix.
- [x] All 93 targeted observability tests passed.
- [x] Refreshed the local installation and exported real spans through both LangSmith and HoneyHive adapters to loopback HTTP receivers.

## Checklist

- [x] Root, workflow, and standalone RL checks pass locally via `make check`.
- [x] Documentation updated.
