### PR TITLE
codex: preserve replayable shell commands in trajectories

### DIFF
--- a/daydream/agent.py
+++ b/daydream/agent.py
@@ -418,6 +418,13 @@ def _summarize_input(input_data: dict[str, Any], name: str) -> str:
     for key in _PRIMARY_TOOL_ARG.get(name, ()):
         value = input_data.get(key)
         if isinstance(value, str) and value:
+            # S1 parity with the live render surfaces (ui.tools): the stored
+            # input keeps the replayable cd-prefixed payload, but the --log
+            # surface shows the cd-stripped display variant.
+            if key == "command":
+                from daydream.backends.codex import display_shell_command
+
+                value = display_shell_command(value)
             return redact_structured_text(value)[:_BASH_COMMAND_MAX_CHARS]
     if "path" in input_data:
         complete = f"{input_data['path']}" + (

--- a/daydream/agent.py
+++ b/daydream/agent.py
@@ -420,8 +420,10 @@ def _summarize_input(input_data: dict[str, Any], name: str) -> str:
         if isinstance(value, str) and value:
             # S1 parity with the live render surfaces (ui.tools): the stored
             # input keeps the replayable cd-prefixed payload, but the --log
-            # surface shows the cd-stripped display variant.
-            if key == "command":
+            # surface shows the cd-stripped display variant. Codex-only
+            # ('shell'): Claude/Pi Bash commands never pass through the Codex
+            # wrapper, so their operator-authored cd prefix must render.
+            if key == "command" and name == "shell":
                 from daydream.backends.codex import display_shell_command
 
                 value = display_shell_command(value)
@@ -786,7 +788,23 @@ async def _run_agent(
 
                                 if tool_supervisor is not None:
                                     try:
-                                        decision = tool_supervisor(event.name, event.input, phase=phase)
+                                        # Extension tool supervisors matched
+                                        # start-anchored deny patterns against the
+                                        # pre-#1124 wrapper-decoded, cd-stripped
+                                        # command value. The stored
+                                        # ToolStartEvent keeps the replayable
+                                        # cd-prefixed payload; hand the supervisor
+                                        # the display variant so e.g. '^make'
+                                        # keeps matching Codex shell commands.
+                                        supervisor_input = event.input
+                                        if event.name == "shell" and isinstance(event.input, dict):
+                                            command = event.input.get("command")
+                                            if isinstance(command, str):
+                                                from daydream.backends.codex import display_shell_command
+
+                                                supervisor_input = dict(event.input)
+                                                supervisor_input["command"] = display_shell_command(command)
+                                        decision = tool_supervisor(event.name, supervisor_input, phase=phase)
                                     except Exception as exc:  # noqa: BLE001 - policy failures must propagate
                                         raise _ToolSupervisorFailure(exc) from exc
                                     if decision.veto:

--- a/daydream/backends/codex.py
+++ b/daydream/backends/codex.py
@@ -293,6 +293,9 @@ def _rebind_source_paths(prompt: str, source: Path, execution: Path) -> str:
     return prompt
 
 
+_SHELL_LC_PREFIX_RE = re.compile(r"^/bin/(?:zsh|bash|sh)\s+-lc\s+")
+
+
 def _unwrap_shell_command(command: str) -> str:
     """Decode the replayable ``-lc`` payload from a Codex shell command wrapper.
 
@@ -302,21 +305,34 @@ def _unwrap_shell_command(command: str) -> str:
     :func:`shlex.split` so the stored command is byte-identical to what actually
     executed — replayable verbatim, including any leading ``cd`` prefix.
 
-    Decoding happens only when the wrapper shape is recognized exactly: non-empty
-    argv, ``argv[0]`` in {"/bin/zsh", "/bin/bash", "/bin/sh"}, ``argv[1] == "-lc"``,
-    and exactly one argument. The returned value is ``argv[2]`` verbatim — no
-    stripping, no quote reprocessing, no cd removal.
+    Decoding happens only when the wrapper shape is recognized: non-empty argv,
+    ``argv[0]`` in {"/bin/zsh", "/bin/bash", "/bin/sh"}, ``argv[1] == "-lc"``.
+    An exactly one-argument payload returns ``argv[2]`` verbatim — no stripping,
+    no quote reprocessing, no cd removal. Real Codex also sends bare multi-word
+    payloads without quotes ('/bin/zsh -lc make test'): the payload argument then
+    splits into several argv tokens, and the raw command bytes after the ``-lc``
+    prefix are returned verbatim so embedded quoting survives.
 
-    Fails open: any other shape (non-wrapper, trailing argv, missing ``-lc``
-    argument) or a :class:`ValueError` from unbalanced quoting returns the input
-    unchanged, byte-for-byte.
+    Fails open: any other shape (non-wrapper, a shell-quoted payload followed by
+    trailing argv, missing ``-lc`` argument) or a :class:`ValueError` from
+    unbalanced quoting returns the input unchanged, byte-for-byte.
     """
     try:
         argv = shlex.split(command)
     except ValueError:
         return command
-    if len(argv) == 3 and argv[0] in ("/bin/zsh", "/bin/bash", "/bin/sh") and argv[1] == "-lc":
-        return argv[2]
+    if len(argv) >= 2 and argv[0] in ("/bin/zsh", "/bin/bash", "/bin/sh") and argv[1] == "-lc":
+        if len(argv) == 3:
+            return argv[2]
+        # More than one word after '-lc': a shell-quoted payload with trailing
+        # argv is not a valid wrapper (fail open), but a bare, unquoted payload
+        # is the real-Codex shape for simple commands ('/bin/zsh -lc ls -la').
+        # Recover it from the raw command so embedded quoting is preserved.
+        wrapper = _SHELL_LC_PREFIX_RE.match(command)
+        if wrapper is not None:
+            payload = command[wrapper.end() :]
+            if payload and payload[0] not in ("'", '"'):
+                return payload
     return command
 
 

--- a/daydream/backends/codex.py
+++ b/daydream/backends/codex.py
@@ -320,6 +320,26 @@ def _unwrap_shell_command(command: str) -> str:
     return command
 
 
+_CD_PREFIX_RE = re.compile(r"^cd\s+\S+\s*&&\s*")
+
+
+def display_shell_command(command: str) -> str:
+    """Decode a Codex shell wrapper AND strip the leading ``cd`` prefix, for display.
+
+    This reproduces the pre-#1124 friendly rendering: the same ``shlex`` decode
+    as :func:`_unwrap_shell_command`, then removal of a leading ``cd <dir> &&``
+    prefix from the decoded value. The result is purely presentational — the
+    value stored in ``ToolStartEvent.input["command"]`` must come from
+    :func:`_unwrap_shell_command` so it stays replayable, cd prefix retained.
+
+    Fails open exactly like the decode step: unparseable input passes through
+    unchanged and the cd regex simply does not match, returning the input
+    byte-for-byte.
+    """
+    decoded = _unwrap_shell_command(command)
+    return _CD_PREFIX_RE.sub("", decoded, count=1)
+
+
 class CodexError(Exception):
     """Raised when a Codex turn fails or the Codex CLI subprocess exits non-zero.
 

--- a/daydream/backends/codex.py
+++ b/daydream/backends/codex.py
@@ -11,6 +11,7 @@ import json
 import logging
 import os
 import re
+import shlex
 import shutil
 import subprocess as subprocess
 import sys as sys
@@ -45,8 +46,6 @@ from daydream.backends._transport import (
 )
 from daydream.pricing import compute_cost_from_totals, load_user_prices, resolve_prices
 
-_SHELL_WRAPPER_RE = re.compile(r"/bin/(?:zsh|bash|sh)\s+-lc\s+(.+)$", re.DOTALL)
-_CD_PREFIX_RE = re.compile(r"^cd\s+\S+\s*&&\s*")
 _CODEX_STDOUT_LIMIT_BYTES = 10 * 1024 * 1024
 
 _logger = logging.getLogger(__name__)
@@ -295,24 +294,30 @@ def _rebind_source_paths(prompt: str, source: Path, execution: Path) -> str:
 
 
 def _unwrap_shell_command(command: str) -> str:
-    """Strip shell wrapper from Codex command_execution commands.
+    """Decode the replayable ``-lc`` payload from a Codex shell command wrapper.
 
-    Codex wraps commands in three forms::
+    Codex wraps command_execution commands as ``/bin/{zsh,bash,sh} -lc <payload>``,
+    where the payload is shell-quoted (single-quoted, double-quoted, or bare) and
+    may itself contain nested quotes, ``$`` substitutions, or newlines. Decode via
+    :func:`shlex.split` so the stored command is byte-identical to what actually
+    executed — replayable verbatim, including any leading ``cd`` prefix.
 
-        /bin/zsh -lc 'actual command'      (single-quoted)
-        /bin/zsh -lc "actual command"      (double-quoted)
-        /bin/zsh -lc actual command         (unquoted)
+    Decoding happens only when the wrapper shape is recognized exactly: non-empty
+    argv, ``argv[0]`` in {"/bin/zsh", "/bin/bash", "/bin/sh"}, ``argv[1] == "-lc"``,
+    and exactly one argument. The returned value is ``argv[2]`` verbatim — no
+    stripping, no quote reprocessing, no cd removal.
 
-    This extracts just the inner command for display purposes.
+    Fails open: any other shape (non-wrapper, trailing argv, missing ``-lc``
+    argument) or a :class:`ValueError` from unbalanced quoting returns the input
+    unchanged, byte-for-byte.
     """
-    m = _SHELL_WRAPPER_RE.match(command)
-    if not m:
+    try:
+        argv = shlex.split(command)
+    except ValueError:
         return command
-    inner = m.group(1)
-    if (inner.startswith('"') and inner.endswith('"')) or (inner.startswith("'") and inner.endswith("'")):
-        inner = inner[1:-1]
-    inner = _CD_PREFIX_RE.sub("", inner)  # Strip leading "cd /some/path &&".
-    return inner.strip()
+    if len(argv) == 3 and argv[0] in ("/bin/zsh", "/bin/bash", "/bin/sh") and argv[1] == "-lc":
+        return argv[2]
+    return command
 
 
 class CodexError(Exception):

--- a/daydream/ui/tools.py
+++ b/daydream/ui/tools.py
@@ -256,11 +256,16 @@ def format_callback_progress(
         # fragment.
         display_value = value
         if name in ("Bash", "shell") and key == "command":
-            # Display variant only: strip the stored Codex wrapper / cd prefix for
-            # rendering. The stored ToolStartEvent input is untouched.
-            from daydream.backends.codex import display_shell_command
+            # Display variant only, and only for Codex ('shell') commands that
+            # passed through the wrapper: strip the decoded cd prefix for
+            # rendering. The stored ToolStartEvent input is untouched, and
+            # Claude/Pi Bash commands — which never pass through a Codex
+            # wrapper — keep their operator-authored cd prefix.
+            if name == "shell":
+                from daydream.backends.codex import display_shell_command
 
-            display_value = redact_structured_text(display_shell_command(value))
+                value = display_shell_command(value)
+            display_value = redact_structured_text(value)
         line.append(" ")
         line.append(display_value[:max_len], style=_primary_value_style(key))
     return line
@@ -490,14 +495,23 @@ def _build_tool_header(
 
         # Import lazily because trajectory initializes the UI facade used to
         # reach this renderer while the application import graph is loading.
-        # The stored command is the replayable -lc argument (Codex wrapper kept,
-        # cd prefix retained); display the cd-stripped friendly variant instead.
-        from daydream.backends.codex import display_shell_command
         from daydream.trajectory import redact_structured_text
+
+        raw_command = str(args.get("command", ""))
+        if name == "shell":
+            # Codex-only ('shell') display variant: the stored command is the
+            # replayable -lc argument (cd prefix retained); show the
+            # cd-stripped friendly variant instead. Claude/Pi Bash commands
+            # never pass through the Codex wrapper, so their operator-authored
+            # cd prefix must render — stripping it hides cwd context and makes
+            # distinct cd-targeted commands display identically.
+            from daydream.backends.codex import display_shell_command
+
+            raw_command = display_shell_command(raw_command)
 
         # Redact the complete command before slicing so a credential crossing
         # the display boundary cannot be truncated into an unmatchable fragment.
-        full_command = redact_structured_text(display_shell_command(str(args.get("command", ""))))
+        full_command = redact_structured_text(raw_command)
         command = full_command[:_BASH_COMMAND_MAX_CHARS]
         if len(full_command) > _BASH_COMMAND_MAX_CHARS:
             command = f"{command}..."

--- a/daydream/ui/tools.py
+++ b/daydream/ui/tools.py
@@ -256,7 +256,11 @@ def format_callback_progress(
         # fragment.
         display_value = value
         if name in ("Bash", "shell") and key == "command":
-            display_value = redact_structured_text(value)
+            # Display variant only: strip the stored Codex wrapper / cd prefix for
+            # rendering. The stored ToolStartEvent input is untouched.
+            from daydream.backends.codex import display_shell_command
+
+            display_value = redact_structured_text(display_shell_command(value))
         line.append(" ")
         line.append(display_value[:max_len], style=_primary_value_style(key))
     return line
@@ -486,11 +490,14 @@ def _build_tool_header(
 
         # Import lazily because trajectory initializes the UI facade used to
         # reach this renderer while the application import graph is loading.
+        # The stored command is the replayable -lc argument (Codex wrapper kept,
+        # cd prefix retained); display the cd-stripped friendly variant instead.
+        from daydream.backends.codex import display_shell_command
         from daydream.trajectory import redact_structured_text
 
         # Redact the complete command before slicing so a credential crossing
         # the display boundary cannot be truncated into an unmatchable fragment.
-        full_command = redact_structured_text(str(args.get("command", "")))
+        full_command = redact_structured_text(display_shell_command(str(args.get("command", ""))))
         command = full_command[:_BASH_COMMAND_MAX_CHARS]
         if len(full_command) > _BASH_COMMAND_MAX_CHARS:
             command = f"{command}..."

--- a/tests/fixtures/codex_jsonl/issue1124_unwrap.jsonl
+++ b/tests/fixtures/codex_jsonl/issue1124_unwrap.jsonl
@@ -1,0 +1,16 @@
+{"type": "thread.started", "thread_id": "th_1124"}
+{"type": "item.started", "item": {"type": "command_execution", "id": "cmd_1", "command": "/bin/zsh -lc 'awk '\\''{print $1}'\\'' file.txt'", "status": "running"}}
+{"type": "item.completed", "item": {"type": "command_execution", "id": "cmd_1", "command": "/bin/zsh -lc 'awk '\\''{print $1}'\\'' file.txt'", "status": "completed", "exit_code": 0, "aggregated_output": "ok"}}
+{"type": "item.started", "item": {"type": "command_execution", "id": "cmd_2", "command": "/bin/zsh -lc \"echo \\\"hi\\\" and $HOME\"", "status": "running"}}
+{"type": "item.completed", "item": {"type": "command_execution", "id": "cmd_2", "command": "/bin/zsh -lc \"echo \\\"hi\\\" and $HOME\"", "status": "completed", "exit_code": 0, "aggregated_output": "ok"}}
+{"type": "item.started", "item": {"type": "command_execution", "id": "cmd_3", "command": "/bin/zsh -lc \"echo $(date)\"", "status": "running"}}
+{"type": "item.completed", "item": {"type": "command_execution", "id": "cmd_3", "command": "/bin/zsh -lc \"echo $(date)\"", "status": "completed", "exit_code": 0, "aggregated_output": "ok"}}
+{"type": "item.started", "item": {"type": "command_execution", "id": "cmd_4", "command": "/bin/zsh -lc 'echo line1\nline2'", "status": "running"}}
+{"type": "item.completed", "item": {"type": "command_execution", "id": "cmd_4", "command": "/bin/zsh -lc 'echo line1\nline2'", "status": "completed", "exit_code": 0, "aggregated_output": "ok"}}
+{"type": "item.started", "item": {"type": "command_execution", "id": "cmd_5", "command": "/bin/zsh -lc 'cat <<EOF\nhello\nEOF'", "status": "running"}}
+{"type": "item.completed", "item": {"type": "command_execution", "id": "cmd_5", "command": "/bin/zsh -lc 'cat <<EOF\nhello\nEOF'", "status": "completed", "exit_code": 0, "aggregated_output": "ok"}}
+{"type": "item.started", "item": {"type": "command_execution", "id": "cmd_6", "command": "python -c \"print(1)\"", "status": "running"}}
+{"type": "item.completed", "item": {"type": "command_execution", "id": "cmd_6", "command": "python -c \"print(1)\"", "status": "completed", "exit_code": 0, "aggregated_output": "ok"}}
+{"type": "item.started", "item": {"type": "command_execution", "id": "cmd_7", "command": "/bin/zsh -lc 'unbalanced", "status": "running"}}
+{"type": "item.completed", "item": {"type": "command_execution", "id": "cmd_7", "command": "/bin/zsh -lc 'unbalanced", "status": "completed", "exit_code": 0, "aggregated_output": "ok"}}
+{"type": "turn.completed", "usage": {"input_tokens": 10, "output_tokens": 5}}

--- a/tests/fixtures/codex_jsonl/issue1124_unwrap.jsonl
+++ b/tests/fixtures/codex_jsonl/issue1124_unwrap.jsonl
@@ -13,4 +13,6 @@
 {"type": "item.completed", "item": {"type": "command_execution", "id": "cmd_6", "command": "python -c \"print(1)\"", "status": "completed", "exit_code": 0, "aggregated_output": "ok"}}
 {"type": "item.started", "item": {"type": "command_execution", "id": "cmd_7", "command": "/bin/zsh -lc 'unbalanced", "status": "running"}}
 {"type": "item.completed", "item": {"type": "command_execution", "id": "cmd_7", "command": "/bin/zsh -lc 'unbalanced", "status": "completed", "exit_code": 0, "aggregated_output": "ok"}}
+{"type": "item.started", "item": {"type": "command_execution", "id": "cmd_8", "command": "/bin/zsh -lc make test", "status": "running"}}
+{"type": "item.completed", "item": {"type": "command_execution", "id": "cmd_8", "command": "/bin/zsh -lc make test", "status": "completed", "exit_code": 0, "aggregated_output": "ok"}}
 {"type": "turn.completed", "usage": {"input_tokens": 10, "output_tokens": 5}}

--- a/tests/test_backend_codex.py
+++ b/tests/test_backend_codex.py
@@ -1188,17 +1188,60 @@ async def test_concurrent_execute_calls_do_not_share_stdout_reader() -> None:
 class TestUnwrapShellCommand:
     """Tests for _unwrap_shell_command helper."""
 
-    def test_zsh_wrapper_with_cd(self) -> None:
+    def test_zsh_wrapper_with_cd_kept_replayable(self) -> None:
         cmd = '/bin/zsh -lc "cd /home/user/project && make test"'
-        assert _unwrap_shell_command(cmd) == "make test"
+        assert _unwrap_shell_command(cmd) == "cd /home/user/project && make test"
 
-    def test_bash_wrapper_with_cd(self) -> None:
+    def test_bash_wrapper_with_cd_kept_replayable(self) -> None:
         cmd = '/bin/bash -lc "cd /tmp/work && pytest -x"'
-        assert _unwrap_shell_command(cmd) == "pytest -x"
+        assert _unwrap_shell_command(cmd) == "cd /tmp/work && pytest -x"
 
-    def test_sh_wrapper_with_cd(self) -> None:
+    def test_sh_wrapper_with_cd_kept_replayable(self) -> None:
         cmd = '/bin/sh -lc "cd /app && echo hello"'
-        assert _unwrap_shell_command(cmd) == "echo hello"
+        assert _unwrap_shell_command(cmd) == "cd /app && echo hello"
+
+    def test_nested_single_quotes_round_trip(self) -> None:
+        # The reported corruption class: '\' escaping inside the -lc payload.
+        cmd = "/bin/zsh -lc 'awk '\\''{print $1}'\\'' file.txt'"
+        assert _unwrap_shell_command(cmd) == "awk '{print $1}' file.txt"
+
+    def test_escaped_double_quotes_and_env_round_trip(self) -> None:
+        cmd = '/bin/zsh -lc "echo \\"hi\\" and $HOME"'
+        assert _unwrap_shell_command(cmd) == 'echo "hi" and $HOME'
+
+    def test_command_substitution_round_trip(self) -> None:
+        cmd = '/bin/zsh -lc "echo $(date)"'
+        assert _unwrap_shell_command(cmd) == "echo $(date)"
+
+    def test_multiline_round_trip(self) -> None:
+        cmd = "/bin/zsh -lc 'echo line1\nline2'"
+        assert _unwrap_shell_command(cmd) == "echo line1\nline2"
+
+    def test_heredoc_round_trip(self) -> None:
+        cmd = "/bin/zsh -lc 'cat <<EOF\nhello\nEOF'"
+        assert _unwrap_shell_command(cmd) == "cat <<EOF\nhello\nEOF"
+
+    def test_unrecognized_wrapper_passthrough(self) -> None:
+        assert _unwrap_shell_command('python -c "print(1)"') == 'python -c "print(1)"'
+
+    def test_trailing_argv_is_raw_fallback(self) -> None:
+        cmd = '/bin/zsh -lc "cmd" extra_arg'
+        assert _unwrap_shell_command(cmd) == cmd
+
+    def test_unbalanced_quotes_fail_open_to_raw(self) -> None:
+        cmd = "/bin/zsh -lc 'unbalanced"
+        assert _unwrap_shell_command(cmd) == cmd
+
+    def test_flag_only_wrapper_raw_fallback(self) -> None:
+        assert _unwrap_shell_command("/bin/zsh -lc") == "/bin/zsh -lc"
+
+    def test_pending_content_key_uses_raw_command(self) -> None:
+        """M7: the legacy pending-id key is keyed on the raw wrapped command."""
+        raw = '/bin/zsh -lc "ls -la"'
+        # In the parser: pending_item_ids[f"command_execution:{item.get('command', '')}"]
+        # must be built from item['command'] BEFORE _unwrap_shell_command runs.
+        from daydream.backends.codex import _unwrap_shell_command  # noqa: F401  (import site pinned)
+        assert raw.startswith("/bin/zsh -lc ")  # key shape: raw, not decoded
 
     def test_wrapper_without_cd(self) -> None:
         cmd = '/bin/zsh -lc "ls -la"'
@@ -1212,7 +1255,7 @@ class TestUnwrapShellCommand:
 
     def test_single_quotes(self) -> None:
         cmd = "/bin/zsh -lc 'cd /project && git status'"
-        assert _unwrap_shell_command(cmd) == "git status"
+        assert _unwrap_shell_command(cmd) == "cd /project && git status"
 
     def test_unquoted_simple(self) -> None:
         """Real Codex format: no quotes around simple commands."""

--- a/tests/test_backend_codex.py
+++ b/tests/test_backend_codex.py
@@ -1685,3 +1685,18 @@ class TestIsolatedChildEnvDarwinPath:
 
         assert codex._isolated_child_env(Path("/work"), Path("/work")) is None  # M7
         assert called == []  # resolver never invoked on the non-clone path
+
+
+@pytest.mark.asyncio
+async def test_issue1124_stored_commands_are_replayable() -> None:
+    """M1-M3: ToolStartEvent.input['command'] is the exact -lc argument (or raw fallback)."""
+    backend = CodexBackend(model="fixture-model")
+    events = await _run_fixture(backend, "Run the commands", "issue1124_unwrap.jsonl")
+    starts = {e.id: e.input["command"] for e in events if isinstance(e, ToolStartEvent)}
+    assert starts["cmd_1"] == "awk '{print $1}' file.txt"
+    assert starts["cmd_2"] == 'echo "hi" and $HOME'
+    assert starts["cmd_3"] == "echo $(date)"
+    assert starts["cmd_4"] == "echo line1\nline2"
+    assert starts["cmd_5"] == "cat <<EOF\nhello\nEOF"
+    assert starts["cmd_6"] == 'python -c "print(1)"'
+    assert starts["cmd_7"] == "/bin/zsh -lc 'unbalanced"

--- a/tests/test_backend_codex.py
+++ b/tests/test_backend_codex.py
@@ -1235,13 +1235,88 @@ class TestUnwrapShellCommand:
     def test_flag_only_wrapper_raw_fallback(self) -> None:
         assert _unwrap_shell_command("/bin/zsh -lc") == "/bin/zsh -lc"
 
-    def test_pending_content_key_uses_raw_command(self) -> None:
-        """M7: the legacy pending-id key is keyed on the raw wrapped command."""
+    @pytest.mark.asyncio
+    async def test_pending_content_key_uses_raw_command(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """M7: the legacy pending-id key is built from the raw wrapped command.
+
+        Drives the real parser over two no-id ``command_execution`` items, one
+        Codex-wrapped so the raw command differs from its decoded payload, plus
+        a trailing duplicate completion. The duplicate arrives once the FIFO
+        head is drained, so ``_claim_tool_id`` must resolve it through the
+        legacy content-key fallback — a lookup that only matches when both the
+        item.started registration and the item.completed claim key
+        ``pending_item_ids`` on the raw ``item['command']`` (never
+        ``_unwrap_shell_command`` output). A regression re-keying either site
+        by the decoded payload makes the fallback miss and must surface as an
+        'unmatched tool result' warning.
+        """
         raw = '/bin/zsh -lc "ls -la"'
-        # In the parser: pending_item_ids[f"command_execution:{item.get('command', '')}"]
-        # must be built from item['command'] BEFORE _unwrap_shell_command runs.
-        from daydream.backends.codex import _unwrap_shell_command  # noqa: F401  (import site pinned)
-        assert raw.startswith("/bin/zsh -lc ")  # key shape: raw, not decoded
+
+        def line(event_type: str, item: dict[str, Any]) -> str:
+            return json.dumps({"type": event_type, "item": item}, separators=(",", ":"))
+
+        lines = [
+            json.dumps({"type": "thread.started", "thread_id": "th_m7"}),
+            line("item.started", {"type": "command_execution", "command": "echo one"}),
+            line("item.started", {"type": "command_execution", "command": raw}),
+            line(
+                "item.completed",
+                {
+                    "type": "command_execution",
+                    "command": "echo one",
+                    "status": "completed",
+                    "exit_code": 0,
+                    "aggregated_output": "one",
+                },
+            ),
+            line(
+                "item.completed",
+                {
+                    "type": "command_execution",
+                    "command": raw,
+                    "status": "completed",
+                    "exit_code": 0,
+                    "aggregated_output": "ls",
+                },
+            ),
+            line(
+                "item.completed",
+                {
+                    "type": "command_execution",
+                    "command": raw,
+                    "status": "completed",
+                    "exit_code": 0,
+                    "aggregated_output": "ls (dup)",
+                },
+            ),
+            json.dumps({"type": "turn.completed", "usage": {"input_tokens": 10, "output_tokens": 5}}),
+        ]
+
+        backend = CodexBackend(model="fixture-model")
+        mock_proc = make_mock_process(lines)
+        with caplog.at_level(logging.WARNING, logger="daydream.backends.codex"):
+            with patch("daydream.backends._transport.asyncio.create_subprocess_exec", return_value=mock_proc):
+                events = [event async for event in backend.execute(Path("/tmp"), "M7 content key")]
+
+        starts = [e for e in events if isinstance(e, ToolStartEvent)]
+        results = [e for e in events if isinstance(e, ToolResultEvent)]
+
+        # The parse site unwraps for the stored command but must NOT re-key by it.
+        assert [s.input["command"] for s in starts] == ["echo one", "ls -la"]
+        # FIFO pairs the first two completions; the trailing duplicate must resolve
+        # via the content-key fallback keyed on the raw wrapped command.
+        start_ids = [s.id for s in starts]
+        assert [r.id for r in results] == start_ids + [start_ids[1]], (
+            f"duplicate completion must resolve to its started item via the raw-command "
+            f"content key; starts={start_ids} results={[r.id for r in results]}"
+        )
+        warnings = [r.getMessage() for r in caplog.records if r.levelno >= logging.WARNING]
+        assert not warnings, (
+            f"content-key fallback must key on the raw wrapped command, not the decoded "
+            f"payload; got warnings: {warnings}"
+        )
 
     def test_wrapper_without_cd(self) -> None:
         cmd = '/bin/zsh -lc "ls -la"'

--- a/tests/test_backend_codex.py
+++ b/tests/test_backend_codex.py
@@ -1318,6 +1318,67 @@ class TestUnwrapShellCommand:
             f"payload; got warnings: {warnings}"
         )
 
+    @pytest.mark.asyncio
+    async def test_tool_supervisor_sees_cd_stripped_display_variant(self) -> None:
+        """Extension tool supervisors match the pre-#1124 cd-stripped value.
+
+        The stored ToolStartEvent input keeps the replayable cd-prefixed payload
+        ('cd /home/user/project && make test'), but the extension tool supervisor
+        — a matching surface holding start-anchored deny patterns such as
+        '^make' — must keep receiving the pre-#1124 wrapper-decoded, cd-stripped
+        command. A regression handing the supervisor the stored value would let
+        'cd <dir> && make test' silently evade '^make'.
+        """
+        from daydream.agent import run_agent
+        from daydream.extensions import Registry, ToolDecision, set_registry
+        from daydream.trajectory import DaydreamPhase
+
+        raw = '/bin/zsh -lc "cd /home/user/project && make test"'
+        lines = [
+            json.dumps({"type": "thread.started", "thread_id": "th_sup"}),
+            json.dumps(
+                {"type": "item.started", "item": {"type": "command_execution", "command": raw}}
+            ),
+            json.dumps(
+                {
+                    "type": "item.completed",
+                    "item": {
+                        "type": "command_execution",
+                        "command": raw,
+                        "status": "completed",
+                        "exit_code": 0,
+                        "aggregated_output": "ok",
+                    },
+                }
+            ),
+            json.dumps({"type": "turn.completed", "usage": {"input_tokens": 10, "output_tokens": 5}}),
+        ]
+
+        seen: dict[str, str] = {}
+
+        def supervisor(tool_name: str, tool_input: dict[str, Any], *, phase: DaydreamPhase) -> ToolDecision:
+            del phase
+            assert tool_name == "shell"
+            seen["command"] = str(tool_input.get("command", ""))
+            if seen["command"].startswith("make"):
+                return ToolDecision(veto=True, reason="^make deny")
+            return ToolDecision(veto=False)
+
+        registry = Registry()
+        registry.register_tool_supervisor(supervisor)
+        set_registry(registry)
+        backend = CodexBackend(model="fixture-model")
+        mock_proc = make_mock_process(lines)
+        with patch("daydream.backends._transport.asyncio.create_subprocess_exec", return_value=mock_proc):
+            _, _, budget_reason = await run_agent(
+                backend, Path("/tmp"), "run", phase=DaydreamPhase.REVIEW,
+            )
+
+        # The supervisor matched the cd-stripped display variant, so the
+        # start-anchored '^make' deny fired against the pre-#1124 shape.
+        assert seen["command"] == "make test"
+        assert budget_reason == "tool_vetoed:shell"
+
     def test_wrapper_without_cd(self) -> None:
         cmd = '/bin/zsh -lc "ls -la"'
         assert _unwrap_shell_command(cmd) == "ls -la"
@@ -1335,6 +1396,32 @@ class TestUnwrapShellCommand:
     def test_unquoted_simple(self) -> None:
         """Real Codex format: no quotes around simple commands."""
         assert _unwrap_shell_command("/bin/zsh -lc ls") == "ls"
+
+    def test_unquoted_multi_word(self) -> None:
+        """Real Codex format: no quotes around simple multi-word commands.
+
+        '/bin/zsh -lc make test' splits to four shlex tokens, so the strict
+        3-token shape check used to fall open to the wrapper for both storage
+        and display. A bare payload decodes to the raw command bytes after
+        '-lc'; a shell-quoted payload with trailing argv still fails open
+        (see test_trailing_argv_is_raw_fallback).
+        """
+        assert _unwrap_shell_command("/bin/zsh -lc make test") == "make test"
+        assert _unwrap_shell_command("/bin/zsh -lc ls -la") == "ls -la"
+        assert _unwrap_shell_command("/bin/bash -lc git status --short") == "git status --short"
+
+    def test_unquoted_multi_word_keeps_embedded_quotes(self) -> None:
+        """The raw-remainder decode preserves embedded quoting byte-for-byte."""
+        cmd = "/bin/zsh -lc echo 'hello world'"
+        assert _unwrap_shell_command(cmd) == "echo 'hello world'"
+
+    def test_unquoted_multi_word_cd_display(self) -> None:
+        """Unquoted multi-word cd chains stay replayable stored, cd-stripped on display."""
+        from daydream.backends.codex import display_shell_command
+
+        raw = "/bin/zsh -lc cd /app && make test"
+        assert _unwrap_shell_command(raw) == "cd /app && make test"
+        assert display_shell_command(raw) == "make test"
 
     def test_single_quoted_git_diff(self) -> None:
         """Real Codex format: single-quoted multi-word command."""
@@ -1775,3 +1862,4 @@ async def test_issue1124_stored_commands_are_replayable() -> None:
     assert starts["cmd_5"] == "cat <<EOF\nhello\nEOF"
     assert starts["cmd_6"] == 'python -c "print(1)"'
     assert starts["cmd_7"] == "/bin/zsh -lc 'unbalanced"
+    assert starts["cmd_8"] == "make test"

--- a/tests/test_backend_codex.py
+++ b/tests/test_backend_codex.py
@@ -1454,6 +1454,31 @@ async def test_codex_preserves_exit_code_and_status_on_results() -> None:
     assert ok.status == "completed"
 
 
+class TestDisplayShellCommand:
+    """S1/M5: display variant decodes AND strips the leading cd prefix."""
+
+    def test_display_strips_cd_prefix(self) -> None:
+        from daydream.backends.codex import display_shell_command
+        assert display_shell_command('/bin/zsh -lc "cd /home/user/project && make test"') == "make test"
+
+    def test_display_decodes_nested_quotes(self) -> None:
+        from daydream.backends.codex import display_shell_command
+        cmd = "/bin/zsh -lc 'awk '\\''{print $1}'\\'' file.txt'"
+        assert display_shell_command(cmd) == "awk '{print $1}' file.txt"
+
+    def test_display_passthrough_for_non_wrapper(self) -> None:
+        from daydream.backends.codex import display_shell_command
+        assert display_shell_command("ls -la") == "ls -la"
+        assert display_shell_command("") == ""
+
+    def test_raw_and_display_distinct_for_cd_command(self) -> None:
+        """M5: the stored value and the display value are different outputs."""
+        from daydream.backends.codex import _unwrap_shell_command, display_shell_command
+        raw = '/bin/zsh -lc "cd /app && echo hello"'
+        assert _unwrap_shell_command(raw) == "cd /app && echo hello"
+        assert display_shell_command(raw) == "echo hello"
+
+
 @pytest.fixture(autouse=True)
 def _reset_real_git_resolution() -> Iterator[Any]:
     """Clear the real-git resolver cache before AND after every test (S1 cache)."""

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -540,3 +540,11 @@ def test_bash_primary_field_consistent_across_three_render_surfaces() -> None:
     long_line = format_callback_progress("Bash", {"command": long_command}, None)
     assert "b" * _BASH_COMMAND_MAX_CHARS in long_line.plain
     assert len(_summarize_input({"command": long_command}, "Bash")) == _BASH_COMMAND_MAX_CHARS
+
+
+def test_bash_header_shows_cd_stripped_display_variant() -> None:
+    """S1: UI renders the cd-stripped display variant, not the stored replayable value."""
+    from daydream.ui.tools import _build_tool_header
+    header = _build_tool_header("Bash", {"command": "cd /app && echo hello"})
+    assert "echo hello" in header.plain
+    assert "cd /app" not in header.plain  # the stored replayable value must not leak through

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -548,3 +548,11 @@ def test_bash_header_shows_cd_stripped_display_variant() -> None:
     header = _build_tool_header("Bash", {"command": "cd /app && echo hello"})
     assert "echo hello" in header.plain
     assert "cd /app" not in header.plain  # the stored replayable value must not leak through
+
+
+def test_log_summary_shows_cd_stripped_display_variant() -> None:
+    """S1 parity: --log (_summarize_input) shows the cd-stripped variant like the live surfaces."""
+    from daydream.agent import _summarize_input
+
+    assert _summarize_input({"command": "cd /app && echo hello"}, "Bash") == "echo hello"
+    assert _summarize_input({"command": "cd /app && echo hello"}, "shell") == "echo hello"

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -542,17 +542,48 @@ def test_bash_primary_field_consistent_across_three_render_surfaces() -> None:
     assert len(_summarize_input({"command": long_command}, "Bash")) == _BASH_COMMAND_MAX_CHARS
 
 
-def test_bash_header_shows_cd_stripped_display_variant() -> None:
-    """S1: UI renders the cd-stripped display variant, not the stored replayable value."""
+def test_bash_header_preserves_operator_cd_prefix() -> None:
+    """Claude/Pi Bash commands never pass through the Codex wrapper (issue #336).
+
+    The operator-authored cd prefix must render — stripping it would hide cwd
+    context and make 'cd backend && pytest' vs 'cd frontend && pytest'
+    display identically.
+    """
     from daydream.ui.tools import _build_tool_header
+
     header = _build_tool_header("Bash", {"command": "cd /app && echo hello"})
+    assert "cd /app && echo hello" in header.plain
+
+
+def test_shell_header_shows_cd_stripped_display_variant() -> None:
+    """S1: Codex ('shell') renders the cd-stripped display variant, not the stored replayable value."""
+    from daydream.ui.tools import _build_tool_header
+
+    header = _build_tool_header("shell", {"command": "cd /app && echo hello"})
     assert "echo hello" in header.plain
     assert "cd /app" not in header.plain  # the stored replayable value must not leak through
 
 
 def test_log_summary_shows_cd_stripped_display_variant() -> None:
-    """S1 parity: --log (_summarize_input) shows the cd-stripped variant like the live surfaces."""
+    """S1 parity: --log (_summarize_input) shows the cd-stripped variant for Codex ('shell')."""
     from daydream.agent import _summarize_input
 
-    assert _summarize_input({"command": "cd /app && echo hello"}, "Bash") == "echo hello"
     assert _summarize_input({"command": "cd /app && echo hello"}, "shell") == "echo hello"
+
+
+def test_log_summary_preserves_operator_cd_prefix() -> None:
+    """--log keeps the operator-authored cd prefix for Claude/Pi Bash commands (issue #336)."""
+    from daydream.agent import _summarize_input
+
+    assert _summarize_input({"command": "cd /app && echo hello"}, "Bash") == "cd /app && echo hello"
+
+
+def test_callback_progress_cd_split_matches_live_surfaces() -> None:
+    """format_callback_progress splits the same way: cd-strip Codex 'shell' only."""
+    from daydream.ui.tools import format_callback_progress
+
+    bash_line = format_callback_progress("Bash", {"command": "cd /app && echo hello"}, None)
+    assert "cd /app && echo hello" in bash_line.plain
+    shell_line = format_callback_progress("shell", {"command": "cd /app && echo hello"}, None)
+    assert "echo hello" in shell_line.plain
+    assert "cd /app" not in shell_line.plain


### PR DESCRIPTION
## Summary
- Preserves replayable shell commands in Codex trajectory archives so archived commands actually execute under `zsh -n`
- Handles unquoted multi-word `-lc` payloads (e.g. `/bin/zsh -lc make test`), keeps the operator `cd` prefix in Bash commands, and renders a cd-stripped display variant in the UI
- Adds e2e replayability fixtures

Closes #1124

## Test Plan
- [x] Full gate green after round-2 review fixes: 6312 passed / 24 skipped, coverage 88.32% (required 86.0%)
- [x] Two sequential daydream deep-precision review rounds completed (round-2 fixes committed as 55d03dd)