### PR TITLE
fix: scope review posting to an explicit compatible repository context

### DIFF
--- a/daydream/cli.py
+++ b/daydream/cli.py
@@ -2591,6 +2591,13 @@ def _build_post_findings_parser() -> argparse.ArgumentParser:
         help="Path to the findings artifact written by --findings-out.",
     )
     parser.add_argument(
+        "--target",
+        type=Path,
+        default=None,
+        metavar="PATH",
+        help="Checkout directory for configuration, diagram evidence, and GitHub operations (default: cwd).",
+    )
+    parser.add_argument(
         "--pr",
         type=int,
         required=True,
@@ -2656,16 +2663,21 @@ def _handle_post_findings_command(argv: list[str]) -> int:
     if "/" not in args.repo:
         parser.error(f"--repo must be an OWNER/REPO slug, got {args.repo!r}")
 
+    target_dir = (args.target if args.target is not None else Path.cwd()).resolve()
+    if not target_dir.is_dir():
+        parser.error(f"--target must be an existing directory: {target_dir}")
+
     console = create_console()
     # Best-effort config read: the poster previously never consulted the repo
     # config, so a malformed .daydream.toml/pyproject.toml in the CI checkout
     # must not abort the unattended post — warn and fall back to the CLI flag.
     approve = args.approve_on_clean
     try:
-        approve = approve or bool(load_file_config(Path.cwd()).approve_on_clean)
+        approve = approve or bool(load_file_config(target_dir).approve_on_clean)
     except ValueError as exc:
         print_warning(console, f"Ignoring malformed repo config: {exc}")
     return pr_review.post_findings_from_artifact(
+        target_dir,
         args.artifact,
         pr_number=args.pr_number,
         head_sha=args.head_sha,

--- a/daydream/deep/orchestrator.py
+++ b/daydream/deep/orchestrator.py
@@ -1373,7 +1373,15 @@ async def _step_intent(ctx: FlowContext) -> None:
     print_stage_progress(console, 1, 5, _PIPELINE_STAGE_NAMES[0])
     pr_description: str | None = None
     if config.pr_number is not None:
-        pr_view = git_ops.gh_pr_view(target_dir, config.pr_number)
+        try:
+            pr_view = git_ops.gh_pr_view(target_dir, config.pr_number)
+        except git_ops.GitError as exc:
+            print_warning(
+                console,
+                f"Could not load PR #{config.pr_number} description ({exc}); "
+                "continuing without PR description context",
+            )
+            pr_view = None
         if pr_view is not None:
             pr_state = pr_view.get("state", "")
             pr_head_oid = pr_view.get("headRefOid", "")
@@ -2832,6 +2840,11 @@ async def _step_post_review(ctx: FlowContext) -> Stop | None:
     from daydream.pr_review import PostStatus, post_review_to_pr_from_report
 
     items_file: Path = ctx.data["items_file"]
+    pr_kwargs = (
+        {"pr_number": ctx.config.pr_number}
+        if ctx.config.pr_number is not None
+        else {}
+    )
     outcome = await post_review_to_pr_from_report(
         ctx.work.repo,
         items_file,
@@ -2839,6 +2852,7 @@ async def _step_post_review(ctx: FlowContext) -> Stop | None:
         post=_mode_of(ctx) == "comment",
         approve_on_clean=_approve_on_clean(ctx.config),
         diagram_blocks=(ctx.data.get("diagrams") or {}).get("blocks"),
+        **pr_kwargs,
     )
     if _mode_of(ctx) == "comment" and outcome in (PostStatus.NO_PR, PostStatus.FAILED):
         return Stop(1)
@@ -3369,6 +3383,7 @@ async def _step_post_diagram(ctx: FlowContext) -> Stop:
     ``--comment`` -- an unresolvable PR or a failed POST ends the run with
     exit 1, because the comment was the whole point of the run.
     """
+    from daydream.git_ops import GitError
     from daydream.pr_review import (
         _resolve_pr,
         diagram_comment_kinds,
@@ -3383,7 +3398,11 @@ async def _step_post_diagram(ctx: FlowContext) -> Stop:
     if ctx.config.findings_out is not None:
         return Stop(_emit_diagram_findings(ctx.work.repo, ctx.config, payload))
 
-    pr = _resolve_pr(ctx.work.repo, console, ctx.config.pr_number)
+    try:
+        pr = _resolve_pr(ctx.work.repo, console, ctx.config.pr_number)
+    except GitError as exc:
+        print_error(console, "Diagram PR Lookup Failed", str(exc))
+        return Stop(1)
     if pr is None:
         print_error(
             console,

--- a/daydream/git_ops.py
+++ b/daydream/git_ops.py
@@ -164,7 +164,9 @@ _APP_MANIFEST_CONVERSION_CODE_RE = re.compile(r"(/app-manifests/)[^/\s]+(/conver
 _GITHUB_TOKEN_RE = re.compile(
     r"\b(?:gh[pousr]_[A-Za-z0-9_]{20,}|github_pat_[A-Za-z0-9_]{20,})\b"
 )
-_URL_USERINFO_RE = re.compile(r"([A-Za-z][A-Za-z0-9+.-]*://)[^/@\s]+@")
+# Start at the fixed authority delimiter. Searching for an arbitrary-length
+# scheme at every input character makes long non-URL diagnostics quadratic.
+_URL_USERINFO_RE = re.compile(r"://[^/@\s]+@")
 
 
 def _redact_sensitive_text(text: str) -> str:
@@ -179,7 +181,7 @@ def _redact_sensitive_text(text: str) -> str:
     """
     redacted = _APP_MANIFEST_CONVERSION_CODE_RE.sub(r"\1***\2", text)
     redacted = _GITHUB_TOKEN_RE.sub("***", redacted)
-    redacted = _URL_USERINFO_RE.sub(r"\1***@", redacted)
+    redacted = _URL_USERINFO_RE.sub("://***@", redacted)
     for key in ("GH_TOKEN", "GITHUB_TOKEN"):
         token = os.environ.get(key)
         if token and len(token) >= 8:

--- a/daydream/git_ops.py
+++ b/daydream/git_ops.py
@@ -27,7 +27,7 @@ Error-handling patterns:
     **Soft failure (return sentinel)**: Used when "data not available" is a
     valid, expected outcome the caller can handle inline. These return
     ``None``, ``False``, ``0``, or ``[]`` on non-zero exit instead of raising.
-    Examples: :func:`remote_url`, :func:`merge_base`, :func:`gh_pr_view`.
+    Examples: :func:`remote_url`, :func:`merge_base`, :func:`gh_repo_view`.
 
     Each function's docstring specifies which pattern it follows under its
     **Raises** or **Returns** section.
@@ -161,6 +161,10 @@ _SENSITIVE_HEADER_PREFIXES = ("authorization:",)
 # rendered diagnostic so the code never leaks verbatim, while preserving the
 # route for debuggability.
 _APP_MANIFEST_CONVERSION_CODE_RE = re.compile(r"(/app-manifests/)[^/\s]+(/conversions)")
+_GITHUB_TOKEN_RE = re.compile(
+    r"\b(?:gh[pousr]_[A-Za-z0-9_]{20,}|github_pat_[A-Za-z0-9_]{20,})\b"
+)
+_URL_USERINFO_RE = re.compile(r"([A-Za-z][A-Za-z0-9+.-]*://)[^/@\s]+@")
 
 
 def _redact_sensitive_text(text: str) -> str:
@@ -173,7 +177,14 @@ def _redact_sensitive_text(text: str) -> str:
     list passed to :func:`subprocess.run`, which keeps the original endpoint so
     GitHub still receives the real credential.
     """
-    return _APP_MANIFEST_CONVERSION_CODE_RE.sub(r"\1***\2", text)
+    redacted = _APP_MANIFEST_CONVERSION_CODE_RE.sub(r"\1***\2", text)
+    redacted = _GITHUB_TOKEN_RE.sub("***", redacted)
+    redacted = _URL_USERINFO_RE.sub(r"\1***@", redacted)
+    for key in ("GH_TOKEN", "GITHUB_TOKEN"):
+        token = os.environ.get(key)
+        if token and len(token) >= 8:
+            redacted = redacted.replace(token, "***")
+    return redacted
 
 
 def _redact_args(args: list[str]) -> list[str]:
@@ -647,6 +658,43 @@ def remote_url(repo: Path, remote: str = "origin") -> str | None:
     if proc.returncode != 0:
         return None
     return proc.stdout.strip() or None
+
+
+def remote_urls(repo: Path) -> dict[str, str]:
+    """Return every configured remote's nonempty fetch URL.
+
+    An empty repository remote set is valid. Any enumeration or per-remote URL
+    failure is hard because PR base selection must not silently ignore a
+    partially readable remote configuration.
+    """
+    proc = _run_git(
+        repo,
+        ["config", "--null", "--name-only", "--get-regexp", r"^remote\..*\."],
+        timeout=5,
+    )
+    if proc.returncode not in (0, 1):
+        raise GitError(f"cannot enumerate remotes in {repo}: {proc.stderr.strip()}")
+    names: set[str] = set()
+    for key in proc.stdout.split("\0"):
+        match = re.fullmatch(r"remote\.(.+)\.[^.]+", key)
+        if match is not None:
+            names.add(match.group(1))
+    result: dict[str, str] = {}
+    for name in sorted(names):
+        url_proc = _run_git(repo, ["config", "--get", f"remote.{name}.url"], timeout=5)
+        url = url_proc.stdout.strip() if url_proc.returncode == 0 else ""
+        if not url:
+            raise GitError(f"remote {name!r} has no readable fetch URL in {repo}")
+        result[name] = url
+    return result
+
+
+def validate_branch_name(repo: Path, name: str) -> None:
+    """Raise when *name* is not a literal Git branch name."""
+    proc = _run_git(repo, ["check-ref-format", "--branch", name], timeout=5)
+    if proc.returncode != 0:
+        display = name[:120] + ("..." if len(name) > 120 else "")
+        raise GitError(f"invalid PR base branch name {display!r} in {repo}")
 
 
 def current_branch(repo: Path) -> str | None:
@@ -1621,6 +1669,80 @@ def stash_create(repo: Path) -> str | None:
     return proc.stdout.strip() or None
 
 
+_FULL_OBJECT_ID_RE = re.compile(r"(?:[0-9a-fA-F]{40}|[0-9a-fA-F]{64})")
+
+
+def _validate_pr_base_ref(repo: Path, ref: str, *, prefix: str) -> None:
+    if not ref.startswith(prefix):
+        raise GitError(f"invalid PR base ref {ref[:120]!r} in {repo}")
+    proc = _run_git(repo, ["check-ref-format", ref], timeout=5)
+    if proc.returncode != 0:
+        raise GitError(f"invalid PR base ref {ref[:120]!r} in {repo}")
+
+
+def _merge_base_strict(repo: Path, base_ref: str, head_sha: str) -> str:
+    proc = _run_git(repo, ["merge-base", base_ref, head_sha], timeout=10)
+    merge_sha = proc.stdout.strip()
+    if proc.returncode != 0 or _FULL_OBJECT_ID_RE.fullmatch(merge_sha) is None:
+        raise GitError(
+            f"no merge-base for PR head {head_sha} and base {base_ref} in {repo}"
+        )
+    return merge_sha.lower()
+
+
+def resolve_pr_merge_base(
+    repo: Path,
+    remote_base_refs: Sequence[str],
+    local_base_ref: str,
+    head_sha: str,
+) -> str:
+    """Resolve the exact PR head's merge-base against authoritative local refs."""
+    if _FULL_OBJECT_ID_RE.fullmatch(head_sha) is None:
+        raise GitError(f"exact PR head {head_sha[:120]!r} is not a full object ID in {repo}")
+    head_proc = _run_git(repo, ["rev-parse", "--verify", f"{head_sha}^{{commit}}"], timeout=5)
+    resolved_head = head_proc.stdout.strip()
+    if (
+        head_proc.returncode != 0
+        or _FULL_OBJECT_ID_RE.fullmatch(resolved_head) is None
+        or resolved_head.lower() != head_sha.lower()
+    ):
+        raise GitError(f"exact PR head {head_sha} is not a local commit in {repo}")
+
+    _validate_pr_base_ref(repo, local_base_ref, prefix="refs/heads/")
+    unique_remote_refs = sorted(set(remote_base_refs))
+    for ref in unique_remote_refs:
+        _validate_pr_base_ref(repo, ref, prefix="refs/remotes/")
+
+    present_remote_refs: list[str] = []
+    for ref in unique_remote_refs:
+        check = _run_git(repo, ["rev-parse", "--verify", f"{ref}^{{commit}}"], timeout=5)
+        if check.returncode == 0:
+            present_remote_refs.append(ref)
+
+    if present_remote_refs:
+        bases = {
+            ref: _merge_base_strict(repo, ref, head_sha)
+            for ref in present_remote_refs
+        }
+        distinct = set(bases.values())
+        if len(distinct) != 1:
+            refs = ", ".join(present_remote_refs)
+            raise GitError(
+                f"matching PR base remotes disagree ({refs}) in {repo}; "
+                "fetch/align the base remote refs"
+            )
+        return next(iter(distinct))
+
+    local_check = _run_git(
+        repo, ["rev-parse", "--verify", f"{local_base_ref}^{{commit}}"], timeout=5
+    )
+    if local_check.returncode != 0:
+        raise GitError(
+            f"PR base {local_base_ref} is unavailable for head {head_sha} in {repo}"
+        )
+    return _merge_base_strict(repo, local_base_ref, head_sha)
+
+
 def upstream_ahead_count(repo: Path, branch: str) -> int:
     """Return the number of commits ``<branch>@{upstream}`` is ahead of *branch*.
 
@@ -2233,15 +2355,61 @@ def push_branch(repo: Path, branch: str, *, remote: str = "origin") -> None:
 # --- gh wrappers -------------------------------------------------------------
 
 
+GH_PR_VIEW_FIELDS: tuple[str, ...] = (
+    "number",
+    "title",
+    "body",
+    "state",
+    "headRefName",
+    "baseRefName",
+    "headRefOid",
+    "url",
+    "headRepository",
+    "headRepositoryOwner",
+)
+GH_PR_LIST_FIELDS: tuple[str, ...] = (
+    "number",
+    "headRefOid",
+    "baseRefName",
+    "url",
+    "headRepository",
+    "headRepositoryOwner",
+)
+_GH_DIAGNOSTIC_LIMIT = 2_000
+_MISSING_BRANCH_PR_RE = re.compile(r'^no pull requests found for branch "[^"\r\n]+"$')
+
+
+def _safe_gh_diagnostic(stderr: str) -> str:
+    """Return a redacted, bounded one-command diagnostic."""
+    redacted = _redact_sensitive_text(stderr.strip())
+    if len(redacted) <= _GH_DIAGNOSTIC_LIMIT:
+        return redacted
+    return redacted[:_GH_DIAGNOSTIC_LIMIT] + "...[truncated]"
+
+
+def _pr_view_is_absent(stderr: str, pr: int | None) -> bool:
+    """Recognize only gh's two established PR-absence diagnostics."""
+    diagnostic = stderr.strip()
+    if pr is None:
+        return _MISSING_BRANCH_PR_RE.fullmatch(diagnostic) is not None
+    return diagnostic == (
+        f"GraphQL: Could not resolve to a PullRequest with the number of {pr}. "
+        "(repository.pullRequest)"
+    )
+
+
 def gh_pr_view(repo: Path, pr: int | None = None) -> dict[str, Any] | None:
-    """Return ``gh pr view`` output as a dict, or ``None`` on failure.
+    """Return ``gh pr view`` output, or ``None`` only when the PR is absent.
 
     When *pr* is ``None``, ``gh pr view`` infers the PR from the currently
     checked-out branch. This mirrors the auto-detection flow used by the CLI
     when the user does not pass an explicit PR number.
 
     Returns:
-        Parsed JSON dict, or ``None`` when no PR is found / the call fails.
+        Parsed JSON dict, or ``None`` for a recognized missing PR diagnostic.
+
+    Raises:
+        GitError: If gh fails for any other reason or returns malformed output.
     """
     args = ["pr", "view"]
     if pr is not None:
@@ -2249,28 +2417,32 @@ def gh_pr_view(repo: Path, pr: int | None = None) -> dict[str, Any] | None:
     args.extend(
         [
             "--json",
-            "number,title,body,state,headRefName,baseRefName,headRefOid,baseRefOid,url",
+            ",".join(GH_PR_VIEW_FIELDS),
         ]
     )
-    try:
-        proc = _run_gh(repo, args, retries=_gh_retries())
-    except GitError as exc:
-        _logger.warning("gh pr view failed (%s, returning None): %s", type(exc).__name__, exc)
-        return None
+    proc = _run_gh(repo, args, retries=_gh_retries())
     if proc.returncode != 0:
-        return None
+        if _pr_view_is_absent(proc.stderr, pr):
+            return None
+        diagnostic = _safe_gh_diagnostic(proc.stderr) or "no diagnostic"
+        raise _gh_error_for(f"gh pr view failed: {diagnostic}", proc.stderr)
     try:
         data = json.loads(proc.stdout)
-    except json.JSONDecodeError:
-        return None
-    return data if isinstance(data, dict) else None
+    except json.JSONDecodeError as exc:
+        raise GitError("gh pr view returned invalid JSON") from exc
+    if not isinstance(data, dict):
+        raise GitError("gh pr view expected a JSON object")
+    return data
 
 
 def gh_pr_list_for_branch(repo: Path, branch: str) -> list[dict[str, Any]]:
     """List open PRs whose head ref is *branch*.
 
     Returns:
-        List of PR dicts (empty when no PRs match or the call fails).
+        List of PR dicts. An empty list means the successful query had no rows.
+
+    Raises:
+        GitError: If gh fails or returns malformed output.
     """
     proc = _run_gh(
         repo,
@@ -2282,17 +2454,22 @@ def gh_pr_list_for_branch(repo: Path, branch: str) -> list[dict[str, Any]]:
             "--state",
             "open",
             "--json",
-            "number,headRefOid,baseRefOid,baseRefName,url,headRepository,headRepositoryOwner",
+            ",".join(GH_PR_LIST_FIELDS),
         ],
         retries=_gh_retries(),
     )
     if proc.returncode != 0:
-        return []
+        diagnostic = _safe_gh_diagnostic(proc.stderr) or "no diagnostic"
+        raise _gh_error_for(f"gh pr list failed: {diagnostic}", proc.stderr)
     try:
-        rows = json.loads(proc.stdout or "[]")
-    except json.JSONDecodeError:
-        return []
-    return rows if isinstance(rows, list) else []
+        rows = json.loads(proc.stdout)
+    except json.JSONDecodeError as exc:
+        raise GitError("gh pr list returned invalid JSON") from exc
+    if not isinstance(rows, list):
+        raise GitError("gh pr list expected a JSON list")
+    if any(not isinstance(row, dict) for row in rows):
+        raise GitError("gh pr list returned a non-object row")
+    return rows
 
 
 def gh_pr_diff(repo: Path, pr: int) -> str:
@@ -2314,10 +2491,10 @@ def split_owner_repo(slug: str) -> tuple[str, str] | None:
         A ``(owner, repo)`` tuple when *slug* contains exactly one ``"/"``
         and both parts are non-empty, or ``None`` otherwise.
     """
-    if "/" not in slug:
+    if slug.count("/") != 1:
         return None
     owner, _, repo = slug.partition("/")
-    if not owner or not repo:
+    if not owner or not repo or any(char.isspace() for char in owner + repo):
         return None
     return owner, repo
 
@@ -2386,6 +2563,23 @@ def gh_repo_view(repo: Path) -> tuple[str, str] | None:
     if proc.returncode != 0:
         return None
     return split_owner_repo(proc.stdout.strip())
+
+
+def gh_repo_view_required(repo: Path) -> tuple[str, str]:
+    """Return the current repository slug, raising on command or shape failure."""
+    proc = _run_gh(
+        repo,
+        ["repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner"],
+        retries=_gh_retries(),
+    )
+    if proc.returncode != 0:
+        diagnostic = _safe_gh_diagnostic(proc.stderr) or "no diagnostic"
+        raise _gh_error_for(f"gh repo view failed: {diagnostic}", proc.stderr)
+    raw_slug = proc.stdout.rstrip("\r\n")
+    slug = split_owner_repo(raw_slug)
+    if slug is None:
+        raise GitError("gh repo view returned an invalid repository slug")
+    return slug
 
 
 def _gh_error_for(message: str, stderr: str) -> GitError:

--- a/daydream/pr_review.py
+++ b/daydream/pr_review.py
@@ -18,7 +18,9 @@ Flow:
     6. Build a single review payload, show a summary, ask y/n.
     7. On yes, POST to `/repos/<owner>/<repo>/pulls/<num>/reviews`.
 
-Everything is best-effort: failures warn and return, never raise.
+Posting boundaries translate failures into explicit statuses. PR lookup and
+local-object helpers raise :class:`GitError` so operational failures cannot be
+misreported as an absent pull request.
 """
 
 from __future__ import annotations
@@ -474,37 +476,51 @@ def parsed_issues_from_items(items: list[dict[str, Any]]) -> list[ParsedIssue]:
 
 
 def _current_branch(target_dir: Path) -> str | None:
-    try:
-        return git_ops.current_branch(target_dir)
-    except GitError:
-        return None
+    return git_ops.current_branch(target_dir)
 
 
 def _head_repo_slug_from_row(row: dict[str, Any]) -> str | None:
     """The ``owner/repo`` slug that holds the PR's head commit, or ``None``.
 
-    ``gh pr list --json headRepository,headRepositoryOwner`` rows carry the
-    head repository — the fork for fork-head PRs, where the head commit
-    actually exists. ``gh pr view`` rows carry neither key, so callers fall
-    back to the base-repo slug for those.
+    Both PR lookup modes request the head repository and owner. An explicitly
+    null repository (for example a deleted fork) permits base-repository link
+    fallback; missing or malformed requested metadata is a schema failure.
     """
-    head_repo = row.get("headRepository")
-    if not isinstance(head_repo, dict):
+    if "headRepository" not in row or "headRepositoryOwner" not in row:
+        raise GitError("invalid PR row: missing requested head repository metadata")
+    head_owner = row["headRepositoryOwner"]
+    owner_login: str | None = None
+    if head_owner is not None:
+        if not isinstance(head_owner, dict) or not isinstance(head_owner.get("login"), str):
+            raise GitError("invalid PR row: malformed head repository owner")
+        owner_login = head_owner["login"]
+        if git_ops.split_owner_repo(f"{owner_login}/repository") is None:
+            raise GitError("invalid PR row: malformed head repository owner")
+    head_repo = row["headRepository"]
+    if head_repo is None:
         return None
-    name_with_owner = head_repo.get("nameWithOwner")
-    if isinstance(name_with_owner, str) and "/" in name_with_owner:
-        return name_with_owner
-    head_owner = row.get("headRepositoryOwner")
-    if (
-        isinstance(head_owner, dict)
-        and isinstance(head_owner.get("login"), str)
-        and isinstance(head_repo.get("name"), str)
-    ):
-        return f"{head_owner['login']}/{head_repo['name']}"
-    return None
+    if not isinstance(head_repo, dict):
+        raise GitError("invalid PR row: headRepository must be an object or null")
+    if "nameWithOwner" in head_repo:
+        name_with_owner = head_repo["nameWithOwner"]
+        if not isinstance(name_with_owner, str):
+            raise GitError("invalid PR row: malformed head repository slug")
+        slug = git_ops.split_owner_repo(name_with_owner)
+        if slug is None:
+            raise GitError("invalid PR row: malformed head repository slug")
+        owner, repo = slug
+        return f"{owner}/{repo}"
+    if owner_login is not None and isinstance(head_repo.get("name"), str):
+        candidate_slug = f"{owner_login}/{head_repo['name']}"
+        parsed_slug = git_ops.split_owner_repo(candidate_slug)
+        if parsed_slug is None:
+            raise GitError("invalid PR row: malformed head repository slug")
+        owner, repo = parsed_slug
+        return f"{owner}/{repo}"
+    raise GitError("invalid PR row: incomplete head repository metadata")
 
 
-def _pr_info_from_row(target_dir: Path, row: dict[str, Any]) -> PRInfo | None:
+def _pr_info_from_row(target_dir: Path, row: dict[str, Any]) -> PRInfo:
     """Build :class:`PRInfo` from a ``gh`` PR row, resolving the owner/repo slug.
 
     ``owner``/``repo`` (the posting target) come from ``gh repo view`` — the
@@ -512,22 +528,47 @@ def _pr_info_from_row(target_dir: Path, row: dict[str, Any]) -> PRInfo | None:
     reviewed-commit link target) comes from the row's head-repository entry
     when present, so fork-head PRs link to the fork that holds the commit.
 
-    Returns None when the owner/repo slug cannot be resolved.
+    Raises :class:`GitError` when the row or repository context is invalid.
     """
-    # Owner/repo lookup via `gh repo view` — the base repo hosts the PR.
-    slug = git_ops.gh_repo_view(target_dir)
-    if slug is None:
-        return None
-    owner, repo = slug
+    from daydream.archive.git_safe import normalize_remote_url
+
+    number = row.get("number")
+    head_sha = row.get("headRefOid")
+    base_ref = row.get("baseRefName")
+    url = row.get("url")
+    if isinstance(number, bool) or not isinstance(number, int) or number <= 0:
+        raise GitError("invalid PR row: number must be a positive integer")
+    if not isinstance(head_sha, str):
+        raise GitError("invalid PR row: headRefOid must be a string")
+    if not isinstance(base_ref, str) or not base_ref:
+        raise GitError("invalid PR row: baseRefName must be a non-empty string")
+    if not isinstance(url, str) or not url:
+        raise GitError("invalid PR row: url must be a non-empty string")
+    head_repo = _head_repo_slug_from_row(row)
+    git_ops.validate_branch_name(target_dir, base_ref)
+
+    owner, repo = git_ops.gh_repo_view_required(target_dir)
+    base_slug = f"{owner}/{repo}"
+    matching_remotes: list[str] = []
+    for remote, raw_url in git_ops.remote_urls(target_dir).items():
+        identity, _safe_url = normalize_remote_url(raw_url)
+        if identity is not None and identity.lower() == base_slug.lower():
+            matching_remotes.append(f"refs/remotes/{remote}/{base_ref}")
+    base_sha = git_ops.resolve_pr_merge_base(
+        target_dir,
+        matching_remotes,
+        f"refs/heads/{base_ref}",
+        head_sha,
+    )
     return PRInfo(
-        number=int(row["number"]),
-        head_sha=row["headRefOid"],
-        base_sha=row["baseRefOid"],
-        base_ref=row.get("baseRefName", ""),
+        number=number,
+        head_sha=head_sha,
+        base_sha=base_sha,
+        base_ref=base_ref,
         owner=owner,
         repo=repo,
-        url=row.get("url", ""),
-        head_repo=_head_repo_slug_from_row(row),
+        url=url,
+        head_repo=head_repo,
     )
 
 
@@ -549,8 +590,11 @@ def find_pr_by_number(target_dir: Path, pr_number: int) -> PRInfo | None:
     deriving it from the current branch like :func:`find_open_pr`.
 
     Returns:
-        The resolved :class:`PRInfo`, or ``None`` when the PR or the
-        owner/repo slug cannot be resolved.
+        The resolved :class:`PRInfo`, or ``None`` only when the PR is absent.
+
+    Raises:
+        GitError: If repository identity, PR data, or local Git objects cannot
+            be resolved safely.
     """
     data = git_ops.gh_pr_view(target_dir, pr_number)
     if data is None:
@@ -1529,9 +1573,9 @@ def _resolve_pr(
     """Resolve the target PR for posting.
 
     Handles both the current-branch discovery path (:func:`find_open_pr`) and
-    the explicitly-pinned path (:func:`find_pr_by_number`). On failure it
-    prints a warning describing the cause — distinguishing a missing PR from a
-    failed owner/repo slug resolution — and returns ``None``.
+    the explicitly-pinned path (:func:`find_pr_by_number`). A genuine absence
+    prints a warning and returns ``None``; operational failures propagate for
+    the caller to report as failures.
 
     Returns:
         The resolved :class:`PRInfo`, or ``None`` (after warning) when the PR
@@ -1540,20 +1584,10 @@ def _resolve_pr(
     if pr_number is not None:
         pr = find_pr_by_number(target_dir, pr_number)
         if pr is None:
-            # Distinguish "PR not found" from "owner/repo slug unresolvable"
-            # so the operator gets a precise diagnostic rather than a generic
-            # "could not resolve" message.
-            if git_ops.gh_pr_view(target_dir, pr_number) is None:
-                print_warning(
-                    console,
-                    f"PR #{pr_number} not found via `gh pr view`; skipping PR post.",
-                )
-            else:
-                print_warning(
-                    console,
-                    f"PR #{pr_number} resolved via `gh pr view` but the owner/repo "
-                    "slug could not be resolved via `gh repo view`; skipping PR post.",
-                )
+            print_warning(
+                console,
+                f"PR #{pr_number} not found via `gh pr view`; skipping PR post.",
+            )
             return None
         return pr
     pr = find_open_pr(target_dir)
@@ -1576,7 +1610,11 @@ async def _post(
     pr_number: int | None = None,
     diagram_blocks: str | None = None,
 ) -> PostStatus:
-    pr = _resolve_pr(target_dir, console, pr_number)
+    try:
+        pr = _resolve_pr(target_dir, console, pr_number)
+    except GitError as exc:
+        print_error(console, "PR Lookup Failed", str(exc))
+        return PostStatus.FAILED
     if pr is None:
         return PostStatus.NO_PR
 
@@ -2289,6 +2327,7 @@ def _post_diagram_artifact(
 
 
 def post_findings_from_artifact(
+    target_dir: Path,
     artifact_path: Path,
     *,
     pr_number: int,
@@ -2308,6 +2347,7 @@ def post_findings_from_artifact(
     No prompting and no ATIF trajectory — there is no agent work here.
 
     Args:
+        target_dir: Explicit checkout for local evidence and every GitHub operation.
         artifact_path: Path to the ``--findings-out`` artifact.
         pr_number: Event-derived target PR number.
         head_sha: Event-derived PR head SHA.
@@ -2348,7 +2388,6 @@ def post_findings_from_artifact(
             "REST dedup unavailable) — may double-post, will never suppress.",
         )
 
-    target_dir = Path.cwd()
     try:
         artifact = load_findings_artifact(
             artifact_path,

--- a/daydream/pr_review.py
+++ b/daydream/pr_review.py
@@ -220,8 +220,9 @@ async def post_review_to_pr_from_report(
 
     ``pr_number``: when set, resolves the target PR by explicit number via
     ``gh pr view`` (redrive) instead of the current branch's open PR;
-    a failing explicit lookup returns :attr:`PostStatus.NO_PR` with no
-    fallback to current-branch discovery.
+    an absent PR returns :attr:`PostStatus.NO_PR`, while an operational
+    lookup failure returns :attr:`PostStatus.FAILED`. Neither falls back to
+    current-branch discovery.
 
     ``diagram_blocks`` (issue #1113): host-rendered grounded-diagram markdown,
     threaded through to :func:`build_payload`.
@@ -508,15 +509,13 @@ def _head_repo_slug_from_row(row: dict[str, Any]) -> str | None:
         slug = git_ops.split_owner_repo(name_with_owner)
         if slug is None:
             raise GitError("invalid PR row: malformed head repository slug")
-        owner, repo = slug
-        return f"{owner}/{repo}"
+        return name_with_owner
     if owner_login is not None and isinstance(head_repo.get("name"), str):
         candidate_slug = f"{owner_login}/{head_repo['name']}"
         parsed_slug = git_ops.split_owner_repo(candidate_slug)
         if parsed_slug is None:
             raise GitError("invalid PR row: malformed head repository slug")
-        owner, repo = parsed_slug
-        return f"{owner}/{repo}"
+        return candidate_slug
     raise GitError("invalid PR row: incomplete head repository metadata")
 
 
@@ -573,7 +572,15 @@ def _pr_info_from_row(target_dir: Path, row: dict[str, Any]) -> PRInfo:
 
 
 def find_open_pr(target_dir: Path) -> PRInfo | None:
-    """Locate the open PR for the current branch. Returns None if not found."""
+    """Locate the open PR for the current branch.
+
+    Returns:
+        None only when there is no current branch or matching open PR.
+
+    Raises:
+        GitError: If branch discovery, GitHub data, repository identity, or
+            the local PR merge base cannot be resolved safely.
+    """
     branch = _current_branch(target_dir)
     if not branch:
         return None

--- a/daydream/workspace.py
+++ b/daydream/workspace.py
@@ -569,7 +569,11 @@ def _resolve_base(source: Path, branch: str | None, base: str | None) -> str:
         return base
 
     if branch is not None and shutil.which("gh") is not None:
-        prs = git_ops.gh_pr_list_for_branch(source, branch)
+        try:
+            prs = git_ops.gh_pr_list_for_branch(source, branch)
+        except GitError as exc:
+            _logger.debug("PR base lookup failed for branch %r: %s", branch, exc)
+            prs = []
         if not prs:
             _logger.debug("gh_pr_list_for_branch returned empty for branch %r", branch)
         for pr in prs:

--- a/tests/harness/fake_gh.py
+++ b/tests/harness/fake_gh.py
@@ -75,6 +75,24 @@ _LS_REMOTE_DEFAULT = (
     "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\trefs/heads/base\n"
 )
 
+# Frozen to the subset verified present in gh 2.45 by issue #1109. The fake
+# rejects every other requested PR JSON field before serving a response, just
+# as the real CLI validates --json before contacting GitHub.
+_GH_245_PR_JSON_FIELDS = frozenset(
+    {
+        "number",
+        "title",
+        "body",
+        "state",
+        "headRefName",
+        "baseRefName",
+        "headRefOid",
+        "url",
+        "headRepository",
+        "headRepositoryOwner",
+    }
+)
+
 _EMPTY_THREADS_RESPONSE: dict[str, Any] = {
     "data": {
         "repository": {
@@ -181,6 +199,8 @@ def _handle_pr_view(argv: list[str], state: Path) -> tuple[int, str, str]:
     value = _read_responses(state).get("pr-view")
     if value is None:
         return 1, "", "fake gh: no pr-view response configured\n"
+    if isinstance(value, dict) and isinstance(value.get("__error__"), str):
+        return 1, "", value["__error__"] + "\n"
     return 0, json.dumps(value) + "\n", ""
 
 
@@ -192,7 +212,11 @@ def _handle_pr_list(argv: list[str], state: Path) -> tuple[int, str, str]:
         pr_view = responses.get("pr-view")
         if pr_view is None:
             return 1, "", "fake gh: no pr-list or pr-view response configured\n"
+        if isinstance(pr_view, dict) and isinstance(pr_view.get("__error__"), str):
+            return 1, "", pr_view["__error__"] + "\n"
         value = [pr_view]
+    if isinstance(value, dict) and isinstance(value.get("__error__"), str):
+        return 1, "", value["__error__"] + "\n"
     return 0, json.dumps(value) + "\n", ""
 
 
@@ -309,6 +333,11 @@ def _handle_api(argv: list[str], state: Path) -> tuple[int, str, str]:
 
 def _handle_gh(argv: list[str], stdin_text: str, state: Path) -> tuple[int, str, str]:
     """Answer one ``gh`` invocation (argv after ``gh``). Returns (rc, stdout, stderr)."""
+    if argv[:2] in (["pr", "view"], ["pr", "list"]):
+        requested = (_argv_opt(argv, "--json") or "").split(",")
+        unsupported = sorted(set(requested) - _GH_245_PR_JSON_FIELDS)
+        if unsupported:
+            return 1, "", f'Unknown JSON field: "{unsupported[0]}"\n'
     if argv[:2] in (["secret", "set"], ["variable", "set"]):
         return _handle_set(argv[0], argv, stdin_text, state)
     if argv[:2] in (["secret", "list"], ["variable", "list"]):
@@ -367,6 +396,14 @@ class GhCommandCall:
     kind: str
     argv: list[str]
     env: dict[str, Any] | None = None
+
+
+@dataclass
+class GhProcessCall:
+    """One intercepted ``gh`` process with its exact checkout context."""
+
+    cwd: Path
+    argv: list[str]
 
 
 @dataclass
@@ -430,6 +467,22 @@ class FakeGh:
             record = json.loads(line)
             if record.get("kind") == kind:
                 out.append(GhCommandCall(kind=kind, argv=record["argv"], env=record.get("env")))
+        return out
+
+    def process_calls(self) -> list[GhProcessCall]:
+        """Return every intercepted ``gh`` process in invocation order."""
+        out: list[GhProcessCall] = []
+        if not self._calls_path.exists():
+            return out
+        for line in self._calls_path.read_text(encoding="utf-8").splitlines():
+            record = json.loads(line)
+            if record.get("kind") == "gh process":
+                out.append(
+                    GhProcessCall(
+                        cwd=Path(record["cwd"]),
+                        argv=record["argv"],
+                    )
+                )
         return out
 
     def pr_view_calls(self) -> list[GhCommandCall]:
@@ -690,6 +743,11 @@ def install_fake_gh(state_dir: Path, monkeypatch: pytest.MonkeyPatch) -> FakeGh:
 
     def router(args: Any, *pargs: Any, **kwargs: Any) -> Any:
         if isinstance(args, (list, tuple)) and args and args[0] == "gh":
+            cwd = Path(kwargs.get("cwd") or Path.cwd()).resolve()
+            _record(
+                state_dir,
+                {"kind": "gh process", "cwd": str(cwd), "argv": list(args)},
+            )
             rc, out, err = _handle_gh(list(args[1:]), kwargs.get("input") or "", state_dir)
             return subprocess.CompletedProcess(list(args), rc, stdout=out, stderr=err)
         if (

--- a/tests/test_bot_setup_integration.py
+++ b/tests/test_bot_setup_integration.py
@@ -100,6 +100,7 @@ def test_land_workflows_writes_three_files_on_branch_and_opens_pr(
     fake_gh: FakeGh, repo_with_origin: Path
 ) -> None:
     """land_workflows copies the templates on a new branch, pushes, opens a PR."""
+    fake_gh.set_response("pr-list", value=[])
     fake_gh.set_response("pr-create", value="https://github.com/o/r/pull/3")
     url = bot_setup.land_workflows(repo_with_origin, branch="daydream/setup-bot")
     wf = repo_with_origin / ".github/workflows"
@@ -390,6 +391,7 @@ def test_setup_verb_full_auto_deposits_secrets_and_opens_pr(
     monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant")
     # App already installed on the owner → the Install-click wait is satisfied.
     fake_gh.serve_installations([{"account": {"login": "o"}}])
+    fake_gh.set_response("pr-list", value=[])
     fake_gh.set_response("pr-create", value="https://github.com/o/r/pull/5")
 
     code = cli_main(["setup", str(repo_with_origin), "--repo", "o/r"])
@@ -401,6 +403,18 @@ def test_setup_verb_full_auto_deposits_secrets_and_opens_pr(
     pr_calls = fake_gh.command_calls("pr create")
     assert len(pr_calls) == 1
     assert git_ops.ref_exists(repo_with_origin, "origin/daydream/setup-bot")
+
+
+def test_land_workflows_pr_lookup_failure_never_creates_duplicate_pr(
+    fake_gh: FakeGh, repo_with_origin: Path
+) -> None:
+    fake_gh.set_response("pr-list", value={"__error__": "authentication required"})
+    fake_gh.set_response("pr-create", value="https://github.com/o/r/pull/unsafe")
+
+    with pytest.raises(git_ops.GitError, match="authentication required"):
+        bot_setup.land_workflows(repo_with_origin, branch="daydream/setup-bot")
+
+    assert fake_gh.command_calls("pr create") == []
 
 
 def test_setup_fails_cleanly_when_key_absent_and_noninteractive(

--- a/tests/test_capture_loop.py
+++ b/tests/test_capture_loop.py
@@ -88,7 +88,8 @@ def _review_run_env(
             "headRefName": "feature",
             "baseRefName": "main",
             "headRefOid": git_ops.head_sha(repo),
-            "baseRefOid": git_ops.merge_base(repo, "main"),
+            "headRepository": {"name": "widgets", "nameWithOwner": "acme/widgets"},
+            "headRepositoryOwner": {"login": "acme"},
             "url": "https://github.com/acme/widgets/pull/7",
             "body": "",
         }

--- a/tests/test_deep_orchestrator.py
+++ b/tests/test_deep_orchestrator.py
@@ -3119,6 +3119,37 @@ async def test_no_pr_body_degrades_cleanly(
     _assert_authoritative_rule_gated(stub, expect_present=False)
 
 
+async def test_pr_lookup_failure_warns_and_degrades_intent_cleanly(
+    multi_stack_target: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    make_config: MakeConfig,
+) -> None:
+    """An advisory PR-body lookup failure cannot abort the review pipeline."""
+    from daydream.git_ops import GitError
+    from daydream.runner import run
+
+    _silence(monkeypatch)
+
+    def fail_view(_repo: Path, _pr: int | None = None) -> dict[str, Any] | None:
+        raise GitError("gh pr view failed: authentication required")
+
+    monkeypatch.setattr("daydream.git_ops.gh_pr_view", fail_view)
+    warnings: list[str] = []
+    monkeypatch.setattr(
+        "daydream.deep.orchestrator.print_warning",
+        lambda _console, message: warnings.append(message),
+    )
+    stub = _install_stub_backend(monkeypatch, multi_stack_target)
+    stub.parse_severity = "high"
+
+    rc = await run(make_config(multi_stack_target, pr_number=7))
+
+    assert rc == 0
+    assert "pull request description" not in _intent_prompt(stub).lower()
+    assert any("authentication required" in warning for warning in warnings)
+    _assert_authoritative_rule_gated(stub, expect_present=False)
+
+
 async def test_whitespace_only_pr_body_is_not_authoritative(
     multi_stack_target: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_diagram_only_integration.py
+++ b/tests/test_diagram_only_integration.py
@@ -49,7 +49,8 @@ def _serve_pr(fake_gh: FakeGh, target: Path) -> None:
             "headRefName": "feature",
             "baseRefName": "main",
             "headRefOid": git_ops.head_sha(target),
-            "baseRefOid": git_ops.merge_base(target, "main"),
+            "headRepository": {"name": "widgets", "nameWithOwner": "acme/widgets"},
+            "headRepositoryOwner": {"login": "acme"},
             "url": "https://github.com/acme/widgets/pull/7",
             "body": "",
         }

--- a/tests/test_diagram_only_integration.py
+++ b/tests/test_diagram_only_integration.py
@@ -605,6 +605,32 @@ async def test_no_resolvable_pr_in_diagram_only_mode_exits_one(
     assert _issue_comments(fake_gh) == []
 
 
+async def test_pr_lookup_failure_in_diagram_only_mode_exits_one_with_diagnostic(
+    tmp_path: Path,
+    diagram_run: Callable[..., Any],
+    fake_gh: FakeGh,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An operational lookup failure is reported, not misclassified as absence."""
+    target = dr.build_cross_module_repo(tmp_path)
+    fake_gh.set_response("pr-view", value={"__error__": "authentication required"})
+    errors: list[tuple[str, str]] = []
+    monkeypatch.setattr(
+        "daydream.deep.orchestrator.print_error",
+        lambda _console, title, message: errors.append((title, message)),
+    )
+
+    exit_code, _ = await diagram_run(
+        target, diagram="sequence", specs={"sequence": [dr.sequence_spec()]}
+    )
+
+    assert exit_code == 1
+    assert len(errors) == 1
+    assert errors[0][0] == "Diagram PR Lookup Failed"
+    assert "authentication required" in errors[0][1]
+    assert _issue_comments(fake_gh) == []
+
+
 # --- Regression (a): prior deep artifacts survive ---------------------------
 
 

--- a/tests/test_extension_seam_integration.py
+++ b/tests/test_extension_seam_integration.py
@@ -136,7 +136,8 @@ def _serve_pr_view(fake_gh: FakeGh, target: Path) -> None:
             "headRefName": "feature",
             "baseRefName": "main",
             "headRefOid": git_ops.head_sha(target),
-            "baseRefOid": git_ops.merge_base(target, "main"),
+            "headRepository": {"name": "widgets", "nameWithOwner": "acme/widgets"},
+            "headRepositoryOwner": {"login": "acme"},
             "url": "https://github.com/acme/widgets/pull/7",
             "body": "",
         }

--- a/tests/test_git_ops.py
+++ b/tests/test_git_ops.py
@@ -13,6 +13,7 @@ import logging
 import re
 import shutil
 import subprocess
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -1622,6 +1623,29 @@ def test_gh_repo_view_required_returns_exact_slug(
         lambda cmd, **kwargs: subprocess.CompletedProcess(cmd, 0, stdout="Owner/Repo\n", stderr=""),
     )
     assert git_ops.gh_repo_view_required(repo) == ("Owner", "Repo")
+
+
+def test_diagnostic_url_redaction_is_bounded_on_long_untrusted_text() -> None:
+    """Non-URL diagnostics must not trigger quadratic scheme-prefix searches."""
+    checked = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "from daydream.git_ops import _redact_sensitive_text\n"
+            "for text in ('A' * 100_000, 'A.' * 50_000):\n"
+            "    assert _redact_sensitive_text(text) == text\n"
+            "for scheme in ('https', 'ssh', 'git+custom.transport'):\n"
+            "    raw = f'failed {scheme}://user:password@example.invalid/o/r'\n"
+            "    assert _redact_sensitive_text(raw) == "
+            "f'failed {scheme}://***@example.invalid/o/r'\n",
+        ],
+        cwd=Path(__file__).parents[1],
+        capture_output=True,
+        text=True,
+        timeout=5,
+        check=False,
+    )
+    assert checked.returncode == 0, checked.stderr
 
 
 def test_gh_repo_view_required_preserves_safe_failure_diagnostic(

--- a/tests/test_git_ops.py
+++ b/tests/test_git_ops.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 import shutil
 import subprocess
 from pathlib import Path
@@ -400,6 +401,90 @@ def test_merge_base_returns_none_for_leading_dash_ref(
     """Treat leading-dash revisions as invalid refs rather than Git options."""
     repo = _make_repo_with_main(tmp_path)
     assert git_ops.merge_base(repo, *refs) is None
+
+
+def test_remote_urls_is_strict_and_allows_no_remotes(tmp_path: Path) -> None:
+    repo = _make_repo_with_main(tmp_path)
+    assert git_ops.remote_urls(repo) == {}
+
+    _git(repo, "remote", "add", "origin", "https://github.com/acme/widgets.git")
+    _git(repo, "remote", "add", "upstream", "git@github.com:other/widgets.git")
+    assert git_ops.remote_urls(repo) == {
+        "origin": "https://github.com/acme/widgets.git",
+        "upstream": "git@github.com:other/widgets.git",
+    }
+
+    _git(repo, "config", "remote.broken.fetch", "+refs/heads/*:refs/remotes/broken/*")
+    with pytest.raises(GitError, match="remote 'broken'.*fetch URL"):
+        git_ops.remote_urls(repo)
+
+
+def test_resolve_pr_merge_base_uses_local_branch_without_remotes(tmp_path: Path) -> None:
+    repo = _make_repo_with_main(tmp_path)
+    base = git_ops.head_sha(repo)
+    _git(repo, "checkout", "-b", "feature")
+    (repo / "feature.txt").write_text("feature\n")
+    _git(repo, "add", "feature.txt")
+    head = _commit(repo, "feature")
+
+    assert git_ops.resolve_pr_merge_base(repo, [], "refs/heads/main", head) == base
+
+
+def test_resolve_pr_merge_base_prefers_present_remote_over_stale_local(tmp_path: Path) -> None:
+    remote = _bare_remote(tmp_path / "remote.git")
+    repo = _make_repo_with_main(tmp_path, name="repo")
+    stale_local = git_ops.head_sha(repo)
+    _git(repo, "remote", "add", "origin", str(remote))
+    _git(repo, "push", "-u", "origin", "main")
+    (repo / "base-update.txt").write_text("new base\n")
+    _git(repo, "add", "base-update.txt")
+    remote_base = _commit(repo, "base update")
+    _git(repo, "push", "origin", "main")
+    _git(repo, "checkout", "-b", "feature")
+    (repo / "feature.txt").write_text("feature\n")
+    _git(repo, "add", "feature.txt")
+    head = _commit(repo, "feature")
+    _git(repo, "branch", "-f", "main", stale_local)
+
+    assert git_ops.resolve_pr_merge_base(
+        repo, ["refs/remotes/origin/main"], "refs/heads/main", head
+    ) == remote_base
+
+
+def test_resolve_pr_merge_base_rejects_divergent_matching_remotes(tmp_path: Path) -> None:
+    repo = _make_repo_with_main(tmp_path)
+    oldest = git_ops.head_sha(repo)
+    (repo / "base-update.txt").write_text("new base\n")
+    _git(repo, "add", "base-update.txt")
+    newer = _commit(repo, "base update")
+    _git(repo, "checkout", "-b", "feature")
+    (repo / "feature.txt").write_text("feature\n")
+    _git(repo, "add", "feature.txt")
+    head = _commit(repo, "feature")
+    _git(repo, "update-ref", "refs/remotes/one/main", newer)
+    _git(repo, "update-ref", "refs/remotes/two/main", oldest)
+
+    with pytest.raises(GitError, match="fetch/align the base remote"):
+        git_ops.resolve_pr_merge_base(
+            repo,
+            ["refs/remotes/one/main", "refs/remotes/two/main"],
+            "refs/heads/main",
+            head,
+        )
+
+
+@pytest.mark.parametrize("head", ["HEAD", "deadbeef", "f" * 40])
+def test_resolve_pr_merge_base_requires_exact_present_head(tmp_path: Path, head: str) -> None:
+    repo = _make_repo_with_main(tmp_path)
+    with pytest.raises(GitError, match="exact PR head"):
+        git_ops.resolve_pr_merge_base(repo, [], "refs/heads/main", head)
+
+
+@pytest.mark.parametrize("local_ref", ["main", "refs/heads/-bad", "refs/heads/main~1"])
+def test_resolve_pr_merge_base_rejects_invalid_base_ref(tmp_path: Path, local_ref: str) -> None:
+    repo = _make_repo_with_main(tmp_path)
+    with pytest.raises(GitError, match="base ref"):
+        git_ops.resolve_pr_merge_base(repo, [], local_ref, git_ops.head_sha(repo))
 
 
 # --- diff / log / show / grep / status / upstream_ahead_count ---------------
@@ -1294,16 +1379,17 @@ def test_gh_repo_view_returns_none_outside_github_repo(tmp_path: Path) -> None:
 
 
 @gh_required
-def test_gh_pr_view_returns_none_for_missing_pr(tmp_path: Path) -> None:
+def test_gh_pr_view_raises_without_remote(tmp_path: Path) -> None:
     repo = _make_repo_with_main(tmp_path)
-    # No GitHub remote → gh fails → wrapper returns None instead of raising.
-    assert git_ops.gh_pr_view(repo, 999999) is None
+    with pytest.raises(GitError, match="no git remotes found"):
+        git_ops.gh_pr_view(repo, 999999)
 
 
 @gh_required
-def test_gh_pr_list_for_branch_returns_empty_without_remote(tmp_path: Path) -> None:
+def test_gh_pr_list_for_branch_raises_without_remote(tmp_path: Path) -> None:
     repo = _make_repo_with_main(tmp_path)
-    assert git_ops.gh_pr_list_for_branch(repo, "main") == []
+    with pytest.raises(GitError, match="no git remotes found"):
+        git_ops.gh_pr_list_for_branch(repo, "main")
 
 
 @gh_required
@@ -1403,6 +1489,176 @@ def test_diff_paths_raises_on_invalid_ref(tmp_path: Path) -> None:
 # --- gh_api(input_data=...) and gh_pr_view(pr=None) -------------------------
 # These tests exercise wrapper logic, not gh itself: subprocess is monkeypatched
 # to capture argv and drive success/failure paths deterministically.
+
+
+def test_gh_pr_queries_request_only_legacy_fields(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo = _make_repo_with_main(tmp_path)
+    calls: list[list[str]] = []
+
+    def fake_run(cmd: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        calls.append(cmd)
+        stdout = "{}" if cmd[1:3] == ["pr", "view"] else "[]"
+        return subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr="")
+
+    monkeypatch.setattr("daydream.git_ops.subprocess.run", fake_run)
+    assert git_ops.gh_pr_view(repo) == {}
+    assert git_ops.gh_pr_list_for_branch(repo, "feature") == []
+
+    assert calls[0][calls[0].index("--json") + 1].split(",") == list(git_ops.GH_PR_VIEW_FIELDS)
+    assert calls[1][calls[1].index("--json") + 1].split(",") == list(git_ops.GH_PR_LIST_FIELDS)
+    assert "baseRefOid" not in git_ops.GH_PR_VIEW_FIELDS
+    assert "baseRefOid" not in git_ops.GH_PR_LIST_FIELDS
+    for fields in (git_ops.GH_PR_VIEW_FIELDS, git_ops.GH_PR_LIST_FIELDS):
+        assert "headRepository" in fields
+        assert "headRepositoryOwner" in fields
+
+
+@pytest.mark.parametrize(
+    ("pr", "stderr"),
+    [
+        (None, 'no pull requests found for branch "feature"\n'),
+        (42, "GraphQL: Could not resolve to a PullRequest with the number of 42. (repository.pullRequest)\n"),
+    ],
+)
+def test_gh_pr_view_returns_none_only_for_anchored_absence(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    pr: int | None,
+    stderr: str,
+) -> None:
+    repo = _make_repo_with_main(tmp_path)
+    monkeypatch.setattr(
+        "daydream.git_ops.subprocess.run",
+        lambda cmd, **kwargs: subprocess.CompletedProcess(cmd, 1, stdout="", stderr=stderr),
+    )
+    assert git_ops.gh_pr_view(repo, pr) is None
+
+
+@pytest.mark.parametrize(
+    "stderr",
+    [
+        "no git remotes found",
+        "HTTP 401: authentication required",
+        "Unknown JSON field: futureField",
+        "GraphQL: Could not resolve to a PullRequest with the number of 41. (repository.pullRequest)",
+        'prefix: no pull requests found for branch "feature"',
+        "HTTP 404: resource not found",
+    ],
+)
+def test_gh_pr_view_unknown_failures_raise(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, stderr: str
+) -> None:
+    repo = _make_repo_with_main(tmp_path)
+    monkeypatch.setattr(
+        "daydream.git_ops.subprocess.run",
+        lambda cmd, **kwargs: subprocess.CompletedProcess(cmd, 1, stdout="", stderr=stderr),
+    )
+    with pytest.raises(GitError, match=re.escape(stderr)):
+        git_ops.gh_pr_view(repo, 42)
+
+
+@pytest.mark.parametrize("stdout", ["not-json", "[]", "null", "42"])
+def test_gh_pr_view_rejects_invalid_json_shape(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, stdout: str
+) -> None:
+    repo = _make_repo_with_main(tmp_path)
+    monkeypatch.setattr(
+        "daydream.git_ops.subprocess.run",
+        lambda cmd, **kwargs: subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr=""),
+    )
+    with pytest.raises(GitError, match="invalid JSON|JSON object"):
+        git_ops.gh_pr_view(repo, 42)
+
+
+@pytest.mark.parametrize("stdout", ["not-json", "{}", "[42]", '[{"number": 1}, null]'])
+def test_gh_pr_list_rejects_failure_and_invalid_shape(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, stdout: str
+) -> None:
+    repo = _make_repo_with_main(tmp_path)
+    monkeypatch.setattr(
+        "daydream.git_ops.subprocess.run",
+        lambda cmd, **kwargs: subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr=""),
+    )
+    with pytest.raises(GitError, match="invalid JSON|JSON list|row"):
+        git_ops.gh_pr_list_for_branch(repo, "feature")
+
+
+def test_gh_pr_list_nonzero_uses_gh_error_classifier(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo = _make_repo_with_main(tmp_path)
+    monkeypatch.setattr(
+        "daydream.git_ops.subprocess.run",
+        lambda cmd, **kwargs: subprocess.CompletedProcess(
+            cmd, 1, stdout="", stderr="rate limit exceeded; retry-after: 7"
+        ),
+    )
+    with pytest.raises(git_ops.RateLimitError) as excinfo:
+        git_ops.gh_pr_list_for_branch(repo, "feature")
+    assert excinfo.value.retry_after == 7
+
+
+@pytest.mark.parametrize("slug", ["owner", "owner/repo/extra", "owner/ ", " owner/repo", "/repo"])
+def test_gh_repo_view_required_rejects_invalid_slug(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, slug: str
+) -> None:
+    repo = _make_repo_with_main(tmp_path)
+    monkeypatch.setattr(
+        "daydream.git_ops.subprocess.run",
+        lambda cmd, **kwargs: subprocess.CompletedProcess(cmd, 0, stdout=slug + "\n", stderr=""),
+    )
+    with pytest.raises(GitError, match="invalid repository slug"):
+        git_ops.gh_repo_view_required(repo)
+
+
+def test_gh_repo_view_required_returns_exact_slug(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo = _make_repo_with_main(tmp_path)
+    monkeypatch.setattr(
+        "daydream.git_ops.subprocess.run",
+        lambda cmd, **kwargs: subprocess.CompletedProcess(cmd, 0, stdout="Owner/Repo\n", stderr=""),
+    )
+    assert git_ops.gh_repo_view_required(repo) == ("Owner", "Repo")
+
+
+def test_gh_repo_view_required_preserves_safe_failure_diagnostic(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo = _make_repo_with_main(tmp_path)
+    monkeypatch.setattr(
+        "daydream.git_ops.subprocess.run",
+        lambda cmd, **kwargs: subprocess.CompletedProcess(
+            cmd,
+            1,
+            stdout="",
+            stderr="HTTP 401: authentication required for token ghp_abcdefghijklmnopqrstuvwxyz1234567890",
+        ),
+    )
+
+    with pytest.raises(GitError) as excinfo:
+        git_ops.gh_repo_view_required(repo)
+    assert "authentication required" in str(excinfo.value)
+    assert "ghp_abcdefghijklmnopqrstuvwxyz1234567890" not in str(excinfo.value)
+
+
+@gh_required
+@pytest.mark.parametrize("fields", ["view", "list"])
+def test_installed_gh_accepts_production_pr_fields_without_network(
+    tmp_path: Path, fields: str
+) -> None:
+    repo = _make_repo_with_main(tmp_path)
+    selected = git_ops.GH_PR_VIEW_FIELDS if fields == "view" else git_ops.GH_PR_LIST_FIELDS
+    proc = subprocess.run(
+        ["gh", "pr", fields, "--json", ",".join(selected)],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert "Unknown JSON field" not in proc.stderr
 
 
 def test_gh_api_input_data_passes_tempfile_and_cleans_up(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -2014,6 +2270,26 @@ def test_gh_api_jq_invalid_line_raises_git_error(monkeypatch: pytest.MonkeyPatch
 # --- gh secret/variable/PR primitives (Task 2) ------------------------------
 
 from tests.harness.fake_gh import FakeGh  # noqa: E402
+
+
+@pytest.mark.parametrize("extra_field", ["baseRefOid", "futureCompatibilityFloor"])
+@pytest.mark.parametrize("query_kind", ["view", "list"])
+def test_fake_gh_rejects_every_field_outside_legacy_allowlist(
+    fake_gh: FakeGh,
+    git_repo: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    query_kind: str,
+    extra_field: str,
+) -> None:
+    fake_gh.serve_pr_view({"number": 7})
+    constant = "GH_PR_VIEW_FIELDS" if query_kind == "view" else "GH_PR_LIST_FIELDS"
+    monkeypatch.setattr(git_ops, constant, (*getattr(git_ops, constant), extra_field))
+
+    with pytest.raises(GitError, match=rf'Unknown JSON field: "{extra_field}"'):
+        if query_kind == "view":
+            git_ops.gh_pr_view(git_repo, 7)
+        else:
+            git_ops.gh_pr_list_for_branch(git_repo, "feature")
 
 
 def test_gh_secret_set_requires_exactly_one_scope(fake_gh: FakeGh, git_repo: Path) -> None:

--- a/tests/test_git_ops.py
+++ b/tests/test_git_ops.py
@@ -1372,6 +1372,19 @@ _gh_available = shutil.which("gh") is not None
 gh_required = pytest.mark.skipif(not _gh_available, reason="gh CLI not installed")
 
 
+@pytest.fixture
+def local_only_gh(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Reach local remote discovery without depending on host authentication.
+
+    These repositories have no remotes, so gh fails before making a request.
+    The synthetic token only suppresses its earlier login/configuration gate.
+    """
+    monkeypatch.setenv("GH_CONFIG_DIR", str(tmp_path / "isolated-gh-config"))
+    monkeypatch.setenv("GH_HOST", "github.com")
+    monkeypatch.setenv("GH_TOKEN", "test-local-only-no-network")
+    monkeypatch.delenv("GH_REPO", raising=False)
+
+
 @gh_required
 def test_gh_repo_view_returns_none_outside_github_repo(tmp_path: Path) -> None:
     """A local-only repo with no GitHub remote yields ``None``."""
@@ -1380,6 +1393,7 @@ def test_gh_repo_view_returns_none_outside_github_repo(tmp_path: Path) -> None:
 
 
 @gh_required
+@pytest.mark.usefixtures("local_only_gh")
 def test_gh_pr_view_raises_without_remote(tmp_path: Path) -> None:
     repo = _make_repo_with_main(tmp_path)
     with pytest.raises(GitError, match="no git remotes found"):
@@ -1387,6 +1401,7 @@ def test_gh_pr_view_raises_without_remote(tmp_path: Path) -> None:
 
 
 @gh_required
+@pytest.mark.usefixtures("local_only_gh")
 def test_gh_pr_list_for_branch_raises_without_remote(tmp_path: Path) -> None:
     repo = _make_repo_with_main(tmp_path)
     with pytest.raises(GitError, match="no git remotes found"):

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -23,6 +23,7 @@ from daydream.trajectory import DaydreamPhase
 from daydream.ui import NEON_THEME
 from daydream.workspace import WorkContext
 from tests.harness.backend import ScriptedBackend
+from tests.harness.fake_gh import FakeGh
 from tests.harness.git_helpers import bare_remote
 from tests.harness.git_helpers import commit as _commit
 from tests.harness.git_helpers import git as _git
@@ -622,6 +623,7 @@ async def test_run_comment_full_flow(
         console: Any,
         post: Any,
         approve_on_clean: Any=False,
+        pr_number: int | None = None,
         diagram_blocks: Any=None,
     ) -> None:
         posted.extend(json.loads(merged_items_path.read_text())["items"])
@@ -641,6 +643,131 @@ async def test_run_comment_full_flow(
     assert any(item.get("file") for item in posted), posted
     # The diff was materialised for the review prompts.
     assert (tmp_path / ".daydream" / "diff.patch").exists()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("pr_number", [None, 7], ids=["branch", "explicit"])
+async def test_run_comment_resolves_pr_through_real_cli_boundary(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    make_config: Callable[..., "RunConfig"],
+    fake_gh: FakeGh,
+    pr_number: int | None,
+) -> None:
+    """Production runner, PR assembly, and posting use one explicit checkout."""
+    from tests.test_deep_orchestrator import _install_stub_backend, _silence
+
+    _two_commit_repo(tmp_path, "api.py", "print('hello')", "print('world')", "feat/test")
+    head = _git(tmp_path, "rev-parse", "HEAD")
+    fake_gh.serve_pr_view(
+        {
+            "number": 7,
+            "title": "Change greeting",
+            "body": "",
+            "state": "OPEN",
+            "headRefName": "feat/test",
+            "baseRefName": "main",
+            "headRefOid": head,
+            "url": "https://github.test/acme/widgets/pull/7",
+            "headRepository": {
+                "name": "widgets",
+                "nameWithOwner": "acme/widgets",
+            },
+            "headRepositoryOwner": {"login": "acme"},
+        }
+    )
+    _silence(monkeypatch)
+    _install_stub_backend(monkeypatch, tmp_path)
+
+    exit_code = await run(
+        make_config(tmp_path, output_mode="comment", pr_number=pr_number)
+    )
+
+    assert exit_code == 0
+    review_calls = fake_gh.calls("POST", "repos/acme/widgets/pulls/7/reviews")
+    assert len(review_calls) == 1
+    assert review_calls[0].payload["commit_id"] == head
+    assert review_calls[0].payload["comments"][0]["path"] == "api.py"
+    assert fake_gh.process_calls()
+    assert {call.cwd for call in fake_gh.process_calls()} == {tmp_path.resolve()}
+    list_calls = [
+        call for call in fake_gh.process_calls() if call.argv[1:3] == ["pr", "list"]
+    ]
+    if pr_number is None:
+        assert len(list_calls) == 1
+        assert "baseRefOid" not in list_calls[0].argv
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("pr_number", [None, 7], ids=["branch", "explicit"])
+@pytest.mark.parametrize("outcome", ["auth_failure", "schema_failure", "malformed_head", "absence"])
+async def test_run_comment_pr_lookup_failure_and_absence_exit_nonzero(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    make_config: Callable[..., "RunConfig"],
+    fake_gh: FakeGh,
+    pr_number: int | None,
+    outcome: str,
+) -> None:
+    """Both lookup modes fail closed without attempting a review POST."""
+    from tests.test_deep_orchestrator import _install_stub_backend, _silence
+
+    _two_commit_repo(tmp_path, "app.py", "print('hello')", "print('world')", "feat/test")
+    if outcome == "malformed_head":
+        fake_gh.serve_pr_view({
+            "number": 7, "title": "Change greeting", "body": "", "state": "OPEN",
+            "headRefName": "feat/test", "baseRefName": "main",
+            "headRefOid": _git(tmp_path, "rev-parse", "HEAD"),
+            "url": "https://github.test/acme/widgets/pull/7",
+            "headRepository": {}, "headRepositoryOwner": {"login": "acme"},
+        })
+    elif pr_number is None and outcome == "absence":
+        fake_gh.set_response("pr-list", value=[])
+    else:
+        diagnostic = (
+            "authentication required"
+            if outcome == "auth_failure"
+            else 'Unknown JSON field: "futureCompatibilityFloor"'
+        )
+        if outcome == "absence":
+            diagnostic = (
+                "GraphQL: Could not resolve to a PullRequest with the number of 7. "
+                "(repository.pullRequest)"
+            )
+        fake_gh.set_response("pr-view", value={"__error__": diagnostic})
+        if pr_number is None:
+            fake_gh.set_response("pr-list", value={"__error__": diagnostic})
+    _silence(monkeypatch)
+    _install_stub_backend(monkeypatch, tmp_path)
+    errors: list[str] = []
+    warnings: list[str] = []
+    monkeypatch.setattr(
+        "daydream.pr_review.print_error",
+        lambda _console, _title, message: errors.append(message),
+    )
+    monkeypatch.setattr(
+        "daydream.pr_review.print_warning",
+        lambda _console, message: warnings.append(message),
+    )
+
+    exit_code = await run(
+        make_config(tmp_path, output_mode="comment", pr_number=pr_number)
+    )
+
+    assert exit_code == 1
+    assert fake_gh.calls("POST", "repos/acme/widgets/pulls/7/reviews") == []
+    messages = errors + warnings
+    if outcome != "absence":
+        expected = (
+            "authentication required"
+            if outcome == "auth_failure"
+            else "invalid PR row" if outcome == "malformed_head" else "futureCompatibilityFloor"
+        )
+        assert any(expected in message for message in messages)
+        assert all("No open PR found" not in message for message in messages)
+    else:
+        expected = "No open PR found" if pr_number is None else "PR #7 not found"
+        assert any(expected in message for message in messages)
 
 
 @pytest.mark.asyncio

--- a/tests/test_post_findings_integration.py
+++ b/tests/test_post_findings_integration.py
@@ -15,6 +15,7 @@ in-process bookkeeping.
 from __future__ import annotations
 
 import json
+import os
 import sys
 from pathlib import Path
 from typing import Any
@@ -25,7 +26,7 @@ from daydream import cli
 from daydream.findings import FINDINGS_SCHEMA_VERSION, write_findings_artifact
 from daydream.pr_review import parse_finding_markers, validate_diagram_payload
 from tests.harness.fake_gh import FakeGh
-from tests.harness.git_helpers import commit, git
+from tests.harness.git_helpers import commit, git, init_repo
 
 
 def cli_main(argv: list[str]) -> int:
@@ -42,7 +43,7 @@ def cli_main(argv: list[str]) -> int:
 
 
 def _post_argv(
-    artifact: Path, *, pr: int = 7, head_sha: str | None = None
+    artifact: Path, *, pr: int = 7, head_sha: str | None = None, target: Path | None = None,
 ) -> list[str]:
     """The ``post-findings`` argv for *artifact*; override only what a test varies."""
     return [
@@ -54,7 +55,83 @@ def _post_argv(
         head_sha or "h" * 40,
         "--repo",
         "o/r",
+        *(["--target", str(target)] if target is not None else []),
     ]
+
+
+def test_post_findings_uses_two_explicit_checkout_configs_without_chdir(
+    fake_gh: FakeGh, tmp_path: Path,
+) -> None:
+    ambient = Path.cwd()
+    targets = [tmp_path / "checkout A", tmp_path / "checkout B"]
+    for target in targets:
+        init_repo(target)
+    fake_gh.serve_prior_threads(
+        fingerprints=["a" * 64], thread_ids=["RT_OLD"], viewer_did_author=True,
+    )
+    for index, target in enumerate(targets):
+        (target / ".daydream.toml").write_text(f"approve_on_clean = {'true' if index == 0 else 'false'}\n")
+        artifact = _write_artifact(target / "findings.json", [
+            _finding(
+                ("b" if index == 0 else "c") * 64, path="a.py", line=1,
+                placement="inline", title=f"Checkout {index} finding", severity="low",
+            ),
+        ])
+        before = len(fake_gh.process_calls())
+        # The second invocation pins relative paths with spaces against the
+        # unchanged ambient cwd, not against the artifact or first checkout.
+        argument = target if index == 0 else Path(os.path.relpath(target, ambient))
+        assert cli_main(_post_argv(artifact, target=argument)) == 0
+        processes = fake_gh.process_calls()[before:]
+        assert processes and all(call.cwd == target.resolve() for call in processes)
+        assert Path.cwd() == ambient
+    posts = fake_gh.calls("POST", "/repos/o/r/pulls/7/reviews")
+    assert [call.payload["event"] for call in posts] == ["APPROVE", "COMMENT"]
+    assert [call.payload["comments"][0]["path"] for call in posts] == ["a.py", "a.py"]
+    assert sum("minimizeComment" in call.payload.get("query", "")
+               for call in fake_gh.calls("POST", "graphql")) == 2
+
+
+@pytest.mark.parametrize("target_kind", ["missing", "file"])
+def test_post_findings_rejects_invalid_target_before_github(
+    fake_gh: FakeGh, tmp_path: Path, capsys: pytest.CaptureFixture[str], target_kind: str,
+) -> None:
+    target = tmp_path / target_kind
+    if target_kind == "file":
+        target.write_text("not a directory")
+    artifact = _write_artifact(tmp_path / "findings.json", [])
+    assert cli_main(_post_argv(artifact, target=target)) == 2
+    assert "--target must be an existing directory" in capsys.readouterr().err
+    assert fake_gh.process_calls() == []
+
+
+def test_post_findings_omitted_target_preserves_invocation_directory(
+    fake_gh: FakeGh, artifact_on_disk: Path,
+) -> None:
+    assert cli_main(_post_argv(artifact_on_disk)) == 0
+    assert fake_gh.process_calls()
+    assert all(call.cwd == Path.cwd().resolve() for call in fake_gh.process_calls())
+    assert len(fake_gh.calls("POST", "/repos/o/r/pulls/7/reviews")) == 1
+
+
+def test_post_findings_reads_valid_diagram_evidence_from_explicit_target(
+    fake_gh: FakeGh, git_repo: Path,
+) -> None:
+    ambient = Path.cwd()
+    (git_repo / "a.py").write_text("def run():\n    return 1\n")
+    git(git_repo, "add", "a.py")
+    head = commit(git_repo, "seed diagram evidence")
+    artifact = _write_artifact(
+        git_repo / "findings.json", [], diagrams=_flowchart_payload(), head_sha=head,
+    )
+    assert cli_main(_post_argv(artifact, head_sha=head, target=git_repo)) == 0
+    assert Path.cwd() == ambient
+    posts = fake_gh.calls("POST", "/repos/o/r/pulls/7/reviews")
+    assert len(posts) == 1
+    assert "```mermaid" in posts[0].payload["body"]
+    assert posts[0].payload["commit_id"] == head
+    assert fake_gh.process_calls()
+    assert all(call.cwd == git_repo.resolve() for call in fake_gh.process_calls())
 
 
 def _finding(
@@ -423,7 +500,6 @@ def test_malformed_artifact_aborts(fake_gh: FakeGh, tmp_path: Path) -> None:
 def test_malformed_repo_config_warns_and_still_posts(
     fake_gh: FakeGh,
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """A malformed .daydream.toml in the checkout must not abort the unattended post.
 
@@ -431,10 +507,9 @@ def test_malformed_repo_config_warns_and_still_posts(
     approve-on-clean lookup is best-effort, so a malformed TOML degrades to a
     warning plus the CLI flag instead of a Fatal Error (exit 1).
     """
-    monkeypatch.chdir(tmp_path)
     (tmp_path / ".daydream.toml").write_text("this is [not valid toml ==")
     artifact = _write_single_finding_artifact(tmp_path, "a" * 64)
-    code = cli_main(_forged_marker_argv(artifact))
+    code = cli_main(_forged_marker_argv(artifact, "--target", str(tmp_path)))
     assert code == 0
     assert len(fake_gh.calls("POST", "/repos/o/r/pulls/7/reviews")) == 1
 
@@ -616,12 +691,11 @@ def test_post_findings_all_matched_no_approve_without_flag(
 
 
 def test_post_findings_rejects_forged_diagram_grounding_attestation(
-    fake_gh: FakeGh, git_repo: Path, monkeypatch: pytest.MonkeyPatch
+    fake_gh: FakeGh, git_repo: Path,
 ) -> None:
     (git_repo / "a.py").write_text("def run():\n    return 1\n")
     git(git_repo, "add", "a.py")
     head_sha = commit(git_repo, "add flowchart source")
-    monkeypatch.chdir(git_repo)
     payload = _flowchart_payload()
     flowchart = payload["results"]["flowchart"]
     flowchart["spec_final"]["nodes"] = [
@@ -703,7 +777,7 @@ def test_post_findings_rejects_forged_diagram_grounding_attestation(
     )
 
     code = cli_main(
-        _post_argv(artifact, head_sha=head_sha) + ["--bot-login", "daydream"]
+        _post_argv(artifact, head_sha=head_sha, target=git_repo) + ["--bot-login", "daydream"]
     )
 
     assert code == 1
@@ -711,7 +785,7 @@ def test_post_findings_rejects_forged_diagram_grounding_attestation(
 
 
 def test_post_findings_rejects_forged_sequence_grounding_attestation(
-    fake_gh: FakeGh, git_repo: Path, monkeypatch: pytest.MonkeyPatch
+    fake_gh: FakeGh, git_repo: Path,
 ) -> None:
     (git_repo / "api.py").write_text(
         "from worker import worker\n"
@@ -726,7 +800,6 @@ def test_post_findings_rejects_forged_sequence_grounding_attestation(
     )
     git(git_repo, "add", "api.py", "worker.py")
     head_sha = commit(git_repo, "add sequence source")
-    monkeypatch.chdir(git_repo)
     payload = _sequence_payload()
     assert validate_diagram_payload(payload, target_dir=git_repo, head_sha=head_sha) is None
     payload["results"]["sequence"]["spec_final"]["messages"][0]["evidence"] = {
@@ -738,19 +811,18 @@ def test_post_findings_rejects_forged_sequence_grounding_attestation(
         git_repo / "findings.json", [], diagrams=payload, head_sha=head_sha
     )
 
-    code = cli_main(_post_argv(artifact, head_sha=head_sha))
+    code = cli_main(_post_argv(artifact, head_sha=head_sha, target=git_repo))
 
     assert code == 1
     assert fake_gh.calls("POST") == []
 
 
 def test_post_findings_rejects_diagram_evidence_absent_from_immutable_head(
-    fake_gh: FakeGh, git_repo: Path, monkeypatch: pytest.MonkeyPatch
+    fake_gh: FakeGh, git_repo: Path,
 ) -> None:
     (git_repo / "a.py").write_text("def run():\n    return 1\n")
     git(git_repo, "add", "a.py")
     head_sha = commit(git_repo, "add flowchart source")
-    monkeypatch.chdir(git_repo)
 
     payload = _flowchart_payload()
     flowchart = payload["results"]["flowchart"]
@@ -766,7 +838,7 @@ def test_post_findings_rejects_diagram_evidence_absent_from_immutable_head(
     )
 
     code = cli_main(
-        _post_argv(artifact, head_sha=head_sha) + ["--bot-login", "daydream"]
+        _post_argv(artifact, head_sha=head_sha, target=git_repo) + ["--bot-login", "daydream"]
     )
 
     assert code == 1

--- a/tests/test_pr_review.py
+++ b/tests/test_pr_review.py
@@ -12,6 +12,7 @@ import pytest
 
 from daydream import git_ops, pr_comment_renderer, pr_review
 from daydream.findings import ArtifactFinding
+from daydream.git_ops import GitError
 from daydream.pr_review import (
     DAYDREAM_FOOTER,
     ParsedIssue,
@@ -826,26 +827,39 @@ def test_find_open_pr_returns_none_on_empty_list(
     assert pr_review.find_open_pr(git_repo) is None
 
 
+def _local_pr_row(repo: Path, *, head_owner: str = "o") -> tuple[dict[str, Any], str, str]:
+    base = git_ops.head_sha(repo)
+    _git(repo, "checkout", "-b", "feature")
+    (repo / "feature.py").write_text("value = 1\n")
+    _git(repo, "add", "feature.py")
+    _git(repo, "commit", "-m", "feature")
+    head = git_ops.head_sha(repo)
+    return (
+        {
+            "number": 7,
+            "headRefOid": head,
+            "baseRefName": "main",
+            "url": "https://github.com/o/r/pull/7",
+            "headRepository": {"name": "r", "nameWithOwner": f"{head_owner}/r"},
+            "headRepositoryOwner": {"login": head_owner},
+        },
+        base,
+        head,
+    )
+
+
 def test_find_open_pr_returns_pr_info(
     monkeypatch: pytest.MonkeyPatch, git_repo: Path
 ) -> None:
     """Real git for branch; gh wrappers stubbed for the PR + repo lookups."""
-    rows = [
-        {
-            "number": 7,
-            "headRefOid": "h",
-            "baseRefOid": "b",
-            "baseRefName": "main",
-            "url": "u",
-        }
-    ]
-    monkeypatch.setattr(git_ops, "gh_pr_list_for_branch", lambda *_a, **_k: rows)
-    monkeypatch.setattr(git_ops, "gh_repo_view", lambda _r: ("o", "r"))
+    row, base, head = _local_pr_row(git_repo)
+    monkeypatch.setattr(git_ops, "gh_pr_list_for_branch", lambda *_a, **_k: [row])
+    monkeypatch.setattr(git_ops, "gh_repo_view_required", lambda _r: ("o", "r"))
     info = pr_review.find_open_pr(git_repo)
     assert info is not None
-    assert info.number == 7
-    assert info.owner == "o"
-    assert info.repo == "r"
+    assert (info.number, info.head_sha, info.base_sha, info.owner, info.repo) == (
+        7, head, base, "o", "r",
+    )
 
 
 def test_find_open_pr_captures_head_repo_for_fork_pr(
@@ -854,19 +868,10 @@ def test_find_open_pr_captures_head_repo_for_fork_pr(
     """Fork-head PR: the row's headRepository/headRepositoryOwner (the fork)
     is captured as ``head_repo`` for the reviewed-commit link, while
     owner/repo (the POST target) stay the base repo from ``gh repo view``."""
-    rows = [
-        {
-            "number": 7,
-            "headRefOid": "h",
-            "baseRefOid": "b",
-            "baseRefName": "main",
-            "url": "u",
-            "headRepository": {"name": "widgets", "nameWithOwner": "forky/widgets"},
-            "headRepositoryOwner": {"login": "forky"},
-        }
-    ]
-    monkeypatch.setattr(git_ops, "gh_pr_list_for_branch", lambda *_a, **_k: rows)
-    monkeypatch.setattr(git_ops, "gh_repo_view", lambda _r: ("acme", "widgets"))
+    row, _, _ = _local_pr_row(git_repo, head_owner="forky")
+    row["headRepository"] = {"name": "widgets", "nameWithOwner": "forky/widgets"}
+    monkeypatch.setattr(git_ops, "gh_pr_list_for_branch", lambda *_a, **_k: [row])
+    monkeypatch.setattr(git_ops, "gh_repo_view_required", lambda _r: ("acme", "widgets"))
     info = pr_review.find_open_pr(git_repo)
     assert info is not None
     assert (info.owner, info.repo) == ("acme", "widgets")
@@ -881,32 +886,168 @@ def test_find_pr_by_number_returns_none_when_pr_missing(
     assert pr_review.find_pr_by_number(git_repo, 7) is None
 
 
-def test_find_pr_by_number_returns_none_when_slug_unresolved(
+def test_find_pr_by_number_raises_when_slug_unresolved(
     monkeypatch: pytest.MonkeyPatch, git_repo: Path
 ) -> None:
-    """A resolvable PR but unresolvable owner/repo slug yields None (no PRInfo)."""
-    monkeypatch.setattr(git_ops, "gh_pr_view", lambda *_a, **_k: {"number": 7})
-    monkeypatch.setattr(git_ops, "gh_repo_view", lambda _r: None)
-    assert pr_review.find_pr_by_number(git_repo, 7) is None
+    """A resolvable PR but failed owner/repo lookup is a hard error."""
+    row, _, _ = _local_pr_row(git_repo)
+    monkeypatch.setattr(git_ops, "gh_pr_view", lambda *_a, **_k: row)
+
+    def fail_slug(_repo: Path) -> tuple[str, str]:
+        raise GitError("gh repo view failed: auth")
+
+    monkeypatch.setattr(git_ops, "gh_repo_view_required", fail_slug)
+    with pytest.raises(GitError, match="auth"):
+        pr_review.find_pr_by_number(git_repo, 7)
 
 
 def test_find_pr_by_number_assembles_pr_info(
     monkeypatch: pytest.MonkeyPatch, git_repo: Path
 ) -> None:
     """Valid lookups assemble a fully-populated PRInfo from the gh view row."""
-    monkeypatch.setattr(git_ops, "gh_pr_view", lambda *_a, **_k: {
-        "number": 7,
-        "headRefOid": "h",
-        "baseRefOid": "b",
-        "baseRefName": "main",
-        "url": "u",
-    })
-    monkeypatch.setattr(git_ops, "gh_repo_view", lambda _r: ("o", "r"))
+    row, base, head = _local_pr_row(git_repo, head_owner="forky")
+    monkeypatch.setattr(git_ops, "gh_pr_view", lambda *_a, **_k: row)
+    monkeypatch.setattr(git_ops, "gh_repo_view_required", lambda _r: ("o", "r"))
     info = pr_review.find_pr_by_number(git_repo, 7)
     assert info is not None
-    assert (info.number, info.head_sha, info.base_sha, info.base_ref, info.owner, info.repo, info.url) == (
-        7, "h", "b", "main", "o", "r", "u",
+    assert (
+        info.number, info.head_sha, info.base_sha, info.base_ref,
+        info.owner, info.repo, info.url, info.head_repo,
+    ) == (
+        7, head, base, "main", "o", "r", "https://github.com/o/r/pull/7", "forky/r",
     )
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("number", True),
+        ("number", 0),
+        ("headRefOid", "HEAD"),
+        ("headRefOid", "deadbeef"),
+        ("baseRefName", ""),
+        ("baseRefName", "main~1"),
+        ("url", ""),
+        ("url", 7),
+        ("headRepository", "fork/r"),
+        ("headRepository", {"nameWithOwner": "fork/r/extra"}),
+        ("headRepository", {}),
+        ("headRepository", {"nameWithOwner": 7, "name": "r"}),
+        ("headRepositoryOwner", {}),
+        ("headRepositoryOwner", {"login": 7}),
+        ("headRepositoryOwner", {"login": ""}),
+        ("headRepositoryOwner", "fork"),
+    ],
+)
+def test_pr_info_rejects_malformed_row_fields(
+    monkeypatch: pytest.MonkeyPatch,
+    git_repo: Path,
+    field: str,
+    value: Any,
+) -> None:
+    row, _, _ = _local_pr_row(git_repo)
+    row[field] = value
+    monkeypatch.setattr(git_ops, "gh_repo_view_required", lambda _r: ("o", "r"))
+    with pytest.raises(GitError, match="invalid PR row|base branch|exact PR head"):
+        pr_review._pr_info_from_row(git_repo, row)
+
+
+@pytest.mark.parametrize("missing_field", ["headRepository", "headRepositoryOwner"])
+def test_pr_info_rejects_missing_requested_head_metadata(
+    monkeypatch: pytest.MonkeyPatch, git_repo: Path, missing_field: str,
+) -> None:
+    row, _, _ = _local_pr_row(git_repo)
+    del row[missing_field]
+    monkeypatch.setattr(git_ops, "gh_repo_view_required", lambda _r: ("o", "r"))
+    with pytest.raises(GitError, match="invalid PR row"):
+        pr_review._pr_info_from_row(git_repo, row)
+
+
+def test_pr_info_rejects_malformed_owner_even_with_null_head_repository(
+    monkeypatch: pytest.MonkeyPatch, git_repo: Path,
+) -> None:
+    row, _, _ = _local_pr_row(git_repo)
+    row["headRepository"] = None
+    row["headRepositoryOwner"] = {"login": 7}
+    monkeypatch.setattr(git_ops, "gh_repo_view_required", lambda _r: ("o", "r"))
+    with pytest.raises(GitError, match="invalid PR row"):
+        pr_review._pr_info_from_row(git_repo, row)
+
+
+@pytest.mark.parametrize("head_owner", [None, {"login": "former-owner"}])
+def test_pr_info_accepts_null_same_repo_head_metadata(
+    monkeypatch: pytest.MonkeyPatch, git_repo: Path, head_owner: Any,
+) -> None:
+    row, _, _ = _local_pr_row(git_repo)
+    row["headRepository"] = None
+    row["headRepositoryOwner"] = head_owner
+    monkeypatch.setattr(git_ops, "gh_repo_view_required", lambda _r: ("o", "r"))
+
+    assert pr_review._pr_info_from_row(git_repo, row).head_repo is None
+
+
+def test_find_open_pr_propagates_current_branch_failure(
+    monkeypatch: pytest.MonkeyPatch, git_repo: Path
+) -> None:
+    def fail_branch(_repo: Path) -> str | None:
+        raise GitError("cannot read current branch")
+
+    monkeypatch.setattr(git_ops, "current_branch", fail_branch)
+    with pytest.raises(GitError, match="cannot read current branch"):
+        pr_review.find_open_pr(git_repo)
+
+
+@pytest.mark.parametrize("lookup", ["branch", "number"])
+def test_fork_pr_uses_upstream_base_for_both_lookup_paths(
+    monkeypatch: pytest.MonkeyPatch, git_repo: Path, lookup: str
+) -> None:
+    row, base, _ = _local_pr_row(git_repo, head_owner="forky")
+    _git(git_repo, "remote", "add", "origin", "https://github.com/forky/r.git")
+    _git(git_repo, "remote", "add", "upstream", "https://github.com/acme/widgets.git")
+    _git(git_repo, "update-ref", "refs/remotes/upstream/main", base)
+    monkeypatch.setattr(git_ops, "gh_repo_view_required", lambda _r: ("acme", "widgets"))
+    monkeypatch.setattr(git_ops, "gh_pr_list_for_branch", lambda *_a, **_k: [row])
+    monkeypatch.setattr(git_ops, "gh_pr_view", lambda *_a, **_k: row)
+
+    info = (
+        pr_review.find_open_pr(git_repo)
+        if lookup == "branch"
+        else pr_review.find_pr_by_number(git_repo, 7)
+    )
+    assert info is not None
+    assert info.base_sha == base
+    assert info.head_repo == "forky/r"
+
+
+def test_pr_base_remote_matching_is_credential_safe(
+    monkeypatch: pytest.MonkeyPatch, git_repo: Path
+) -> None:
+    row, base, _ = _local_pr_row(git_repo)
+    tree = _git(git_repo, "write-tree")
+    unrelated = _git(git_repo, "commit-tree", tree, "-m", "unrelated base")
+    _git(
+        git_repo,
+        "remote",
+        "add",
+        "origin",
+        "https://user:top-secret@github.com/acme/widgets.git?token=private",
+    )
+    _git(git_repo, "update-ref", "refs/remotes/origin/main", unrelated)
+    monkeypatch.setattr(git_ops, "gh_repo_view_required", lambda _r: ("acme", "widgets"))
+
+    with pytest.raises(GitError) as excinfo:
+        pr_review._pr_info_from_row(git_repo, row)
+    assert "top-secret" not in str(excinfo.value)
+    assert "token=private" not in str(excinfo.value)
+
+    _git(
+        git_repo,
+        "remote",
+        "set-url",
+        "origin",
+        "https://user:fork-secret@github.com/forky/widgets.git?token=fork",
+    )
+    assert pr_review._pr_info_from_row(git_repo, row).base_sha == base
 
 
 class _FakeConsole:
@@ -932,6 +1073,33 @@ async def test_post_skips_when_no_pr(
     )
     assert warnings and "No open PR" in warnings[0]
     assert status == pr_review.PostStatus.NO_PR
+
+
+@pytest.mark.asyncio
+async def test_post_fails_with_safe_diagnostic_when_pr_lookup_errors(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    def fail_lookup(_target_dir: Path) -> PRInfo | None:
+        raise GitError("gh pr list failed: authentication required")
+
+    monkeypatch.setattr(pr_review, "find_open_pr", fail_lookup)
+    errors: list[tuple[str, str]] = []
+    monkeypatch.setattr(
+        pr_review,
+        "print_error",
+        lambda _console, title, message: errors.append((title, message)),
+    )
+
+    status = await pr_review._post(
+        tmp_path,
+        [ParsedIssue(path="x.py", line=1, title="t", body="b")],
+        console=_FakeConsole(),  # type: ignore[arg-type]
+    )
+
+    assert status == pr_review.PostStatus.FAILED
+    assert errors == [
+        ("PR Lookup Failed", "gh pr list failed: authentication required")
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -21,6 +21,7 @@ from daydream.git_ops import BranchNotFoundError, GitError
 from daydream.workspace import (
     WorkContext,
     WorkspaceCopyPathError,
+    _resolve_base,
     copy_files_into_ephemeral,
     open_audit_workspace,
     open_workspace,
@@ -33,6 +34,20 @@ from tests.harness.git_helpers import git as _git
 from tests.harness.git_helpers import init_repo as _init_repo
 
 # --- Helpers (workspace-specific: bare-origin push plumbing) ----------------
+
+
+def test_resolve_base_falls_back_when_pr_lookup_fails(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr("daydream.workspace.shutil.which", lambda _name: "/bin/gh")
+    monkeypatch.setattr(
+        git_ops,
+        "gh_pr_list_for_branch",
+        lambda *_args: (_ for _ in ()).throw(GitError("gh auth failed")),
+    )
+    monkeypatch.setattr(git_ops, "default_branch", lambda _repo: "trunk")
+
+    assert _resolve_base(tmp_path, "feature", None) == "trunk"
 
 
 def _make_repo_with_origin(tmp_path: Path) -> tuple[Path, Path]:


### PR DESCRIPTION
## Summary

Resolve privileged review posting in an explicit target checkout, and discover PRs using JSON fields supported by older GitHub CLI releases. Treat operational and malformed-data failures as errors, not as missing PRs.

## Motivation

Closes #1006. Closes #1109. `post-findings --target` now controls configuration and all Git/GitHub operations independently of the artifact's location or the caller's directory. Omitted `--target` retains current-directory behavior.

## Changes

- Request only frozen gh 2.45-compatible fields; remove unsupported `baseRefOid` requests and resolve the merge base locally from the exact reviewed head and matching base-repository refs.
- Validate PR identities and fork-head metadata, allowing explicit deleted-repository nulls while rejecting missing or malformed requested data. Prefer matching upstream remotes over a fork's origin, and reject ambiguous divergent base refs.
- Preserve advisory fallback where appropriate, but fail posting and diagram lookup safely on auth, schema, API, or Git resolution errors. Recognize genuine PR absence narrowly.
- Keep the artifact as findings data, never as authority for the privileged checkout/configuration.
- Bound credential-redaction scanning on long untrusted diagnostics while preserving URL schemes and masking userinfo.

## Testing

- Real CLI two-checkout regression verifies target configuration, approval/stale policy, and every GitHub call's working directory. Invalid targets fail before GitHub calls; omitted targets remain compatible.
- Real Git/runner fixtures exercise branch and explicit-number discovery, fork/upstream selection, exact commit IDs, inline placement, malformed metadata, and no-POST failure behavior.
- Installed-gh non-network capability probe plus a frozen fake-field allowlist covers legacy CLI compatibility.
- Independent code review found one malformed-metadata gap; tests reproduced it, the fix passed 23 focused cases, and independent re-review approved.
- Full hooks exposed 15 older integration failures due to three incomplete external GitHub fixtures. The fixtures now supply the real requested head fields; all 47 affected-module tests, Ruff, mypy, and diff checks pass. No production validation or hook was weakened.
- CodeQL exposed a quadratic credential-redaction regex. A bounded subprocess regression reproduced the timeout on 100,000-character diagnostics; the constant-delimiter fix passes all 11 focused redaction cases and CodeQL.
- CI exposed two real-gh tests depending on host login. An isolated gh configuration and synthetic local-only token now reach the exact no-remote failure without a network request; all 208 Git-operation tests pass.
- Current main is integrated. Ordinary signed commits and the final normal hook-enabled push passed full `make check`: 6,522 root tests and 202 standalone tests passed, 89.05% coverage, plus lint, types, dead-code, locks, and workflow checks. Existing skips: 9 root and 2 standalone.
- Executed `daydream . --precision --backend pi --trace-to honeyhive --trace-to langsmith` after PR creation (run `8658fb23-3e1e-4ad4-a5d0-7eef74fc5a0e`), exit 0. Fixed the two stale failure-contract docstrings and redundant validated-slug rebuilding. All 104 PR-review tests, Ruff and mypy passed before the final full hook gate. The suggestion to add a missing-base-history fallback was not adopted: exact local merge-base evidence and no implicit fetch remain intentional, and incomplete checkouts fail with an explicit error rather than being treated as absent PRs. All six CI checks passed on final head `e35a9767a1413f43c0eca44f355e9d8b29884b3f`.

## Checklist

- [x] Production-entrypoint and real-Git acceptance tests.
- [x] Explicit target and fail-closed error behavior documented in CLI/API help.
- [x] No dependency changes or hook bypasses.
