### PR TITLE
fix(benchmark): strip transport markers from finding projections

### DIFF
--- a/daydream/benchmark/github_import.py
+++ b/daydream/benchmark/github_import.py
@@ -37,6 +37,7 @@ from daydream import git_ops
 from daydream.benchmark import curation as cu
 from daydream.benchmark import schema, snapshot, storage
 from daydream.benchmark.schema import EXTRACTION_VERSION
+from daydream.pr_review import FINDING_MARKER_RE
 
 
 def _run_gh_preflight_status(root: Path) -> subprocess.CompletedProcess[str]:
@@ -823,6 +824,11 @@ def _normalize_body(body: str) -> str:
     return body.replace("\r\n", "\n").replace("\r", "\n").rstrip()
 
 
+def _projected_body(body: str) -> str:
+    """Normalize candidate text after removing canonical Daydream markers."""
+    return _normalize_body(FINDING_MARKER_RE.sub("", body))
+
+
 _MARKDOWN_PREFIX = re.compile(r"^(#{1,6}\s+|[-*]\s+)")
 
 
@@ -905,7 +911,7 @@ def _anchor_location(
 
 
 def _project_one(evidence: schema.EvidenceRecord, head_sha: str) -> schema.Candidate:
-    body = _normalize_body(evidence.body)
+    body = _projected_body(evidence.body)
     title = _derive_title(body)
     title_ok = _title_ok(title)
 

--- a/tests/test_benchmark_harbor_build.py
+++ b/tests/test_benchmark_harbor_build.py
@@ -121,13 +121,15 @@ def _seed_local_origin(tmp_path: Path, fake_gh: FakeGh, *, number: int = 101, li
     return str(bare), base_sha, head_sha
 
 
-def _seed_candidate(fake_gh: FakeGh, *, number: int = 101, head_sha: str) -> None:
+def _seed_candidate(
+    fake_gh: FakeGh, *, number: int = 101, head_sha: str, body: str = "please fix",
+) -> None:
     """Seed one REST inline comment so the case has one exact-acceptable candidate."""
     comment = {
         "id": number,
         "node_id": f"DIFF_{number}",
         "user": {"login": "alice", "type": "User"},
-        "body": "please fix",
+        "body": body,
         "commit_id": head_sha,
         "original_commit_id": head_sha,
         "path": "feature.py",
@@ -579,6 +581,94 @@ def test_copy_assets_places_templates_and_keeps_verifier_core_byte_identical(tmp
 def _load_json(path: Path) -> Any:
     import json as _json
     return _json.loads(path.read_bytes())
+
+
+def test_finding_marker_import_curate_compile_preserves_raw_source(
+    tmp_path: Path, fake_gh: FakeGh, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import importlib.metadata
+
+    import yaml
+
+    from daydream.benchmark import curation as cu
+    from daydream.benchmark import github_import as gi
+    from daydream.benchmark import storage
+    from daydream.benchmark.cli import _handle_benchmark_command
+    from daydream.benchmark.harbor import build
+    from daydream.benchmark.workspace import init_workspace
+    from daydream.pr_review import FINDING_MARKER_RE, finding_marker
+
+    marker = finding_marker("f" * 64)
+    raw_body = f"\n{marker}\n## Cache race\nProtect the shared cache.\n{marker}\n"
+    ws = tmp_path / "ws-marker-flow"
+    init_workspace(ws, "o/r", ["h1.example.com"], ["h2.example.com"])
+    _seed_preflight(fake_gh)
+    origin_url, _base_sha, head_sha = _seed_local_origin(tmp_path, fake_gh)
+    _seed_candidate(fake_gh, head_sha=head_sha, body=raw_body)
+    config_index = int(os.environ.get("GIT_CONFIG_COUNT", "0"))
+    monkeypatch.setenv(f"GIT_CONFIG_KEY_{config_index}", f"url.{origin_url}.insteadOf")
+    monkeypatch.setenv(f"GIT_CONFIG_VALUE_{config_index}", "https://github.com/o/r.git")
+    monkeypatch.setenv("GIT_CONFIG_COUNT", str(config_index + 1))
+
+    assert _handle_benchmark_command(["import-prs", str(ws), "--pr", "101"]) == 0
+    manifest = storage.load_yaml_strict(ws / "benchmark.yaml")
+    ledger_entry = manifest["pull_requests"][0]
+    case_id = ledger_entry["case_ids"][0]
+    case = cu.get_case(ws, case_id)
+    import_path = ws / ledger_entry["import_file"]
+    import_doc = storage.load_json_strict(import_path)
+    evidence = import_doc["evidence"][0]
+    assert evidence["body"] == raw_body
+    assert evidence["body_sha256"] == hashlib.sha256(raw_body.encode()).hexdigest()
+    payload = {
+        key: import_doc[key]
+        for key in ("schema_version", "repository", "pull_request", "evidence")
+    }
+    assert import_doc["fetch"]["payload_sha256"] == gi._payload_sha256(payload)
+    assert ledger_entry["import_sha256"] == storage.sha256_file(import_path)
+    candidate = case["candidates"][0]
+    assert candidate["source_id"] == evidence["source_id"]
+    assert candidate["title"] == "Cache race"
+    assert candidate["exact_acceptable"] is True
+    assert candidate["location"] == {"path": "feature.py", "start_line": 2, "end_line": 2}
+    assert not FINDING_MARKER_RE.search(candidate["body"])
+
+    edited_body = candidate["body"] + "\nCurator clarification."
+    fragment = tmp_path / "gold.yaml"
+    fragment.write_text(yaml.safe_dump({
+        "findings": [{
+            "title": candidate["title"], "body": edited_body, "severity": None,
+            "location": candidate["location"], "source_ids": [candidate["source_id"]],
+        }],
+        "exclusions": [], "case_exclusion": None, "clean": False,
+    }, sort_keys=False))
+    assert _handle_benchmark_command([
+        "curate", str(ws), "--case", case_id, "--apply-gold", str(fragment),
+    ]) == 0
+    curated = storage.load_yaml_strict(ws / "cases" / f"{case_id}.yaml")
+    finding = curated["curation"]["findings"][0]
+    assert finding["provenance"]["kind"] == "edited"
+    assert finding["provenance"]["source_ids"] == [evidence["source_id"]]
+    assert finding["body"] == edited_body
+    _mark_ready(ws, case_id, head_sha)
+    version = importlib.metadata.version("daydream")
+    wheel = tmp_path / f"daydream-{version}-py3-none-any.whl"
+    wheel.write_bytes(b"PK\x05\x06" + b"\x00" * 18)
+    assert _handle_benchmark_command([
+        "build-harbor", str(ws), "--daydream-wheel", str(wheel),
+    ]) == 0
+
+    compiled = ws / "harbor" / build.derive_task_key(case_id)
+    for relative in ("tests/golden-review.json", "solution/golden-review.json"):
+        artifact_path = compiled / relative
+        serialized = artifact_path.read_text()
+        assert "daydream-finding" not in serialized
+        assert not FINDING_MARKER_RE.search(serialized)
+        artifact = _load_json(artifact_path)
+        emitted = artifact if isinstance(artifact, list) else artifact["findings"]
+        assert len(emitted) == 1
+        assert emitted[0]["title"] == "Cache race"
+        assert emitted[0]["body"] == edited_body
 
 
 def test_compile_findings_case_full_tree_and_gold_oracle_agree(tmp_path: Path, fake_gh: FakeGh) -> None:

--- a/tests/test_benchmark_import_prs.py
+++ b/tests/test_benchmark_import_prs.py
@@ -517,6 +517,51 @@ def _project_from_anchor(
     return gi._project_one(rec, head_sha=head_sha)
 
 
+@pytest.mark.parametrize("outdated", [False, True])
+@pytest.mark.parametrize(
+    ("raw_template", "expected_title", "expected_body"),
+    [
+        ("\n{marker}\r\n## Cache race\r\nDetails.\r\n", "Cache race", "\n\n## Cache race\nDetails."),
+        ("Before {marker} after\n{marker}\n", "Before after", "Before  after"),
+        ("{marker}", "", ""),
+        ("<!-- daydream-finding: ab -->", "<!-- daydream-finding: ab -->", "<!-- daydream-finding: ab -->"),
+    ],
+)
+def test_finding_marker_projection_preserves_raw_evidence_and_eligibility(
+    raw_template: str, expected_title: str, expected_body: str, outdated: bool,
+) -> None:
+    from daydream.benchmark import github_import as gi
+    from daydream.benchmark import schema
+    from daydream.pr_review import FINDING_MARKER_RE, finding_marker
+
+    raw_body = raw_template.format(marker=finding_marker("f" * 64))
+    rec = schema.EvidenceRecord(
+        source_id="github:inline_comment:1", kind="inline_comment", database_id=1,
+        node_id="DIFF_1", author=schema._EvidenceAuthor(login="alice", type="User"),
+        body=raw_body, body_sha256=hashlib.sha256(raw_body.encode()).hexdigest(),
+        created_at=_TS, updated_at=_TS, commit_id="a" * 40, original_commit_id="a" * 40,
+        path="feature.py", line=2, original_line=2, subject_type="line", side="RIGHT",
+        authoring_anchor=schema.AuthoringAnchor(
+            version=1, status="derived", commit_id="a" * 40,
+            path="feature.py", start_line=2, end_line=2,
+        ),
+        outdated=outdated, is_bot=False,
+        url="https://github.com/o/r/pull/101#discussion_r1",
+    )
+    before = rec.model_dump()
+
+    candidate = gi._project_one(rec, head_sha="a" * 40)
+
+    assert candidate.title == expected_title
+    assert candidate.body == expected_body
+    assert not FINDING_MARKER_RE.search(candidate.title + "\n" + candidate.body)
+    assert candidate.source_id == rec.source_id
+    assert candidate.location == schema.Location(path="feature.py", start_line=2, end_line=2)
+    assert candidate.exact_acceptable is (bool(expected_title) and not outdated)
+    assert candidate.not_exact_reason == ("outdated" if outdated else "title" if not expected_title else None)
+    assert rec.model_dump() == before
+
+
 def test_exact_acceptance_from_authoring_anchor_matches_head(fake_gh: FakeGh) -> None:
     """A comment GitHub re-anchored onto the head (``commit_id == head`` but
     originally authored elsewhere) is denied exact acceptance: the anchor's


### PR DESCRIPTION
## Summary

Remove exact Daydream finding-marker comments from newly projected review titles and bodies, while preserving the original GitHub evidence and its hashes unchanged. Reuse the existing shared marker grammar.

## Motivation

Closes #836. Transport markers could become a gold finding's title or leak into compiled benchmark findings. Fresh import → curate → compile flows now expose only the finding text; existing curated artifacts are not silently rewritten and require explicit re-curation to update their text.

## Testing

- Tests-first matrix covers leading, embedded, repeated, marker-only, CRLF, and malformed-lookalike comments, with both current and outdated evidence. It verifies unchanged candidacy, source location, and complete raw evidence.
- Real CLI import → curator edit → mark-ready → Harbor compile regression checks both golden-review outputs, source IDs, original body, body hash, exact fetch-payload hash, and ledger file hash. Only the external GitHub boundary is faked; Git, filesystem, and production compilation are real.
- Independent code review approved the implementation and repeated the focused acceptance tests.
- Ordinary signed commit and hook-enabled push passed full `make check`: 6,368 root tests and 202 standalone tests passed, 88.94% coverage, plus lint, types, dead-code, locks, and workflow checks. Existing skips: 9 root and 2 standalone.
- Required local `daydream . --precision --backend pi --trace-to honeyhive --trace-to langsmith` completed successfully after PR creation (run `dcfa6ef2-1bcf-408a-94fd-4343a7bf1267`, exit 0). It found no issues; all three changed files were reviewed. All six final-SHA CI checks passed, with the optional codesmith check skipped.

## Checklist

- [x] Real production-entrypoint regression and historical-data control.
- [x] Full ordinary repository hooks passed.
- [x] No evidence mutation, schema change, dependency change, or automatic migration.
