### PR TITLE
fix(rl): reject non-canonical protected test paths

### DIFF
--- a/rl/daydream_review_v1/daydream_review_v1/taskset.py
+++ b/rl/daydream_review_v1/daydream_review_v1/taskset.py
@@ -907,11 +907,11 @@ class _ManifestEntry(BaseModel):
         The manifest promises LITERAL repository-relative paths, but the scoring
         gate passes each entry to git as a bare pathspec (``_protected_test_paths_unchanged``),
         where ``*``, ``?`` and ``[`` are glob metacharacters and a leading ``:``
-        is pathspec magic. Absolute paths and exact ``.``/``..`` components are
-        also non-canonical. A path that matches nothing would read as a clean diff
-        and an empty ``ls-files`` list, letting ``test_command`` run against an
-        unprotected oracle — so such entries must fail the load rather than ship a
-        silently-inert protection.
+        is pathspec magic. Git normalizes exact ``.``/``..`` components, which
+        can redirect a declared path to an unintended location that matches
+        nothing. Absolute paths instead make the oracle probe fail closed.
+        Reject both non-canonical forms at load time to preserve the manifest's
+        literal repository-relative path contract; do not normalize entries.
         """
         for path in paths:
             if (

--- a/rl/daydream_review_v1/daydream_review_v1/taskset.py
+++ b/rl/daydream_review_v1/daydream_review_v1/taskset.py
@@ -907,16 +907,24 @@ class _ManifestEntry(BaseModel):
         The manifest promises LITERAL repository-relative paths, but the scoring
         gate passes each entry to git as a bare pathspec (``_protected_test_paths_unchanged``),
         where ``*``, ``?`` and ``[`` are glob metacharacters and a leading ``:``
-        is pathspec magic. A glob-shaped entry that matches nothing would read as
-        a clean diff and an empty ``ls-files`` list, letting ``test_command`` run
-        against an unprotected oracle — so such entries must fail the load rather
-        than ship a silently-inert protection.
+        is pathspec magic. Absolute paths and exact ``.``/``..`` components are
+        also non-canonical. A path that matches nothing would read as a clean diff
+        and an empty ``ls-files`` list, letting ``test_command`` run against an
+        unprotected oracle — so such entries must fail the load rather than ship a
+        silently-inert protection.
         """
         for path in paths:
-            if not path or path[0] == ":" or any(ch in path for ch in "*?["):
+            if (
+                not path
+                or path[0] == ":"
+                or path.startswith("/")
+                or any(component in {".", ".."} for component in path.split("/"))
+                or any(ch in path for ch in "*?[")
+            ):
                 raise ValueError(
                     "protected_test_paths must be LITERAL repository-relative paths "
-                    "(nonempty, no leading ':', no '*', '?' or '['); got "
+                    "(nonempty, no leading ':', '/', '.', or '..' components, "
+                    "no '*', '?' or '['); got "
                     f"{path!r}"
                 )
         return paths

--- a/rl/daydream_review_v1/tests/test_taskset.py
+++ b/rl/daydream_review_v1/tests/test_taskset.py
@@ -327,8 +327,34 @@ def test_load_manifest_rejects_missing_or_empty_protected_test_paths(
 
 @pytest.mark.parametrize(
     "entry",
-    ["", ":(exclude)tests", "tests/*", "tests/?", "tests/[x]"],
-    ids=["empty", "leading-colon-magic", "glob-star", "glob-question", "glob-bracket"],
+    [
+        "",
+        ":(exclude)tests",
+        "tests/*",
+        "tests/?",
+        "tests/[x]",
+        "/tests",
+        "tests/./unit",
+        "docs/../missing",
+        "./tests",
+        "tests/.",
+        "../tests",
+        "tests/..",
+    ],
+    ids=[
+        "empty",
+        "leading-colon-magic",
+        "glob-star",
+        "glob-question",
+        "glob-bracket",
+        "absolute",
+        "dot-component",
+        "dotdot-component",
+        "leading-dot-component",
+        "trailing-dot-component",
+        "leading-dotdot-component",
+        "trailing-dotdot-component",
+    ],
 )
 def test_load_manifest_rejects_non_literal_protected_test_paths(
     tmp_path: Path, entry: str
@@ -357,6 +383,24 @@ def test_load_manifest_rejects_non_literal_protected_test_paths(
         load_manifest(manifest)
     assert ("value_error", ("protected_test_paths",)) in [
         (err["type"], err["loc"]) for err in excinfo.value.errors()
+    ]
+
+
+def test_load_manifest_accepts_canonical_protected_test_paths(tmp_path: Path) -> None:
+    """Canonical nested paths and dotfiles load unchanged through the loader."""
+    manifest = tmp_path / "manifest.toml"
+    manifest.write_text(
+        '[repos."acme/widgets"]\n'
+        'clone_url = "https://github.com/acme/widgets"\n'
+        'image = "daydream-rl/widgets"\n'
+        'test_command = "pytest -q"\n'
+        'setup_cmds = []\n'
+        'protected_test_paths = ["tests/unit", "tests/unit/test_api.py", ".pytest.ini", "tests/.hidden"]\n',
+        encoding="utf-8",
+    )
+    loaded = load_manifest(manifest)
+    assert loaded["acme/widgets"].protected_test_paths == [
+        "tests/unit", "tests/unit/test_api.py", ".pytest.ini", "tests/.hidden"
     ]
 
 


### PR DESCRIPTION
## Summary

Reject absolute paths and exact `.` or `..` components in `protected_test_paths` when loading an RL manifest. Absolute paths now fail at load instead of during the oracle probe, and dot components cannot silently redirect a declared path. Canonical nested paths and dotfiles retain their original values.

## Motivation

Closes #711. Validation stays lexical and preserves the existing empty, pathspec-magic, and glob checks.

## Test Plan

- Added seven failing loader regressions before implementation, then confirmed all 39 taskset tests pass, including unchanged nested/dotfile paths.
- Targeted Ruff and mypy checks pass.
- Ordinary signed commit and hook-enabled push succeeded. The pre-push `make check` passed lint, types, dead-code checks, lock checks, actionlint, 6,334 root tests, 202 standalone RL tests, and the coverage gate (88.90%). Existing environment-gated skips: 9 root and 2 RL.
- Ran `daydream . --precision --backend pi --trace-to honeyhive --trace-to langsmith` from the PR checkout with the operator's HoneyHive URL. Exit 0; run `190b57af-efe3-41fb-95e6-84a72229821d`. Reviewed the two final low-severity findings manually: clarified the docstring's Git normalization/fail-closed rationale; declined broader backslash restrictions because #711 explicitly excludes broader path policy and a backslash may be a literal POSIX filename character. The preliminary double-slash concern was disproved by actual Git probes and was not a final finding.
- After the wording fix, all 39 taskset tests and targeted Ruff/mypy pass. The follow-up ordinary hook-enabled push passed the complete gate again: 6,334 root tests, 202 standalone tests, and 88.90% coverage. Final head `b3fe6aae2653edf0c4bb9c296d858346d1239650` passed root CI, standalone CI, training dry-path CI, and CodeQL; optional codesmith was skipped by its workflow.

## Checklist

- [x] Root, workflow, and standalone RL checks pass locally via `make check`.
- [x] Existing README contract remains accurate; no documentation change needed.
