### PR TITLE
fix: preserve authorized supporting files through fix finalization

### DIFF
--- a/daydream/archive/__init__.py
+++ b/daydream/archive/__init__.py
@@ -217,6 +217,7 @@ def _archive_run_inner(
         runs_merge=runs_merge,
         runs_fix=runs_fix,
         runs_test=runs_test,
+        session_id=recorder.session_id,
     )
     pipeline_status = derive_pipeline_status(
         status, fix_failures, phase_states, runs_fix=runs_fix, runs_test=runs_test,

--- a/daydream/archive/pipeline.py
+++ b/daydream/archive/pipeline.py
@@ -49,13 +49,36 @@ def _merge_state(target_dir: Path) -> dict[str, Any]:
     return {"ran": False, "status": _ABSENT}
 
 
-def _fix_state(target_dir: Path, phase_events: list[Any]) -> dict[str, Any]:
-    """Derive the fix terminal state from ``fix-failures.json`` + phase events.
+def _matching_stabilization_failure(
+    target_dir: Path, session_id: str | None
+) -> bool:
+    """Return whether a well-formed terminal failure belongs to this run."""
+    failure = _read_json_artifact(
+        _deep_dir(target_dir) / "stabilization-failed.json", dict
+    )
+    return bool(
+        failure is not None
+        and session_id is not None
+        and failure.get("session_id") == session_id
+        and isinstance(failure.get("reason"), str)
+        and failure["reason"].strip()
+    )
 
-    A present non-empty ``fix-failures.json`` means fix groups were
-    dropped/reverted (partial); otherwise a ``phase_start`` for
-    ``DaydreamPhase.FIX`` marks the fix phase as having run successfully.
+
+def _fix_state(
+    target_dir: Path,
+    phase_events: list[Any],
+    *,
+    stabilization_failed: bool,
+) -> dict[str, Any]:
+    """Derive fix state from stabilization/fix failures and phase events.
+
+    A current-session stabilization failure wins because the retained fix was
+    deliberately rejected.  Otherwise non-empty group failures are partial and
+    a FIX phase start is successful.
     """
+    if stabilization_failed:
+        return {"ran": True, "status": _FAILED}
     fix_failures = _read_json_artifact(_deep_dir(target_dir) / "fix-failures.json", dict)
     if fix_failures:
         return {"ran": True, "status": _PARTIAL}
@@ -66,12 +89,19 @@ def _fix_state(target_dir: Path, phase_events: list[Any]) -> dict[str, Any]:
     return {"ran": False, "status": _ABSENT}
 
 
-def _test_state(target_dir: Path, session_id: str | None) -> dict[str, Any]:
-    """Derive the test terminal state from ``test-verdict.json``.
+def _test_state(
+    target_dir: Path,
+    session_id: str | None,
+    *,
+    stabilization_failed: bool,
+) -> dict[str, Any]:
+    """Derive test state from final stabilization and ``test-verdict.json``.
 
-    The verdict is written for BOTH outcomes before the failure early-return, so
-    presence ⇔ the test phase ran; ``passed: false`` ⇔ failed.
+    The pre-finalization verdict is not sufficient when a matching terminal
+    stabilization artifact rejects that evidence.
     """
+    if stabilization_failed:
+        return {"ran": True, "status": _FAILED}
     verdict = _read_json_artifact(_deep_dir(target_dir) / "test-verdict.json", dict)
     if verdict is None or session_id is None or verdict.get("session_id") != session_id:
         return {"ran": False, "status": _ABSENT}
@@ -102,16 +132,34 @@ def derive_phase_states(
     raises on absent/malformed artifacts (they read as ``absent``).
 
     Most deep artifacts are repository-local rather than run-qualified.
-    ``test-verdict.json`` therefore carries a ``session_id`` and is accepted
-    only when it matches this archive session; stale or unbound test evidence
-    reads as absent. ``runs_merge`` / ``runs_fix`` / ``runs_test`` additionally
-    gate reads to phases the current flow executes, so a skipped phase remains
-    neutral regardless of artifacts left by prior runs.
+    ``test-verdict.json`` and ``stabilization-failed.json`` therefore carry a
+    ``session_id`` and are accepted only when they match this archive session;
+    stale or unbound evidence reads as absent. ``runs_merge`` / ``runs_fix`` /
+    ``runs_test`` additionally gate reads to phases the current flow executes,
+    so a skipped phase remains neutral regardless of artifacts left by prior
+    runs.
     """
+    stabilization_failed = _matching_stabilization_failure(target_dir, session_id)
     return {
         "merge": _merge_state(target_dir) if runs_merge else _absent(),
-        "fix": _fix_state(target_dir, phase_events) if runs_fix else _absent(),
-        "test": _test_state(target_dir, session_id) if runs_test else _absent(),
+        "fix": (
+            _fix_state(
+                target_dir,
+                phase_events,
+                stabilization_failed=stabilization_failed,
+            )
+            if runs_fix
+            else _absent()
+        ),
+        "test": (
+            _test_state(
+                target_dir,
+                session_id,
+                stabilization_failed=stabilization_failed,
+            )
+            if runs_test
+            else _absent()
+        ),
     }
 
 
@@ -139,7 +187,7 @@ def derive_pipeline_status(
     Precedence:
     1. ``cancelled`` when the archive is ``partial`` with no fix failures
        (``write_partial`` signal flush — the run stopped early, nothing failed).
-    2. ``failed`` when merge or test reports failed.
+    2. ``failed`` when merge, fix stabilization, or test reports failed.
     3. ``partial`` when ``fix_failures`` are present.
     4. ``partial`` when a phase the flow runs never ran (run stopped early).
     5. ``succeeded`` when every phase is succeeded or absent AND at least one
@@ -152,7 +200,8 @@ def derive_pipeline_status(
         return "cancelled"
     merge_status = _phase(phase_states, "merge").get("status")
     test_status = _phase(phase_states, "test").get("status")
-    if merge_status == _FAILED or test_status == _FAILED:
+    fix_status = _phase(phase_states, "fix").get("status")
+    if merge_status == _FAILED or fix_status == _FAILED or test_status == _FAILED:
         return _FAILED
     if fix_failures:
         return _PARTIAL

--- a/daydream/archive/pipeline.py
+++ b/daydream/archive/pipeline.py
@@ -66,14 +66,14 @@ def _fix_state(target_dir: Path, phase_events: list[Any]) -> dict[str, Any]:
     return {"ran": False, "status": _ABSENT}
 
 
-def _test_state(target_dir: Path) -> dict[str, Any]:
+def _test_state(target_dir: Path, session_id: str | None) -> dict[str, Any]:
     """Derive the test terminal state from ``test-verdict.json``.
 
     The verdict is written for BOTH outcomes before the failure early-return, so
     presence ⇔ the test phase ran; ``passed: false`` ⇔ failed.
     """
     verdict = _read_json_artifact(_deep_dir(target_dir) / "test-verdict.json", dict)
-    if verdict is None:
+    if verdict is None or session_id is None or verdict.get("session_id") != session_id:
         return {"ran": False, "status": _ABSENT}
     if verdict.get("passed") is False:
         return {"ran": True, "status": _FAILED}
@@ -92,6 +92,7 @@ def derive_phase_states(
     runs_merge: bool = True,
     runs_fix: bool = True,
     runs_test: bool = True,
+    session_id: str | None = None,
 ) -> dict[str, dict[str, Any]]:
     """Return per-phase terminal states for ``merge``, ``fix``, and ``test``.
 
@@ -100,19 +101,17 @@ def derive_phase_states(
     derivation over on-disk deep artifacts + recorder phase events; never
     raises on absent/malformed artifacts (they read as ``absent``).
 
-    The deep artifacts (``per-stack-failures.json`` / ``merged-items.json`` /
-    ``test-verdict.json`` / ``fix-failures.json``) are session-agnostic -- they
-    live in ``target_dir/.daydream/deep`` with no run-bound ``session_id``. A
-    non-deep flow run against a previously deep-reviewed repo would otherwise
-    inherit a PRIOR run's artifacts as its own pipeline state. ``runs_merge`` /
-    ``runs_fix`` / ``runs_test`` gate each phase read to only the phases the
-    current flow actually executes; a phase the flow never runs reads
-    ``absent`` (neutral) regardless of what stale artifacts sit on disk.
+    Most deep artifacts are repository-local rather than run-qualified.
+    ``test-verdict.json`` therefore carries a ``session_id`` and is accepted
+    only when it matches this archive session; stale or unbound test evidence
+    reads as absent. ``runs_merge`` / ``runs_fix`` / ``runs_test`` additionally
+    gate reads to phases the current flow executes, so a skipped phase remains
+    neutral regardless of artifacts left by prior runs.
     """
     return {
         "merge": _merge_state(target_dir) if runs_merge else _absent(),
         "fix": _fix_state(target_dir, phase_events) if runs_fix else _absent(),
-        "test": _test_state(target_dir) if runs_test else _absent(),
+        "test": _test_state(target_dir, session_id) if runs_test else _absent(),
     }
 
 

--- a/daydream/deep/artifacts.py
+++ b/daydream/deep/artifacts.py
@@ -174,11 +174,9 @@ def fix_failures_path(deep_dir_path: Path) -> Path:
 def fix_outcomes_path(deep_dir_path: Path) -> Path:
     """Post-fix verifier outcomes ({finding_id: verdict} JSON, issue #744).
 
-    Sidecar adjacent to :func:`fix_failures_path`: every finding the fix phase
-    dispatched has exactly one recorded terminal verdict here (``resolved`` /
-    ``unresolved`` / ``wrong_target`` / ``regressed``), so an attempted-but-
-    unconfirmed finding cannot silently pass as fixed. Accumulates across
-    rounds; deleted when empty.
+    Sidecar adjacent to :func:`fix_failures_path`: the current session and
+    evidence key bind one full-canonical verification result, keyed by durable
+    item UID. Each verification replaces the preceding round's envelope.
     """
     return deep_dir_path / "fix-outcomes.json"
 

--- a/daydream/deep/artifacts.py
+++ b/daydream/deep/artifacts.py
@@ -183,6 +183,16 @@ def fix_outcomes_path(deep_dir_path: Path) -> Path:
     return deep_dir_path / "fix-outcomes.json"
 
 
+def fix_footprint_path(deep_dir_path: Path) -> Path:
+    """Session-bound authorization and enforcement audit for the fix cycle."""
+    return deep_dir_path / "fix-footprint.json"
+
+
+def stabilization_failed_path(deep_dir_path: Path) -> Path:
+    """Terminal reason emitted when the bounded retained tree cannot stabilize."""
+    return deep_dir_path / "stabilization-failed.json"
+
+
 def recommended_capture_path(deep_dir_path: Path) -> Path:
     """Capture-point sidecar recording which tree produced recommended.patch.
 

--- a/daydream/deep/orchestrator.py
+++ b/daydream/deep/orchestrator.py
@@ -3287,6 +3287,7 @@ async def _step_fix_gate(ctx: FlowContext) -> Stop | None:
         preexisting_untracked = git_ops.snapshot_untracked_paths(
             ctx.work.repo, include_runtime_artifacts=False
         )
+        preexisting_gitlinks = git_ops.snapshot_worktree_gitlinks(ctx.work.repo)
         footprint = AuthorizedFixFootprint.build(
             ctx.work.repo, set(changed_files or []), items
         )
@@ -3301,6 +3302,7 @@ async def _step_fix_gate(ctx: FlowContext) -> Stop | None:
         stable_head=stable_head,
         initial_index=initial_index,
         preexisting_untracked=preexisting_untracked,
+        preexisting_gitlinks=preexisting_gitlinks,
         footprint=footprint,
     )
     ctx.data["fix_cycle_state"] = state
@@ -3895,6 +3897,7 @@ class FixCycleState:
     stable_head: str
     initial_index: IndexSnapshot
     preexisting_untracked: dict[str, GitPathState]
+    preexisting_gitlinks: tuple[GitPathState, ...]
     footprint: AuthorizedFixFootprint
     latest_retained: RetainedTreeSnapshot | None = None
     verifier_key: EvidenceKey | None = None
@@ -3916,24 +3919,32 @@ def _capture_full_delta_key(work: WorkContext, state: FixCycleState) -> str:
             work.repo,
             state.stable_ref,
             preexisting_untracked=state.preexisting_untracked,
+            preexisting_gitlinks=state.preexisting_gitlinks,
         )
     )
 
 
 def capture_retained_tree(work: WorkContext, state: FixCycleState) -> RetainedTreeSnapshot:
-    """Capture the authorized delta while keying the complete observable tree."""
+    """Capture the authorized HEAD delta while keying the run-relative tree.
+
+    ``stable_ref`` includes pre-gate tracked edits so it remains the authority
+    for mutation attribution, rollback, and test identity.  Commit selection is
+    deliberately relative to the original HEAD: authorized reviewed edits that
+    predate the gate are part of the result even when no fixer touches them.
+    """
     from daydream import git_ops
 
-    changed = set(git_ops.changed_paths_z(work.repo, state.stable_ref))
+    changed = set(git_ops.changed_paths_z(work.repo, state.stable_head))
     paths = frozenset(changed & set(state.footprint.run_allowed_paths))
     states = git_ops.snapshot_worktree_paths(work.repo, paths)
     full_states = git_ops.snapshot_worktree_delta(
         work.repo,
         state.stable_ref,
         preexisting_untracked=state.preexisting_untracked,
+        preexisting_gitlinks=state.preexisting_gitlinks,
     )
     recommended = git_ops.build_recommended_patch_strict(
-        work.repo, state.stable_ref, paths
+        work.repo, state.stable_head, paths
     )
     return RetainedTreeSnapshot(
         paths=paths,
@@ -4087,6 +4098,7 @@ def _strict_scope_and_scrub(
         state.stable_ref,
         state.footprint,
         preexisting_untracked=state.preexisting_untracked,
+        preexisting_gitlinks=state.preexisting_gitlinks,
         phase=phase,
         round_number=round_number,
         file_scope_issues=_scope_issue_filing(ctx.config),
@@ -4098,6 +4110,58 @@ def _strict_scope_and_scrub(
     )
     after = _capture_full_delta_key(ctx.work, state)
     return bool(generated_restores) or enforced.mutated or before != after
+
+
+def _enforce_terminal_confinement(
+    ctx: FlowContext,
+    state: FixCycleState,
+    *,
+    phase: str,
+    round_number: int | None,
+) -> str | None:
+    """Restore all out-of-run/protected state and durably audit a failed exit."""
+    try:
+        enforce_authorized_fix_footprint(
+            ctx.work,
+            state.stable_ref,
+            state.footprint,
+            preexisting_untracked=state.preexisting_untracked,
+            preexisting_gitlinks=state.preexisting_gitlinks,
+            phase=phase,
+            round_number=round_number,
+            file_scope_issues=_scope_issue_filing(ctx.config),
+        )
+        key = EvidenceKey(
+            _capture_full_delta_key(ctx.work, state),
+            state.footprint.policy_revision,
+        )
+        _write_footprint_audit(ctx, state, key)
+    except Exception as exc:
+        return str(exc)
+    return None
+
+
+def _stabilization_stop(
+    ctx: FlowContext,
+    state: FixCycleState,
+    reason: str,
+    *,
+    round_number: int | None,
+) -> Stop:
+    """Fail closed after finalization while still restoring and auditing scope."""
+    confinement_error = _enforce_terminal_confinement(
+        ctx,
+        state,
+        phase="post_test_failure",
+        round_number=round_number,
+    )
+    if confinement_error is not None:
+        reason = f"{reason}; confinement failed: {confinement_error}"
+    try:
+        _persist_stabilization_failure(ctx, state, reason)
+    except OSError as exc:
+        print_error(console, "Stabilization failure audit failed", str(exc))
+    return Stop(1)
 
 
 async def _step_fix_authorized(ctx: FlowContext, state: FixCycleState) -> Stop | None:
@@ -4148,26 +4212,48 @@ async def _step_fix_authorized(ctx: FlowContext, state: FixCycleState) -> Stop |
                 round_snapshot=round_snapshot,
             )
         except Exception as exc:
+            confinement_error = _enforce_terminal_confinement(
+                ctx,
+                state,
+                phase="fix_failure",
+                round_number=ctx.data.get("iteration"),
+            )
             print_error(console, "Fix failed", str(exc))
+            if confinement_error is not None:
+                print_error(console, "Fix failure confinement failed", confinement_error)
             return Stop(1)
     if failures:
-        atomic_write_json(fix_failures_path(ctx.data["dd"]), failures, sort_keys=True)
         from daydream import git_ops
 
-        leftover = sorted(
-            set(
-                git_ops.snapshot_untracked_paths(
-                    ctx.work.repo, include_runtime_artifacts=False
-                )
-            )
-            - set(state.preexisting_untracked)
+        confinement_error = _enforce_terminal_confinement(
+            ctx,
+            state,
+            phase="fix_failure",
+            round_number=ctx.data.get("iteration"),
         )
-        if leftover:
-            atomic_write_json(fix_leftover_untracked_path(ctx.data["dd"]), leftover)
+        artifact_errors: list[str] = []
+        try:
+            atomic_write_json(fix_failures_path(ctx.data["dd"]), failures, sort_keys=True)
+            leftover = sorted(
+                set(
+                    git_ops.snapshot_untracked_paths(
+                        ctx.work.repo, include_runtime_artifacts=False
+                    )
+                )
+                - set(state.preexisting_untracked)
+            )
+            if leftover:
+                atomic_write_json(fix_leftover_untracked_path(ctx.data["dd"]), leftover)
+        except Exception as exc:
+            artifact_errors.append(str(exc))
         print_warning(
             console,
             "Fix groups failed and were rolled back: " + ", ".join(sorted(failures)),
         )
+        if confinement_error is not None:
+            print_error(console, "Fix failure confinement failed", confinement_error)
+        if artifact_errors:
+            print_error(console, "Fix failure audit failed", "; ".join(artifact_errors))
         return Stop(1)
     try:
         _strict_scope_and_scrub(
@@ -4178,35 +4264,55 @@ async def _step_fix_authorized(ctx: FlowContext, state: FixCycleState) -> Stop |
         )
         snapshot = capture_retained_tree(ctx.work, state)
     except Exception as exc:
+        confinement_error = _enforce_terminal_confinement(
+            ctx,
+            state,
+            phase="fix_failure",
+            round_number=ctx.data.get("iteration"),
+        )
         print_error(console, "Fix scope enforcement failed", str(exc))
+        if confinement_error is not None:
+            print_error(console, "Fix failure confinement failed", confinement_error)
         return Stop(1)
     ctx.data["fix_round_snapshot"] = snapshot
-    await _evaluate_quality_gate(
-        enabled=quality_enabled,
-        erosion_delta_threshold=_quality_gate_threshold(
-            config, "quality_gate_erosion_delta", DEFAULT_QUALITY_GATE_EROSION_DELTA
-        ),
-        verbosity_delta_threshold=_quality_gate_threshold(
-            config, "quality_gate_verbosity_delta", DEFAULT_QUALITY_GATE_VERBOSITY_DELTA
-        ),
-        erosion_absolute_threshold=_quality_gate_threshold(
-            config, "quality_gate_erosion_absolute", DEFAULT_QUALITY_GATE_EROSION_ABSOLUTE
-        ),
-        verbosity_absolute_threshold=_quality_gate_threshold(
-            config, "quality_gate_verbosity_absolute", DEFAULT_QUALITY_GATE_VERBOSITY_ABSOLUTE
-        ),
-        daydream_dir=ctx.work.repo / ".daydream",
-        dd=ctx.data["dd"],
-        candidates={path for path in snapshot.paths if path.endswith(".py")}
-        | {
-            str(item["file"])
-            for item in ctx.data["items"]
-            if isinstance(item.get("file"), str) and str(item["file"]).endswith(".py")
-        },
-        before=quality_before,
-        before_unavailable_reason=quality_unavailable,
-        iteration=ctx.data.get("iteration"),
-    )
+    try:
+        await _evaluate_quality_gate(
+            enabled=quality_enabled,
+            erosion_delta_threshold=_quality_gate_threshold(
+                config, "quality_gate_erosion_delta", DEFAULT_QUALITY_GATE_EROSION_DELTA
+            ),
+            verbosity_delta_threshold=_quality_gate_threshold(
+                config, "quality_gate_verbosity_delta", DEFAULT_QUALITY_GATE_VERBOSITY_DELTA
+            ),
+            erosion_absolute_threshold=_quality_gate_threshold(
+                config, "quality_gate_erosion_absolute", DEFAULT_QUALITY_GATE_EROSION_ABSOLUTE
+            ),
+            verbosity_absolute_threshold=_quality_gate_threshold(
+                config, "quality_gate_verbosity_absolute", DEFAULT_QUALITY_GATE_VERBOSITY_ABSOLUTE
+            ),
+            daydream_dir=ctx.work.repo / ".daydream",
+            dd=ctx.data["dd"],
+            candidates={path for path in snapshot.paths if path.endswith(".py")}
+            | {
+                str(item["file"])
+                for item in ctx.data["items"]
+                if isinstance(item.get("file"), str) and str(item["file"]).endswith(".py")
+            },
+            before=quality_before,
+            before_unavailable_reason=quality_unavailable,
+            iteration=ctx.data.get("iteration"),
+        )
+    except Exception as exc:
+        confinement_error = _enforce_terminal_confinement(
+            ctx,
+            state,
+            phase="fix_failure",
+            round_number=ctx.data.get("iteration"),
+        )
+        print_error(console, "Fix quality evaluation failed", str(exc))
+        if confinement_error is not None:
+            print_error(console, "Fix failure confinement failed", confinement_error)
+        return Stop(1)
     return None
 
 
@@ -4275,7 +4381,15 @@ async def _step_fix_verify_authorized(
         try:
             snapshot = capture_retained_tree(ctx.work, state)
         except Exception as exc:
+            confinement_error = _enforce_terminal_confinement(
+                ctx,
+                state,
+                phase="fix_verify_failure",
+                round_number=ctx.data.get("iteration"),
+            )
             print_error(console, "Fix verification capture failed", str(exc))
+            if confinement_error is not None:
+                print_error(console, "Fix failure confinement failed", confinement_error)
             return Stop(1)
     iteration = ctx.data.get("iteration")
     round_number = iteration if isinstance(iteration, int) else 1
@@ -4290,7 +4404,15 @@ async def _step_fix_verify_authorized(
         _persist_fix_outcomes_current(ctx, state, key, outcomes)
         _write_footprint_audit(ctx, state, key)
     except Exception as exc:
+        confinement_error = _enforce_terminal_confinement(
+            ctx,
+            state,
+            phase="fix_verify_failure",
+            round_number=round_number,
+        )
         print_error(console, "Fix verification failed", str(exc))
+        if confinement_error is not None:
+            print_error(console, "Fix failure confinement failed", confinement_error)
         return Stop(1)
     actionable = _actionable_verdicts(outcomes)
     if actionable and iteration not in (None, 3):
@@ -4412,8 +4534,9 @@ async def finalize_retained_tree_after_test(
     state = _fix_cycle_state(ctx)
     attempts = list(result.attempts)
     if not attempts:
-        _persist_stabilization_failure(ctx, state, "test produced no evidence")
-        return Stop(1)
+        return _stabilization_stop(
+            ctx, state, "test produced no evidence", round_number=None
+        )
     evidence = attempts[-1]
     state.test_evidence = evidence
     ignored = result.ignored
@@ -4430,8 +4553,12 @@ async def finalize_retained_tree_after_test(
             key = EvidenceKey(snapshot.tree_key, state.footprint.policy_revision)
             _write_footprint_audit(ctx, state, key)
         except Exception as exc:
-            _persist_stabilization_failure(ctx, state, f"guard/capture/audit failed: {exc}")
-            return Stop(1)
+            return _stabilization_stop(
+                ctx,
+                state,
+                f"guard/capture/audit failed: {exc}",
+                round_number=pass_number,
+            )
 
         if state.verifier_key != key:
             try:
@@ -4440,13 +4567,21 @@ async def finalize_retained_tree_after_test(
                 )
                 _persist_fix_outcomes_current(ctx, state, key, outcomes)
             except Exception as exc:
-                _persist_stabilization_failure(ctx, state, f"final verifier failed: {exc}")
-                return Stop(1)
+                return _stabilization_stop(
+                    ctx,
+                    state,
+                    f"final verifier failed: {exc}",
+                    round_number=pass_number,
+                )
             state.verifier_key = key
             ctx.data["fix_outcomes"] = outcomes
             if _actionable_verdicts(outcomes):
-                _persist_stabilization_failure(ctx, state, "final verifier remains actionable")
-                return Stop(1)
+                return _stabilization_stop(
+                    ctx,
+                    state,
+                    "final verifier remains actionable",
+                    round_number=pass_number,
+                )
 
         matching_test = (
             evidence.session_id == state.session_id
@@ -4464,8 +4599,12 @@ async def finalize_retained_tree_after_test(
                     capture_tree_key=lambda: _capture_full_delta_key(ctx.work, state),
                 )
             except Exception as exc:
-                _persist_stabilization_failure(ctx, state, f"final test failed to run: {exc}")
-                return Stop(1)
+                return _stabilization_stop(
+                    ctx,
+                    state,
+                    f"final test failed to run: {exc}",
+                    round_number=pass_number,
+                )
             attempts.append(evidence)
             state.test_evidence = evidence
             ignored = False if evidence.passed else _authorize_final_red_override()
@@ -4486,8 +4625,12 @@ async def finalize_retained_tree_after_test(
             and (evidence.passed or ignored)
         )
         if mutated or state.verifier_key != key or not stable_test:
-            _persist_stabilization_failure(ctx, state, "post-test tree did not stabilize")
-            return Stop(1)
+            return _stabilization_stop(
+                ctx,
+                state,
+                "post-test tree did not stabilize",
+                round_number=pass_number,
+            )
 
         try:
             patch_path = ctx.work.repo / ".daydream" / "recommended.patch"
@@ -4504,13 +4647,21 @@ async def finalize_retained_tree_after_test(
                 sort_keys=True,
             )
         except OSError as exc:
-            _persist_stabilization_failure(ctx, state, f"recommended capture failed: {exc}")
-            return Stop(1)
+            return _stabilization_stop(
+                ctx,
+                state,
+                f"recommended capture failed: {exc}",
+                round_number=pass_number,
+            )
         state.latest_retained = snapshot
         return None
 
-    _persist_stabilization_failure(ctx, state, "post-test pass bound exhausted")
-    return Stop(1)
+    return _stabilization_stop(
+        ctx,
+        state,
+        "post-test pass bound exhausted",
+        round_number=MAX_POST_TEST_STABILIZATION_PASSES,
+    )
 
 
 
@@ -4538,10 +4689,26 @@ async def _step_test(ctx: FlowContext) -> Stop | None:
                 attempts=list(result.attempts),
             )
         except Exception as exc:
+            confinement_error = _enforce_terminal_confinement(
+                ctx,
+                state,
+                phase="test_failure",
+                round_number=None,
+            )
             print_error(console, "Test evidence failed", str(exc))
+            if confinement_error is not None:
+                print_error(console, "Test failure confinement failed", confinement_error)
             return Stop(1)
     if not result.proceed:
+        confinement_error = _enforce_terminal_confinement(
+            ctx,
+            state,
+            phase="test_failure",
+            round_number=None,
+        )
         print_warning(console, "Tests failed after fix attempt.")
+        if confinement_error is not None:
+            print_error(console, "Test failure confinement failed", confinement_error)
         return Stop(1)
     return await finalize_retained_tree_after_test(ctx, result)
 

--- a/daydream/deep/orchestrator.py
+++ b/daydream/deep/orchestrator.py
@@ -18,7 +18,7 @@ import inspect
 import json
 import os
 import shutil
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, field
 from functools import lru_cache
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Awaitable, cast
@@ -3233,6 +3233,18 @@ async def _step_post_diagram(ctx: FlowContext) -> Stop:
     return Stop(0)
 
 
+def _record_fix_preflight_rejection(dd: Path, items: list[dict[str, Any]]) -> None:
+    """Record an admitted cycle's blocked items without reflecting unsafe paths."""
+    failures = {
+        item["item_uid"]: "fix_preflight_rejected: fix cycle did not start"
+        for item in items
+    }
+    try:
+        atomic_write_json(fix_failures_path(dd), failures, sort_keys=True)
+    except OSError as exc:
+        print_error(console, "Fix preflight failure audit failed", str(exc))
+
+
 async def _step_fix_gate(ctx: FlowContext) -> Stop | None:
     """Fix-apply gate; on accept, load and severity-sort the canonical items."""
     # Fix-apply gate across the two interaction axes. ``--yes`` auto-applies;
@@ -3318,6 +3330,7 @@ async def _step_fix_gate(ctx: FlowContext) -> Stop | None:
             ctx.work.repo, set(changed_files or []), items
         )
     except (OSError, ValueError, git_ops.GitError) as exc:
+        _record_fix_preflight_rejection(dd, items)
         print_error(console, "Fix preflight failed", str(exc))
         return Stop(1)
 
@@ -3336,6 +3349,7 @@ async def _step_fix_gate(ctx: FlowContext) -> Stop | None:
         initial_key = EvidenceKey(_capture_full_delta_key(ctx.work, state), footprint.policy_revision)
         _write_footprint_audit(ctx, state, initial_key)
     except (OSError, git_ops.GitError) as exc:
+        _record_fix_preflight_rejection(dd, items)
         print_error(console, "Fix preflight failed", str(exc))
         return Stop(1)
 
@@ -3928,6 +3942,7 @@ class FixCycleState:
     latest_retained: RetainedTreeSnapshot | None = None
     verifier_key: EvidenceKey | None = None
     test_evidence: TestAttemptEvidence | None = None
+    last_fix_target_by_uid: dict[str, str] = field(default_factory=dict)
 
 
 def _fix_cycle_state(ctx: FlowContext) -> FixCycleState:
@@ -4019,9 +4034,15 @@ def _round_dispatch_items(ctx: FlowContext, canonical: list[dict[str, Any]]) -> 
     """
     iteration = ctx.data.get("iteration")
     outcomes = ctx.data.get("fix_outcomes") or {}
-    if iteration in (None, 1) or not outcomes:
-        return [dict(i) for i in canonical]
     state = _fix_cycle_state(ctx)
+    if iteration in (None, 1) or not outcomes:
+        initial_dispatch = [dict(i) for i in canonical]
+        for item in initial_dispatch:
+            uid = item.get("item_uid")
+            target = item.get("file")
+            if isinstance(uid, str) and isinstance(target, str):
+                state.last_fix_target_by_uid[uid] = target
+        return initial_dispatch
     round_number = iteration if isinstance(iteration, int) else 1
     dispatched: list[dict[str, Any]] = []
     for item in canonical:
@@ -4043,6 +4064,9 @@ def _round_dispatch_items(ctx: FlowContext, canonical: list[dict[str, Any]]) -> 
                 copy["fix_verify_path"] = accepted
         copy["fix_verify_verdict"] = outcome.get("verdict")
         copy["fix_verify_reason"] = outcome.get("reason") or ""
+        target = copy.get("file")
+        if isinstance(uid, str) and isinstance(target, str):
+            state.last_fix_target_by_uid[uid] = target
         dispatched.append(copy)
     return dispatched
 
@@ -4399,6 +4423,7 @@ async def verify_retained_tree(
         for item in items
         if isinstance(item.get("id"), int) and isinstance(item.get("item_uid"), str)
     }
+    state = _fix_cycle_state(ctx)
     outcomes: dict[str, dict[str, Any]] = {}
     for verdict in verdicts:
         item = by_id.get(verdict.get("issue_id"))
@@ -4406,7 +4431,12 @@ async def verify_retained_tree(
             continue
         stored = dict(verdict)
         stored["issue_id"] = item["id"]
-        outcomes[item["item_uid"]] = stored
+        uid = item["item_uid"]
+        if stored.get("verdict") == "resolved":
+            target = state.last_fix_target_by_uid.get(uid)
+            if target is not None:
+                stored["path"] = target
+        outcomes[uid] = stored
     return outcomes
 
 

--- a/daydream/deep/orchestrator.py
+++ b/daydream/deep/orchestrator.py
@@ -14,7 +14,6 @@ phase primitive (D-39).
 
 from __future__ import annotations
 
-import hashlib
 import inspect
 import json
 import os
@@ -22,7 +21,7 @@ import shutil
 from dataclasses import asdict, dataclass
 from functools import lru_cache
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Awaitable, Iterable, cast
+from typing import TYPE_CHECKING, Any, Awaitable, cast
 
 import anyio
 from rich.markup import escape as escape_markup
@@ -64,6 +63,7 @@ from daydream.deep.artifacts import (
     diff_key,
     diff_key_path,
     fix_failures_path,
+    fix_footprint_path,
     fix_leftover_untracked_path,
     fix_outcomes_path,
     fix_quality_gate_path,
@@ -73,6 +73,7 @@ from daydream.deep.artifacts import (
     per_stack_failures_path,
     per_stack_records_path,
     recommended_capture_path,
+    stabilization_failed_path,
     test_verdict_path,
 )
 from daydream.deep.artifacts import (
@@ -118,36 +119,33 @@ from daydream.deep.records import (
     record_uid,
     stack_name_from_records_source,
     stack_name_from_uid,
+    stamp_item_uids,
     stamp_record_uids,
 )
 from daydream.deep.render import insert_diagrams_section, render_held_section, render_report
 from daydream.deep.scope_issues import (
-    _file_out_of_scope_issue,
     _resolve_changed_files,
-    _revert_out_of_scope_edits,
-    _scope_filing_note,
+    enforce_authorized_fix_footprint,
 )
 from daydream.deep.sharding import shard_stacks
 from daydream.eval.analyzer import _agent_label, _records_issues_or_empty, load_trajectories
 from daydream.extensions import get_registry
 from daydream.extensions.api import BreakLoop, FlowStep, Stop
+from daydream.fix_footprint import AuthorizedFixFootprint
 from daydream.flows.engine import FlowContext, run_flow
 from daydream.generated_files import (
-    _changed_untracked_generated_files,
-    _restore_untracked_generated_file,
-    _snapshot_untracked_generated_files,
     is_generated_file,
     related_manifest_paths,
 )
+from daydream.git_ops import GitPathState, IndexSnapshot, WorktreeRollbackSnapshot
 from daydream.json_utils import atomic_write_json
 from daydream.phases import (
     FIX_VERIFY_ACTIONABLE_VERDICTS,
     FIX_VERIFY_RETARGETABLE_VERDICTS,
     UNCOVERED_SWEEP_SCHEMA,
     CrossStackMergeError,
-    UnconfinedFindingError,
-    _record_fix_failure,
-    _resolve_finding_file_ref,
+    TestAndHealResult,
+    TestAttemptEvidence,
     _write_single_stack_merged_items,
     phase_alternative_review,
     phase_arbiter_review,
@@ -158,8 +156,10 @@ from daydream.phases import (
     phase_supervise_review,
     phase_suppression_review,
     phase_test_and_heal,
+    phase_test_once,
     phase_understand_intent,
     phase_verify_recommendations,
+    require_empty_staged_index,
     severity_sorted,
 )
 from daydream.quote_scrub import scrub_smart_quotes_changed_files
@@ -995,199 +995,6 @@ def _rewrite_stack_records(
         )
 
 
-def _protect_tree_after_fix_failures(
-    work: WorkContext,
-    target_dir: Path,
-    fix_failures: dict[str, str],
-    *,
-    snapshot: str | None,
-    snapshot_captured: bool,
-    pre_untracked: set[str],
-) -> None:
-    """Roll each failed fix group's file back to its pre-fix content.
-
-    For every dropped file-group (keyed by repo-relative path), the partial-fix
-    content is FIRST saved to ``.daydream/partial-fixes/<slug>.patch`` (a
-    ``git diff`` against the pre-fix snapshot) so no agent work is destroyed,
-    THEN the path is restored to exactly its pre-fix state. Only the failed
-    paths are touched -- successful groups and unrelated paths are never
-    reverted. A failed group's newly-created untracked file (absent from
-    *pre_untracked*) has its raw content preserved and is then removed; untracked
-    files we cannot attribute to the failed group are left in place.
-
-    Args:
-        work: The run's workspace (``work.repo`` is the git working dir).
-        target_dir: Resolved target dir (``== work.repo``); root for the
-            ``.daydream/partial-fixes`` recovery directory.
-        fix_failures: ``{file_group: reason}`` for groups that failed.
-        snapshot: ``git stash create`` SHA captured before fixes, or ``None``
-            when the pre-fix tracked tree equalled ``HEAD``.
-        pre_untracked: Untracked paths present before the fix pass.
-    """
-    from daydream import git_ops
-    from daydream.git_ops import GitError
-
-    if not snapshot_captured:
-        # HEAD is not a safe substitute when capturing the pre-fix state
-        # failed: it may discard edits that were present before this pass.
-        return
-
-    repo = work.repo
-    ref = snapshot or "HEAD"
-    recovery_dir = target_dir / ".daydream" / "partial-fixes"
-    recovery_dir.mkdir(parents=True, exist_ok=True)
-
-    for fkey in sorted(fix_failures):
-        slug = fkey.replace("/", "-").replace("\\", "-")
-        file_path = repo / fkey
-        # 1. Save the partial-fix content first -- non-negotiable, before revert.
-        try:
-            patch = git_ops.diff_worktree_against(repo, ref, [fkey])
-        except GitError as exc:
-            patch = ""
-            print_warning(console, f"Could not diff partial fix for '{fkey}': {exc}")
-        if patch:
-            (recovery_dir / f"{slug}.patch").write_text(patch, encoding="utf-8")
-        elif file_path.is_file() and fkey not in pre_untracked:
-            # Newly-created untracked file (no diff vs ref): preserve raw content.
-            try:
-                (recovery_dir / f"{slug}.orphan").write_text(
-                    file_path.read_text(encoding="utf-8", errors="replace"),
-                    encoding="utf-8",
-                )
-            except OSError:
-                pass
-        # 2. Restore the path to its pre-fix content.
-        try:
-            git_ops.restore_paths_from_ref(repo, ref, [fkey])
-        except GitError:
-            # Path absent at ref => the failed group newly created it. Remove the
-            # orphan only when it was not already present pre-fix (attributable).
-            if file_path.is_file() and fkey not in pre_untracked:
-                try:
-                    file_path.unlink()
-                except OSError:
-                    pass
-
-
-def _reject_generated_file_edits(
-    work: WorkContext,
-    target_dir: Path,
-    *,
-    snapshot: str | None,
-    snapshot_captured: bool,
-    pre_untracked: set[str],
-    pre_untracked_contents: dict[str, bytes] | None = None,
-) -> list[str] | None:
-    """Restore changed generated files, returning ``None`` if restoration fails."""
-    from daydream import git_ops
-    from daydream.git_ops import GitError
-
-    if not snapshot_captured:
-        # A failed snapshot has no trustworthy pre-fix baseline.  In
-        # particular, falling back to HEAD could erase a user's existing edit.
-        return []
-
-    repo = work.repo
-    ref = snapshot or "HEAD"
-    changed = git_ops.changed_files_against(
-        repo, ref, preexisting_untracked=pre_untracked
-    )
-
-    tracked_violations: list[str] = []
-    patches: dict[str, str] = {}
-    recovery_dir = target_dir / ".daydream" / "partial-fixes"
-    for path in changed:
-        try:
-            baseline = git_ops.show(repo, ref, path)
-        except GitError:
-            # Newly-created generated files (notably new migrations) are
-            # deliberately allowed.
-            continue
-        if not is_generated_file(path, baseline):
-            continue
-        try:
-            patch = git_ops.diff_worktree_against(repo, ref, [path])
-        except GitError as exc:
-            patch = ""
-            print_warning(console, f"Could not save forbidden generated-file edit for '{path}': {exc}")
-        if not patch:
-            # New generated files (notably new migrations) have no baseline
-            # diff and are deliberately allowed.
-            continue
-        tracked_violations.append(path)
-        patches[path] = patch
-
-    untracked_baselines = pre_untracked_contents or {}
-    untracked_violations = _changed_untracked_generated_files(repo, untracked_baselines)
-    direct_violations = [*tracked_violations, *untracked_violations]
-    paths_to_restore = list(tracked_violations)
-    for path in direct_violations:
-        for manifest_path in related_manifest_paths(path):
-            if manifest_path in paths_to_restore:
-                continue
-            try:
-                manifest_patch = git_ops.diff_worktree_against(repo, ref, [manifest_path])
-                if not manifest_patch:
-                    continue
-                git_ops.show(repo, ref, manifest_path)
-            except GitError:
-                continue
-            paths_to_restore.append(manifest_path)
-            patches[manifest_path] = manifest_patch
-
-    for path, patch in patches.items():
-        slug = path.replace("/", "-").replace("\\", "-")
-        digest = hashlib.sha256(path.encode("utf-8", errors="surrogateescape")).hexdigest()[:12]
-        try:
-            recovery_dir.mkdir(parents=True, exist_ok=True)
-            (recovery_dir / f"{slug}-{digest}.patch").write_text(patch, encoding="utf-8")
-        except OSError as exc:
-            print_warning(console, f"Could not write recovery patch for '{path}': {exc}")
-
-    for path in untracked_violations:
-        file_path = repo / path
-        if not file_path.is_file():
-            continue
-        slug = path.replace("/", "-").replace("\\", "-")
-        digest = hashlib.sha256(path.encode("utf-8", errors="surrogateescape")).hexdigest()[:12]
-        try:
-            recovery_dir.mkdir(parents=True, exist_ok=True)
-            (recovery_dir / f"{slug}-{digest}.orphan").write_bytes(file_path.read_bytes())
-        except OSError as exc:
-            print_warning(console, f"Could not save forbidden generated-file edit for '{path}': {exc}")
-
-    restoration_failed = False
-    if paths_to_restore:
-        try:
-            git_ops.restore_paths_from_ref(repo, ref, paths_to_restore)
-        except GitError as exc:
-            print_warning(console, f"Could not restore generated files: {exc}")
-            restoration_failed = True
-
-    for path in untracked_violations:
-        try:
-            _restore_untracked_generated_file(repo, path, untracked_baselines[path])
-        except OSError as exc:
-            print_warning(console, f"Could not restore generated file '{path}': {exc}")
-            restoration_failed = True
-
-    if direct_violations:
-        artifact = generated_file_violations_path(deep_dir(target_dir))
-        try:
-            artifact.write_text(
-                json.dumps({"violations": direct_violations, "ref": ref}, indent=2),
-                encoding="utf-8",
-            )
-        except OSError as exc:
-            print_warning(console, f"Could not record generated-file violations: {exc}")
-        if not restoration_failed:
-            print_warning(
-                console,
-                f"Reverted forbidden edits to existing generated files: {', '.join(direct_violations)}. "
-                "Add a new migration file instead.",
-            )
-    return None if restoration_failed else direct_violations
 
 
 def _has_non_daydream_worktree_changes(status: str) -> bool:
@@ -3423,6 +3230,27 @@ async def _step_fix_gate(ctx: FlowContext) -> Stop | None:
         print_success(console, f"Report written to {ctx.data['merged_report']}. Exiting.")
         return Stop(0)
 
+    # An accepted gate starts a new evidence session. No prior run's success,
+    # patch, or policy audit may be inherited if this run later stops early.
+    dd: Path = ctx.data["dd"]
+    stale_paths = (
+        fix_footprint_path(dd),
+        fix_outcomes_path(dd),
+        test_verdict_path(dd),
+        recommended_capture_path(dd),
+        generated_file_violations_path(dd),
+        fix_failures_path(dd),
+        fix_leftover_untracked_path(dd),
+        stabilization_failed_path(dd),
+        ctx.work.repo / ".daydream" / "recommended.patch",
+    )
+    try:
+        for stale in stale_paths:
+            stale.unlink(missing_ok=True)
+    except OSError as exc:
+        print_error(console, "Fix preflight failed", str(exc))
+        return Stop(1)
+
     # Read canonical merged items directly (validated above). Replaces an LLM
     # re-parse of the markdown, which silently dropped structural findings; here
     # they are ordinary tagged items that reach phase_fix like any other.
@@ -3438,49 +3266,50 @@ async def _step_fix_gate(ctx: FlowContext) -> Stop | None:
         _file = _item.get("file")
         if isinstance(_file, str) and _file.startswith("./"):
             _item["file"] = _file[2:]
+    stamp_item_uids(items)
     if not items:
         print_success(console, "No actionable items -- done.")
         return Stop(0)
 
-    # Issue #336 — pre-fix scope partition. Findings on files OUTSIDE the
-    # reviewed diff are excluded from auto-fix; issue filing is gated by
-    # ``scope_issue_filing`` (#1056). The loop must not expand the PR's scope. The reviewed-diff file
-    # set is resolved via _resolve_changed_files (shared with _step_fix) so the
-    # gate and the post-fix residual net agree on the allowed set (a divergence
-    # left the residual net strictly weaker than the gate on the resume path).
+    # The footprint deliberately admits canonical finding primary/related
+    # paths even when they were not themselves in the reviewed diff. This is
+    # the explicit authorization that lets a regression test or sibling source
+    # file travel with a finding without turning every reviewed file into every
+    # fixer's edit scope.
     changed_files = _resolve_changed_files(ctx)
-    if changed_files is not None:
-        in_scope: list[dict[str, Any]] = []
-        out_of_scope: list[dict[str, Any]] = []
-        for item in items:
-            (in_scope if (item.get("file") or "") in changed_files else out_of_scope).append(item)
-        file_scope_issues = _scope_issue_filing(ctx.config)
-        for item in out_of_scope:
-            if file_scope_issues:
-                _file_out_of_scope_issue(ctx, item)
-        if out_of_scope:
-            print_warning(
-                console,
-                f"{len(out_of_scope)} finding(s) outside the reviewed diff "
-                f"{_scope_filing_note(file_scope_issues)}, not fixed.",
-            )
-        items = in_scope
-        # Issue #336 — every finding routed out of the fix list leaves nothing
-        # to auto-fix, so short-circuit before a no-op fix pass, a full target
-        # test-suite run, and a commit-agent turn. Matches the pre-partition
-        # "no actionable items" Stop(0) above. Keying on identity (``is not
-        # None``) distinguishes an empty reviewed diff — every file is out of
-        # scope, so every finding is excluded from auto-fix (filed as an issue
-        # only under the ``scope_issue_filing`` opt-in, issue #1056) and the
-        # run ends — from ``None``, which skips the partition entirely because
-        # scope cannot be judged.
-        if not items:
-            print_success(
-                console,
-                f"All findings outside the reviewed diff -- {_scope_filing_note(file_scope_issues)}, "
-                "nothing to fix.",
-            )
-            return Stop(0)
+
+    from daydream import git_ops
+
+    try:
+        initial_index = require_empty_staged_index(ctx.work)
+        stable_head = git_ops.head_sha(ctx.work.repo)
+        stable_ref = git_ops.stash_create(ctx.work.repo) or stable_head
+        preexisting_untracked = git_ops.snapshot_untracked_paths(
+            ctx.work.repo, include_runtime_artifacts=False
+        )
+        footprint = AuthorizedFixFootprint.build(
+            ctx.work.repo, set(changed_files or []), items
+        )
+    except (OSError, ValueError, git_ops.GitError) as exc:
+        print_error(console, "Fix preflight failed", str(exc))
+        return Stop(1)
+
+    session_id = _current_session_id() or ctx.work.run_id
+    state = FixCycleState(
+        session_id=session_id,
+        stable_ref=stable_ref,
+        stable_head=stable_head,
+        initial_index=initial_index,
+        preexisting_untracked=preexisting_untracked,
+        footprint=footprint,
+    )
+    ctx.data["fix_cycle_state"] = state
+    try:
+        initial_key = EvidenceKey(_capture_full_delta_key(ctx.work, state), footprint.policy_revision)
+        _write_footprint_audit(ctx, state, initial_key)
+    except (OSError, git_ops.GitError) as exc:
+        print_error(console, "Fix preflight failed", str(exc))
+        return Stop(1)
 
     # Severity-ordered (high before medium before low), stable within a
     # tier so equal-severity items keep their canonical merge order.
@@ -4033,127 +3862,104 @@ async def _evaluate_quality_gate(
                 f"({type(inner).__name__}: {inner})",
             )
 
-
-def _first_unconfined_finding(
-    repo: Path, items: list[dict[str, Any]]
-) -> dict[str, Any] | None:
-    """Return the first item whose ``file`` ref the confinement gate rejects.
-
-    Mirrors ``_preflight_finding_file_refs``'s item order (items[0] first,
-    then the rest) and reuses the phase's own predicate
-    (``_resolve_finding_file_ref``) so there is no grammar drift between the
-    phase's preflight raise and this guard's offender identification.
-    Returns ``None`` when every item is confined.
-    """
-    for item in items:
-        try:
-            _resolve_finding_file_ref(repo, item.get("file"))
-        except UnconfinedFindingError:
-            return item
-    return None
+MAX_POST_TEST_STABILIZATION_PASSES = 2
+ACTIONABLE_VERDICTS = frozenset(FIX_VERIFY_ACTIONABLE_VERDICTS)
+RETARGETABLE_VERDICTS = frozenset(FIX_VERIFY_RETARGETABLE_VERDICTS)
 
 
-def _record_unconfined_finding_failure(
-    repo: Path,
-    items: list[dict[str, Any]],
-    exc: UnconfinedFindingError,
-) -> tuple[dict[str, str], str]:
-    """Record an unconfined-finding preflight rejection in ``fix_failures``.
+@dataclass(frozen=True)
+class EvidenceKey:
+    """Tree and policy identity required by verifier evidence."""
 
-    ``phase_fix_parallel``'s confinement gate raises ``UnconfinedFindingError``
-    before dispatching any fix. This routes the rejection through the same
-    exception-failure recovery as a normal fix-group failure (patch capture,
-    fix_failures persistence, tree restore, generated-file reject, Stop(1))
-    instead of letting it escape to cli.py's generic handler.
-
-    The failure entry is keyed by the finding's STABLE id -- never the
-    unconfined path -- so the unsafe ref cannot become a grouping key or
-    restore argument. Returns the single-entry ``fix_failures`` dict along
-    with its key, so the caller can exclude the entry from path-based
-    tree-restore machinery: the id is not a repo-relative path, and the
-    preflight aborted before any dispatch, so no rollback is owed for it.
-    """
-    offender = _first_unconfined_finding(repo, items)
-    offender_id = offender.get("id") if offender else None
-    offender_file = offender.get("file") if offender else None
-    detail = f" (finding {offender_id}, file {offender_file!r})"
-    fix_key = str(offender_id) if offender_id is not None else "<unconfined-finding>"
-    fix_failures: dict[str, str] = {}
-    _record_fix_failure(fix_failures, fix_key, exc)
-    fix_failures[fix_key] += detail
-    print_warning(
-        console,
-        f"Fix preflight rejected an unconfined finding{detail}; no fixes applied.",
-    )
-    return fix_failures, fix_key
+    tree_key: str
+    policy_revision: int
 
 
-def _scrub_smart_quotes(
-    work: WorkContext,
-    *,
-    changed_files: list[str] | None = None,
-    ref: str = "HEAD",
-    preexisting_untracked: set[str] | None = None,
-    trustworthy: bool = True,
-    skip_reason: str = "Smart-quote scrub skipped: no trustworthy pre-fix snapshot.",
-) -> None:
-    """Best-effort ASCII-quote scrub of changed files about to be committed (#687).
+@dataclass(frozen=True)
+class RetainedTreeSnapshot:
+    """Authorized retained patch plus full observed-tree identity."""
 
-    Rewrites typographic smart quotes (U+201C/U+201D/U+2018/U+2019) back to ASCII
-    straight quotes in the given ``changed_files`` set, or — when ``changed_files``
-    is None — in the set freshly enumerated against ``ref`` with
-    ``preexisting_untracked`` filtered out. The driver attributes the agent-added
-    lines against ``ref`` (only those lines are rewritten; pre-existing smart
-    quotes in baseline content are preserved). Shared by the deep fix pass and
-    the deep test-heal pass.
+    paths: frozenset[str]
+    states: tuple[GitPathState, ...]
+    tree_key: str
+    verifier_patch: str
+    recommended_patch: bytes
 
-    Fail-open by design, never a gate: a missing, binary, or generated file is
-    skipped by the driver, an enumeration or attribution ``GitError`` degrades to
-    a warning, and an untrustworthy pre-fix base (``trustworthy=False``) skips
-    with ``skip_reason``. The scrub must never abort a run or block a commit.
-    """
+
+@dataclass
+class FixCycleState:
+    """One accepted fix gate's stable policy, baseline, and evidence."""
+
+    session_id: str
+    stable_ref: str
+    stable_head: str
+    initial_index: IndexSnapshot
+    preexisting_untracked: dict[str, GitPathState]
+    footprint: AuthorizedFixFootprint
+    latest_retained: RetainedTreeSnapshot | None = None
+    verifier_key: EvidenceKey | None = None
+    test_evidence: TestAttemptEvidence | None = None
+
+
+def _fix_cycle_state(ctx: FlowContext) -> FixCycleState:
+    state = ctx.data.get("fix_cycle_state")
+    if not isinstance(state, FixCycleState):
+        raise RuntimeError("fix cycle was not initialized at the accepted gate")
+    return state
+
+
+def _capture_full_delta_key(work: WorkContext, state: FixCycleState) -> str:
     from daydream import git_ops
 
-    if not trustworthy:
-        print_warning(console, skip_reason)
-        return
-    if changed_files is None:
-        try:
-            changed_files = git_ops.changed_files_against(
-                work.repo, ref, preexisting_untracked=preexisting_untracked,
-            )
-        except git_ops.GitError as exc:
-            print_warning(
-                console,
-                f"Could not enumerate changed files for smart-quote scrub: {exc}",
-            )
-            return
-    try:
-        scrubbed = scrub_smart_quotes_changed_files(
-            work.repo, changed_files, pre_fix_ref=ref,
+    return git_ops.tree_key(
+        git_ops.snapshot_worktree_delta(
+            work.repo,
+            state.stable_ref,
+            preexisting_untracked=state.preexisting_untracked,
         )
-    except git_ops.GitError as exc:
-        # Attribution diff could not be computed: fail-open, never abort.
-        print_warning(console, f"Could not scrub smart quotes in changed files: {exc}")
-        return
-    if scrubbed:
-        print_warning(
-            console,
-            "Normalized smart quotes to ASCII in: " + ", ".join(sorted(scrubbed)),
-        )
+    )
 
 
-# Actionable verdicts shared by every round/report consumer (issue #744).
-# Aliases into the single authority in ``daydream.phases`` (FIX_VERIFY_VERDICTS),
-# so _round_dispatch_items, _actionable_verdicts, and _render_fix_outcome_summary
-# all derive actionability from one source. Anything not in this set (notably
-# ``resolved``) is a terminal pass and is never re-dispatched.
-ACTIONABLE_VERDICTS = FIX_VERIFY_ACTIONABLE_VERDICTS
+def capture_retained_tree(work: WorkContext, state: FixCycleState) -> RetainedTreeSnapshot:
+    """Capture the authorized delta while keying the complete observable tree."""
+    from daydream import git_ops
 
-# Verdicts that may carry a corrected target ``path`` for re-dispatch (a
-# subset of ACTIONABLE_VERDICTS: only these retarget the file; ``unresolved``
-# keeps the item's full file next round).
-RETARGETABLE_VERDICTS = FIX_VERIFY_RETARGETABLE_VERDICTS
+    changed = set(git_ops.changed_paths_z(work.repo, state.stable_ref))
+    paths = frozenset(changed & set(state.footprint.run_allowed_paths))
+    states = git_ops.snapshot_worktree_paths(work.repo, paths)
+    full_states = git_ops.snapshot_worktree_delta(
+        work.repo,
+        state.stable_ref,
+        preexisting_untracked=state.preexisting_untracked,
+    )
+    recommended = git_ops.build_recommended_patch_strict(
+        work.repo, state.stable_ref, paths
+    )
+    return RetainedTreeSnapshot(
+        paths=paths,
+        states=states,
+        tree_key=git_ops.tree_key(full_states),
+        verifier_patch=recommended.decode("utf-8", errors="replace"),
+        recommended_patch=recommended,
+    )
+
+
+def _evidence_payload(key: EvidenceKey) -> dict[str, Any]:
+    return {"tree_key": key.tree_key, "policy_revision": key.policy_revision}
+
+
+def _write_footprint_audit(ctx: FlowContext, state: FixCycleState, key: EvidenceKey) -> None:
+    atomic_write_json(
+        fix_footprint_path(ctx.data["dd"]),
+        state.footprint.audit_payload(state.session_id, evidence_key=_evidence_payload(key)),
+    )
+
+
+def _persist_stabilization_failure(ctx: FlowContext, state: FixCycleState, reason: str) -> None:
+    atomic_write_json(
+        stabilization_failed_path(ctx.data["dd"]),
+        {"session_id": state.session_id, "reason": reason},
+    )
 
 
 def _round_dispatch_items(ctx: FlowContext, canonical: list[dict[str, Any]]) -> list[dict[str, Any]]:
@@ -4173,556 +3979,334 @@ def _round_dispatch_items(ctx: FlowContext, canonical: list[dict[str, Any]]) -> 
     outcomes = ctx.data.get("fix_outcomes") or {}
     if iteration in (None, 1) or not outcomes:
         return [dict(i) for i in canonical]
-    allowed = set(_resolve_changed_files(ctx) or [])
-    allowed |= {f for i in canonical if isinstance((f := i.get("file")), str)}
+    state = _fix_cycle_state(ctx)
+    round_number = iteration if isinstance(iteration, int) else 1
     dispatched: list[dict[str, Any]] = []
     for item in canonical:
-        iid = item.get("id")
-        outcome = outcomes.get(iid) if isinstance(iid, int) else None
+        uid = item.get("item_uid")
+        outcome = outcomes.get(uid) if isinstance(uid, str) else None
         if not outcome or outcome.get("verdict") not in ACTIONABLE_VERDICTS:
             continue
         copy = dict(item)
         if outcome.get("verdict") in RETARGETABLE_VERDICTS:
-            path = outcome.get("path")
-            if isinstance(path, str) and path in allowed:
-                copy["file"] = path
-                copy["fix_verify_path"] = path
+            accepted = state.footprint.accept_retarget(
+                ctx.work.repo,
+                str(uid),
+                outcome.get("path"),
+                phase="fix",
+                round_number=round_number,
+            )
+            if accepted is not None:
+                copy["file"] = accepted
+                copy["fix_verify_path"] = accepted
         copy["fix_verify_verdict"] = outcome.get("verdict")
         copy["fix_verify_reason"] = outcome.get("reason") or ""
         dispatched.append(copy)
     return dispatched
 
 
-def _capture_fix_round_snapshot(
-    work: WorkContext,
-    pre_fix_ref: str,
-    changed_after_fix: list[str] | None,
-) -> str:
-    """Issue #744: capture the round's changed hunks for post-fix fix-verify.
 
-    Returns the round's worktree diff (the hunks the fix pass produced) as a
-    single string for the read-only verifier, which audits only these hunks,
-    never the whole tree. The caller computes ``changed_after_fix`` against
-    ``pre_fix_ref`` after the residual net + scrub, so the verifier sees the
-    exact state the round left behind. Best-effort: ``None`` (no diff context,
-    i.e. a failed enumeration) or a diff failure degrades to an empty hunks
-    string, never a crash.
-    """
+
+def _round_rollback_snapshot(state: FixCycleState, work: WorkContext) -> WorktreeRollbackSnapshot:
+    """Capture one exact rollback point for all authorized group paths."""
     from daydream import git_ops
 
-    if changed_after_fix is None:
-        return ""
-    try:
-        diff = git_ops.diff_worktree_against(
-            work.repo, pre_fix_ref, sorted(changed_after_fix)
-        )
-    except git_ops.GitError as exc:
-        print_warning(console, f"Could not capture round diff for fix-verify: {exc}")
-        return ""
-    return _append_new_file_hunks(work.repo, changed_after_fix, diff)
+    return WorktreeRollbackSnapshot(
+        ref=state.stable_ref,
+        index=git_ops.snapshot_index(work.repo),
+        path_states=git_ops.snapshot_worktree_paths(
+            work.repo, state.footprint.run_allowed_paths
+        ),
+        untracked=git_ops.snapshot_untracked_paths(
+            work.repo, include_runtime_artifacts=False
+        ),
+    )
 
 
-def _append_new_file_hunks(
-    repo: Path, changed_files: list[str], hunks: str
-) -> str:
-    """Append added-file hunks for changed files that are still untracked (issue #4).
-
-    ``git diff <ref> -- <paths>`` never emits content for paths that were
-    untracked at the base ref, so a fix that resolves a finding by creating a
-    new file would have that file absent from the hunks the fix-verify agent
-    is mandated to audit. Re-snapshot the worktree's untracked set and render
-    each changed path in it as an added-file hunk so the new file is named in
-    the verifier's hunks (its content stays in the tree for the read-only
-    verifier to Read, not inlined into the prompt). Best-effort: a failed
-    enumeration degrades to the tracked hunks only, never a crash.
-    """
+def _strict_scope_and_scrub(
+    ctx: FlowContext,
+    state: FixCycleState,
+    *,
+    phase: str,
+    round_number: int | None,
+) -> bool:
+    """Apply the run-wide guard and quote scrub, returning whether bytes changed."""
     from daydream import git_ops
 
-    untracked = set(git_ops.list_untracked(repo))
-    new_files = sorted({p for p in changed_files if p in untracked})
-    if not new_files:
-        return hunks
-    pieces: list[str] = [hunks] if hunks else []
-    for rel in new_files:
-        pieces.append(
-            f"diff --git a/{rel} b/{rel}\n"
-            "new file mode 100644\n"
-            f"--- /dev/null\n"
-            f"+++ b/{rel}\n"
-        )
-    return "\n".join(pieces)
-
-
-async def _step_fix(ctx: FlowContext) -> Stop | None:
-    """Parallel fix pass: pre-fix snapshot capture, phase_fix_parallel, failure protection.
-
-    Round-aware dispatch (issue #744): the canonical ``ctx.data["items"]`` is
-    the full list for the run; each round dispatches only its own set — round 1
-    the full list, later rounds only the actionable subset from the prior
-    round's fix-verify outcomes, each carrying the verifier's reason forward.
-    """
-    from daydream import git_ops
-
-    config = ctx.config
-    work = ctx.work
-    target_dir = work.repo
-    daydream_dir = target_dir / ".daydream"
-    dd = ctx.data["dd"]
-    items: list[dict[str, Any]] = _round_dispatch_items(ctx, ctx.data["items"])
-    intent_p: Path = ctx.data["intent_path"]
-
-    # Only forward confirmed intent when we ran the intent phase in
-    # this invocation.  When resuming via --start-at fix/merge/per-stack
-    # the intent phase was skipped, so intent_p may hold a stale
-    # artifact from a prior run; injecting it as authoritative would
-    # contradict the current diff's context.
-    intent_grounded_this_run = config.start_at not in ("per-stack", "merge", "fix")
-    # Snapshot the tracked tree + untracked set BEFORE fixes so a failed
-    # group's partial, possibly non-compiling edits can be captured and
-    # rolled back to exactly their pre-fix content (#203 follow-up).
-    try:
-        pre_fix_snapshot = git_ops.stash_create(work.repo)
-        pre_fix_untracked = set(git_ops.list_untracked(work.repo))
-        pre_fix_untracked_contents = _snapshot_untracked_generated_files(work.repo, pre_fix_untracked)
-    except (git_ops.GitError, OSError) as exc:
-        print_warning(console, f"Could not snapshot tree before fixes: {exc}")
-        pre_fix_snapshot = None
-        pre_fix_untracked = set()
-        pre_fix_untracked_contents = {}
-        pre_fix_snapshot_captured = False
-    else:
-        pre_fix_snapshot_captured = True
-    # Issue #543: thread the pre-fix untracked snapshot into the commit steps so
-    # the host-native _do_commit can exclude user scratch files from the
-    # daydream commit (it never stages beyond the daydream change set).
-    ctx.data["pre_fix_untracked"] = pre_fix_untracked
-    # Pre-fix HEAD is the recommended-patch base only when the tree was
-    # clean (stash_create returns None then) -- otherwise the snapshot is
-    # the base and HEAD is unused, so skip the rev-parse. Captured now
-    # because the commit phase below advances HEAD past the fix.
-    if pre_fix_snapshot is None:
+    before = _capture_full_delta_key(ctx.work, state)
+    generated_restores: list[str] = []
+    for path in git_ops.changed_paths_z(ctx.work.repo, state.stable_ref):
+        if path.startswith(".daydream/") or path == REVIEW_OUTPUT_FILE:
+            continue
         try:
-            pre_fix_head = git_ops.head_sha(work.repo)
+            baseline = git_ops.show(ctx.work.repo, state.stable_ref, path)
         except git_ops.GitError:
-            pre_fix_head = None
-    else:
-        pre_fix_head = None
-    # Resolve per-file-group fix budgets (#201): file-config override wins, else
-    # the config.py default. A runaway file group cannot silently dominate a run.
-    group_wall_s = _resolve_config_value(config, "group_max_wall_s", DEFAULT_GROUP_MAX_WALL_S)
-    group_serial = _resolve_config_value(config, "group_max_serial_items", DEFAULT_GROUP_MAX_SERIAL_ITEMS)
-    # Issue #315: anti-degradation quality gate. Capture the pre-fix quality
-    # snapshot before any fix runs; the post-fix capture + verdict happen after
-    # failure protection below. Fail-open: a snapshot failure means the gate is
-    # unavailable for this run, never a run failure.
-    quality_gate_enabled = _resolve_config_value(config, "quality_gate_enabled", DEFAULT_QUALITY_GATE_ENABLED)
-    quality_gate_erosion_delta = _quality_gate_threshold(
-        config, "quality_gate_erosion_delta", DEFAULT_QUALITY_GATE_EROSION_DELTA
-    )
-    quality_gate_verbosity_delta = _quality_gate_threshold(
-        config, "quality_gate_verbosity_delta", DEFAULT_QUALITY_GATE_VERBOSITY_DELTA
-    )
-    quality_gate_erosion_absolute = _quality_gate_threshold(
-        config, "quality_gate_erosion_absolute", DEFAULT_QUALITY_GATE_EROSION_ABSOLUTE
-    )
-    quality_gate_verbosity_absolute = _quality_gate_threshold(
-        config, "quality_gate_verbosity_absolute", DEFAULT_QUALITY_GATE_VERBOSITY_ABSOLUTE
-    )
-    # Issue #336 — fix-loop scope bound. Thread the reviewed diff's file set
-    # into every fix prompt as an explicit "Allowed files" clause. ``None``
-    # (no diff context, e.g. a resume that lost ctx.data["diff"]) leaves the
-    # prompt unchanged; the prose scope boundary still applies. Resolved via
-    # _resolve_changed_files (shared with the gate) so a missing key never
-    # crashes and the gate and post-fix residual net agree on the allowed set.
-    # Issue #457: resolved BEFORE the pre-fix quality capture so the same
-    # reviewed set scopes both gate captures (parsing only reviewed ``*.py``)
-    # and the residual net.
-    changed_files = _resolve_changed_files(ctx)
-
-    # Set when the preflight confinement gate aborts the fix pass; its
-    # id-keyed failure entry is excluded from path-based tree restore below.
-    unconfined_fix_key: str | None = None
-
-    def _py_only(paths: Iterable[str]) -> set[str]:
-        return {p for p in paths if p.endswith(".py")}
-
-    if quality_gate_enabled:
-        # Issue #457: scope the pre-fix snapshot to the reviewed ``*.py`` set.
-        # ``None`` (no diff context, e.g. a resume that lost ctx.data["diff"])
-        # keeps the whole-workspace capture, exactly today's behavior on that
-        # resume path.
-        quality_before_paths: set[str] | None = (
-            _py_only(changed_files) if changed_files is not None else None
+            absolute = ctx.work.repo / path
+            try:
+                current = absolute.read_bytes()
+            except OSError:
+                current = None
+            if current is not None and is_generated_file(path, current):
+                state.footprint.authorize_new_generated(
+                    ctx.work.repo,
+                    path,
+                    phase=phase,
+                    round_number=round_number,
+                    reason="new generated output approved by generated-file policy",
+                )
+            continue
+        if is_generated_file(path, baseline):
+            generated_restores.append(path)
+            generated_restores.extend(related_manifest_paths(path))
+    if generated_restores:
+        restore_paths = sorted(set(generated_restores))
+        git_ops.restore_worktree_paths_from_ref(
+            ctx.work.repo, state.stable_ref, restore_paths
         )
-        quality_before, quality_before_unavailable = await _capture_quality_before(
-            daydream_dir, quality_before_paths
-        )
-    else:
-        quality_before, quality_before_unavailable = None, None
-    exploration_dir = ctx.data.get("exploration_dir")
-    exploration_dir = exploration_dir if isinstance(exploration_dir, Path) else None
-    test_map_path = exploration_dir / "test-map.json" if exploration_dir is not None else None
-    # Issue #744: record THIS round's dispatch set so the post-round fix-verify
-    # step audits exactly the findings that were dispatched (round 1: the full
-    # canonical list; later rounds: the actionable subset derived in _step_fix).
-    ctx.data["fix_round_items"] = list(items)
-    async with phase_scope(DaydreamPhase.FIX):
-        try:
-            fix_failures: dict[str, str] = await phase_fix_parallel(
-                ctx.backend_for("fix"),
-                work,
-                items,
-                intent_path=intent_p if (intent_grounded_this_run and intent_p.exists()) else None,
-                group_max_wall_s=group_wall_s,
-                group_max_serial_items=group_serial,
-                changed_files=changed_files,
-                exploration_dir=exploration_dir,
-                test_map_path=test_map_path,
+        for path in restore_paths:
+            state.footprint.record_git_event(
+                action="restore",
+                path=path,
+                origin="guard",
+                phase=phase,
+                round_number=round_number,
+                reason="restored an edit to existing generated output or its manifest",
             )
-        except UnconfinedFindingError as exc:
-            # Issue #574: the phase's preflight confinement gate raises on an
-            # unconfined/missing/non-string finding ``file`` ref. Route it
-            # through the same exception-failure recovery below (patch capture,
-            # fix_failures persistence, tree restore, generated-file reject,
-            # Stop(1)) instead of letting it escape to cli.py's generic
-            # handler. Only this exact type is caught so a ValueError from
-            # elsewhere inside phase_fix_parallel (e.g. a parser) is never
-            # misattributed to an unconfined finding.
-            fix_failures, unconfined_fix_key = _record_unconfined_finding_failure(
-                work.repo, items, exc
-            )
-    # Capture daydream's proposed diff (pre-fix tree → post-fix worktree)
-    # NOW, before the fix-failure and test-failure early returns below, so
-    # a run that generated a recommendation always archives it — even when
-    # tests fail or a fix group is reverted. Best-effort; never raises.
-    git_ops.capture_recommended_patch_with_base(
-        work.repo,
-        pre_fix_snapshot,
-        pre_fix_head,
-        daydream_dir / "recommended.patch",
-        preexisting_untracked=pre_fix_untracked,
-    )
-    fix_failures_p = fix_failures_path(dd)
-    # Partition failures: budget-exceeded groups have their already-applied fixes
-    # intact (only remaining findings were skipped) and must NOT be reverted.
-    # Exception-failed groups may hold broken partial edits and must be reverted.
-    _BUDGET_PREFIX = "file_group_budget_exceeded:"
-    exception_failures = {k: v for k, v in fix_failures.items() if not v.startswith(_BUDGET_PREFIX)}
-    budget_skips = {k: v for k, v in fix_failures.items() if v.startswith(_BUDGET_PREFIX)}
-
-    all_non_success = {**exception_failures, **budget_skips}
-    if all_non_success:
-        # Persist so the archive marks the run "partial" instead of
-        # "complete" -- the tree holds skipped or reverted groups.
-        fix_failures_p.write_text(json.dumps(all_non_success, indent=2, sort_keys=True))
-    elif fix_failures_p.exists():
-        fix_failures_p.unlink()
-
-    # Issue #744: fix-outcomes sidecar adjacent to the fix-failure record.
-    # Every dispatched finding's accumulated terminal verdict lives here so an
-    # attempted-but-unconfirmed finding cannot silently pass as fixed. The
-    # verifier step merges verdicts into ctx.data["fix_outcomes"]; this write
-    # keeps the sidecar current at every round boundary (and deletes it when
-    # empty -- no dispatched findings means no outcomes).
-    _persist_fix_outcomes(dd, ctx.data.get("fix_outcomes") or {})
-
-    if exception_failures:
-        # Only revert and abort for exception-failed groups; budget-exceeded
-        # groups' applied fixes are preserved and the run continues. The
-        # unconfined-finding entry (id-keyed, not a repo-relative path) is
-        # excluded: its preflight abort dispatched no fixes, and the id must
-        # never reach path-based restore machinery as a file path.
-        _protect_tree_after_fix_failures(
-            work,
-            target_dir,
-            {k: v for k, v in exception_failures.items() if k != unconfined_fix_key},
-            snapshot=pre_fix_snapshot,
-            snapshot_captured=pre_fix_snapshot_captured,
-            pre_untracked=pre_fix_untracked,
+        atomic_write_json(
+            generated_file_violations_path(ctx.data["dd"]),
+            {
+                "session_id": state.session_id,
+                "violations": restore_paths,
+                "phase": phase,
+                "round_number": round_number,
+            },
+            sort_keys=True,
         )
-        _reject_generated_file_edits(
-            work,
-            target_dir,
-            snapshot=pre_fix_snapshot,
-            snapshot_captured=pre_fix_snapshot_captured,
-            pre_untracked=pre_fix_untracked,
-            pre_untracked_contents=pre_fix_untracked_contents,
-        )
-        # Enumerate every untracked path that appeared during the fix
-        # pass and survived protection. Attribution to a specific group
-        # is impossible (shared tree, parallel groups), so we never
-        # delete these -- we record them so the partial state is fully
-        # auditable instead of silently leaving stray files unaccounted.
-        try:
-            leftover = sorted(set(git_ops.list_untracked(work.repo)) - pre_fix_untracked)
-        except git_ops.GitError:
-            leftover = []
-        leftover_p = fix_leftover_untracked_path(dd)
-        if leftover:
-            leftover_p.write_text(json.dumps(leftover, indent=2))
-        elif leftover_p.exists():
-            leftover_p.unlink()
-        print_warning(
-            console,
-            f"{len(exception_failures)} fix group(s) failed: {sorted(exception_failures)}; "
-            "partial edits reverted (patches saved under .daydream/partial-fixes/).",
-        )
-        return Stop(1)
-
-    # No exception failures: budget-skipped groups (if any) already warned via
-    # _record_budget_stop; proceed to test/commit with the applied fixes intact.
-    stale_leftover_p = fix_leftover_untracked_path(dd)
-    if stale_leftover_p.exists():
-        stale_leftover_p.unlink()
-    generated_guard_result = _reject_generated_file_edits(
-        work,
-        target_dir,
-        snapshot=pre_fix_snapshot,
-        snapshot_captured=pre_fix_snapshot_captured,
-        pre_untracked=pre_fix_untracked,
-        pre_untracked_contents=pre_fix_untracked_contents,
-    )
-    if generated_guard_result is None:
-        return Stop(1)
-    # Issue #336 (Task 4) — post-fix residual scope check: revert any edit the
-    # fix pass made outside the reviewed diff and file an issue per residual, so
-    # the commit step below can only land in-scope changes. Runs AFTER the
-    # generated-file guard (which already reverted generated-file edits, so no
-    # double-revert) and BEFORE the quality gate (which then measures the
-    # now-scoped edited set).
-    pre_fix_ref = pre_fix_snapshot or "HEAD"
-    # Thread the pre-fix base + snapshot trust into the test-heal scrub
-    # (_step_test) so it measures the same base on the same trust gate.
-    ctx.data["pre_fix_ref"] = pre_fix_ref
-    ctx.data["pre_fix_snapshot_captured"] = pre_fix_snapshot_captured
-    # Thread the raw pre-fix base onto ctx.data so _step_test's post-test
-    # re-capture passes an IDENTICAL base to the archived recommended.patch.
-    # pre_fix_head is None when a snapshot was captured (the snapshot is the
-    # base), and the pre-fix HEAD SHA when the tree was clean — exactly what
-    # the first capture passed at :3367-3368.
-    ctx.data["pre_fix_snapshot"] = pre_fix_snapshot
-    ctx.data["pre_fix_head"] = pre_fix_head
-    residual_guard_result = _revert_out_of_scope_edits(
-        work,
-        pre_fix_ref=pre_fix_ref,
-        snapshot_captured=pre_fix_snapshot_captured,
-        pre_fix_untracked=pre_fix_untracked,
-        changed_files=changed_files,
-        finding_files={item["file"] for item in ctx.data["items"] if item.get("file")},
-        # Issue #1056 — reverted-edit filing is opt-in; the revert itself is not.
+    enforced = enforce_authorized_fix_footprint(
+        ctx.work,
+        state.stable_ref,
+        state.footprint,
+        preexisting_untracked=state.preexisting_untracked,
+        phase=phase,
+        round_number=round_number,
         file_scope_issues=_scope_issue_filing(ctx.config),
     )
-    if residual_guard_result is None:
-        # Fail-close to match the generated-file guard: an unreverted
-        # out-of-scope edit must never reach the commit step.
-        return Stop(1)
-    # Issue #687: ASCII-quote normalization on the fix path. A fix agent that
-    # writes typographic smart quotes (U+201C/U+201D/U+2018/U+2019) into a
-    # changed file would otherwise commit those bytes and re-trigger the same
-    # typographic finding on every re-review. Scrub the same changed-file set
-    # the residual net and quality gate use (pre_fix_ref base) back to ASCII
-    # straight quotes BEFORE the quality gate measures the tree, so the gate
-    # and the commit stage the final scrubbed bytes. Only the lines the fix
-    # pass added are normalized (attributed from the working-tree diff against
-    # the same base), so pre-existing smart quotes in baseline content are
-    # never rewritten. Best-effort, never a gate: a missing, binary, or
-    # generated file is skipped, a write failure degrades to a warning, and a
-    # changed-file enumeration failure degrades to a warning rather than
-    # aborting the run or blocking the commit. The scrub and the quality gate
-    # below both enumerate the same post-residual tree with no mutation between
-    # them, so enumerate the changed-file set ONCE (Issue #336): one two-
-    # subprocess enumeration per fix run instead of two byte-identical ones,
-    # collapsing the repeated try/except -> warn/None shape.
-    try:
-        changed_after_fix = git_ops.changed_files_against(
-            work.repo, pre_fix_ref, preexisting_untracked=pre_fix_untracked
-        )
-    except git_ops.GitError as exc:
-        print_warning(console, f"Could not enumerate changed files after fix: {exc}")
-        changed_after_fix = None
-    # Trust gate: when the pre-fix snapshot could not be captured, pre_fix_ref
-    # falls back to HEAD, which may include user edits present before the fix
-    # pass — scrubbing them would rewrite the user's in-progress work. Match the
-    # sibling guards: fail-open, skip with a warning.
-    if changed_after_fix is not None:
-        _scrub_smart_quotes(
-            work,
-            changed_files=changed_after_fix,
-            ref=pre_fix_ref,
-            trustworthy=pre_fix_snapshot_captured,
-            skip_reason=(
-                "Smart-quote scrub skipped: no trustworthy pre-fix snapshot; "
-                "HEAD may include edits present before the fix pass."
-            ),
-        )
-    # Issue #744: capture the round's changed hunks for the post-fix fix-verify
-    # step (read-only verifier audits the round's hunks only, never the whole
-    # tree). Written after the residual net + scrub so the verifier sees the
-    # exact state the round left behind; best-effort (a failed enumeration or
-    # diff degrades to an empty hunks string, never a crash). Only ``hunks``
-    # crosses the round barrier -- the changed-file set stays local to this
-    # step (the quality gate consumes it live below), so no ``fix_round_changed``
-    # intermediate is written.
-    ctx.data["fix_round_hunks"] = _capture_fix_round_snapshot(
-        work, pre_fix_ref, changed_after_fix
+    scrub_smart_quotes_changed_files(
+        ctx.work.repo,
+        sorted(enforced.retained_paths),
+        pre_fix_ref=state.stable_ref,
     )
-    # Issue #315: post-fix anti-degradation gate over the files the fix phase
-    # edited. Tree is post-fix here (every applied or budget-preserved fix is
-    # intact); a regression is flagged and surfaced, never fatal.
-    #
-    # Issue #329 / Finding 6: gate every python file the fix pass changed, not
-    # just the finding-group targets. The fix agent is explicitly allowed to
-    # touch files outside a group's named file, so a regression in such a
-    # secondary file would otherwise bypass the gate, the artifact, the
-    # manifest, and SQLite. The candidate set is derived from the PRE-FIX git
-    # snapshot (clean tree -> HEAD; dirty tree -> the stash snapshot) -- the
-    # same base the generated-file guard and recommended-patch capture use --
-    # scoped to ``*.py``, then unioned with the finding-target files so finding
-    # targets stay covered even when their on-disk content did not change.
-    # Fail-open: if enumeration raises, candidates stay ``None`` and the gate
-    # persists an explicit ``unavailable`` verdict rather than gating on a
-    # partial candidate set.
-    #
-    # The PRE-FIX snapshot, by contrast, is scoped to the reviewed ``*.py``
-    # set only (#457), so a candidate that survived the residual net outside
-    # the reviewed diff (e.g. a newly-created untracked ``*.py``) has no
-    # before baseline; ``_evaluate_quality_gate`` records those explicitly as
-    # flagged missing-baseline entries rather than computing an undefined delta.
-    quality_candidates: set[str] | None
-    if quality_gate_enabled:
-        if changed_after_fix is not None:
-            quality_candidates = _py_only(changed_after_fix)
-            quality_candidates |= _py_only(
-                item["file"] for item in ctx.data["items"] if item.get("file")
-            )
-        else:
-            # Enumeration failed: gate records an explicit ``unavailable`` verdict
-            # rather than gating on a partial candidate set (same fail-open
-            # contract as before).
-            quality_candidates = None
+    after = _capture_full_delta_key(ctx.work, state)
+    return bool(generated_restores) or enforced.mutated or before != after
+
+
+async def _step_fix_authorized(ctx: FlowContext, state: FixCycleState) -> Stop | None:
+    """Run one policy-bound fix round using its own complete rollback point."""
+    items = _round_dispatch_items(ctx, ctx.data["items"])
+    ctx.data["fix_round_items"] = list(items)
+    if not items:
+        return None
+    try:
+        round_snapshot = _round_rollback_snapshot(state, ctx.work)
+    except Exception as exc:
+        print_error(console, "Fix snapshot failed", str(exc))
+        return Stop(1)
+    config = ctx.config
+    quality_enabled = _resolve_config_value(
+        config, "quality_gate_enabled", DEFAULT_QUALITY_GATE_ENABLED
+    )
+    reviewed_python = {
+        path for path in (_resolve_changed_files(ctx) or []) if path.endswith(".py")
+    }
+    if quality_enabled:
+        quality_before, quality_unavailable = await _capture_quality_before(
+            ctx.work.repo / ".daydream", reviewed_python
+        )
     else:
-        quality_candidates = set()
+        quality_before, quality_unavailable = None, None
+    exploration_dir = ctx.data.get("exploration_dir")
+    exploration_dir = exploration_dir if isinstance(exploration_dir, Path) else None
+    test_map_path = exploration_dir / "test-map.json" if exploration_dir else None
+    intent_p: Path = ctx.data["intent_path"]
+    grounded = config.start_at not in ("per-stack", "merge", "fix")
+    async with phase_scope(DaydreamPhase.FIX):
+        try:
+            failures = await phase_fix_parallel(
+                ctx.backend_for("fix"),
+                ctx.work,
+                items,
+                intent_path=intent_p if grounded and intent_p.exists() else None,
+                group_max_wall_s=_resolve_config_value(
+                    config, "group_max_wall_s", DEFAULT_GROUP_MAX_WALL_S
+                ),
+                group_max_serial_items=_resolve_config_value(
+                    config, "group_max_serial_items", DEFAULT_GROUP_MAX_SERIAL_ITEMS
+                ),
+                exploration_dir=exploration_dir,
+                test_map_path=test_map_path,
+                footprint=state.footprint,
+                round_snapshot=round_snapshot,
+            )
+        except Exception as exc:
+            print_error(console, "Fix failed", str(exc))
+            return Stop(1)
+    if failures:
+        atomic_write_json(fix_failures_path(ctx.data["dd"]), failures, sort_keys=True)
+        from daydream import git_ops
+
+        leftover = sorted(
+            set(
+                git_ops.snapshot_untracked_paths(
+                    ctx.work.repo, include_runtime_artifacts=False
+                )
+            )
+            - set(state.preexisting_untracked)
+        )
+        if leftover:
+            atomic_write_json(fix_leftover_untracked_path(ctx.data["dd"]), leftover)
+        print_warning(
+            console,
+            "Fix groups failed and were rolled back: " + ", ".join(sorted(failures)),
+        )
+        return Stop(1)
+    try:
+        _strict_scope_and_scrub(
+            ctx,
+            state,
+            phase="fix",
+            round_number=ctx.data.get("iteration"),
+        )
+        snapshot = capture_retained_tree(ctx.work, state)
+    except Exception as exc:
+        print_error(console, "Fix scope enforcement failed", str(exc))
+        return Stop(1)
+    ctx.data["fix_round_snapshot"] = snapshot
     await _evaluate_quality_gate(
-        enabled=quality_gate_enabled,
-        erosion_delta_threshold=quality_gate_erosion_delta,
-        verbosity_delta_threshold=quality_gate_verbosity_delta,
-        erosion_absolute_threshold=quality_gate_erosion_absolute,
-        verbosity_absolute_threshold=quality_gate_verbosity_absolute,
-        daydream_dir=daydream_dir,
-        dd=dd,
-        candidates=quality_candidates,
+        enabled=quality_enabled,
+        erosion_delta_threshold=_quality_gate_threshold(
+            config, "quality_gate_erosion_delta", DEFAULT_QUALITY_GATE_EROSION_DELTA
+        ),
+        verbosity_delta_threshold=_quality_gate_threshold(
+            config, "quality_gate_verbosity_delta", DEFAULT_QUALITY_GATE_VERBOSITY_DELTA
+        ),
+        erosion_absolute_threshold=_quality_gate_threshold(
+            config, "quality_gate_erosion_absolute", DEFAULT_QUALITY_GATE_EROSION_ABSOLUTE
+        ),
+        verbosity_absolute_threshold=_quality_gate_threshold(
+            config, "quality_gate_verbosity_absolute", DEFAULT_QUALITY_GATE_VERBOSITY_ABSOLUTE
+        ),
+        daydream_dir=ctx.work.repo / ".daydream",
+        dd=ctx.data["dd"],
+        candidates={path for path in snapshot.paths if path.endswith(".py")}
+        | {
+            str(item["file"])
+            for item in ctx.data["items"]
+            if isinstance(item.get("file"), str) and str(item["file"]).endswith(".py")
+        },
         before=quality_before,
-        before_unavailable_reason=quality_before_unavailable,
+        before_unavailable_reason=quality_unavailable,
         iteration=ctx.data.get("iteration"),
     )
     return None
 
 
-def _merge_round_verdicts(
-    round_items: list[dict[str, Any]],
-    per_group_verdicts: Iterable[list[dict[str, Any]]],
-) -> dict[int, dict[str, Any]]:
-    """Id-keyed merge of one round's per-fix-group verdicts (issue #744).
-
-    A retargetable verdict (the ``RETARGETABLE_VERDICTS`` members
-    ``wrong_target``/``regressed``) is re-dispatched to the corrected path;
-    when that re-dispatch finally resolves, keep the path on the terminal
-    outcome so the record says where the defect was actually fixed (#336 net
-    never widened). Verdicts lacking an int ``issue_id`` are dropped.
-    """
-    merged: dict[int, dict[str, Any]] = {}
-    round_items_by_id = {
-        item["id"]: item for item in round_items if isinstance(item.get("id"), int)
-    }
-    for verdicts in per_group_verdicts:
-        for verdict in verdicts:
-            issue_id = verdict.get("issue_id")
-            if not isinstance(issue_id, int):
-                continue
-            prior = round_items_by_id.get(issue_id)
-            if (
-                verdict.get("verdict") == "resolved"
-                and prior is not None
-                and prior.get("fix_verify_verdict") in RETARGETABLE_VERDICTS
-                and isinstance(prior.get("fix_verify_path"), str)
-            ):
-                stored = dict(verdict)
-                stored["path"] = prior["fix_verify_path"]
-            else:
-                stored = verdict
-            merged[issue_id] = stored
-    return merged
+async def _step_fix(ctx: FlowContext) -> Stop | None:
+    """Run one policy-bound fix round against the stable fix-cycle baseline."""
+    return await _step_fix_authorized(ctx, _fix_cycle_state(ctx))
 
 
-async def _step_fix_verify(ctx: FlowContext) -> BreakLoop | None:
-    """Post-round fix verifier step (issue #744): one verdict per dispatched finding.
 
-    Runs after every fix group in a round finishes (the round barrier) on the
-    round's changed hunks only. Phase work is delegated to
-    ``phase_fix_verify`` (read-only, advisory); each dispatched finding is
-    recorded in ``ctx.data["fix_outcomes"]`` keyed by its canonical id so the
-    dispatched-count == outcome-count invariant holds. Round 1 dispatches the
-    full canonical item list; later rounds re-dispatch only the actionable
-    subset (see ``_step_fix``).
 
-    Returns:
-        ``BreakLoop`` when no actionable verdicts remain — or when the round
-        budget is spent (iteration 3) — after persisting ``fix-outcomes.json``
-        and rendering the honest per-finding summary. ``None`` keeps the
-        enclosing LoopGroup iterating.
-    """
-    from daydream import git_ops
-    from daydream.phases import group_items_by_footprint, phase_fix_verify
+async def verify_retained_tree(
+    ctx: FlowContext,
+    snapshot: RetainedTreeSnapshot,
+    items: list[dict[str, Any]],
+    *,
+    pass_number: int,
+) -> dict[str, dict[str, Any]]:
+    """Verify all canonical findings and join numeric wire ids to durable uids."""
+    from daydream.phases import phase_fix_verify
 
-    round_value = ctx.data.get("fix_round_items")
-    round_items: list[dict[str, Any]] = (
-        list(round_value) if round_value is not None else list(ctx.data["items"])
+    verdicts = await phase_fix_verify(
+        ctx.backend_for("verify"),
+        ctx.work,
+        items,
+        snapshot.verifier_patch,
+        round_number=pass_number,
     )
-    if not round_items:
-        _persist_fix_outcomes(ctx.data["dd"], ctx.data.get("fix_outcomes") or {})
-        return BreakLoop()
-    hunks: str = ctx.data.get("fix_round_hunks") or ""
-    if not hunks:
-        # Best-effort whole-tree fallback: diff every uncommitted tracked change
-        # vs HEAD and append any untracked files as added hunks, so a lost round
-        # snapshot still lets the verifier audit the real tree rather than
-        # degrading to "(no hunks provided)". Never raises.
+    by_id = {
+        item.get("id"): item
+        for item in items
+        if isinstance(item.get("id"), int) and isinstance(item.get("item_uid"), str)
+    }
+    outcomes: dict[str, dict[str, Any]] = {}
+    for verdict in verdicts:
+        item = by_id.get(verdict.get("issue_id"))
+        if item is None:
+            continue
+        stored = dict(verdict)
+        stored["issue_id"] = item["id"]
+        outcomes[item["item_uid"]] = stored
+    return outcomes
+
+
+def _persist_fix_outcomes_current(
+    ctx: FlowContext,
+    state: FixCycleState,
+    key: EvidenceKey,
+    outcomes: dict[str, dict[str, Any]],
+) -> None:
+    atomic_write_json(
+        fix_outcomes_path(ctx.data["dd"]),
+        {
+            "session_id": state.session_id,
+            "evidence_key": _evidence_payload(key),
+            "outcomes": outcomes,
+        },
+        sort_keys=True,
+    )
+
+
+async def _step_fix_verify_authorized(
+    ctx: FlowContext, state: FixCycleState
+) -> BreakLoop | Stop | None:
+    snapshot = ctx.data.get("fix_round_snapshot")
+    if not isinstance(snapshot, RetainedTreeSnapshot):
         try:
-            hunks = git_ops.diff(ctx.work.repo, "HEAD", "HEAD")
-            hunks = _append_new_file_hunks(
-                ctx.work.repo, list(git_ops.list_untracked(ctx.work.repo)), hunks
-            )
-        except git_ops.GitError:
-            hunks = ""
-    outcomes: dict[int, dict[str, Any]] = ctx.data.setdefault("fix_outcomes", {})
+            snapshot = capture_retained_tree(ctx.work, state)
+        except Exception as exc:
+            print_error(console, "Fix verification capture failed", str(exc))
+            return Stop(1)
     iteration = ctx.data.get("iteration")
-    async with phase_scope(DaydreamPhase.VERIFY):
-        per_group_verdicts: list[list[dict[str, Any]]] = []
-        groups = group_items_by_footprint(round_items)
-        for _, group_items in groups:
-            per_group_verdicts.append(
-                await phase_fix_verify(
-                    ctx.backend_for("verify"),
-                    ctx.work,
-                    group_items,
-                    hunks,
-                    round_number=iteration if isinstance(iteration, int) else 1,
-                )
-            )
-    outcomes.update(_merge_round_verdicts(round_items, per_group_verdicts))
+    round_number = iteration if isinstance(iteration, int) else 1
+    try:
+        outcomes = await verify_retained_tree(
+            ctx, snapshot, ctx.data["items"], pass_number=round_number
+        )
+        key = EvidenceKey(snapshot.tree_key, state.footprint.policy_revision)
+        state.latest_retained = snapshot
+        state.verifier_key = key
+        ctx.data["fix_outcomes"] = outcomes
+        _persist_fix_outcomes_current(ctx, state, key, outcomes)
+        _write_footprint_audit(ctx, state, key)
+    except Exception as exc:
+        print_error(console, "Fix verification failed", str(exc))
+        return Stop(1)
     actionable = _actionable_verdicts(outcomes)
-    # Budget spent (iteration == 3), a flat/no-loop pass (iteration unset), or
-    # nothing left to re-dispatch all terminate the loop. In every terminal
-    # case the accumulated outcomes are persisted and the honest per-finding
-    # summary rendered (attempted-not-fixed for still-unresolved findings).
     if actionable and iteration not in (None, 3):
         return None
-    _persist_fix_outcomes(ctx.data["dd"], outcomes)
-    _render_fix_outcome_summary(ctx.data["dd"], round_items, outcomes)
+    if actionable:
+        return Stop(1)
+    _render_fix_outcome_summary(ctx.data["dd"], ctx.data["items"], outcomes)
     return BreakLoop()
 
 
-def _actionable_verdicts(outcomes: dict[int, dict[str, Any]]) -> list[str]:
+async def _step_fix_verify(ctx: FlowContext) -> BreakLoop | Stop | None:
+    """Verify every canonical finding against the complete retained tree."""
+    return await _step_fix_verify_authorized(ctx, _fix_cycle_state(ctx))
+
+
+def _actionable_verdicts(outcomes: dict[Any, dict[str, Any]]) -> list[str]:
     """Verdicts that schedule re-dispatch in a later round (issue #744)."""
     return [
         v["verdict"]
@@ -4731,25 +4315,12 @@ def _actionable_verdicts(outcomes: dict[int, dict[str, Any]]) -> list[str]:
     ]
 
 
-def _persist_fix_outcomes(dd: Path, outcomes: dict[int, dict[str, Any]]) -> None:
-    """Write ``fix-outcomes.json`` beside the fix-failure record (issue #744).
-
-    Keys are finding ids (JSON stringified), values the terminal verdict dicts.
-    Deleted when empty — no dispatched findings means no outcomes.
-    """
-    fix_outcomes_p = fix_outcomes_path(dd)
-    if outcomes:
-        fix_outcomes_p.write_text(
-            json.dumps({str(k): v for k, v in outcomes.items()}, indent=2, sort_keys=True)
-        )
-    elif fix_outcomes_p.exists():
-        fix_outcomes_p.unlink()
 
 
 def _render_fix_outcome_summary(
     dd: Path,
     items: list[dict[str, Any]],
-    outcomes: dict[int, dict[str, Any]],
+    outcomes: dict[Any, dict[str, Any]],
 ) -> None:
     """Render the terminal per-finding fix-verdict lines (issue #744).
 
@@ -4765,83 +4336,214 @@ def _render_fix_outcome_summary(
     """
     if not outcomes:
         return
-    numbering = {
+    numbering_by_id = {
         item["id"]: num
         for num, item in enumerate(items, start=1)
         if isinstance(item.get("id"), int)
     }
+    numbering_by_uid = {
+        item["item_uid"]: num
+        for num, item in enumerate(items, start=1)
+        if isinstance(item.get("item_uid"), str)
+    }
     total = len(items)
-    for issue_id, verdict in outcomes.items():
-        num = numbering.get(issue_id)
+    for outcome_key, verdict in outcomes.items():
+        num = (
+            numbering_by_uid.get(outcome_key)
+            if isinstance(outcome_key, str)
+            else numbering_by_id.get(outcome_key)
+        )
+        if num is None:
+            num = numbering_by_id.get(verdict.get("issue_id"))
         if num is None:
             continue
         print_fix_complete(console, num, total, outcome=verdict.get("verdict"))
 
 
+def _test_attempt_payload(attempt: TestAttemptEvidence) -> dict[str, Any]:
+    return {
+        "session_id": attempt.session_id,
+        "kind": attempt.kind,
+        "command": list(attempt.command) if attempt.command is not None else "agent-fallback",
+        "passed": attempt.passed,
+        "input_tree_key": attempt.input_tree_key,
+        "output_tree_key": attempt.output_tree_key,
+    }
+
+
+def _persist_test_verdict(
+    ctx: FlowContext,
+    state: FixCycleState,
+    *,
+    passed: bool,
+    ignored: bool,
+    attempts: list[TestAttemptEvidence],
+) -> None:
+    atomic_write_json(
+        test_verdict_path(ctx.data["dd"]),
+        {
+            "session_id": state.session_id,
+            "passed": passed,
+            "ignored": ignored,
+            "retries": max(0, len(attempts) - 1),
+            "attempts": [_test_attempt_payload(attempt) for attempt in attempts],
+        },
+        sort_keys=True,
+    )
+
+
+def _authorize_final_red_override() -> bool:
+    """Require a fresh interactive decision for a changed-tree red retest."""
+    if get_assume() is not None or get_non_interactive():
+        return False
+    return resolve_or_prompt(
+        assume=None,
+        interactive=True,
+        safe_default=False,
+        question="Final no-heal validation is still red. Ignore and continue? [y/N]",
+        default="n",
+    )
+
+
+async def finalize_retained_tree_after_test(
+    ctx: FlowContext, result: TestAndHealResult
+) -> Stop | None:
+    """Strictly stabilize post-heal state in at most two guard passes."""
+    state = _fix_cycle_state(ctx)
+    attempts = list(result.attempts)
+    if not attempts:
+        _persist_stabilization_failure(ctx, state, "test produced no evidence")
+        return Stop(1)
+    evidence = attempts[-1]
+    state.test_evidence = evidence
+    ignored = result.ignored
+
+    for pass_number in range(1, MAX_POST_TEST_STABILIZATION_PASSES + 1):
+        try:
+            mutated = _strict_scope_and_scrub(
+                ctx,
+                state,
+                phase="post_test",
+                round_number=pass_number,
+            )
+            snapshot = capture_retained_tree(ctx.work, state)
+            key = EvidenceKey(snapshot.tree_key, state.footprint.policy_revision)
+            _write_footprint_audit(ctx, state, key)
+        except Exception as exc:
+            _persist_stabilization_failure(ctx, state, f"guard/capture/audit failed: {exc}")
+            return Stop(1)
+
+        if state.verifier_key != key:
+            try:
+                outcomes = await verify_retained_tree(
+                    ctx, snapshot, ctx.data["items"], pass_number=pass_number
+                )
+                _persist_fix_outcomes_current(ctx, state, key, outcomes)
+            except Exception as exc:
+                _persist_stabilization_failure(ctx, state, f"final verifier failed: {exc}")
+                return Stop(1)
+            state.verifier_key = key
+            ctx.data["fix_outcomes"] = outcomes
+            if _actionable_verdicts(outcomes):
+                _persist_stabilization_failure(ctx, state, "final verifier remains actionable")
+                return Stop(1)
+
+        matching_test = (
+            evidence.session_id == state.session_id
+            and evidence.input_tree_key == snapshot.tree_key
+            and evidence.output_tree_key == snapshot.tree_key
+        )
+        ran_test = False
+        if not matching_test and pass_number == 1:
+            try:
+                evidence, _, _ = await phase_test_once(
+                    ctx.backend_for("test"),
+                    ctx.work,
+                    config=ctx.config,
+                    session_id=state.session_id,
+                    capture_tree_key=lambda: _capture_full_delta_key(ctx.work, state),
+                )
+            except Exception as exc:
+                _persist_stabilization_failure(ctx, state, f"final test failed to run: {exc}")
+                return Stop(1)
+            attempts.append(evidence)
+            state.test_evidence = evidence
+            ignored = False if evidence.passed else _authorize_final_red_override()
+            ran_test = True
+            _persist_test_verdict(
+                ctx,
+                state,
+                passed=evidence.passed,
+                ignored=ignored,
+                attempts=attempts,
+            )
+
+        if pass_number == 1 and (mutated or ran_test):
+            continue
+        stable_test = (
+            evidence.input_tree_key == snapshot.tree_key
+            and evidence.output_tree_key == snapshot.tree_key
+            and (evidence.passed or ignored)
+        )
+        if mutated or state.verifier_key != key or not stable_test:
+            _persist_stabilization_failure(ctx, state, "post-test tree did not stabilize")
+            return Stop(1)
+
+        try:
+            patch_path = ctx.work.repo / ".daydream" / "recommended.patch"
+            patch_path.parent.mkdir(parents=True, exist_ok=True)
+            patch_path.write_bytes(snapshot.recommended_patch)
+            atomic_write_json(
+                recommended_capture_path(ctx.data["dd"]),
+                {
+                    "session_id": state.session_id,
+                    "capture_point": "post_test",
+                    "tree_key": snapshot.tree_key,
+                    "evidence_key": _evidence_payload(key),
+                },
+                sort_keys=True,
+            )
+        except OSError as exc:
+            _persist_stabilization_failure(ctx, state, f"recommended capture failed: {exc}")
+            return Stop(1)
+        state.latest_retained = snapshot
+        return None
+
+    _persist_stabilization_failure(ctx, state, "post-test pass bound exhausted")
+    return Stop(1)
+
+
 
 async def _step_test(ctx: FlowContext) -> Stop | None:
-    """Post-fix test validation."""
-    from daydream import git_ops
+    """Run typed, identity-bound tests and strictly finalize the retained tree."""
+    state = _fix_cycle_state(ctx)
     async with phase_scope(DaydreamPhase.TEST):
-        passed, retries, proceed = await phase_test_and_heal(
-            ctx.backend_for("test"), ctx.work, feedback_items=ctx.data["items"],
-            config=ctx.config,
-        )
-    # Persisted before the failure early-return so both outcomes leave a verdict.
-    # ``passed`` is always the suite's own result: an operator who continues past
-    # a red suite records the override in ``ignored``, never as a green verdict.
-    test_verdict_path(ctx.data["dd"]).write_text(
-        json.dumps({"passed": passed, "retries": retries, "ignored": proceed and not passed}, indent=2)
-    )
-    if not proceed:
+        try:
+            result = await phase_test_and_heal(
+                ctx.backend_for("test"),
+                ctx.work,
+                feedback_items=ctx.data["items"],
+                config=ctx.config,
+                session_id=state.session_id,
+                capture_tree_key=lambda: _capture_full_delta_key(ctx.work, state),
+                footprint=state.footprint,
+            )
+            if not isinstance(result, TestAndHealResult):
+                raise TypeError("phase_test_and_heal returned an invalid evidence result")
+            _persist_test_verdict(
+                ctx,
+                state,
+                passed=result.passed,
+                ignored=result.ignored,
+                attempts=list(result.attempts),
+            )
+        except Exception as exc:
+            print_error(console, "Test evidence failed", str(exc))
+            return Stop(1)
+    if not result.proceed:
         print_warning(console, "Tests failed after fix attempt.")
         return Stop(1)
-    # Issue #687: test healing (phase_test_and_heal) writes agent edits after
-    # _step_fix's scrub, so re-scrub the tree about to be committed on the same
-    # pre_fix_ref base and trust gate (skip with a warning when the pre-fix
-    # snapshot could not be captured). Idempotent for the already-scrubbed fix
-    # edits; catches the test-heal edits before _step_commit stages the tree.
-    _scrub_smart_quotes(
-        ctx.work,
-        ref=ctx.data.get("pre_fix_ref") or "HEAD",
-        preexisting_untracked=ctx.data.get("pre_fix_untracked"),
-        trustworthy=bool(ctx.data.get("pre_fix_snapshot_captured", False)),
-        skip_reason=(
-            "Smart-quote scrub skipped after test healing: no trustworthy "
-            "pre-fix snapshot; HEAD may include edits present before the fix pass."
-        ),
-    )
-    # Issue #743: best-effort post-test re-capture. The pre-test capture above
-    # (in _step_fix) predates test-and-heal edits; re-capture the post-heal
-    # (post-scrub) tree here so the archived recommended.patch reproduces the
-    # exact tree _step_commit commits. Runs only on the success path (after the
-    # test-failure early return) and only in flows with a fix/test cycle.
-    # Best-effort: a raise writes nothing and leaves the pre-test patch intact.
-    re_captured = False
-    try:
-        git_ops.capture_recommended_patch_with_base(
-            ctx.work.repo,
-            ctx.data.get("pre_fix_snapshot"),
-            ctx.data.get("pre_fix_head"),
-            ctx.work.repo / ".daydream" / "recommended.patch",
-            preexisting_untracked=ctx.data.get("pre_fix_untracked"),
-        )
-        re_captured = True
-    except Exception:
-        pass
-    # Session-bound capture-point sidecar, mirrored from fix-quality-gate.json.
-    # Only record "post_test" when the re-capture succeeded; otherwise the patched
-    # tree on disk is still the pre-test capture, not the post-heal tree.
-    if re_captured:
-        try:
-            recommended_capture_path(ctx.data["dd"]).write_text(
-                json.dumps(
-                    {"session_id": _current_session_id(), "capture_point": "post_test"}, indent=2
-                )
-            )
-        except Exception:
-            pass
-    return None
+    return await finalize_retained_tree_after_test(ctx, result)
 
 
 async def _commit_push_or_stop(coro: Awaitable[None]) -> Stop | None:
@@ -4861,20 +4563,37 @@ async def _commit_push_or_stop(coro: Awaitable[None]) -> Stop | None:
 
 
 async def _step_commit(ctx: FlowContext) -> Stop | None:
-    """Commit-and-push the applied fixes."""
-    # phase_commit_push runs as part of the fix/commit cycle — reuse
-    # the fix backend (no separate "commit" phase identifier).
-    # stage_paths can raise GitError synchronously before the agent turn;
-    # _commit_push_or_stop surfaces that as a clean Stop(1) instead of
-    # an unhandled traceback terminating the deep run.
-    # The applied fix items are threaded through to build_commit_message so
-    # the deterministic commit message lists them instead of static boilerplate.
+    """Stage the finalized retained paths once, then commit and push them."""
+    state = _fix_cycle_state(ctx)
+    snapshot = state.latest_retained
+    if snapshot is None:
+        print_error(console, "Commit/Push Failed", "retained tree was not finalized")
+        return Stop(1)
+    key = EvidenceKey(snapshot.tree_key, state.footprint.policy_revision)
+    try:
+        for path in sorted(snapshot.paths):
+            state.footprint.record_git_event(
+                action="stage",
+                path=path,
+                origin="staging",
+                phase="commit",
+                round_number=None,
+                reason="final retained path selected for the validated index",
+            )
+        _write_footprint_audit(ctx, state, key)
+    except Exception as exc:
+        print_error(console, "Commit/Push Failed", str(exc))
+        return Stop(1)
     return await _commit_push_or_stop(
         phase_commit_push(
-            ctx.backend_for("fix"), ctx.work,
-            preexisting_untracked=ctx.data.get("pre_fix_untracked"),
+            ctx.backend_for("fix"),
+            ctx.work,
+            preexisting_untracked=set(state.preexisting_untracked),
             config=ctx.config,
             items=ctx.data.get("items") or [],
+            retained_paths=snapshot.paths,
+            retained_states=snapshot.states,
+            initial_index=state.initial_index,
         )
     )
 

--- a/daydream/deep/orchestrator.py
+++ b/daydream/deep/orchestrator.py
@@ -3249,6 +3249,16 @@ async def _step_fix_gate(ctx: FlowContext) -> Stop | None:
         print_success(console, f"Report written to {ctx.data['merged_report']}. Exiting.")
         return Stop(0)
 
+    from daydream import git_ops
+
+    # A rejected index preflight must preserve prior artifacts as well as
+    # source bytes. Only an admitted run may start a new evidence session.
+    try:
+        initial_index = require_empty_staged_index(ctx.work)
+    except (OSError, git_ops.GitError) as exc:
+        print_error(console, "Fix preflight failed", str(exc))
+        return Stop(1)
+
     # An accepted gate starts a new evidence session. No prior run's success,
     # patch, or policy audit may be inherited if this run later stops early.
     dd: Path = ctx.data["dd"]
@@ -3297,10 +3307,7 @@ async def _step_fix_gate(ctx: FlowContext) -> Stop | None:
     # fixer's edit scope.
     changed_files = _resolve_changed_files(ctx)
 
-    from daydream import git_ops
-
     try:
-        initial_index = require_empty_staged_index(ctx.work)
         stable_head = git_ops.head_sha(ctx.work.repo)
         stable_ref = git_ops.stash_create(ctx.work.repo) or stable_head
         preexisting_untracked = git_ops.snapshot_untracked_paths(
@@ -3950,11 +3957,16 @@ def capture_retained_tree(work: WorkContext, state: FixCycleState) -> RetainedTr
     for mutation attribution, rollback, and test identity.  Commit selection is
     deliberately relative to the original HEAD: authorized reviewed edits that
     predate the gate are part of the result even when no fixer touches them.
+    Pre-existing untracked owner files remain protected even when a finding
+    names them; authorization cannot silently enroll that private draft in a
+    commit. New related files created after the gate are still retained.
     """
     from daydream import git_ops
 
     changed = set(git_ops.changed_paths_z(work.repo, state.stable_head))
-    paths = frozenset(changed & set(state.footprint.run_allowed_paths))
+    paths = frozenset(
+        (changed & set(state.footprint.run_allowed_paths)) - set(state.preexisting_untracked)
+    )
     states = git_ops.snapshot_worktree_paths(work.repo, paths)
     full_states = git_ops.snapshot_worktree_delta(
         work.repo,
@@ -4241,7 +4253,30 @@ async def _step_fix_authorized(ctx: FlowContext, state: FixCycleState) -> Stop |
             if confinement_error is not None:
                 print_error(console, "Fix failure confinement failed", confinement_error)
             return Stop(1)
-    if failures:
+    budget_prefix = "file_group_budget_exceeded:"
+    exception_failures = {
+        path: reason
+        for path, reason in failures.items()
+        if not reason.startswith(budget_prefix)
+    }
+    failures_artifact = fix_failures_path(ctx.data["dd"])
+    try:
+        if failures:
+            atomic_write_json(failures_artifact, failures, sort_keys=True)
+        else:
+            failures_artifact.unlink(missing_ok=True)
+    except Exception as exc:
+        confinement_error = _enforce_terminal_confinement(
+            ctx,
+            state,
+            phase="fix_failure",
+            round_number=ctx.data.get("iteration"),
+        )
+        print_error(console, "Fix failure audit failed", str(exc))
+        if confinement_error is not None:
+            print_error(console, "Fix failure confinement failed", confinement_error)
+        return Stop(1)
+    if exception_failures:
         from daydream import git_ops
 
         confinement_error = _enforce_terminal_confinement(
@@ -4252,7 +4287,6 @@ async def _step_fix_authorized(ctx: FlowContext, state: FixCycleState) -> Stop |
         )
         artifact_errors: list[str] = []
         try:
-            atomic_write_json(fix_failures_path(ctx.data["dd"]), failures, sort_keys=True)
             leftover = sorted(
                 set(
                     git_ops.snapshot_untracked_paths(
@@ -4267,7 +4301,8 @@ async def _step_fix_authorized(ctx: FlowContext, state: FixCycleState) -> Stop |
             artifact_errors.append(str(exc))
         print_warning(
             console,
-            "Fix groups failed and were rolled back: " + ", ".join(sorted(failures)),
+            "Failed fix groups were restored; this run will not commit successful "
+            "sibling-group edits: " + ", ".join(sorted(exception_failures)),
         )
         if confinement_error is not None:
             print_error(console, "Fix failure confinement failed", confinement_error)
@@ -4436,9 +4471,9 @@ async def _step_fix_verify_authorized(
     actionable = _actionable_verdicts(outcomes)
     if actionable and iteration not in (None, 3):
         return None
+    _render_fix_outcome_summary(ctx.data["dd"], ctx.data["items"], outcomes)
     if actionable:
         return Stop(1)
-    _render_fix_outcome_summary(ctx.data["dd"], ctx.data["items"], outcomes)
     return BreakLoop()
 
 

--- a/daydream/deep/prompts.py
+++ b/daydream/deep/prompts.py
@@ -1170,9 +1170,8 @@ def build_fix_verify_prompt(
 ) -> str:
     """Assemble the read-only post-fix fix-verify prompt (issue #744).
 
-    Runs after every fix group in a round finishes (the round barrier) and
-    audits the round's changed hunks only -- never the whole tree. For each
-    dispatched finding listed below the verifier returns EXACTLY one verdict
+    Audits the complete current retained patch against every canonical finding.
+    For each finding listed below the verifier returns EXACTLY one verdict
     from the four-value enum: ``resolved`` (the named defect is gone),
     ``unresolved`` (still present, wholly or partly), ``wrong_target`` (the
     defect lives in a file the finding did not name -- carry ``path``), or
@@ -1185,11 +1184,10 @@ def build_fix_verify_prompt(
     pays for twice.
 
     Args:
-        items: The round's dispatched canonical items, rendered inline into the
+        items: All canonical items, rendered inline into the
             prompt; verdicts are keyed by each item's canonical ``id``.
-        changed_hunks: The round's diff text (changed hunks only) the verifier
-            audits. May be empty; the verifier is told these hunks are all it
-            may inspect.
+        changed_hunks: The complete retained patch the verifier audits. May be
+            empty when the retained tree matches the stable base.
         cwd: Absolute working directory the verifier runs in (grounds path resolution).
     """
     from daydream.deep.render import render_report
@@ -1197,19 +1195,19 @@ def build_fix_verify_prompt(
     hunks_block = changed_hunks if changed_hunks.strip() else "(no hunks provided)"
     parts: list[str] = []
     parts.append(
-        "You are the post-fix fix-verifier agent (the `fix-verify` step). A fix "
-        "round just ran on this "
-        "worktree; your job is to audit what the round produced and return "
+        "You are the post-fix fix-verifier agent (the `fix-verify` step). The "
+        "fix cycle is stabilizing this "
+        "worktree; your job is to audit the complete retained result and return "
         "EXACTLY one verdict per finding below. This is a READ-ONLY pass: you "
         "inspect the diff and the code, you do not edit anything.\n\n"
-        f"Round {round_number} of up to 3 check passes.\n\n"
+        f"Verification pass {round_number}.\n\n"
         f"{CWD_GROUNDING_INSTRUCTION.format(cwd=cwd)}\n"
-        "You audit the round's changed hunks ONLY, never the whole tree:\n"
+        "Audit this complete current retained patch:\n"
         "\n"
         "<changed-hunks>\n"
         f"{hunks_block}\n"
         "</changed-hunks>\n\n"
-        "The numbered findings the round dispatched (each `issue_id` in your "
+        "Audit all canonical findings (each `issue_id` in your "
         "output MUST match the leading number `N.` of the finding it "
         "verifies):\n\n"
         + render_report(items)
@@ -1217,11 +1215,11 @@ def build_fix_verify_prompt(
     )
     parts.append(
         "Verdict semantics (MANDATORY):\n"
-        "  - `resolved` -- the named defect is gone from the changed hunks.\n"
+        "  - `resolved` -- the named defect is gone from the retained result.\n"
         "  - `unresolved` -- the defect is still present, wholly or partly.\n"
         "  - `wrong_target` -- the defect lives in a file the finding did NOT "
         "name; emit `path` with the corrected repo-relative file.\n"
-        "  - `regressed` -- the round introduced a NEW instance of the named "
+        "  - `regressed` -- the retained result contains a NEW instance of the named "
         "defect; emit `path` with the file where it now appears.\n"
         "  - `wrong_target` and `regressed` verdicts MUST carry `path`; the "
         "other two never carry it.\n"
@@ -1235,7 +1233,7 @@ def build_fix_verify_prompt(
         "  - Do NOT write, edit, or move files. Do NOT run `git commit`, "
         "`git add`, `git checkout`, `git reset`, `git stash`, or any other "
         "state-changing command.\n"
-        "  - Depth: inspect the changed hunks' files, but do not roam the whole "
+        "  - Depth: inspect the retained patch's files, but do not roam the whole "
         "tree; prefer Grep/Glob to narrow."
     )
     return "\n\n".join(parts)

--- a/daydream/deep/scope_issues.py
+++ b/daydream/deep/scope_issues.py
@@ -41,6 +41,7 @@ def enforce_authorized_fix_footprint(
     footprint: AuthorizedFixFootprint,
     *,
     preexisting_untracked: dict[str, GitPathState],
+    preexisting_gitlinks: tuple[GitPathState, ...] = (),
     phase: str,
     round_number: int | None,
     file_scope_issues: bool = False,
@@ -58,6 +59,16 @@ def enforce_authorized_fix_footprint(
     repo = work.repo
     index_before = git_ops.snapshot_index(repo)
     tracked_changed = set(git_ops.changed_paths_z(repo, stable_ref, include_untracked=False))
+    gitlink_baseline = {state.path: state for state in preexisting_gitlinks}
+    current_gitlinks = {
+        state.path: state
+        for state in git_ops.snapshot_worktree_paths(repo, gitlink_baseline)
+    }
+    mutated_gitlinks = {
+        path
+        for path, baseline in gitlink_baseline.items()
+        if current_gitlinks[path] != baseline
+    }
     current_untracked = git_ops.snapshot_untracked_paths(repo, include_runtime_artifacts=False)
     current_protected: dict[str, GitPathState] = {}
     for path in preexisting_untracked:
@@ -72,8 +83,21 @@ def enforce_authorized_fix_footprint(
     }
     new_untracked = set(current_untracked) - set(preexisting_untracked)
     residual_tracked = tracked_changed - set(footprint.run_allowed_paths)
+    # A pre-run checkout different from the superproject entry is owner state,
+    # not a run-created residual.  Preserve it unless the run changed it.
+    residual_tracked -= {
+        path
+        for path, baseline in gitlink_baseline.items()
+        if current_gitlinks[path] == baseline
+    }
     residual_new = new_untracked - set(footprint.run_allowed_paths)
-    to_restore = residual_tracked | residual_new | mutated_protected
+    protected_gitlink_mutations = mutated_gitlinks - set(footprint.run_allowed_paths)
+    to_restore = (
+        residual_tracked
+        | residual_new
+        | mutated_protected
+        | protected_gitlink_mutations
+    )
 
     if file_scope_issues:
         paths_to_file = sorted(
@@ -88,12 +112,17 @@ def enforce_authorized_fix_footprint(
         stable_states = git_ops.snapshot_commit_paths(
             repo,
             stable_ref,
-            residual_tracked - set(preexisting_untracked),
+            residual_tracked - set(preexisting_untracked) - set(gitlink_baseline),
         )
         rollback = git_ops.WorktreeRollbackSnapshot(
             ref=stable_ref,
             index=index_before,
-            path_states=stable_states,
+            path_states=tuple(
+                (
+                    *stable_states,
+                    *(gitlink_baseline[path] for path in protected_gitlink_mutations),
+                )
+            ),
             untracked={path: preexisting_untracked[path] for path in mutated_protected},
         )
         git_ops.restore_group_from_snapshot(repo, rollback, to_restore)
@@ -107,7 +136,11 @@ def enforce_authorized_fix_footprint(
                 reason = (
                     "restored protected pre-existing untracked state"
                     if path in preexisting_untracked
-                    else "restored tracked content outside the authorized run footprint"
+                    else (
+                        "restored protected pre-existing gitlink checkout"
+                        if path in gitlink_baseline
+                        else "restored tracked content outside the authorized run footprint"
+                    )
                 )
             footprint.record_git_event(
                 action=action,
@@ -130,6 +163,15 @@ def enforce_authorized_fix_footprint(
         if current != baseline:
             raise git_ops.GitError("scope enforcement did not restore protected untracked state")
     remaining_tracked = set(git_ops.changed_paths_z(repo, stable_ref, include_untracked=False))
+    final_gitlinks = {
+        state.path: state
+        for state in git_ops.snapshot_worktree_paths(repo, gitlink_baseline)
+    }
+    for path, baseline in gitlink_baseline.items():
+        if path in protected_gitlink_mutations and final_gitlinks[path] != baseline:
+            raise git_ops.GitError("scope enforcement did not restore protected gitlink state")
+        if final_gitlinks[path] == baseline:
+            remaining_tracked.discard(path)
     remaining_untracked = set(untracked_after) - set(preexisting_untracked)
     residual_after = (remaining_tracked | remaining_untracked) - set(footprint.run_allowed_paths)
     if residual_after:

--- a/daydream/deep/scope_issues.py
+++ b/daydream/deep/scope_issues.py
@@ -1,24 +1,19 @@
-"""Out-of-scope issue routing for the deep fix loop (issue #336, extracted in #338).
+"""Authorized fix-footprint enforcement and residual-edit issue filing.
 
-The fix loop auto-fixes only findings inside the reviewed diff. Findings on files
-outside the diff, and post-fix edits outside the diff, are routed to tracked
-GitHub issues (best-effort, gated by the ``scope_issue_filing`` opt-in, default
-off — issue #1056) and excluded from auto-fix. This module owns that
-machinery: scope-finding fingerprint -> marker -> cross-run dedup -> filing, plus
-the post-fix residual revert net (whose filing path carries the same
-fingerprint -> marker -> dedup -> file chain, issue #1051). Extracted from
-``deep/orchestrator.py``.
+Canonical finding paths are admitted by :class:`AuthorizedFixFootprint` even
+when they are outside the reviewed diff. Edits outside that run-wide footprint
+are restored here and, when ``scope_issue_filing`` is enabled, filed as tracked
+GitHub issues with cross-run fingerprint deduplication.
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from daydream.agent import console
 from daydream.fix_footprint import AuthorizedFixFootprint
-from daydream.generated_files import is_generated_file
 from daydream.git_ops import GitPathState
 from daydream.ui import print_warning
 
@@ -185,11 +180,9 @@ def enforce_authorized_fix_footprint(
 def _file_scope_issue(repo: Path, *, title: str, body: str, noun: str, ident: str) -> None:
     """Best-effort: file one scope-related GitHub issue; never raise.
 
-    Shared by the out-of-scope *finding* router (pre-fix gate) and the
-    reverted *edit* filer (post-fix residual net). Issue #336 — both file a
-    tracked issue for work the fix loop will not land in the PR. Filing is
-    best-effort: a failed ``gh issue create`` (no auth, cross-org, offline)
-    logs a warning and the scope decision (exclude / revert) stands regardless.
+    The residual-edit filer records work the footprint guard restored instead
+    of landing it in the PR. Filing is best-effort: a failed ``gh issue create``
+    (no auth, cross-org, offline) logs a warning and the restore stands.
     """
     from daydream import git_ops
 
@@ -200,85 +193,22 @@ def _file_scope_issue(repo: Path, *, title: str, body: str, noun: str, ident: st
         print_warning(console, f"Could not file out-of-scope {noun} '{ident}' as issue: {exc}")
 
 
-def _scope_finding_fingerprint(item: dict[str, Any]) -> str:
-    """Stable cross-run identity for an out-of-scope finding.
-
-    Reuses :func:`daydream.pr_review.compute_fingerprint` (path + normalized
-    description + rationale), so minor wording drift across runs still maps to
-    the same fingerprint and a re-review reproducing an out-of-scope finding is
-    recognized as already-filed.
-    """
-    from daydream.pr_review import compute_fingerprint
-
-    return compute_fingerprint(
-        item.get("file") or "",
-        item.get("description", ""),
-        item.get("evidence", ""),
-    )
-
-
-def _scope_finding_marker(fingerprint: str) -> str:
-    """Hidden HTML comment embedding a finding fingerprint in an issue body.
-
-    Distinct from :func:`daydream.pr_review.finding_marker` (the PR-comment
-    store) so the two stores never collide: scope issues are deduped only
-    against scope issues, PR comments only against PR comments.
-    """
-    return f"<!-- daydream-scope-finding: {fingerprint} -->"
-
-
 def _scope_already_filed(repo: Path, marker: str) -> bool:
     """Best-effort: has an open issue already filed this scope marker?
 
-    Shared by the out-of-scope *finding* router (pre-fix gate, issue #336) and
-    the reverted *edit* filer (post-fix residual net, issue #1051). GitHub is
-    the store: scan open issues for the item's fingerprint marker and skip
-    filing when present, so a re-run/resume re-deriving the same item does not
-    re-file a duplicate issue. Best-effort by construction: ``gh_issue_list``
-    itself returns an empty list on any failure (no auth, offline, cross-org),
-    so a failed lookup degrades to filing (the prior behavior), never to
-    silently dropping the item.
+    GitHub is the store: scan open issues for the reverted edit's fingerprint
+    marker and skip filing when present, so a re-run reproducing the same edit
+    does not file a duplicate issue. Best-effort by construction:
+    ``gh_issue_list`` returns an empty list on failure, so a failed lookup
+    degrades to filing rather than silently dropping the restored edit.
 
-    The marker is computed once by the caller and threaded in, so the item's
+    The marker is computed once by the caller and threaded in, so the edit's
     fingerprint is not recomputed for both the dedup lookup and the issue body.
     """
     from daydream import git_ops
 
     issues = git_ops.gh_issue_list(repo, search="out-of-scope")
     return any(marker in (issue.get("body") or "") for issue in issues)
-
-
-def _file_out_of_scope_issue(ctx: FlowContext, item: dict[str, Any]) -> None:
-    """Best-effort: file one out-of-scope finding as a tracked GitHub issue.
-
-    Issue #336 — the fix loop auto-fixes only findings inside the reviewed
-    diff. A finding on a file outside the diff is still *valid*, so instead of
-    silently dropping it we route it to a GitHub issue where it stays tracked.
-    Cross-run dedup: the finding's fingerprint is embedded as a hidden marker
-    in the body, and a re-run/resume skips filing when an open issue already
-    carries it, so the same out-of-scope finding is filed once, not on every
-    run. Filing is best-effort by design: a failed ``gh issue create`` (no auth,
-    cross-org, offline) logs a warning and the item is still excluded from
-    auto-fix — the scope decision never depends on issue-filing success.
-    """
-    file = item.get("file") or "<unknown>"
-    description = item.get("description", "No description")
-    evidence = item.get("evidence", "")
-    # Compute the fingerprint marker once and thread it into both the dedup
-    # lookup and the issue body, rather than recomputing it for each.
-    marker = _scope_finding_marker(_scope_finding_fingerprint(item))
-    if _scope_already_filed(ctx.work.repo, marker):
-        return
-    title = f"[daydream] out-of-scope finding: {file}"
-    body = (
-        f"{description}\n\n"
-        f"- File: `{file}`\n"
-        f"- Line: {item.get('line', '?')}\n"
-        f"- Evidence: {evidence}\n\n"
-        "Filed by daydream fix loop: out of scope for PR.\n"
-        f"{marker}"
-    )
-    _file_scope_issue(ctx.work.repo, title=title, body=body, noun="finding", ident=file)
 
 
 def _scope_edit_fingerprint(path: str, patch: str) -> str:
@@ -294,7 +224,7 @@ def _scope_edit_fingerprint(path: str, patch: str) -> str:
     Stripping the hunk headers and context lines (keeping only the ``+``/``-``
     content lines) mirrors how :func:`daydream.pr_review.compute_fingerprint`
     excludes line numbers so code shifts do not change a finding's identity.
-    Distinct from the finding-path fingerprint so the two stores never collide.
+    Its scope-edit marker namespace stays distinct from PR-comment findings.
     """
     from daydream.pr_review import compute_fingerprint
 
@@ -309,9 +239,8 @@ def _scope_edit_fingerprint(path: str, patch: str) -> str:
 def _scope_edit_marker(fingerprint: str) -> str:
     """Hidden HTML comment embedding an edit fingerprint in an issue body.
 
-    Distinct prefix from ``_scope_finding_marker`` so the finding store and
-    the edit store never collide, mirroring the split between
-    ``_scope_finding_marker`` and ``pr_review.finding_marker``.
+    The distinct ``daydream-scope-edit`` prefix prevents collisions with the
+    PR-comment finding store.
     """
     return f"<!-- daydream-scope-edit: {fingerprint} -->"
 
@@ -343,169 +272,24 @@ def _file_reverted_edit_issue(repo: Path, path: str, patch: str) -> None:
     _file_scope_issue(repo, title=title, body=body, noun="edit", ident=path)
 
 
-def _scope_filing_note(file_scope_issues: bool) -> str:
-    """Filing-status note shared by the gate and residual-net messages.
-
-    Issue #1056 — the pre-fix gate (``_step_fix_gate``) and the post-fix
-    residual net (``_revert_out_of_scope_edits``) both branch on the same
-    ``scope_issue_filing`` opt-in to report whether out-of-scope items were
-    filed as GitHub issues or just excluded/reverted. Only the trailing note
-    differs between the two branches at every message site, so the pair is
-    rendered through this single helper instead of per-module if/else ladders
-    that could drift on future edits.
-    """
-    return "filed as issue(s)" if file_scope_issues else "(issue filing disabled)"
-
-
-def _revert_out_of_scope_edits(
-    work: WorkContext,
-    *,
-    pre_fix_ref: str,
-    snapshot_captured: bool,
-    pre_fix_untracked: set[str],
-    changed_files: set[str] | None,
-    finding_files: set[str],
-    file_scope_issues: bool = False,
-) -> list[str] | None:
-    """Revert post-fix edits outside the reviewed diff; conditionally file issues.
-
-    Issue #336 (Task 4): after ``phase_fix_parallel`` returns, enumerate the
-    files the fix pass actually edited (vs the pre-fix snapshot) and subtract
-    the allowed set — the finding files, the reviewed-diff file set, and
-    newly-created generated files. Every residual is reverted unconditionally to
-    its pre-fix worktree content without changing the index, so the commit step
-    can never land an edit outside the reviewed diff.
-
-    Filing is OPT-IN (issue #1056): when *file_scope_issues* is true each
-    reverted residual is additionally filed as a best-effort GitHub issue
-    carrying the edit's diff as evidence (with cross-run dedup, issue #1051);
-    when false (the default) the revert alone happens and a warning notes that
-    issue filing is disabled. The revert and the fail-close never depend on
-    filing.
-
-    Only TRACKED edits are considered: a path present at *pre_fix_ref*. Newly
-    created untracked files (e.g. the test harness's ``.fixed-*`` sentinels)
-    have no pre-fix content to restore to and are governed by the generated-file
-    guard and the leftover-untracked bookkeeping instead.
-
-    Args:
-        work: The run's workspace (``work.repo`` is the git working dir).
-        pre_fix_ref: ``git stash create`` SHA captured before fixes, or ``HEAD``
-            when the pre-fix tracked tree was clean.
-        snapshot_captured: Whether the pre-fix snapshot exists. When False the
-            baseline is untrustworthy — skip with a warning rather than guess.
-        pre_fix_untracked: Untracked paths present before the fix pass.
-        changed_files: The reviewed diff's file set, or ``None`` when no diff
-            context is available (resume) — then only finding-file scope is
-            enforced and a warning is logged.
-        finding_files: Files named by the findings being fixed.
-
-    Returns:
-        The repo-relative paths that were reverted (empty when none), or ``None``
-        when any revert failed — matching the generated-file guard, the caller
-        aborts the run so an unreverted out-of-scope edit never reaches commit.
-    """
-    from daydream import git_ops
-    from daydream.git_ops import GitError
-
-    if not snapshot_captured:
-        print_warning(
-            console,
-            "Post-fix scope check skipped: no trustworthy pre-fix snapshot "
-            "(cannot judge which edits the fix pass made).",
-        )
-        return []
-
-    repo = work.repo
-    try:
-        edited = set(
-            git_ops.changed_files_against(repo, pre_fix_ref, preexisting_untracked=pre_fix_untracked)
-        )
-    except GitError as exc:
-        print_warning(console, f"Post-fix scope check skipped: could not enumerate edited files: {exc}")
-        return []
-
-    allowed = set(finding_files)
-    if changed_files is not None:
-        allowed |= set(changed_files)
-    else:
-        print_warning(
-            console,
-            "Post-fix scope check: no reviewed-diff file set; enforcing finding-file scope only.",
-        )
-    # Newly-created generated files (e.g. new migrations) are deliberately
-    # permitted by the generated-file guard; never treat them as residuals here.
-    allowed |= {path for path in edited if is_generated_file(path)}
-
-    residual: list[str] = []
-    for path in sorted(edited):
-        # Only tracked files (present at the pre-fix ref) are revertible to a
-        # pre-fix baseline; skip untracked new files (see docstring).
-        try:
-            git_ops.show(repo, pre_fix_ref, path)
-        except GitError:
-            continue
-        if path in allowed:
-            continue
-        residual.append(path)
-
-    restoration_failed = False
-    for path in residual:
-        patch = ""
-        # Capture the diff as evidence BEFORE reverting (the revert destroys
-        # it) — but only when filing is opted in: with filing disabled the
-        # patch has no consumer, so skip the per-residual ``git diff``
-        # subprocess entirely (issue #1056). The revert and fail-close below
-        # never depend on the capture.
-        if file_scope_issues:
-            try:
-                patch = git_ops.diff_worktree_against(repo, pre_fix_ref, [path])
-            except GitError as exc:
-                print_warning(console, f"Could not diff out-of-scope edit '{path}': {exc}")
-        # Revert the worktree only; preserve the index exactly as supplied.
-        try:
-            git_ops.restore_worktree_paths_from_ref(repo, pre_fix_ref, [path])
-        except GitError as exc:
-            print_warning(console, f"Could not revert out-of-scope edit '{path}': {exc}")
-            # Fail-close to match the sibling generated-file guard: an
-            # unreverted out-of-scope edit must never reach the commit step
-            # (the whole point of this net), so signal abort rather than leave
-            # the edit in the worktree. Continue so remaining residuals are
-            # still best-effort reverted before the abort is signalled.
-            restoration_failed = True
-            continue
-        if file_scope_issues:
-            _file_reverted_edit_issue(repo, path, patch)
-    if residual:
-        print_warning(
-            console,
-            f"Reverted {len(residual)} post-fix edit(s) outside the reviewed diff "
-            f"{_scope_filing_note(file_scope_issues)}: {residual}.",
-        )
-    return None if restoration_failed else residual
-
-
 def _resolve_changed_files(ctx: FlowContext) -> set[str] | None:
-    """Resolve the reviewed-diff file set for the fix-loop scope bound.
+    """Resolve the complete reviewed-diff file set for fix-cycle provenance.
 
     Issue #336 — the reviewed-diff file set is computed once in the
     ``_run_review_spine`` preamble and carried in ``ctx.data["changed_files"]``.
     On a ``--start-at fix`` resume that lost it but retained ``diff`` it is
-    recomputed via ``_diff_changed_files``. Shared by ``_step_fix_gate`` (the
-    pre-fix partition) and ``_step_fix`` (the post-fix residual net + the
-    "Allowed files" prompt clause) so the gate and the net agree on the allowed
-    set — a divergence left the residual net strictly weaker than the gate on
-    the resume path.
+    recomputed via ``_diff_changed_files``. The fix gate records these paths as
+    reviewed origins in the authorized footprint, and the quality gate uses the
+    Python subset. Canonical finding paths are authorized independently.
     """
     from daydream.deep.orchestrator import _diff_changed_files, _read_full_diff
 
     changed_files: set[str] | None = ctx.data.get("changed_files")
     if changed_files is None:
         # Issue #644 — ctx.data["diff"] is the gather-time BOUNDED diff; the
-        # resume path must resolve the scope from the FULL diff.patch (via
-        # diff_path) so a truncated-away file is not silently excluded from
-        # the auto-fix scope. Fall back to the bounded text only when the ctx
-        # carries no diff_path (defensive legacy path).
+        # resume path must resolve provenance from the FULL diff.patch (via
+        # diff_path) so a truncated-away file is not silently omitted. Fall
+        # back to the bounded text only when the ctx carries no diff_path.
         try:
             diff_str = _read_full_diff(ctx) or ""
         except OSError:

--- a/daydream/deep/scope_issues.py
+++ b/daydream/deep/scope_issues.py
@@ -94,14 +94,23 @@ def enforce_authorized_fix_footprint(
         | protected_gitlink_mutations
     )
 
+    filing_evidence: list[tuple[str, str]] = []
     if file_scope_issues:
         paths_to_file = sorted(
             residual_tracked - set(preexisting_untracked),
             key=lambda value: value.encode("utf-8", "surrogateescape"),
         )
         for path in paths_to_file:
-            patch = git_ops.diff_worktree_against(repo, stable_ref, [path])
-            _file_reverted_edit_issue(repo, path, patch)
+            try:
+                patch = git_ops.diff_worktree_against(repo, stable_ref, [path])
+            except Exception:  # noqa: BLE001 -- optional evidence must not block restoration
+                print_warning(
+                    console,
+                    "Could not capture optional out-of-scope edit evidence; "
+                    "continuing to restoration without filing.",
+                )
+            else:
+                filing_evidence.append((path, patch))
 
     if to_restore:
         stable_states = git_ops.snapshot_commit_paths(
@@ -174,6 +183,14 @@ def enforce_authorized_fix_footprint(
     retained = ((remaining_tracked | remaining_untracked) & set(footprint.run_allowed_paths)) - set(
         preexisting_untracked
     )
+    for path, patch in filing_evidence:
+        try:
+            _file_reverted_edit_issue(repo, path, patch)
+        except Exception:  # noqa: BLE001 -- all issue filing is best-effort
+            print_warning(
+                console,
+                "Could not file optional out-of-scope edit evidence after restoration.",
+            )
     return ScopeEnforcementResult(retained_paths=frozenset(retained), mutated=bool(to_restore))
 
 

--- a/daydream/deep/scope_issues.py
+++ b/daydream/deep/scope_issues.py
@@ -12,16 +12,132 @@ fingerprint -> marker -> dedup -> file chain, issue #1051). Extracted from
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from daydream.agent import console
+from daydream.fix_footprint import AuthorizedFixFootprint
 from daydream.generated_files import is_generated_file
+from daydream.git_ops import GitPathState
 from daydream.ui import print_warning
 
 if TYPE_CHECKING:
     from daydream.flows.engine import FlowContext
     from daydream.workspace import WorkContext
+
+
+@dataclass(frozen=True)
+class ScopeEnforcementResult:
+    """Outcome of one strict run-wide authorization enforcement boundary."""
+
+    retained_paths: frozenset[str]
+    mutated: bool
+
+
+def enforce_authorized_fix_footprint(
+    work: WorkContext,
+    stable_ref: str,
+    footprint: AuthorizedFixFootprint,
+    *,
+    preexisting_untracked: dict[str, GitPathState],
+    phase: str,
+    round_number: int | None,
+    file_scope_issues: bool = False,
+) -> ScopeEnforcementResult:
+    """Restore every run-external edit while preserving authorized siblings.
+
+    Enumeration, capture, restoration, and verification are strict. Protected
+    pre-existing untracked paths are compared by their stored blob/type/mode
+    state and restored even though they remain untracked throughout the run.
+    The index is snapshotted at entry and restored byte-for-byte after the
+    worktree-only recovery operation.
+    """
+    from daydream import git_ops
+
+    repo = work.repo
+    index_before = git_ops.snapshot_index(repo)
+    tracked_changed = set(git_ops.changed_paths_z(repo, stable_ref, include_untracked=False))
+    current_untracked = git_ops.snapshot_untracked_paths(repo, include_runtime_artifacts=False)
+    current_protected: dict[str, GitPathState] = {}
+    for path in preexisting_untracked:
+        if path in current_untracked:
+            current_protected[path] = current_untracked[path]
+        else:
+            current_protected[path] = git_ops.snapshot_worktree_paths(repo, [path])[0]
+    mutated_protected = {
+        path
+        for path, baseline in preexisting_untracked.items()
+        if current_protected[path] != baseline
+    }
+    new_untracked = set(current_untracked) - set(preexisting_untracked)
+    residual_tracked = tracked_changed - set(footprint.run_allowed_paths)
+    residual_new = new_untracked - set(footprint.run_allowed_paths)
+    to_restore = residual_tracked | residual_new | mutated_protected
+
+    if file_scope_issues:
+        paths_to_file = sorted(
+            residual_tracked - set(preexisting_untracked),
+            key=lambda value: value.encode("utf-8", "surrogateescape"),
+        )
+        for path in paths_to_file:
+            patch = git_ops.diff_worktree_against(repo, stable_ref, [path])
+            _file_reverted_edit_issue(repo, path, patch)
+
+    if to_restore:
+        stable_states = git_ops.snapshot_commit_paths(
+            repo,
+            stable_ref,
+            residual_tracked - set(preexisting_untracked),
+        )
+        rollback = git_ops.WorktreeRollbackSnapshot(
+            ref=stable_ref,
+            index=index_before,
+            path_states=stable_states,
+            untracked={path: preexisting_untracked[path] for path in mutated_protected},
+        )
+        git_ops.restore_group_from_snapshot(repo, rollback, to_restore)
+
+        for path in sorted(to_restore, key=lambda value: value.encode("utf-8", "surrogateescape")):
+            if path in residual_new and path not in preexisting_untracked:
+                action = "remove"
+                reason = "removed a new untracked path outside the authorized run footprint"
+            else:
+                action = "restore"
+                reason = (
+                    "restored protected pre-existing untracked state"
+                    if path in preexisting_untracked
+                    else "restored tracked content outside the authorized run footprint"
+                )
+            footprint.record_git_event(
+                action=action,
+                path=path,
+                origin="guard",
+                phase=phase,
+                round_number=round_number,
+                reason=reason,
+            )
+
+    if git_ops.snapshot_index(repo) != index_before:
+        raise git_ops.GitError("scope enforcement changed the repository index")
+    untracked_after = git_ops.snapshot_untracked_paths(repo, include_runtime_artifacts=False)
+    for path, baseline in preexisting_untracked.items():
+        current = (
+            untracked_after[path]
+            if path in untracked_after
+            else git_ops.snapshot_worktree_paths(repo, [path])[0]
+        )
+        if current != baseline:
+            raise git_ops.GitError("scope enforcement did not restore protected untracked state")
+    remaining_tracked = set(git_ops.changed_paths_z(repo, stable_ref, include_untracked=False))
+    remaining_untracked = set(untracked_after) - set(preexisting_untracked)
+    residual_after = (remaining_tracked | remaining_untracked) - set(footprint.run_allowed_paths)
+    if residual_after:
+        raise git_ops.GitError("scope enforcement left paths outside the authorized run footprint")
+    retained = ((remaining_tracked | remaining_untracked) & set(footprint.run_allowed_paths)) - set(
+        preexisting_untracked
+    )
+    return ScopeEnforcementResult(retained_paths=frozenset(retained), mutated=bool(to_restore))
 
 
 def _file_scope_issue(repo: Path, *, title: str, body: str, noun: str, ident: str) -> None:
@@ -215,9 +331,8 @@ def _revert_out_of_scope_edits(
     files the fix pass actually edited (vs the pre-fix snapshot) and subtract
     the allowed set — the finding files, the reviewed-diff file set, and
     newly-created generated files. Every residual is reverted unconditionally to
-    its pre-fix content (``git checkout <ref> -- <file>``, the same mechanism
-    the generated-file guard uses) so the commit step can never land an
-    edit outside the reviewed diff.
+    its pre-fix worktree content without changing the index, so the commit step
+    can never land an edit outside the reviewed diff.
 
     Filing is OPT-IN (issue #1056): when *file_scope_issues* is true each
     reverted residual is additionally filed as a best-effort GitHub issue
@@ -305,9 +420,9 @@ def _revert_out_of_scope_edits(
                 patch = git_ops.diff_worktree_against(repo, pre_fix_ref, [path])
             except GitError as exc:
                 print_warning(console, f"Could not diff out-of-scope edit '{path}': {exc}")
-        # Revert unconditionally — same mechanism as the generated-file guard.
+        # Revert the worktree only; preserve the index exactly as supplied.
         try:
-            git_ops.restore_paths_from_ref(repo, pre_fix_ref, [path])
+            git_ops.restore_worktree_paths_from_ref(repo, pre_fix_ref, [path])
         except GitError as exc:
             print_warning(console, f"Could not revert out-of-scope edit '{path}': {exc}")
             # Fail-close to match the sibling generated-file guard: an

--- a/daydream/fix_footprint.py
+++ b/daydream/fix_footprint.py
@@ -9,6 +9,7 @@ from typing import Any, Literal, cast
 from daydream.repository_paths import (
     InvalidRepositoryFilePath,
     canonicalize_repository_file_path,
+    git_observed_path_is_confined,
 )
 
 FixFootprintAction = Literal[
@@ -74,10 +75,18 @@ class AuthorizedFixFootprint:
         items: list[dict[str, Any]],
     ) -> AuthorizedFixFootprint:
         """Build a fail-closed footprint from reviewed paths and canonical items."""
-        reviewed = sorted(
-            (canonicalize_repository_file_path(repo, path) for path in (reviewed_paths or set())),
-            key=lambda path: path.encode("utf-8", errors="surrogateescape"),
-        )
+        # Reviewed paths come from the host's Git diff, not model output.
+        # Preserve their exact native spelling while retaining confinement;
+        # item targets and related/retarget paths still use the model grammar.
+        reviewed_set: set[str] = set()
+        for path in reviewed_paths or set():
+            if not isinstance(path, str):
+                raise InvalidRepositoryFilePath("invalid reviewed repository path")
+            normalized = path[2:] if path.startswith("./") else path
+            if not git_observed_path_is_confined(repo, normalized):
+                raise InvalidRepositoryFilePath("invalid reviewed repository path")
+            reviewed_set.add(normalized)
+        reviewed = sorted(reviewed_set, key=lambda path: path.encode("utf-8", errors="surrogateescape"))
 
         normalized_items: list[tuple[str, str, tuple[str, ...]]] = []
         seen_uids: set[str] = set()
@@ -104,7 +113,7 @@ class AuthorizedFixFootprint:
             footprint._append_event(
                 action="authorize",
                 path=path,
-                path_kind="model",
+                path_kind="git",
                 origin="reviewed",
                 item_uid=None,
                 phase="initialization",
@@ -188,6 +197,16 @@ class AuthorizedFixFootprint:
             )
             return None
         if normalized in own_paths:
+            self._append_event(
+                action="authorize",
+                path=normalized,
+                path_kind="model",
+                origin="retarget",
+                item_uid=item_uid,
+                phase=phase,
+                round_number=round_number,
+                reason="retarget selected an existing item-authorized path; policy unchanged",
+            )
             return normalized
         self._append_event(
             action="rejected_retarget",

--- a/daydream/fix_footprint.py
+++ b/daydream/fix_footprint.py
@@ -1,0 +1,298 @@
+"""Normalized authorization policy and audit events for the deep fix loop."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Literal, cast
+
+from daydream.repository_paths import (
+    InvalidRepositoryFilePath,
+    canonicalize_repository_file_path,
+)
+
+FixFootprintAction = Literal[
+    "authorize",
+    "approve_generated",
+    "rejected_retarget",
+    "restore",
+    "remove",
+    "stage",
+    "reject",
+]
+FixFootprintPathKind = Literal["model", "git"]
+FixFootprintOrigin = Literal[
+    "reviewed",
+    "primary",
+    "related",
+    "generated",
+    "guard",
+    "retarget",
+    "staging",
+]
+
+_ACTIONS = frozenset(
+    {"authorize", "approve_generated", "rejected_retarget", "restore", "remove", "stage", "reject"}
+)
+_ORIGINS = frozenset({"reviewed", "primary", "related", "generated", "guard", "retarget", "staging"})
+
+
+@dataclass(frozen=True)
+class FixFootprintEvent:
+    """One monotonically ordered authorization or enforcement decision."""
+
+    sequence: int
+    action: FixFootprintAction
+    path: str
+    path_kind: FixFootprintPathKind
+    origin: FixFootprintOrigin
+    item_uid: str | None
+    phase: str
+    round_number: int | None
+    reason: str
+
+
+@dataclass
+class AuthorizedFixFootprint:
+    """Run-wide and per-item normalized edit authorization.
+
+    The run union is used only after parallel work joins. Mutating fixer groups
+    receive the exact union of their member items through :meth:`group_paths`.
+    """
+
+    run_allowed_paths: frozenset[str]
+    policy_revision: int
+    _item_paths: dict[str, frozenset[str]] = field(default_factory=dict, repr=False)
+    _item_primary: dict[str, str] = field(default_factory=dict, repr=False)
+    _events: list[FixFootprintEvent] = field(default_factory=list, repr=False)
+
+    @classmethod
+    def build(
+        cls,
+        repo: Path,
+        reviewed_paths: set[str] | None,
+        items: list[dict[str, Any]],
+    ) -> AuthorizedFixFootprint:
+        """Build a fail-closed footprint from reviewed paths and canonical items."""
+        reviewed = sorted(
+            (canonicalize_repository_file_path(repo, path) for path in (reviewed_paths or set())),
+            key=lambda path: path.encode("utf-8", errors="surrogateescape"),
+        )
+
+        normalized_items: list[tuple[str, str, tuple[str, ...]]] = []
+        seen_uids: set[str] = set()
+        for item in items:
+            uid = item.get("item_uid")
+            if not isinstance(uid, str) or not uid or uid in seen_uids:
+                raise ValueError("fix footprint requires unique non-empty item_uid values")
+            seen_uids.add(uid)
+            primary = canonicalize_repository_file_path(repo, item.get("file"))
+            raw_related = item.get("related_files")
+            if raw_related is None:
+                related_values: list[object] = []
+            elif isinstance(raw_related, list):
+                related_values = raw_related
+            else:
+                raise InvalidRepositoryFilePath("invalid repository file path")
+            related = tuple(canonicalize_repository_file_path(repo, value) for value in related_values)
+            normalized_items.append((uid, primary, related))
+
+        footprint = cls(run_allowed_paths=frozenset(), policy_revision=1)
+        allowed: set[str] = set()
+        for path in reviewed:
+            allowed.add(path)
+            footprint._append_event(
+                action="authorize",
+                path=path,
+                path_kind="model",
+                origin="reviewed",
+                item_uid=None,
+                phase="initialization",
+                round_number=None,
+                reason="path is part of the reviewed change",
+            )
+        for uid, primary, related in normalized_items:
+            item_set = {primary, *related}
+            footprint._item_paths[uid] = frozenset(item_set)
+            footprint._item_primary[uid] = primary
+            allowed.update(item_set)
+            footprint._append_event(
+                action="authorize",
+                path=primary,
+                path_kind="model",
+                origin="primary",
+                item_uid=uid,
+                phase="initialization",
+                round_number=None,
+                reason="finding primary path",
+            )
+            for path in related:
+                footprint._append_event(
+                    action="authorize",
+                    path=path,
+                    path_kind="model",
+                    origin="related",
+                    item_uid=uid,
+                    phase="initialization",
+                    round_number=None,
+                    reason="finding related path",
+                )
+        footprint.run_allowed_paths = frozenset(allowed)
+        return footprint
+
+    @property
+    def events(self) -> tuple[FixFootprintEvent, ...]:
+        """Return the immutable ordered audit-event view."""
+        return tuple(self._events)
+
+    def item_paths(self, item_uid: str) -> frozenset[str]:
+        """Return the exact edit paths authorized to one durable item identity."""
+        try:
+            return self._item_paths[item_uid]
+        except KeyError as exc:
+            raise ValueError("unknown fix-footprint item_uid") from exc
+
+    def group_paths(self, items: list[dict[str, Any]]) -> frozenset[str]:
+        """Return the exact transitive union for a dispatched item group."""
+        paths: set[str] = set()
+        for item in items:
+            uid = item.get("item_uid")
+            if not isinstance(uid, str):
+                raise ValueError("fix footprint requires item_uid")
+            paths.update(self.item_paths(uid))
+        return frozenset(paths)
+
+    def accept_retarget(
+        self,
+        repo: Path,
+        item_uid: str,
+        candidate: object,
+        *,
+        phase: str,
+        round_number: int,
+    ) -> str | None:
+        """Accept only a normalized retarget already authorized to this item."""
+        own_paths = self.item_paths(item_uid)
+        try:
+            normalized = canonicalize_repository_file_path(repo, candidate)
+        except InvalidRepositoryFilePath:
+            self._append_event(
+                action="rejected_retarget",
+                path=self._item_primary[item_uid],
+                path_kind="model",
+                origin="retarget",
+                item_uid=item_uid,
+                phase=phase,
+                round_number=round_number,
+                reason="retarget path is invalid; original target retained",
+            )
+            return None
+        if normalized in own_paths:
+            return normalized
+        self._append_event(
+            action="rejected_retarget",
+            path=normalized,
+            path_kind="model",
+            origin="retarget",
+            item_uid=item_uid,
+            phase=phase,
+            round_number=round_number,
+            reason="retarget is outside the item's authorized paths; original target retained",
+        )
+        return None
+
+    def authorize_new_generated(
+        self,
+        repo: Path,
+        path: str,
+        *,
+        phase: str,
+        round_number: int | None,
+        reason: str,
+    ) -> None:
+        """Widen the run policy once for a policy-approved generated path."""
+        normalized = canonicalize_repository_file_path(repo, path)
+        if normalized in self.run_allowed_paths:
+            return
+        self.run_allowed_paths = frozenset((*self.run_allowed_paths, normalized))
+        self.policy_revision += 1
+        self._append_event(
+            action="approve_generated",
+            path=normalized,
+            path_kind="model",
+            origin="generated",
+            item_uid=None,
+            phase=phase,
+            round_number=round_number,
+            reason=reason,
+        )
+
+    def record_git_event(
+        self,
+        *,
+        action: str,
+        path: str,
+        origin: str,
+        phase: str,
+        round_number: int | None,
+        reason: str,
+    ) -> None:
+        """Record a decision involving an exact Git-observed path."""
+        if action not in _ACTIONS or origin not in _ORIGINS:
+            raise ValueError("invalid fix-footprint audit event")
+        self._append_event(
+            action=cast(FixFootprintAction, action),
+            path=path,
+            path_kind="git",
+            origin=cast(FixFootprintOrigin, origin),
+            item_uid=None,
+            phase=phase,
+            round_number=round_number,
+            reason=reason,
+        )
+
+    def audit_payload(self, session_id: str, **evidence: Any) -> dict[str, Any]:
+        """Return the complete session-bound JSON-serializable audit payload."""
+        return {
+            "session_id": session_id,
+            "policy_revision": self.policy_revision,
+            "run_allowed_paths": sorted(
+                self.run_allowed_paths,
+                key=lambda path: path.encode("utf-8", errors="surrogateescape"),
+            ),
+            "item_paths": {
+                uid: sorted(paths, key=lambda path: path.encode("utf-8", errors="surrogateescape"))
+                for uid, paths in sorted(self._item_paths.items())
+            },
+            "events": [asdict(event) for event in self._events],
+            **evidence,
+        }
+
+    def _append_event(
+        self,
+        *,
+        action: FixFootprintAction,
+        path: str,
+        path_kind: FixFootprintPathKind,
+        origin: FixFootprintOrigin,
+        item_uid: str | None,
+        phase: str,
+        round_number: int | None,
+        reason: str,
+    ) -> None:
+        self._events.append(
+            FixFootprintEvent(
+                sequence=len(self._events) + 1,
+                action=action,
+                path=path,
+                path_kind=path_kind,
+                origin=origin,
+                item_uid=item_uid,
+                phase=phase,
+                round_number=round_number,
+                reason=reason,
+            )
+        )
+
+
+__all__ = ["AuthorizedFixFootprint", "FixFootprintEvent"]

--- a/daydream/git_ops.py
+++ b/daydream/git_ops.py
@@ -1831,11 +1831,30 @@ def snapshot_worktree_paths(repo: Path, paths: Iterable[str]) -> tuple[GitPathSt
     )
 
 
+def snapshot_worktree_gitlinks(repo: Path) -> tuple[GitPathState, ...]:
+    """Capture every tracked gitlink's actual clean checked-out commit."""
+    proc = _run_git(repo, ["ls-files", "--stage", "-z"], capture_bytes=True)
+    if proc.returncode != 0:
+        raise GitError(
+            f"git ls-files --stage failed in {repo}: {os.fsdecode(proc.stderr).strip()}"
+        )
+    paths: list[str] = []
+    for record in (record for record in proc.stdout.split(b"\0") if record):
+        metadata, separator, raw_path = record.partition(b"\t")
+        if not separator:
+            raise GitError("git returned malformed staged path data")
+        mode, _oid, stage = metadata.decode("ascii").split(" ")
+        if mode == "160000" and stage == "0":
+            paths.append(os.fsdecode(raw_path))
+    return snapshot_worktree_paths(repo, paths)
+
+
 def snapshot_worktree_delta(
     repo: Path,
     ref: str,
     *,
     preexisting_untracked: dict[str, GitPathState],
+    preexisting_gitlinks: tuple[GitPathState, ...] = (),
 ) -> tuple[GitPathState, ...]:
     """Capture source delta plus protected paths, not changing runtime output.
 
@@ -1843,7 +1862,11 @@ def snapshot_worktree_delta(
     makes user-file changes invalidate evidence without audit/trace writes
     recursively invalidating the evidence they describe.
     """
-    paths = set(changed_paths_z(repo, ref, include_runtime_artifacts=False)) | set(preexisting_untracked)
+    paths = (
+        set(changed_paths_z(repo, ref, include_runtime_artifacts=False))
+        | set(preexisting_untracked)
+        | {state.path for state in preexisting_gitlinks}
+    )
     return tuple(
         _snapshot_worktree_path(
             repo,
@@ -2424,7 +2447,6 @@ def _restore_path_state(
     state: GitPathState,
     *,
     allow_leaf_type_replacement: bool,
-    ref: str,
 ) -> None:
     if state.state == "missing":
         _remove_confined_leaf(repo, state.path)
@@ -2435,7 +2457,22 @@ def _restore_path_state(
         allow_leaf_symlink=allow_leaf_type_replacement or state.state == "symlink",
     )
     if state.state == "gitlink":
-        restore_worktree_paths_from_ref(repo, ref, [state.path])
+        nested = _preflight_gitlink_restore(repo, state)
+        assert state.digest is not None
+        proc = _run_git(
+            nested,
+            ["checkout", "--detach", state.digest],
+            timeout=30,
+            retries=0,
+        )
+        if proc.returncode != 0:
+            raise GitError(
+                f"could not restore gitlink {state.path!r} to its captured commit: "
+                f"{proc.stderr.strip()}"
+            )
+        if head_sha(nested) != state.digest:
+            raise GitError(f"gitlink {state.path!r} did not reach its captured commit")
+        _preflight_gitlink_restore(repo, state)
         return
     if state.digest is None or state.mode is None:
         raise GitError("restorable path state is incomplete")
@@ -2461,6 +2498,36 @@ def _restore_path_state(
         raise GitError("could not restore confined worktree path") from exc
 
 
+def _preflight_gitlink_restore(repo: Path, state: GitPathState) -> Path:
+    """Prove a gitlink can be restored without discarding nested user state."""
+    if state.digest is None or state.mode != 0o160000:
+        raise GitError("restorable gitlink state is incomplete")
+    _require_git_path_confined(repo, state.path, allow_leaf_symlink=False)
+    nested = repo / state.path
+    try:
+        assert_is_worktree(nested)
+    except NotAWorktreeError as exc:
+        raise GitError("gitlink working tree is unavailable for exact restoration") from exc
+    dirty = _run_git(
+        nested,
+        ["status", "--porcelain=v1", "-z", "--untracked-files=all", "--ignore-submodules=none"],
+        capture_bytes=True,
+    )
+    if dirty.returncode != 0:
+        raise GitError("could not inspect gitlink before exact restoration")
+    if dirty.stdout:
+        raise GitError("dirty gitlink cannot be restored without discarding nested user state")
+    target = _run_git(
+        nested,
+        ["cat-file", "-e", f"{state.digest}^{{commit}}"],
+        timeout=30,
+        retries=0,
+    )
+    if target.returncode != 0:
+        raise GitError(f"captured gitlink commit is unavailable for {state.path!r}")
+    return nested
+
+
 def restore_group_from_snapshot(
     repo: Path,
     snapshot: WorktreeRollbackSnapshot,
@@ -2477,22 +2544,32 @@ def restore_group_from_snapshot(
             [path for path in requested if path not in tracked and path not in snapshot.untracked],
         )
     }
+    restore_states: list[tuple[GitPathState, bool]] = []
+    for path in requested:
+        if path in snapshot.untracked:
+            state = snapshot.untracked[path]
+            replace_type = True
+        elif path in tracked:
+            state = tracked[path]
+            replace_type = False
+        else:
+            state = committed[path]
+            replace_type = state.state == "missing"
+        restore_states.append((state, replace_type))
+
     try:
-        for path in requested:
-            if path in snapshot.untracked:
-                state = snapshot.untracked[path]
-                replace_type = True
-            elif path in tracked:
-                state = tracked[path]
-                replace_type = False
-            else:
-                state = committed[path]
-                replace_type = state.state == "missing"
+        # Preflight every nested repository before changing any worktree path.
+        # A dirty or unavailable gitlink is a fail-closed condition, never
+        # grounds for a forced checkout that could destroy user content.  The
+        # complete parent index is still restored by ``finally``.
+        for state, _replace_type in restore_states:
+            if state.state == "gitlink":
+                _preflight_gitlink_restore(repo, state)
+        for state, replace_type in restore_states:
             _restore_path_state(
                 repo,
                 state,
                 allow_leaf_type_replacement=replace_type,
-                ref=snapshot.ref,
             )
     finally:
         restore_index(repo, snapshot.index)

--- a/daydream/git_ops.py
+++ b/daydream/git_ops.py
@@ -38,15 +38,19 @@ The module is intentionally dependency-free: stdlib only.
 from __future__ import annotations
 
 import base64
+import hashlib
 import json
 import logging
 import os
 import re
+import shutil
+import stat
 import subprocess
 import tempfile
 import time
-from collections.abc import Sequence
+from collections.abc import Iterable, Sequence
 from contextlib import contextmanager
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable, Generator, Literal, overload
 from urllib.parse import urlparse
@@ -246,6 +250,34 @@ class WrongBranchError(GitError):
     """
 
 
+@dataclass(frozen=True)
+class GitPathState:
+    """Binary-safe identity for one exact repository path."""
+
+    path: str
+    state: Literal["missing", "regular", "symlink", "gitlink"]
+    mode: int | None
+    digest: str | None
+
+
+@dataclass(frozen=True)
+class IndexSnapshot:
+    """A complete index tree plus its HEAD-relative changed path set."""
+
+    tree_sha: str
+    paths: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class WorktreeRollbackSnapshot:
+    """One round's tracked, untracked, and index rollback point."""
+
+    ref: str
+    index: IndexSnapshot
+    path_states: tuple[GitPathState, ...]
+    untracked: dict[str, GitPathState]
+
+
 # --- Internal subprocess helpers --------------------------------------------
 
 
@@ -336,6 +368,7 @@ def _run_git(
     capture_bytes: Literal[True],
     retries: int = _GIT_TIMEOUT_RETRIES,
     input_text: str | None = None,
+    input_bytes: bytes | None = None,
     env_cmd: Any | None = None,
 ) -> subprocess.CompletedProcess[bytes]:
     """Binary-capture variant: ``capture_bytes=True`` reads bytes stdout."""
@@ -350,6 +383,7 @@ def _run_git(
     capture_bytes: Literal[False] = False,
     retries: int = _GIT_TIMEOUT_RETRIES,
     input_text: str | None = None,
+    input_bytes: bytes | None = None,
     env_cmd: Any | None = None,
 ) -> subprocess.CompletedProcess[str]:
     """Text-capture variant (the default): decoded ``str`` stdout."""
@@ -363,6 +397,7 @@ def _run_git(
     capture_bytes: bool = False,
     retries: int = _GIT_TIMEOUT_RETRIES,
     input_text: str | None = None,
+    input_bytes: bytes | None = None,
     env_cmd: Any | None = None,
 ) -> subprocess.CompletedProcess[Any]:
     """Run ``git`` in *repo* with hardened defaults.
@@ -374,6 +409,9 @@ def _run_git(
             cannot express the whole ref set on argv). Encoded to UTF-8 when
             *capture_bytes* is set so the binary variant never feeds ``str``
             to the subprocess.
+        input_bytes: Optional raw bytes piped to stdin. Requires
+            ``capture_bytes=True`` and is mutually exclusive with
+            ``input_text``.
         retries: How many additional attempts to make after a
             :class:`subprocess.TimeoutExpired` (total attempts = ``retries + 1``).
             Only timeouts are retried; other failures raise immediately.
@@ -395,6 +433,10 @@ def _run_git(
         GitError: If the underlying subprocess machinery fails for any other
             reason (missing binary, OS-level error).
     """
+    if input_text is not None and input_bytes is not None:
+        raise GitError("git subprocess input must be text or bytes, not both")
+    if input_bytes is not None and not capture_bytes:
+        raise GitError("binary git subprocess input requires binary capture")
     last_timeout: subprocess.TimeoutExpired | None = None
     for attempt in range(retries + 1):
         try:
@@ -410,7 +452,9 @@ def _run_git(
                 # input_text must be encoded: subprocess.run raises a raw
                 # TypeError for str input with text=False.
                 input=(
-                    input_text.encode("utf-8")
+                    input_bytes
+                    if input_bytes is not None
+                    else input_text.encode("utf-8")
                     if capture_bytes and input_text is not None
                     else input_text
                 ),
@@ -1559,6 +1603,349 @@ def _filter_preexisting_untracked(
     return [path for path in untracked if path not in preexisting_untracked]
 
 
+def _decode_nul_paths(stdout: bytes) -> list[str]:
+    """Decode exact NUL-delimited Git paths with filesystem round-tripping."""
+    return [os.fsdecode(raw) for raw in stdout.split(b"\0") if raw]
+
+
+def _path_sort_key(path: str) -> bytes:
+    return os.fsencode(path)
+
+
+def _literal_pathspec(path: str) -> str:
+    return f":(literal){path}"
+
+
+def _git_path_parent_is_confined(repo: Path, value: str) -> bool:
+    """Confinement check that may inspect, but never follows, the leaf."""
+    if not value or "\0" in value or value.startswith("/"):
+        return False
+    parts = value.split("/")
+    if any(part in {"", ".", ".."} for part in parts):
+        return False
+    root = repo.resolve()
+    candidate = repo
+    for part in parts[:-1]:
+        candidate /= part
+        try:
+            if candidate.is_symlink():
+                return False
+            if not candidate.exists():
+                break
+        except OSError:
+            return False
+    try:
+        return candidate.resolve(strict=False).is_relative_to(root)
+    except OSError:
+        return False
+
+
+def _require_git_path_confined(repo: Path, path: str, *, allow_leaf_symlink: bool = False) -> None:
+    from daydream.repository_paths import git_observed_path_is_confined
+
+    confined = (
+        _git_path_parent_is_confined(repo, path)
+        if allow_leaf_symlink
+        else git_observed_path_is_confined(repo, path)
+    )
+    if not confined:
+        raise GitError("Git-observed path is not confined to the repository")
+
+
+def _is_untracked_runtime_artifact(path: str) -> bool:
+    from daydream.config import REVIEW_OUTPUT_FILE
+
+    return path.startswith(".daydream/") or path == REVIEW_OUTPUT_FILE
+
+
+def changed_paths_z(
+    repo: Path,
+    ref: str,
+    *,
+    include_untracked: bool = True,
+    include_runtime_artifacts: bool = True,
+) -> list[str]:
+    """Strictly enumerate paths changed from *ref* using NUL delimiters.
+
+    Fix evidence may exclude untracked runtime output. Tracked changes are
+    always included, even inside the runtime namespace.
+    """
+    proc = _run_git(repo, ["diff", "--name-only", "-z", ref], timeout=10, capture_bytes=True)
+    if proc.returncode != 0:
+        stderr = os.fsdecode(proc.stderr)
+        raise GitError(f"git diff --name-only -z {ref} failed in {repo}: {stderr.strip()}")
+    paths = _decode_nul_paths(proc.stdout)
+    if include_untracked:
+        others = _run_git(
+            repo,
+            ["ls-files", "--others", "--exclude-standard", "-z"],
+            timeout=10,
+            capture_bytes=True,
+        )
+        if others.returncode != 0:
+            stderr = os.fsdecode(others.stderr)
+            raise GitError(f"git ls-files --others -z failed in {repo}: {stderr.strip()}")
+        paths.extend(
+            path for path in _decode_nul_paths(others.stdout)
+            if include_runtime_artifacts or not _is_untracked_runtime_artifact(path)
+        )
+    unique = dict.fromkeys(paths)
+    for path in unique:
+        _require_git_path_confined(repo, path, allow_leaf_symlink=True)
+    return list(unique)
+
+
+def _write_git_blob(repo: Path, content: bytes) -> str:
+    proc = _run_git(
+        repo,
+        ["hash-object", "-w", "--stdin"],
+        timeout=30,
+        capture_bytes=True,
+        input_bytes=content,
+    )
+    if proc.returncode != 0:
+        raise GitError(f"git hash-object failed in {repo}: {os.fsdecode(proc.stderr).strip()}")
+    oid = os.fsdecode(proc.stdout).strip()
+    if not oid:
+        raise GitError("git hash-object returned no object id")
+    return oid
+
+
+def _read_git_blob(repo: Path, oid: str) -> bytes:
+    proc = _run_git(repo, ["cat-file", "blob", oid], timeout=30, capture_bytes=True)
+    if proc.returncode != 0:
+        raise GitError(f"git cat-file blob failed in {repo}: {os.fsdecode(proc.stderr).strip()}")
+    return proc.stdout
+
+
+def _index_mode_for_path(repo: Path, path: str) -> int | None:
+    proc = _run_git(
+        repo,
+        ["ls-files", "--stage", "-z", "--", _literal_pathspec(path)],
+        capture_bytes=True,
+    )
+    if proc.returncode != 0:
+        raise GitError(f"git ls-files --stage failed in {repo}: {os.fsdecode(proc.stderr).strip()}")
+    records = [record for record in proc.stdout.split(b"\0") if record]
+    if not records:
+        return None
+    if len(records) != 1:
+        raise GitError("index contains unresolved entries for a captured path")
+    metadata, separator, raw_path = records[0].partition(b"\t")
+    if not separator or os.fsdecode(raw_path) != path:
+        raise GitError("git returned an unexpected index path")
+    mode, _oid, stage = metadata.decode("ascii").split(" ")
+    if stage != "0":
+        raise GitError("index contains an unresolved entry")
+    return int(mode, 8)
+
+
+def _snapshot_worktree_path(
+    repo: Path,
+    path: str,
+    *,
+    allow_leaf_symlink: bool,
+) -> GitPathState:
+    _require_git_path_confined(repo, path, allow_leaf_symlink=allow_leaf_symlink)
+    mode_from_index = _index_mode_for_path(repo, path)
+    absolute_bytes = os.fsencode(repo) + b"/" + os.fsencode(path)
+    try:
+        metadata = os.lstat(absolute_bytes)
+    except FileNotFoundError:
+        return GitPathState(path=path, state="missing", mode=None, digest=None)
+    except OSError as exc:
+        raise GitError("could not inspect a confined worktree path") from exc
+
+    if mode_from_index == 0o160000 and stat.S_ISDIR(metadata.st_mode):
+        nested = repo / path
+        try:
+            assert_is_worktree(nested)
+        except NotAWorktreeError as exc:
+            raise GitError("gitlink working tree is unavailable for exact evidence") from exc
+        dirty = _run_git(
+            nested,
+            ["status", "--porcelain=v1", "-z", "--untracked-files=all", "--ignore-submodules=none"],
+            capture_bytes=True,
+        )
+        if dirty.returncode != 0:
+            raise GitError("could not inspect gitlink working tree for exact evidence")
+        if dirty.stdout:
+            # A commit OID cannot identify additional worktree content. Refuse
+            # stale test evidence instead of recursively snapshotting submodules.
+            raise GitError("dirty gitlink cannot provide commit-only test evidence")
+        oid = head_sha(nested)
+        return GitPathState(path=path, state="gitlink", mode=0o160000, digest=oid)
+    if stat.S_ISLNK(metadata.st_mode):
+        target = os.readlink(absolute_bytes)
+        content = target if isinstance(target, bytes) else os.fsencode(target)
+        return GitPathState(path=path, state="symlink", mode=0o120000, digest=_write_git_blob(repo, content))
+    if stat.S_ISREG(metadata.st_mode):
+        flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+        try:
+            descriptor = os.open(absolute_bytes, flags)
+            try:
+                opened = os.fstat(descriptor)
+                if not stat.S_ISREG(opened.st_mode):
+                    raise GitError("captured worktree path changed type during read")
+                chunks: list[bytes] = []
+                while chunk := os.read(descriptor, 1024 * 1024):
+                    chunks.append(chunk)
+            finally:
+                os.close(descriptor)
+        except OSError as exc:
+            raise GitError("could not read a confined worktree path") from exc
+        permissions = stat.S_IMODE(metadata.st_mode)
+        if mode_from_index is not None:
+            permissions = 0o755 if permissions & 0o111 else 0o644
+        mode = stat.S_IFREG | permissions
+        return GitPathState(path=path, state="regular", mode=mode, digest=_write_git_blob(repo, b"".join(chunks)))
+    raise GitError("unsupported worktree path type")
+
+
+def snapshot_untracked_paths(
+    repo: Path, *, include_runtime_artifacts: bool = True,
+) -> dict[str, GitPathState]:
+    """Capture actual untracked content/type/mode, optionally omitting runtime output."""
+    proc = _run_git(
+        repo,
+        ["ls-files", "--others", "--exclude-standard", "-z"],
+        timeout=10,
+        capture_bytes=True,
+    )
+    if proc.returncode != 0:
+        raise GitError(f"git ls-files --others -z failed in {repo}: {os.fsdecode(proc.stderr).strip()}")
+    paths = _decode_nul_paths(proc.stdout)
+    return {
+        path: _snapshot_worktree_path(repo, path, allow_leaf_symlink=True)
+        for path in paths
+        if include_runtime_artifacts or not _is_untracked_runtime_artifact(path)
+    }
+
+
+def snapshot_worktree_paths(repo: Path, paths: Iterable[str]) -> tuple[GitPathState, ...]:
+    """Capture binary-safe worktree states for exact confined paths."""
+    unique = sorted(set(paths), key=_path_sort_key)
+    return tuple(
+        _snapshot_worktree_path(repo, path, allow_leaf_symlink=False)
+        for path in unique
+    )
+
+
+def snapshot_worktree_delta(
+    repo: Path,
+    ref: str,
+    *,
+    preexisting_untracked: dict[str, GitPathState],
+) -> tuple[GitPathState, ...]:
+    """Capture source delta plus protected paths, not changing runtime output.
+
+    Explicitly protected paths remain visible regardless of namespace. This
+    makes user-file changes invalidate evidence without audit/trace writes
+    recursively invalidating the evidence they describe.
+    """
+    paths = set(changed_paths_z(repo, ref, include_runtime_artifacts=False)) | set(preexisting_untracked)
+    return tuple(
+        _snapshot_worktree_path(
+            repo,
+            path,
+            allow_leaf_symlink=path in preexisting_untracked,
+        )
+        for path in sorted(paths, key=_path_sort_key)
+    )
+
+
+def _snapshot_git_tree_paths(
+    repo: Path,
+    args: list[str],
+    paths: Iterable[str],
+) -> tuple[GitPathState, ...]:
+    unique = sorted(set(paths), key=_path_sort_key)
+    for path in unique:
+        _require_git_path_confined(repo, path, allow_leaf_symlink=True)
+    if not unique:
+        return ()
+    proc = _run_git(
+        repo,
+        [*args, "-z", "--", *(_literal_pathspec(path) for path in unique)],
+        capture_bytes=True,
+    )
+    if proc.returncode != 0:
+        raise GitError(f"git tree-state query failed in {repo}: {os.fsdecode(proc.stderr).strip()}")
+    found: dict[str, GitPathState] = {}
+    for record in (record for record in proc.stdout.split(b"\0") if record):
+        metadata, separator, raw_path = record.partition(b"\t")
+        if not separator:
+            raise GitError("git returned malformed tree-state output")
+        path = os.fsdecode(raw_path)
+        if path not in unique:
+            raise GitError("git returned an unexpected tree-state path")
+        fields = metadata.decode("ascii").split(" ")
+        if args[0] == "ls-files":  # ls-files --stage: mode oid stage
+            if len(fields) != 3:
+                raise GitError("git returned malformed index-state metadata")
+            mode_text, oid, stage_text = fields
+            if stage_text != "0":
+                raise GitError("index contains unresolved entries")
+        elif len(fields) == 3:  # ls-tree: mode type oid
+            mode_text, _object_type, oid = fields
+        else:
+            raise GitError("git returned malformed tree-state metadata")
+        mode = int(mode_text, 8)
+        state: Literal["regular", "symlink", "gitlink"]
+        if mode == 0o120000:
+            state = "symlink"
+        elif mode == 0o160000:
+            state = "gitlink"
+        else:
+            state = "regular"
+        found[path] = GitPathState(path=path, state=state, mode=mode, digest=oid)
+    return tuple(
+        found.get(path, GitPathState(path=path, state="missing", mode=None, digest=None))
+        for path in unique
+    )
+
+
+def snapshot_index(repo: Path) -> IndexSnapshot:
+    """Capture the complete index tree without changing the worktree."""
+    tree = _run_git(repo, ["write-tree"], timeout=30)
+    if tree.returncode != 0:
+        raise GitError(f"git write-tree failed in {repo}: {tree.stderr.strip()}")
+    changed = _run_git(
+        repo,
+        ["diff", "--cached", "--name-only", "-z", "HEAD"],
+        capture_bytes=True,
+    )
+    if changed.returncode != 0:
+        raise GitError(f"git diff --cached failed in {repo}: {os.fsdecode(changed.stderr).strip()}")
+    paths = tuple(sorted(set(_decode_nul_paths(changed.stdout)), key=_path_sort_key))
+    return IndexSnapshot(tree_sha=tree.stdout.strip(), paths=paths)
+
+
+def snapshot_index_paths(repo: Path, paths: Iterable[str]) -> tuple[GitPathState, ...]:
+    """Capture exact path states from the current index."""
+    return _snapshot_git_tree_paths(repo, ["ls-files", "--stage"], paths)
+
+
+def snapshot_commit_paths(repo: Path, ref: str, paths: Iterable[str]) -> tuple[GitPathState, ...]:
+    """Capture exact path states from a commit/tree ref."""
+    return _snapshot_git_tree_paths(repo, ["ls-tree", ref], paths)
+
+
+def tree_key(states: Iterable[GitPathState]) -> str:
+    """Hash a canonical binary-safe sequence of content-only path states."""
+    ordered = sorted(states, key=lambda state: _path_sort_key(state.path))
+    digest = hashlib.sha256()
+    for state in ordered:
+        path = os.fsencode(state.path)
+        state_bytes = state.state.encode("ascii")
+        mode = b"-" if state.mode is None else format(state.mode, "o").encode("ascii")
+        object_digest = b"-" if state.digest is None else state.digest.encode("ascii")
+        for field_value in (path, state_bytes, mode, object_digest):
+            digest.update(len(field_value).to_bytes(8, "big"))
+            digest.update(field_value)
+    return digest.hexdigest()
+
+
 def ls_files(repo: Path, *, strict: bool = False) -> list[str]:
     """Return repo-relative paths of tracked files.
 
@@ -1989,6 +2376,178 @@ def restore_paths_from_ref(repo: Path, ref: str, paths: list[str]) -> None:
         raise GitError(f"git checkout {ref} -- {paths} failed in {repo}: {proc.stderr.strip()}")
 
 
+def restore_worktree_paths_from_ref(repo: Path, ref: str, paths: Iterable[str]) -> None:
+    """Restore exact paths from *ref* without changing the index."""
+    unique = sorted(set(paths), key=_path_sort_key)
+    if not unique:
+        return
+    expected = snapshot_commit_paths(repo, ref, unique)
+    for state in expected:
+        _require_git_path_confined(repo, state.path, allow_leaf_symlink=state.state == "symlink")
+    proc = _run_git(
+        repo,
+        [
+            "restore",
+            f"--source={ref}",
+            "--worktree",
+            "--no-overlay",
+            "--",
+            *(_literal_pathspec(path) for path in unique),
+        ],
+        timeout=30,
+        retries=0,
+    )
+    if proc.returncode != 0:
+        raise GitError(f"git restore --worktree from ref failed in {repo}: {proc.stderr.strip()}")
+
+
+def _remove_confined_leaf(repo: Path, path: str) -> None:
+    _require_git_path_confined(repo, path, allow_leaf_symlink=True)
+    absolute = os.fsencode(repo) + b"/" + os.fsencode(path)
+    try:
+        metadata = os.lstat(absolute)
+    except FileNotFoundError:
+        return
+    except OSError as exc:
+        raise GitError("could not inspect path before confined removal") from exc
+    try:
+        if stat.S_ISDIR(metadata.st_mode) and not stat.S_ISLNK(metadata.st_mode):
+            shutil.rmtree(absolute)
+        else:
+            os.unlink(absolute)
+    except OSError as exc:
+        raise GitError("could not remove confined worktree path") from exc
+
+
+def _restore_path_state(
+    repo: Path,
+    state: GitPathState,
+    *,
+    allow_leaf_type_replacement: bool,
+    ref: str,
+) -> None:
+    if state.state == "missing":
+        _remove_confined_leaf(repo, state.path)
+        return
+    _require_git_path_confined(
+        repo,
+        state.path,
+        allow_leaf_symlink=allow_leaf_type_replacement or state.state == "symlink",
+    )
+    if state.state == "gitlink":
+        restore_worktree_paths_from_ref(repo, ref, [state.path])
+        return
+    if state.digest is None or state.mode is None:
+        raise GitError("restorable path state is incomplete")
+    content = _read_git_blob(repo, state.digest)
+    _remove_confined_leaf(repo, state.path)
+    absolute = os.fsencode(repo) + b"/" + os.fsencode(state.path)
+    parent = os.path.dirname(absolute)
+    try:
+        os.makedirs(parent, exist_ok=True)
+        if state.state == "symlink":
+            os.symlink(content, absolute)
+            return
+        descriptor = os.open(absolute, os.O_WRONLY | os.O_CREAT | os.O_EXCL, stat.S_IMODE(state.mode))
+        try:
+            view = memoryview(content)
+            while view:
+                written = os.write(descriptor, view)
+                view = view[written:]
+        finally:
+            os.close(descriptor)
+        os.chmod(absolute, stat.S_IMODE(state.mode))
+    except OSError as exc:
+        raise GitError("could not restore confined worktree path") from exc
+
+
+def restore_group_from_snapshot(
+    repo: Path,
+    snapshot: WorktreeRollbackSnapshot,
+    paths: Iterable[str],
+) -> None:
+    """Restore every requested group path and the supplied round index."""
+    requested = sorted(set(paths), key=_path_sort_key)
+    tracked = {state.path: state for state in snapshot.path_states}
+    committed = {
+        state.path: state
+        for state in snapshot_commit_paths(
+            repo,
+            snapshot.ref,
+            [path for path in requested if path not in tracked and path not in snapshot.untracked],
+        )
+    }
+    try:
+        for path in requested:
+            if path in snapshot.untracked:
+                state = snapshot.untracked[path]
+                replace_type = True
+            elif path in tracked:
+                state = tracked[path]
+                replace_type = False
+            else:
+                state = committed[path]
+                replace_type = state.state == "missing"
+            _restore_path_state(
+                repo,
+                state,
+                allow_leaf_type_replacement=replace_type,
+                ref=snapshot.ref,
+            )
+    finally:
+        restore_index(repo, snapshot.index)
+
+
+def restore_index(repo: Path, snapshot: IndexSnapshot) -> None:
+    """Restore a complete index tree without modifying the worktree."""
+    proc = _run_git(repo, ["read-tree", snapshot.tree_sha], timeout=30, retries=0)
+    if proc.returncode != 0:
+        raise GitError(f"git read-tree failed in {repo}: {proc.stderr.strip()}")
+
+
+def build_recommended_patch_strict(
+    repo: Path,
+    base_ref: str,
+    retained_paths: Iterable[str],
+) -> bytes:
+    """Build deterministic binary-capable presentation output for exact paths."""
+    unique = sorted(set(retained_paths), key=_path_sort_key)
+    if not unique:
+        return b""
+    base_states = {state.path: state for state in snapshot_commit_paths(repo, base_ref, unique)}
+    current_states = {state.path: state for state in snapshot_worktree_paths(repo, unique)}
+    chunks: list[bytes] = []
+    for path in unique:
+        if base_states[path].state == "missing" and current_states[path].state != "missing":
+            proc = _run_git(
+                repo,
+                ["diff", "--no-index", "--binary", "--full-index", "--", "/dev/null", path],
+                timeout=30,
+                capture_bytes=True,
+            )
+            if proc.returncode not in {0, 1}:
+                raise GitError(f"git diff --no-index --binary failed in {repo}: {os.fsdecode(proc.stderr).strip()}")
+        else:
+            proc = _run_git(
+                repo,
+                [
+                    "diff",
+                    "--binary",
+                    "--full-index",
+                    "--no-ext-diff",
+                    base_ref,
+                    "--",
+                    _literal_pathspec(path),
+                ],
+                timeout=30,
+                capture_bytes=True,
+            )
+            if proc.returncode != 0:
+                raise GitError(f"git diff --binary failed in {repo}: {os.fsdecode(proc.stderr).strip()}")
+        chunks.append(proc.stdout)
+    return b"".join(chunks)
+
+
 def clean_untracked(repo: Path) -> None:
     """Run ``git clean -fd`` to remove untracked files and directories.
 
@@ -2178,9 +2737,37 @@ def stage_paths(repo: Path, paths: list[Path]) -> None:
     """
     if not paths:
         raise GitError("stage_paths requires at least one path")
-    add = _run_git(repo, ["add", "--", *(str(p) for p in paths)], timeout=30, retries=0)
+    normalized = [p.as_posix() for p in paths]
+    for path in normalized:
+        _require_git_path_confined(repo, path)
+    add = _run_git(
+        repo,
+        ["--literal-pathspecs", "add", "--", *normalized],
+        timeout=30,
+        retries=0,
+    )
     if add.returncode != 0:
         raise GitError(f"git add {paths} failed in {repo}: {add.stderr.strip()}")
+
+
+def commit_staged(repo: Path, message: str) -> None:
+    """Commit the already-validated index without staging again."""
+    identity_ok = (
+        _run_git(repo, ["config", "user.email"], timeout=5).returncode == 0
+        and _run_git(repo, ["config", "user.name"], timeout=5).returncode == 0
+    )
+    commit_args = ["commit", "-m", message]
+    if not identity_ok:
+        commit_args = [
+            "-c",
+            "user.email=daydream@localhost",
+            "-c",
+            "user.name=daydream",
+            *commit_args,
+        ]
+    commit = _run_git(repo, commit_args, timeout=30, retries=0)
+    if commit.returncode != 0:
+        raise GitError(f"git commit failed in {repo}: {commit.stderr.strip()}")
 
 
 def commit_paths(repo: Path, paths: list[Path], message: str) -> None:
@@ -2199,22 +2786,7 @@ def commit_paths(repo: Path, paths: list[Path], message: str) -> None:
     """
     # Empty-path guard lives in stage_paths (identical GitError).
     stage_paths(repo, paths)
-    # git commit fails "Author identity unknown" with no user.email/user.name
-    # (common in fresh CI). Inject fallback values via -c only when none is set.
-    identity_ok = (
-        _run_git(repo, ["config", "user.email"], timeout=5).returncode == 0
-        and _run_git(repo, ["config", "user.name"], timeout=5).returncode == 0
-    )
-    commit_args = ["commit", "-m", message]
-    if not identity_ok:
-        commit_args = [
-            "-c", "user.email=daydream@localhost",
-            "-c", "user.name=daydream",
-            *commit_args,
-        ]
-    commit = _run_git(repo, commit_args, timeout=30, retries=0)
-    if commit.returncode != 0:
-        raise GitError(f"git commit failed in {repo}: {commit.stderr.strip()}")
+    commit_staged(repo, message)
 
 
 def push_branch(repo: Path, branch: str, *, remote: str = "origin") -> None:

--- a/daydream/git_ops.py
+++ b/daydream/git_ops.py
@@ -1591,21 +1591,25 @@ def diff_name_only_strict(repo: Path, from_ref: str, to_ref: str) -> list[str]:
     """Return repo-relative paths that differ between two refs' trees.
 
     Strict counterpart to :func:`diff_name_only` (which soft-fails to an empty
-    list) for post-commit tree checks: ``git diff --name-only <from_ref>
+    list) for post-commit tree checks: ``git diff --name-only -z <from_ref>
     <to_ref>`` over the two commit trees. Raises :class:`GitError` when the
     diff cannot be computed, so callers can distinguish "no differences" from
     "unknown" (e.g. when verifying that a commit agent did not broaden a
     commit beyond the pre-staged set).
 
     Returns:
-        List of repo-relative path strings (unique, as emitted by git).
+        Exact filesystem-decoded repo-relative paths, without quoting or trimming.
     """
-    proc = _run_git(repo, ["diff", "--name-only", from_ref, to_ref], timeout=10)
+    proc = _run_git(
+        repo, ["diff", "--name-only", "-z", from_ref, to_ref],
+        timeout=10, capture_bytes=True,
+    )
     if proc.returncode != 0:
         raise GitError(
-            f"git diff --name-only {from_ref} {to_ref} failed in {repo}: {proc.stderr.strip()}"
+            f"git diff --name-only -z {from_ref} {to_ref} failed in {repo}: "
+            f"{os.fsdecode(proc.stderr).strip()}"
         )
-    return [line.strip() for line in proc.stdout.splitlines() if line.strip()]
+    return _decode_nul_paths(proc.stdout)
 
 
 def list_untracked(repo: Path, *, strict: bool = False) -> list[str]:

--- a/daydream/git_ops.py
+++ b/daydream/git_ops.py
@@ -1848,10 +1848,11 @@ def _snapshot_worktree_path(
                 os.close(descriptor)
         except OSError as exc:
             raise GitError("could not read a confined worktree path") from exc
-        permissions = stat.S_IMODE(metadata.st_mode)
-        if mode_from_index is not None:
-            permissions = 0o755 if permissions & 0o111 else 0o644
-        mode = stat.S_IFREG | permissions
+        # Worktree evidence preserves actual permissions, including private
+        # owner files. Its identity must not change merely because a formerly
+        # untracked path enters the index. Git-mode projection belongs only at
+        # the worktree-to-index comparison boundary.
+        mode = stat.S_IFREG | stat.S_IMODE(metadata.st_mode)
         return GitPathState(path=path, state="regular", mode=mode, digest=_write_git_blob(repo, b"".join(chunks)))
     raise GitError("unsupported worktree path type")
 
@@ -2656,12 +2657,12 @@ def _preflight_gitlink_restore(repo: Path, state: GitPathState) -> Path:
     return nested
 
 
-def restore_group_from_snapshot(
+def restore_group_worktree_from_snapshot(
     repo: Path,
     snapshot: WorktreeRollbackSnapshot,
     paths: Iterable[str],
 ) -> None:
-    """Restore every requested group path and the supplied round index."""
+    """Restore requested group paths without mutating the parent index."""
     requested = sorted(set(paths), key=_path_sort_key)
     tracked = {state.path: state for state in snapshot.path_states}
     committed = {
@@ -2685,20 +2686,28 @@ def restore_group_from_snapshot(
             replace_type = state.state == "missing"
         restore_states.append((state, replace_type))
 
+    # Preflight every nested repository before changing any worktree path. A
+    # dirty or unavailable gitlink is a fail-closed condition, never grounds
+    # for a forced checkout that could destroy user content.
+    for state, _replace_type in restore_states:
+        if state.state == "gitlink":
+            _preflight_gitlink_restore(repo, state)
+    for state, replace_type in restore_states:
+        _restore_path_state(
+            repo,
+            state,
+            allow_leaf_type_replacement=replace_type,
+        )
+
+
+def restore_group_from_snapshot(
+    repo: Path,
+    snapshot: WorktreeRollbackSnapshot,
+    paths: Iterable[str],
+) -> None:
+    """Restore every requested group path and the supplied complete index."""
     try:
-        # Preflight every nested repository before changing any worktree path.
-        # A dirty or unavailable gitlink is a fail-closed condition, never
-        # grounds for a forced checkout that could destroy user content.  The
-        # complete parent index is still restored by ``finally``.
-        for state, _replace_type in restore_states:
-            if state.state == "gitlink":
-                _preflight_gitlink_restore(repo, state)
-        for state, replace_type in restore_states:
-            _restore_path_state(
-                repo,
-                state,
-                allow_leaf_type_replacement=replace_type,
-            )
+        restore_group_worktree_from_snapshot(repo, snapshot, paths)
     finally:
         restore_index(repo, snapshot.index)
 

--- a/daydream/phases.py
+++ b/daydream/phases.py
@@ -2793,8 +2793,9 @@ async def phase_fix_parallel(
 
     Returns:
         ``failures``: file -> reason string.  Exception-failed groups carry
-        ``"<ExceptionType>: <message>"``; their partial edits may be broken and
-        callers MUST revert them.  Budget-exceeded groups carry
+        ``"<ExceptionType>: <message>"`` and have already been restored from the
+        supplied round snapshot; callers must treat them as terminal without
+        reverting successful sibling groups.  Budget-exceeded groups carry
         ``"file_group_budget_exceeded: <reason>"``; their already-applied fixes
         are intact and callers MUST NOT revert them — only the remaining findings
         were skipped.  Callers distinguish the two by the prefix.  Empty dict on
@@ -2967,8 +2968,8 @@ async def phase_fix_parallel(
                             async with _console_lock:
                                 print_warning(
                                     console,
-                                    f"Fixes for '{fkey}' failed ({reason}); other fixes applied "
-                                    "but this file's changes are left uncommitted.",
+                                    f"Fixes for '{fkey}' failed ({reason}); its complete group was "
+                                    "restored and successful sibling-group edits were preserved.",
                                 )
 
             tg.start_soon(_task)

--- a/daydream/phases.py
+++ b/daydream/phases.py
@@ -7,6 +7,7 @@ import logging
 import re
 import shlex
 from collections.abc import Callable
+from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, overload
@@ -38,6 +39,7 @@ from daydream.clipboard import clipboard_available, copy_to_clipboard
 from daydream.eval.analyzer import _records_issues, _records_issues_or_empty
 from daydream.extensions import get_registry
 from daydream.file_group_budget import FileGroupBudget
+from daydream.fix_footprint import AuthorizedFixFootprint
 from daydream.generated_files import (
     GENERATED_FILES_PROMPT_RULE,
     _changed_untracked_generated_files,
@@ -1238,8 +1240,11 @@ def severity_sorted(items: list[dict[str, Any]]) -> list[dict[str, Any]]:
     return sorted(items, key=lambda it: SEVERITY_RANK.get(it.get("severity") or "", 1))
 
 
-def group_items_by_footprint(items: list[dict[str, Any]]) -> list[tuple[str, list[dict[str, Any]]]]:
-    """Partition fix items by footprint (``{file} ∪ related_files``), widening-only.
+def group_items_by_footprint(
+    items: list[dict[str, Any]],
+    footprint: AuthorizedFixFootprint,
+) -> list[tuple[str, list[dict[str, Any]]]]:
+    """Partition fix items by their normalized authorized footprints.
 
     A finding's footprint is its primary ``file`` plus every ``related_files``
     entry it carries. Any two groups whose footprints share a file are united
@@ -1281,10 +1286,10 @@ def group_items_by_footprint(items: list[dict[str, Any]]) -> list[tuple[str, lis
 
     file_to_indices: dict[str, list[int]] = {}
     for i, item in enumerate(items):
-        footprint = {(item.get("file") or "<no-file>")} | {
-            f for f in (item.get("related_files") or []) if isinstance(f, str)
-        }
-        for f in footprint:
+        item_uid = item.get("item_uid")
+        if not isinstance(item_uid, str) or not item_uid:
+            raise ValueError("fix grouping requires item_uid")
+        for f in footprint.item_paths(item_uid):
             for j in file_to_indices.setdefault(f, []):
                 union(i, j)
             file_to_indices[f].append(i)
@@ -2077,11 +2082,10 @@ async def phase_fix_verify(
     console_lock: anyio.Lock | None = None,
     round_number: int = 1,
 ) -> list[dict[str, Any]]:
-    """Post-round fix verifier: one read-only verdict per dispatched finding.
+    """Read-only verifier: one verdict per supplied canonical finding.
 
-    Runs AFTER every fix group in a round finishes (the round barrier — the
-    caller invokes this once per footprint group). The agent audits the
-    round's changed hunks only (never the whole tree) and returns exactly one
+    The agent audits the complete retained patch supplied by the caller and
+    returns exactly one
     verdict per listed finding from the four-value enum: ``resolved``,
     ``unresolved``, ``wrong_target(path)``, or ``regressed(path)``.
 
@@ -2235,18 +2239,22 @@ report why instead of running it.
 )
 
 
-def _build_allowed_files_clause(changed_files: set[str] | None) -> str:
-    """Build the explicit "Allowed files" clause for a fix prompt.
+def _build_fix_scope_clause(
+    edit_scope: frozenset[str], read_scope: frozenset[str]
+) -> str:
+    """Render separate edit authorization and readable run context.
 
-    Issue #336 threads the reviewed diff's file set into the fix prompt so the
-    prose boundary above is also concrete and checkable. ``None`` (legacy
-    callers, resume without diff context) yields an empty string — the prose
-    boundary still applies, but no enumerated file set is injected (behavior
-    unchanged for those callers).
+    The edit list is the enforcement contract. The wider read list is context
+    only and never grants write authority.
     """
-    if not changed_files:
-        return ""
-    return "\nAllowed files (reviewed diff + this finding): " + ", ".join(sorted(changed_files)) + "\n"
+    edits = ", ".join(sorted(edit_scope)) or "(none)"
+    readable_only = ", ".join(sorted(read_scope - edit_scope)) or "(none)"
+    return (
+        "\nAuthorized edit scope (ONLY these repository-relative paths): "
+        f"{edits}\n"
+        "Run-readable context (read-only unless also listed in the edit scope): "
+        f"{readable_only}\n"
+    )
 
 
 def _item_evidence(item: dict[str, Any]) -> str:
@@ -2504,9 +2512,10 @@ async def phase_fix(
     item_num: int,
     total: int,
     *,
+    edit_scope: frozenset[str] | None = None,
+    read_scope: frozenset[str] | None = None,
     console_lock: anyio.Lock | None = None,
     intent_path: Path | None = None,
-    changed_files: set[str] | None = None,
     exploration_dir: Path | None = None,
     test_map: dict[str, str] | None = None,
 ) -> None:
@@ -2518,6 +2527,8 @@ async def phase_fix(
         item: Feedback item containing description, file, and line
         item_num: Current item number (1-indexed)
         total: Total number of items
+        edit_scope: Exact transitive group paths the fixer may edit.
+        read_scope: Run-wide paths available as read-only context.
         console_lock: Optional lock to serialize console writes across
             concurrent callers.  Pass the same lock to every concurrent
             ``phase_fix`` invocation; leave ``None`` for serial callers.
@@ -2526,17 +2537,14 @@ async def phase_fix(
             with a rule forbidding fixes that undo a deliberate decision. The
             read is best-effort enrichment: a missing or unreadable file is
             skipped silently so an intent-read failure can never block the fix.
-        changed_files: Optional set of files in the reviewed diff (issue #336).
-            When non-None, an explicit "Allowed files" clause is appended to
-            the prompt so the prose scope boundary is also concrete. ``None``
-            (legacy/resume callers) leaves the prompt without the clause; the
-            prose boundary still applies.
         exploration_dir: Optional pre-scan directory whose deterministic
             ``affected_files.md`` index is pointed out to the fixer.
         test_map: Optional pre-parsed ``{test_file: source_file}`` mapping
             (built once by ``_parse_test_map`` at the fan-out root); ``None``
             yields no hint. Invalid maps are ignored.
     """
+    if edit_scope is None or read_scope is None:
+        raise TypeError("phase_fix requires explicit edit_scope and read_scope")
     description = item.get("description", "No description")
     file_ref = _resolve_finding_file_ref(work.repo, item.get("file"))
     line = item.get("line", "Unknown")
@@ -2556,9 +2564,8 @@ File: {file_ref}
 Line: {line}{related_line}{evidence_line}
 
 Make the minimal change needed. {_FIX_GUARDRAILS}"""
-    # Issue #336 — concrete allowed-files list (reviewed diff). None leaves
-    # the prose boundary in place without an enumerated set.
-    prompt += _build_allowed_files_clause(changed_files)
+    # Exact group edit authority is distinct from wider read-only run context.
+    prompt += _build_fix_scope_clause(edit_scope, read_scope)
     prompt += _exploration_pointer(exploration_dir, fixer=True)
     prompt += _build_test_map_hints([item], test_map, work.repo)
 
@@ -2602,9 +2609,10 @@ async def phase_fix_batched(
     item_nums: list[int],
     total: int,
     *,
+    edit_scope: frozenset[str] | None = None,
+    read_scope: frozenset[str] | None = None,
     console_lock: anyio.Lock | None = None,
     intent_path: Path | None = None,
-    changed_files: set[str] | None = None,
     exploration_dir: Path | None = None,
     test_map: dict[str, str] | None = None,
 ) -> None:
@@ -2625,26 +2633,27 @@ async def phase_fix_batched(
         items: Feedback items, all targeting the same file.
         item_nums: 1-based progress counters aligned with ``items``.
         total: Total number of items across the whole fix run.
+        edit_scope: Exact transitive group paths the fixer may edit.
+        read_scope: Run-wide paths available as read-only context.
         console_lock: Optional lock to serialize console writes across concurrent
             callers. Pass the same lock to every concurrent invocation; leave
             ``None`` for serial callers.
         intent_path: Optional path to the confirmed author-intent file, injected
             verbatim (same best-effort handling as ``phase_fix``).
-        changed_files: Optional set of files in the reviewed diff (issue #336),
-            forwarded to the single-item delegation and appended to the batched
-            prompt as an explicit "Allowed files" clause. ``None`` for
-            legacy/resume callers leaves the prompt without the clause.
         exploration_dir: Optional pre-scan directory whose deterministic
             ``affected_files.md`` index is pointed out to the fixer.
         test_map: Optional pre-parsed ``{test_file: source_file}`` mapping
             (built once by ``_parse_test_map`` at the fan-out root); ``None``
             yields no hint. Invalid maps are ignored.
     """
+    if edit_scope is None or read_scope is None:
+        raise TypeError("phase_fix_batched requires explicit edit_scope and read_scope")
     if len(items) == 1:
         await phase_fix(
             backend, work, items[0], item_nums[0], total,
+            edit_scope=edit_scope, read_scope=read_scope,
             console_lock=console_lock, intent_path=intent_path,
-            changed_files=changed_files, exploration_dir=exploration_dir,
+            exploration_dir=exploration_dir,
             test_map=test_map,
         )
         return
@@ -2679,9 +2688,8 @@ async def phase_fix_batched(
     prompt = f"""Fix these {count} issues in {file_ref}:
 {findings_block}
 Make the minimal changes needed to address ALL of the above findings in one coherent patch. {_FIX_GUARDRAILS}"""
-    # Issue #336 — concrete allowed-files list (reviewed diff). None leaves
-    # the prose boundary in place without an enumerated set.
-    prompt += _build_allowed_files_clause(changed_files)
+    # Exact group edit authority is distinct from wider read-only run context.
+    prompt += _build_fix_scope_clause(edit_scope, read_scope)
     prompt += _exploration_pointer(exploration_dir, fixer=True)
     prompt += _build_test_map_hints(items, test_map, work.repo)
 
@@ -2733,29 +2741,26 @@ async def phase_fix_parallel(
     work: WorkContext,
     items: list[dict[str, Any]],
     *,
+    footprint: AuthorizedFixFootprint | None = None,
+    round_snapshot: git_ops.WorktreeRollbackSnapshot | None = None,
     limiter_size: int = 10,
     intent_path: Path | None = None,
     group_max_wall_s: float = DEFAULT_GROUP_MAX_WALL_S,
     group_max_serial_items: int = DEFAULT_GROUP_MAX_SERIAL_ITEMS,
-    changed_files: set[str] | None = None,
     exploration_dir: Path | None = None,
     test_map_path: Path | None = None,
 ) -> dict[str, str]:
     """Phase 3 (parallel): Apply fixes file-partitioned and concurrently.
 
-    Items are grouped by footprint (the item's ``file`` union its
-    ``related_files``, widening-only), preserving the caller's severity order.
+    Items are grouped by their normalized per-item footprint, preserving the
+    caller's severity order.
     Each footprint-group becomes one task whose findings are fixed together in a
     single ``phase_fix_batched`` call (one ``run_agent`` turn per group), while
     distinct files run concurrently under an ``anyio.CapacityLimiter``. If the
     batched turn raises, the group falls back to per-finding ``phase_fix`` calls.
-    Same-file serialization prevents concurrent writes to the *same named file*;
-    it does not guarantee disjoint edits if an agent touches files other than the
-    one named in the item's ``file`` key. Issue #336 bounds that: the caller
-    passes ``changed_files`` (the reviewed diff's file set) so every fix prompt
-    carries an explicit allowed-files clause, and the post-fix residual check
-    in ``_step_fix`` reverts any edited file outside ``changed_files ∪ finding
-    files ∪ generated whitelist``. Commit stays serial and after.
+    Every prompt receives the exact group's edit scope and the wider run scope
+    only as readable context. Failed batch or group execution restores every
+    group path and the supplied round index before fallback/return.
 
     Each file group is bounded by a :class:`FileGroupBudget` (#201): the budget
     is consulted before every fix call (including the batched call), and if a
@@ -2773,15 +2778,13 @@ async def phase_fix_parallel(
         backend: The Backend to execute against (shared across tasks).
         work: Workspace context for the fixes; ``work.repo`` is the agent cwd.
         items: Feedback items, already severity-sorted by the caller.
+        footprint: Normalized run/item authorization policy.
+        round_snapshot: Round rollback point used for whole-group recovery.
         limiter_size: Max number of file-groups to fix concurrently.
         intent_path: Optional confirmed-intent file forwarded unchanged to each
             fix call so every fix carries the deliberate-intent guard.
         group_max_wall_s: Per-file-group wall-clock ceiling (#201).
         group_max_serial_items: Per-file-group serial fix-call ceiling (#201).
-        changed_files: Optional set of files in the reviewed diff (issue #336),
-            forwarded to every ``phase_fix_batched`` / ``phase_fix`` call so each
-            prompt carries an explicit "Allowed files" clause. ``None`` for
-            legacy/resume callers (no diff context) leaves prompts unchanged.
         exploration_dir: Optional pre-scan directory forwarded to every fix
             call so prompts point at its deterministic ``affected_files.md``.
         test_map_path: Optional ``test-map.json`` forwarded to every fix call
@@ -2797,6 +2800,8 @@ async def phase_fix_parallel(
         full success.
 
     """
+    if footprint is None or round_snapshot is None:
+        raise TypeError("phase_fix_parallel requires footprint and round_snapshot")
     # Preflight confinement gate: validate EVERY item's file reference before
     # grouping, progress, prompt construction, recovery, or dispatch. An
     # unconfined (or missing/non-string) reference raises
@@ -2806,7 +2811,7 @@ async def phase_fix_parallel(
     # recompute them.
     _preflight_finding_file_refs(work.repo, items)
 
-    raw_groups = group_items_by_footprint(items)
+    raw_groups = group_items_by_footprint(items, footprint)
     # Assign stable 1-based counters by pairing each item with its number
     # directly, avoiding fragile id()-keyed dicts whose keys are memory
     # addresses and can collide if dicts are reallocated between loops.
@@ -2859,6 +2864,7 @@ async def phase_fix_parallel(
         fkey: str,
         grp: list[tuple[dict[str, Any], int]],
         budget: FileGroupBudget,
+        edit_scope: frozenset[str],
     ) -> None:
         """Fix a group's findings one at a time, honoring the group budget.
 
@@ -2873,9 +2879,10 @@ async def phase_fix_parallel(
                 return
             await phase_fix(
                 backend, work, item, item_num, total,
+                edit_scope=edit_scope,
+                read_scope=footprint.run_allowed_paths,
                 console_lock=_console_lock,
                 intent_path=intent_path,
-                changed_files=changed_files,
                 exploration_dir=exploration_dir,
                 test_map=test_map,
             )
@@ -2898,12 +2905,13 @@ async def phase_fix_parallel(
                         try:
                             grp_items = [item for item, _ in grp]
                             grp_nums = [num for _, num in grp]
+                            edit_scope = footprint.group_paths(grp_items)
                             is_real_batch = len(grp_items) > 1 and fkey != "<no-file>"
                             if not is_real_batch:
                                 # Single-item or <no-file> groups: go straight to
                                 # per-finding phase_fix (no batched prompt to build,
                                 # no fallback retry on failure).
-                                await _fix_group_serially(fkey, grp, budget)
+                                await _fix_group_serially(fkey, grp, budget, edit_scope)
                             else:
                                 # Design-checkpoint #1: consult the group budget
                                 # BEFORE the batched call too, mirroring the serial
@@ -2917,9 +2925,10 @@ async def phase_fix_parallel(
                                 try:
                                     await phase_fix_batched(
                                         backend, work, grp_items, grp_nums, total,
+                                        edit_scope=edit_scope,
+                                        read_scope=footprint.run_allowed_paths,
                                         console_lock=_console_lock,
                                         intent_path=intent_path,
-                                        changed_files=changed_files,
                                         exploration_dir=exploration_dir,
                                         test_map=test_map,
                                     )
@@ -2929,16 +2938,29 @@ async def phase_fix_parallel(
                                     # per-finding fixes don't re-apply partial edits
                                     # that the batched turn may have already written.
                                     try:
-                                        git_ops.checkout_paths(work.repo, [Path(fkey)])
-                                    except Exception as _restore_err:  # noqa: BLE001 -- restore is best-effort; don't block fallback
-                                        if not get_quiet_mode():
-                                            print_warning(
-                                                console,
-                                                f"Could not restore {fkey} before fallback: {_restore_err}",
-                                            )
-                                    await _fix_group_serially(fkey, grp, budget)
+                                        git_ops.restore_group_from_snapshot(
+                                            work.repo, round_snapshot, edit_scope
+                                        )
+                                    except Exception as restore_err:  # noqa: BLE001
+                                        raise RuntimeError(
+                                            "failed to restore the complete fix group before fallback"
+                                        ) from restore_err
+                                    await _fix_group_serially(fkey, grp, budget, edit_scope)
                         except Exception as e:  # noqa: BLE001 -- intentionally broad for parallel isolation
-                            reason = f"{type(e).__name__}: {e}"
+                            failure: BaseException = e
+                            try:
+                                grp_items = [item for item, _ in grp]
+                                git_ops.restore_group_from_snapshot(
+                                    work.repo,
+                                    round_snapshot,
+                                    footprint.group_paths(grp_items),
+                                )
+                            except Exception as restore_err:  # noqa: BLE001
+                                failure = RuntimeError(
+                                    "failed to restore the complete failed fix group"
+                                )
+                                failure.__cause__ = restore_err
+                            reason = f"{type(failure).__name__}: {failure}"
                             async with _failures_lock:
                                 failures[fkey] = reason
                             async with _console_lock:
@@ -3220,12 +3242,108 @@ async def _run_host_test_command(
     )
 
 
+@dataclass(frozen=True)
+class TestAttemptEvidence:
+    """Identity-bound evidence from one real host or TEST-agent execution."""
+
+    session_id: str
+    kind: Literal["host", "agent"]
+    command: tuple[str, ...] | None
+    passed: bool
+    input_tree_key: str
+    output_tree_key: str
+
+
+@dataclass(frozen=True)
+class TestAndHealResult:
+    """Typed outcome of the bounded test-and-heal interaction."""
+
+    passed: bool
+    retries: int
+    proceed: bool
+    ignored: bool
+    attempts: tuple[TestAttemptEvidence, ...]
+
+    def __iter__(self) -> Any:
+        """Keep tuple unpacking source-compatible while callers migrate."""
+        return iter((self.passed, self.retries, self.proceed))
+
+
+async def phase_test_once(
+    backend: Backend,
+    work: WorkContext,
+    *,
+    config: Any,
+    session_id: str,
+    capture_tree_key: Callable[[], str],
+    continuation: ContinuationToken | None = None,
+    command_override: list[str] | None = None,
+) -> tuple[TestAttemptEvidence, ContinuationToken | None, str]:
+    """Execute exactly one canonical test attempt and bind it to tree identity.
+
+    Configured and explicitly approved commands run host-side. With no command,
+    the established TEST-agent/prose path is used. Both paths capture the same
+    before/after identity projection supplied by the fix-cycle orchestrator.
+    """
+    cmd = command_override if command_override is not None else _canonical_test_cmd(config)
+    input_tree_key = capture_tree_key()
+    next_continuation: ContinuationToken | None = None
+    if cmd is not None:
+        try:
+            result = await _run_host_test_command(cmd, work, config)
+        except (OSError, ValueError) as exc:
+            output = f"The configured test command failed to run (spawn): {exc}"
+            passed = False
+        else:
+            if result.timed_out:
+                print_warning(
+                    console,
+                    f"Test command hit the {_test_command_wall_budget(config):g}s "
+                    "wall budget and was killed.",
+                )
+            output = result.merged_output
+            passed = result.passed
+        kind: Literal["host", "agent"] = "host"
+        command: tuple[str, ...] | None = tuple(cmd)
+    else:
+        prompt = f"Run the project's test suite. {_TEST_RUN_INSTRUCTIONS}"
+        output, next_continuation, _ = await run_agent(
+            backend,
+            work.repo,
+            prompt,
+            continuation=continuation,
+            phase=DaydreamPhase.TEST,
+            tool_call_budget=DEFAULT_TOOL_CALL_BUDGET,
+            wall_budget_s=TEST_WALL_BUDGET_S,
+        )
+        passed = detect_test_success(output)
+        kind = "agent"
+        command = None
+    output_tree_key = capture_tree_key()
+    return (
+        TestAttemptEvidence(
+            session_id=session_id,
+            kind=kind,
+            command=command,
+            passed=passed,
+            input_tree_key=input_tree_key,
+            output_tree_key=output_tree_key,
+        ),
+        next_continuation,
+        output,
+    )
+
+
 async def phase_test_and_heal(
     backend: Backend,
     work: WorkContext,
     feedback_items: list[dict[str, Any]] | None = None,
     config: Any = None,
-) -> tuple[bool, int, bool]:
+    *,
+    session_id: str | None = None,
+    capture_tree_key: Callable[[], str] | None = None,
+    footprint: AuthorizedFixFootprint | None = None,
+) -> TestAndHealResult:
     """Phase 4: Run tests and prompt user on failure for action.
 
     Args:
@@ -3239,17 +3357,25 @@ async def phase_test_and_heal(
             #726) — no TEST-phase agent turn and no prose detection. When
             nothing is configured, the deprecated agent-run fallback applies
             (see :func:`_canonical_test_cmd`).
+        session_id: Current fix-cycle session bound into every attempt.
+        capture_tree_key: Full stable-base delta identity callback, invoked
+            immediately before and after each actual test execution.
+        footprint: Run-wide authorization used as the healing edit scope.
 
     Returns:
-        Tuple of (passed: bool, retries_used: int, proceed: bool). ``passed`` is
-        what the suite actually did; ``proceed`` is whether the run continues,
-        which the operator can grant to a red suite via "ignore and continue".
+        A typed result preserving the real verdict, explicit red override, and
+        identity evidence for every actual host or agent test attempt.
 
     """
+    if session_id is None or capture_tree_key is None or footprint is None:
+        raise TypeError(
+            "phase_test_and_heal requires session_id, capture_tree_key, and footprint"
+        )
     print_phase_hero(console, "AWAKEN", phase_subtitle("AWAKEN"))
     print_dim(console, f"Model: {backend.model}")
 
     retries_used = 0
+    attempts: list[TestAttemptEvidence] = []
     continuation: ContinuationToken | None = None
     # Merged (redacted) output of a host-side test-command run whose suite came
     # back red; consumed at the top of the next iteration so it flows through
@@ -3275,6 +3401,9 @@ async def phase_test_and_heal(
         fix_prompt = get_registry().prompt("fix")(
             output, feedback_items, repo=work.repo,
             concise_mode=_backend_concise_fix_prompts(backend),
+        )
+        fix_prompt += _build_fix_scope_clause(
+            footprint.run_allowed_paths, footprint.run_allowed_paths
         )
         await run_agent(
             backend, work.repo, fix_prompt, phase=DaydreamPhase.FIX,
@@ -3305,58 +3434,20 @@ async def phase_test_and_heal(
             output, host_failure_output = host_failure_output, None
             test_passed = False
         else:
-            cmd = _canonical_test_cmd(config)
-            if cmd is None:
-                # Deprecated fallback: no canonical test command is configured,
-                # so a TEST-phase agent turn runs the suite and its prose is
-                # pattern-matched for the verdict (untrusted by design).
-                prompt = f"Run the project's test suite. {_TEST_RUN_INSTRUCTIONS}"
-                output, continuation, _ = await run_agent(
-                    backend,
-                    work.repo,
-                    prompt,
-                    continuation=continuation,
-                    phase=DaydreamPhase.TEST,
-                    tool_call_budget=DEFAULT_TOOL_CALL_BUDGET,
-                    wall_budget_s=TEST_WALL_BUDGET_S,
-                )
-
-                test_passed = detect_test_success(output)
-            else:
-                # Issue #726: the configured canonical test command runs
-                # host-side as a real subprocess; the verdict is the exit
-                # status, never the agent's prose. No agent turn here.
-                try:
-                    result = await _run_host_test_command(cmd, work, config)
-                except (OSError, ValueError) as exc:
-                    # The command could not be spawned (missing binary, a
-                    # shell-builtin argv, or malformed words). That is a test
-                    # failure, not a crash: route the diagnostic through the
-                    # same failure gate/heal menu so the run continues instead
-                    # of dying with an unhandled traceback (issue #726).
-                    print_warning(
-                        console,
-                        f"Configured test command could not be run: {exc}",
-                    )
-                    output = (
-                        "The configured test command failed to run (spawn): "
-                        f"{exc}"
-                    )
-                    test_passed = False
-                else:
-                    if result.timed_out:
-                        print_warning(
-                            console,
-                            f"Test command hit the "
-                            f"{_test_command_wall_budget(config):g}s wall "
-                            "budget and was killed.",
-                        )
-                    output = result.merged_output
-                    test_passed = result.passed
+            evidence, continuation, output = await phase_test_once(
+                backend,
+                work,
+                config=config,
+                session_id=session_id,
+                capture_tree_key=capture_tree_key,
+                continuation=continuation,
+            )
+            attempts.append(evidence)
+            test_passed = evidence.passed
 
         if test_passed:
             print_success(console, "Tests passed")
-            return True, retries_used, True
+            return TestAndHealResult(True, retries_used, True, False, tuple(attempts))
 
         print_warning(console, "Tests may have failed or result is unclear.")
 
@@ -3368,7 +3459,7 @@ async def phase_test_and_heal(
                 "Test failure looks environmental (infrastructure unavailable); "
                 "skipping heal loop.",
             )
-            return False, retries_used, False
+            return TestAndHealResult(False, retries_used, False, False, tuple(attempts))
 
         # Test-heal retry gate across the two interaction axes. With no human at
         # the keyboard, the menu's default "2" (fix-and-retry) would launch an
@@ -3388,13 +3479,13 @@ async def phase_test_and_heal(
                 console, "Tests failed", "Aborting heal loop (no further auto-retries)",
             )
             await _emit_failure_handoff(backend, work, output, offer_clipboard=False)
-            return False, retries_used, False
+            return TestAndHealResult(False, retries_used, False, False, tuple(attempts))
         if decision is True:
             # Bounded auto fix-and-retry: launch one fix attempt, then loop.
             console.print()
             print_info(console, "Launching agent to fix test failures (auto)...")
             if not await _launch_fix(output):
-                return False, retries_used, False
+                return TestAndHealResult(False, retries_used, False, False, tuple(attempts))
             continue
 
         print_menu(console, "What would you like to do?", [
@@ -3456,23 +3547,26 @@ async def phase_test_and_heal(
                             retries_used += 1
                             continue
                         try:
-                            result = await _run_host_test_command(cmd, work, config)
-                        except (OSError, ValueError) as exc:
-                            # Spawn errors (missing binary, shell builtin) and
-                            # remaining argv errors must not escape into a
-                            # traceback; surface as a failed suggestion and
-                            # re-run the original command.
-                            print_warning(
-                                console,
-                                f"Approved test command could not be run: {exc}",
+                            evidence, _, alternate_output = await phase_test_once(
+                                backend,
+                                work,
+                                config=config,
+                                session_id=session_id,
+                                capture_tree_key=capture_tree_key,
+                                command_override=cmd,
                             )
+                        except (OSError, ValueError) as exc:
+                            print_warning(console, f"Approved test command could not be run: {exc}")
                             retries_used += 1
                             continue
-                        if result.passed:
+                        attempts.append(evidence)
+                        if evidence.passed:
                             print_success(console, "Tests passed")
-                            return True, retries_used, True
+                            return TestAndHealResult(
+                                True, retries_used, True, False, tuple(attempts)
+                            )
                         print_warning(console, "Approved test command failed.")
-                        host_failure_output = result.merged_output
+                        host_failure_output = alternate_output
                         continue
 
             retries_used += 1
@@ -3482,21 +3576,21 @@ async def phase_test_and_heal(
             console.print()
             print_info(console, "Launching agent to fix test failures...")
             if not await _launch_fix(output):
-                return False, retries_used, False
+                return TestAndHealResult(False, retries_used, False, False, tuple(attempts))
             continue
 
         elif choice == "3":
             print_warning(console, "Ignoring test failures, continuing...")
-            return False, retries_used, True
+            return TestAndHealResult(False, retries_used, True, True, tuple(attempts))
 
         elif choice == "4":
             print_error(console, "Aborted", "User requested abort")
             await _emit_failure_handoff(backend, work, output, offer_clipboard=True)
-            return False, retries_used, False
+            return TestAndHealResult(False, retries_used, False, False, tuple(attempts))
 
         else:
             print_warning(console, f"Invalid choice '{choice}', aborting")
-            return False, retries_used, False
+            return TestAndHealResult(False, retries_used, False, False, tuple(attempts))
 
 
 def _stage_deterministic(
@@ -3535,6 +3629,85 @@ def _stage_deterministic(
         return None
     git_ops.stage_paths(work.repo, [Path(p) for p in sorted(stage)])
     return stage
+
+
+def require_empty_staged_index(work: WorkContext) -> git_ops.IndexSnapshot:
+    """Capture the pre-run index and reject any staged entry before mutation."""
+    snapshot = git_ops.snapshot_index(work.repo)
+    if snapshot.paths:
+        raise GitError(
+            "Cannot start the fix cycle with staged changes. Unstage or commit "
+            "them first; Daydream did not modify the worktree."
+        )
+    return snapshot
+
+
+def _stage_retained_once(
+    work: WorkContext,
+    *,
+    retained_paths: frozenset[str],
+    retained_states: tuple[git_ops.GitPathState, ...],
+    initial_index: git_ops.IndexSnapshot,
+) -> tuple[git_ops.GitPathState, ...]:
+    """Validate the untouched index, then stage and validate retained paths once."""
+    if initial_index.paths:
+        raise GitError("Fix-cycle preflight index was not empty")
+    current_index = git_ops.snapshot_index(work.repo)
+    if current_index != initial_index:
+        raise GitError("Index changed during the fix cycle; refusing to stage")
+    expected_states = tuple(sorted(retained_states, key=lambda state: state.path.encode()))
+    if frozenset(state.path for state in expected_states) != retained_paths:
+        raise GitError("Retained path set does not match retained tree states")
+    current_states = git_ops.snapshot_worktree_paths(work.repo, retained_paths)
+    if current_states != expected_states:
+        raise GitError("Worktree changed after retained-tree verification")
+    if not retained_paths:
+        return ()
+
+    git_ops.stage_paths(work.repo, [Path(path) for path in sorted(retained_paths)])
+    staged_index = git_ops.snapshot_index(work.repo)
+    if frozenset(staged_index.paths) != retained_paths:
+        raise GitError("Staged index path set does not match the retained path set")
+    staged_states = git_ops.snapshot_index_paths(work.repo, retained_paths)
+    if staged_states != expected_states:
+        raise GitError("Staged index content does not match the retained tree")
+    return staged_states
+
+
+def _verify_strict_commit_and_worktree(
+    work: WorkContext,
+    *,
+    sha_before: str,
+    retained_paths: frozenset[str],
+    staged_states: tuple[git_ops.GitPathState, ...],
+    precommit_paths: frozenset[str],
+    precommit_states: tuple[git_ops.GitPathState, ...],
+) -> None:
+    """Fail closed when commit hooks alter the commit, index, or worktree."""
+    committed_paths = frozenset(git_ops.diff_name_only_strict(work.repo, sha_before, "HEAD"))
+    if committed_paths != retained_paths:
+        raise GitError("Committed path set does not match the validated staged index")
+    if git_ops.snapshot_commit_paths(work.repo, "HEAD", retained_paths) != staged_states:
+        raise GitError("Committed content does not match the validated staged index")
+
+    post_index = git_ops.snapshot_index(work.repo)
+    if post_index.paths:
+        raise GitError("Commit hooks left staged index changes")
+    post_changed = frozenset(
+        git_ops.changed_paths_z(work.repo, "HEAD", include_runtime_artifacts=False)
+    )
+    universe = precommit_paths | post_changed
+    expected_by_path = {state.path: state for state in precommit_states}
+    expected = tuple(
+        expected_by_path.get(
+            path,
+            git_ops.GitPathState(path=path, state="missing", mode=None, digest=None),
+        )
+        for path in sorted(universe, key=lambda value: value.encode())
+    )
+    actual = git_ops.snapshot_worktree_paths(work.repo, universe)
+    if actual != expected:
+        raise GitError("Commit or validation hooks changed the worktree")
 
 
 def _verify_commit_scope(
@@ -3619,6 +3792,9 @@ async def _do_commit(
     items: list[dict[str, Any]] | None = None,
     preexisting_untracked: set[str] | None = None,
     config: Any = None,
+    retained_paths: frozenset[str] | None = None,
+    retained_states: tuple[git_ops.GitPathState, ...] | None = None,
+    initial_index: git_ops.IndexSnapshot | None = None,
 ) -> bool:
     """Stage, commit, and optionally push — all host-side, no agent turn.
 
@@ -3688,6 +3864,16 @@ async def _do_commit(
             await _validate_declined_fixes(work, config)
             return False
 
+    strict_commit = any(
+        value is not None for value in (retained_paths, retained_states, initial_index)
+    )
+    if strict_commit and (
+        retained_paths is None or retained_states is None or initial_index is None
+    ):
+        raise TypeError(
+            "retained_paths, retained_states, and initial_index must be supplied together"
+        )
+
     # Defensive untracked protection: a caller without a pre-run snapshot
     # still must not sweep user scratch files into the commit, so compute the
     # snapshot at commit time rather than dropping the protection. Computed
@@ -3696,14 +3882,44 @@ async def _do_commit(
     if preexisting_untracked is None:
         preexisting_untracked = set(git_ops.list_untracked(work.repo))
 
-    stage = _stage_deterministic(work, preexisting_untracked)
-    if stage is None:
-        return False
-
-    try:
+    stage: set[str]
+    sha_before: str | None
+    staged_states: tuple[git_ops.GitPathState, ...] = ()
+    precommit_paths: frozenset[str] = frozenset()
+    precommit_states: tuple[git_ops.GitPathState, ...] = ()
+    if strict_commit:
+        assert retained_paths is not None
+        assert retained_states is not None
+        assert initial_index is not None
         sha_before = git_ops.head_sha(work.repo)
-    except GitError:
-        sha_before = None
+        # Match fix-cycle evidence: untracked runtime output may change while
+        # recording host phases. Tracked and explicitly retained paths remain
+        # protected even when their names are in the runtime namespace.
+        precommit_paths = retained_paths | frozenset(
+            git_ops.changed_paths_z(
+                work.repo, sha_before, include_runtime_artifacts=False
+            )
+        )
+        precommit_states = git_ops.snapshot_worktree_paths(work.repo, precommit_paths)
+        staged_states = _stage_retained_once(
+            work,
+            retained_paths=retained_paths,
+            retained_states=retained_states,
+            initial_index=initial_index,
+        )
+        if not staged_states:
+            print_info(console, "Nothing to commit — no daydream changes")
+            return False
+        stage = set(retained_paths)
+    else:
+        legacy_stage = _stage_deterministic(work, preexisting_untracked)
+        if legacy_stage is None:
+            return False
+        stage = legacy_stage
+        try:
+            sha_before = git_ops.head_sha(work.repo)
+        except GitError:
+            sha_before = None
 
     message = build_commit_message(
         items=items or [], run_id=work.run_id, version=daydream.__version__,
@@ -3711,11 +3927,30 @@ async def _do_commit(
     # Issue #726 task 12: the commit is its own trajectory phase, so the
     # manifest can time it and tell it apart from test/hook/push phases.
     async with host_phase_scope(DaydreamPhase.COMMIT):
-        git_ops.commit_paths(work.repo, [Path(p) for p in sorted(stage)], message)
+        if strict_commit:
+            git_ops.commit_staged(work.repo, message)
+        else:
+            git_ops.commit_paths(work.repo, [Path(p) for p in sorted(stage)], message)
 
-    # Deterministic-staging invariant check (issue #562): the committed tree
-    # must match the pre-staged daydream set in both directions.
-    if sha_before is not None:
+    if strict_commit:
+        assert sha_before is not None
+        assert retained_paths is not None
+        try:
+            _verify_strict_commit_and_worktree(
+                work,
+                sha_before=sha_before,
+                retained_paths=retained_paths,
+                staged_states=staged_states,
+                precommit_paths=precommit_paths,
+                precommit_states=precommit_states,
+            )
+        except GitError as exc:
+            local_sha = git_ops.head_sha(work.repo)
+            raise GitError(
+                f"Local commit {local_sha} was created, but post-commit validation "
+                f"failed; push blocked: {exc}"
+            ) from exc
+    elif sha_before is not None:
         _verify_commit_scope(work, sha_before, stage)
 
     # Hook-aware validation orchestration (issue #726): with an executable
@@ -3745,6 +3980,25 @@ async def _do_commit(
                     "Pre-push validation failed: the configured test command "
                     "exited non-zero, so the commit was not pushed."
                 )
+
+            if strict_commit:
+                assert sha_before is not None
+                assert retained_paths is not None
+                try:
+                    _verify_strict_commit_and_worktree(
+                        work,
+                        sha_before=sha_before,
+                        retained_paths=retained_paths,
+                        staged_states=staged_states,
+                        precommit_paths=precommit_paths,
+                        precommit_states=precommit_states,
+                    )
+                except GitError as exc:
+                    local_sha = git_ops.head_sha(work.repo)
+                    raise GitError(
+                        f"Local commit {local_sha} was created, but post-hook "
+                        f"validation failed; push blocked: {exc}"
+                    ) from exc
 
     if push:
         # The push + remote verification is its own trajectory phase
@@ -3777,6 +4031,9 @@ async def phase_commit_push(
     preexisting_untracked: set[str] | None = None,
     config: Any = None,
     items: list[dict[str, Any]] | None = None,
+    retained_paths: frozenset[str] | None = None,
+    retained_states: tuple[git_ops.GitPathState, ...] | None = None,
+    initial_index: git_ops.IndexSnapshot | None = None,
 ) -> None:
     """Prompt user to commit and push changes.
 
@@ -3790,6 +4047,10 @@ async def phase_commit_push(
             ``description`` keys) threaded from the production fix cycle;
             folded into the deterministic commit message by
             :func:`build_commit_message`.
+        retained_paths: Exact final authorized HEAD-relative paths to stage.
+        retained_states: Binary-safe final states matching ``retained_paths``.
+        initial_index: Empty pre-dispatch index snapshot. Supplying these three
+            selects strict stage-once and post-hook validation.
     """
     console.print()
     print_info(console, "Committing and pushing changes...")
@@ -3798,6 +4059,9 @@ async def phase_commit_push(
         preexisting_untracked=preexisting_untracked,
         config=config,
         items=items,
+        retained_paths=retained_paths,
+        retained_states=retained_states,
+        initial_index=initial_index,
     )
     if committed:
         print_success(console, "Commit and push complete")

--- a/daydream/phases.py
+++ b/daydream/phases.py
@@ -7,8 +7,9 @@ import logging
 import os
 import re
 import shlex
-from collections.abc import Callable
-from dataclasses import dataclass
+from collections.abc import AsyncIterator, Callable
+from contextlib import asynccontextmanager
+from dataclasses import dataclass, replace
 from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, overload
@@ -2230,10 +2231,10 @@ and never introduce smart quotes when writing new code or comments — use plain
 ASCII straight quotes so the committed tree stays byte-clean and re-reviews do
 not re-surface a typographic finding.
 
-Forbid working-tree git mutation: many fix agents share ONE working tree, and
-a tree mutation is a data-loss race. `git stash`, `git checkout`, `git reset`,
-and `git commit` are each a refusal — if you believe one is needed, stop and
-report why instead of running it.
+Forbid working-tree or index git mutation: many fix agents share ONE working
+tree and index, and either mutation is a data-loss race. `git add`, `git stash`,
+`git checkout`, `git reset`, and `git commit` are each a refusal — if you
+believe one is needed, stop and report why instead of running it.
 """
     + GENERATED_FILES_PROMPT_RULE
     + "\n"
@@ -2737,6 +2738,27 @@ Make the minimal changes needed to address ALL of the above findings in one cohe
             print_fix_complete(console, item_num, total, outcome=None)
 
 
+@asynccontextmanager
+async def _restore_round_index_after_fanout(
+    repo: Path,
+    index: git_ops.IndexSnapshot,
+) -> AsyncIterator[None]:
+    """Restore one shared index only after the enclosed fixer fan-out closes."""
+    try:
+        yield
+    except BaseException as fanout_error:
+        try:
+            git_ops.restore_index(repo, index)
+        except BaseException as restore_error:
+            raise BaseExceptionGroup(
+                "fix fan-out failed and round index restoration also failed",
+                [fanout_error, restore_error],
+            ) from None
+        raise
+    else:
+        git_ops.restore_index(repo, index)
+
+
 async def phase_fix_parallel(
     backend: Backend,
     work: WorkContext,
@@ -2761,7 +2783,8 @@ async def phase_fix_parallel(
     batched turn raises, the group falls back to per-finding ``phase_fix`` calls.
     Every prompt receives the exact group's edit scope and the wider run scope
     only as readable context. Failed batch or group execution restores every
-    group path and the supplied round index before fallback/return.
+    group worktree path before fallback/return. The supplied complete index is
+    restored once, only after every concurrent fixer has joined or cancelled.
 
     Each file group is bounded by a :class:`FileGroupBudget` (#201): the budget
     is consulted before every fix call (including the batched call), and if a
@@ -2890,7 +2913,9 @@ async def phase_fix_parallel(
             )
             budget.record_item()
 
-    async with anyio.create_task_group() as tg:
+    async with _restore_round_index_after_fanout(
+        work.repo, round_snapshot.index
+    ), anyio.create_task_group() as tg:
         for file_key, numbered_items in groups_numbered:
             # Default-arg capture -- prevents late-binding closure bug (Pitfall 2).
             async def _task(
@@ -2940,7 +2965,7 @@ async def phase_fix_parallel(
                                     # per-finding fixes don't re-apply partial edits
                                     # that the batched turn may have already written.
                                     try:
-                                        git_ops.restore_group_from_snapshot(
+                                        git_ops.restore_group_worktree_from_snapshot(
                                             work.repo, round_snapshot, edit_scope
                                         )
                                     except Exception as restore_err:  # noqa: BLE001
@@ -2952,7 +2977,7 @@ async def phase_fix_parallel(
                             failure: BaseException = e
                             try:
                                 grp_items = [item for item, _ in grp]
-                                git_ops.restore_group_from_snapshot(
+                                git_ops.restore_group_worktree_from_snapshot(
                                     work.repo,
                                     round_snapshot,
                                     footprint.group_paths(grp_items),
@@ -3671,7 +3696,15 @@ def _stage_retained_once(
     if frozenset(staged_index.paths) != retained_paths:
         raise GitError("Staged index path set does not match the retained path set")
     staged_states = git_ops.snapshot_index_paths(work.repo, retained_paths)
-    if staged_states != expected_states:
+    # Git regular-file modes retain only the owner's executable bit. Keep
+    # exact filesystem modes in retained/test/post-hook evidence and project
+    # only this index comparison; staging does not chmod the worktree.
+    expected_index_states = tuple(
+        replace(state, mode=0o100755 if state.mode & 0o100 else 0o100644)
+        if state.state == "regular" and state.mode is not None else state
+        for state in expected_states
+    )
+    if staged_states != expected_index_states:
         raise GitError("Staged index content does not match the retained tree")
     return staged_states
 

--- a/daydream/phases.py
+++ b/daydream/phases.py
@@ -4,6 +4,7 @@ import copy
 import hashlib
 import json
 import logging
+import os
 import re
 import shlex
 from collections.abc import Callable
@@ -3655,7 +3656,7 @@ def _stage_retained_once(
     current_index = git_ops.snapshot_index(work.repo)
     if current_index != initial_index:
         raise GitError("Index changed during the fix cycle; refusing to stage")
-    expected_states = tuple(sorted(retained_states, key=lambda state: state.path.encode()))
+    expected_states = tuple(sorted(retained_states, key=lambda state: os.fsencode(state.path)))
     if frozenset(state.path for state in expected_states) != retained_paths:
         raise GitError("Retained path set does not match retained tree states")
     current_states = git_ops.snapshot_worktree_paths(work.repo, retained_paths)
@@ -3703,7 +3704,7 @@ def _verify_strict_commit_and_worktree(
             path,
             git_ops.GitPathState(path=path, state="missing", mode=None, digest=None),
         )
-        for path in sorted(universe, key=lambda value: value.encode())
+        for path in sorted(universe, key=os.fsencode)
     )
     actual = git_ops.snapshot_worktree_paths(work.repo, universe)
     if actual != expected:

--- a/daydream/repository_paths.py
+++ b/daydream/repository_paths.py
@@ -63,18 +63,69 @@ _REPOSITORY_FILE_PATH = re.compile(REPOSITORY_FILE_PATH_PATTERN)
 _DIRECTORY_SCOPE = re.compile(DIRECTORY_SCOPE_PATTERN)
 
 
+class InvalidRepositoryFilePath(ValueError):
+    """Raised when a model-authored repository file path is unsafe.
+
+    The message deliberately does not reflect the rejected value. Model output
+    may contain terminal control characters or other untrusted text.
+    """
+
+
 def valid_repository_file_path(value: str) -> bool:
     """Return whether ``value`` has the safe repository-file grammar."""
-    return len(value.encode("utf-8")) <= REPOSITORY_FILE_PATH_MAX_LENGTH and bool(
-        _REPOSITORY_FILE_PATH.fullmatch(value)
-    )
+    try:
+        encoded = value.encode("utf-8")
+    except UnicodeEncodeError:
+        return False
+    return len(encoded) <= REPOSITORY_FILE_PATH_MAX_LENGTH and bool(_REPOSITORY_FILE_PATH.fullmatch(value))
+
+
+def canonicalize_repository_file_path(repo: Path, value: object) -> str:
+    """Validate and canonicalize one model-authored repository file path.
+
+    Only the schema's optional leading ``./`` is normalized. Absolute paths,
+    parent traversal, malformed values, and paths crossing a current symlink
+    boundary are rejected with a non-reflective error.
+    """
+    if not isinstance(value, str) or not valid_repository_file_path(value):
+        raise InvalidRepositoryFilePath("invalid repository file path")
+    canonical = value[2:] if value.startswith("./") else value
+    if not canonical or not path_is_confined(repo, canonical):
+        raise InvalidRepositoryFilePath("invalid repository file path")
+    return canonical
+
+
+def git_observed_path_is_confined(repo: Path, value: str) -> bool:
+    """Return whether an exact Git-observed path remains inside *repo*.
+
+    Git can track names outside the deliberately narrow model-output grammar
+    (newlines and shell metacharacters included), so this boundary performs no
+    schema validation. It rejects absolute paths, NUL, empty/dot/parent
+    components, and every current symlink component before checking resolved
+    containment.
+    """
+    if not isinstance(value, str) or not value or "\0" in value or value.startswith("/"):
+        return False
+    parts = value.split("/")
+    if any(part in {"", ".", ".."} for part in parts):
+        return False
+    root = repo.resolve()
+    walked = _walk_components(repo, parts)
+    if walked is None:
+        return False
+    try:
+        return walked.resolve(strict=False).is_relative_to(root)
+    except OSError:
+        return False
 
 
 def valid_directory_scope_lexical(value: str) -> bool:
     """Return whether ``value`` is a safe file-or-directory scope."""
-    return len(value.encode("utf-8")) <= REPOSITORY_FILE_PATH_MAX_LENGTH and bool(
-        _DIRECTORY_SCOPE.fullmatch(value)
-    )
+    try:
+        encoded = value.encode("utf-8")
+    except UnicodeEncodeError:
+        return False
+    return len(encoded) <= REPOSITORY_FILE_PATH_MAX_LENGTH and bool(_DIRECTORY_SCOPE.fullmatch(value))
 
 
 def _strip_prefix(
@@ -245,8 +296,11 @@ __all__ = [
     "REPOSITORY_FILE_PATH_PATTERN",
     "REPOSITORY_FILE_PATH_SCHEMA",
     "REPOSITORY_FILE_PATH_SEGMENTS",
+    "InvalidRepositoryFilePath",
+    "canonicalize_repository_file_path",
     "canonicalize_directory_scope",
     "canonicalize_working_directory",
+    "git_observed_path_is_confined",
     "is_test_path",
     "path_is_confined",
     "valid_directory_scope_lexical",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -573,8 +573,28 @@ def mute_side_effects(monkeypatch: pytest.MonkeyPatch) -> Callable[..., None]:
         async def _no_post(*_args: object, **_kwargs: object) -> None:
             return None
 
-        async def _ok(*_args: object, **_kwargs: object) -> tuple[bool, int, bool]:
-            return True, 0, True
+        async def _ok(*_args: object, **kwargs: object) -> object:
+            from daydream.phases import TestAndHealResult, TestAttemptEvidence
+
+            capture = kwargs["capture_tree_key"]
+            session_id = str(kwargs["session_id"])
+            key = capture()  # type: ignore[operator]
+            return TestAndHealResult(
+                passed=True,
+                retries=0,
+                proceed=True,
+                ignored=False,
+                attempts=(
+                    TestAttemptEvidence(
+                        session_id=session_id,
+                        kind="agent",
+                        command=None,
+                        passed=True,
+                        input_tree_key=key,
+                        output_tree_key=key,
+                    ),
+                ),
+            )
 
         if post:
             monkeypatch.setattr(

--- a/tests/harness/phase_backend.py
+++ b/tests/harness/phase_backend.py
@@ -11,6 +11,7 @@ per-iteration parse queue. Two response modes:
 
 from __future__ import annotations
 
+import re
 from collections.abc import AsyncGenerator
 from typing import Any
 
@@ -171,6 +172,22 @@ class PhaseDispatchBackend:
             # payload always carries it (empty when not exercised).
             yield ResultEvent(
                 structured_output={"issues": issues, "verdicts": []}, continuation=None
+            )
+        elif "post-fix fix-verifier agent" in prompt_lower:
+            ids = [int(value) for value in re.findall(r"(?m)^(\d+)\. \[", prompt)]
+            yield TextEvent(text="")
+            yield ResultEvent(
+                structured_output={
+                    "verdicts": [
+                        {
+                            "issue_id": issue_id,
+                            "verdict": "resolved",
+                            "reason": "harness fix accepted",
+                        }
+                        for issue_id in ids
+                    ]
+                },
+                continuation=None,
             )
         elif "fix this issue" in prompt_lower or prompt_lower.startswith("fix these"):
             yield TextEvent(text="Fixed.")

--- a/tests/harness/stub_backend.py
+++ b/tests/harness/stub_backend.py
@@ -415,6 +415,9 @@ class StubBackend:
         if sm is None or sm.group(1) not in self.parse_by_stack:
             return [issue]
         ov = self.parse_by_stack[sm.group(1)]
+        payload = ov.get("issue")
+        if isinstance(payload, dict):
+            issue.update(payload)
         issue["severity"] = ov["severity"]
         issue["confidence"] = ov["confidence"]
         issue["file"] = ov.get("file", issue["file"])
@@ -1086,8 +1089,11 @@ class StubBackend:
         if "post-fix fix-verifier agent" in pl:
             if self.fix_verify_requires_read_only and not read_only:
                 raise AssertionError("fix-verify turn must arrive read_only=True")
-            round_match = re.search(r"Round (\d+) of up to 3 check passes", prompt)
-            round_num = int(round_match.group(1)) if round_match else 1
+            round_match = re.search(
+                r"(?:Round (\d+) of up to 3 check passes|Verification pass (\d+))",
+                prompt,
+            )
+            round_num = int(next(group for group in round_match.groups() if group)) if round_match else 1
             ids = [int(i) for i in re.findall(r"(?m)^(\d+)\. \[", prompt)]
             verdicts = []
             for i in ids:

--- a/tests/harness/stub_backend.py
+++ b/tests/harness/stub_backend.py
@@ -150,6 +150,9 @@ class StubBackend:
         # before raising (e.g. "store/uuid.go") -- NOT the group's key file, so
         # it survives tree-protection and must surface in fix_leftover_untracked.
         self.fix_orphan_file: str | None = None
+        # Existing untracked user file damaged by the same failed turn.  The
+        # run-wide terminal guard must restore its exact pre-run bytes.
+        self.fix_damage_protected_file: str | None = None
         # Repo-relative generated path created by a successful fix turn.
         self.fix_new_generated: str | None = None
         # Repo-relative historical generated path modified by a test-healing
@@ -1017,6 +1020,8 @@ class StubBackend:
                     orphan = cwd / self.fix_orphan_file
                     orphan.parent.mkdir(parents=True, exist_ok=True)
                     orphan.write_text("// stray file from a dead fix agent\n")
+                if self.fix_damage_protected_file is not None:
+                    (cwd / self.fix_damage_protected_file).write_bytes(b"damaged by failed fixer")
                 raise MaxTurnsError(f"stub: max turns exhausted mid-fix for {fixed_name}")
             if self.fix_fail_file is not None and fixed_name == self.fix_fail_file:
                 raise RuntimeError(f"stub fix failure for {fixed_name}")

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -2505,6 +2505,86 @@ def test_session_bound_start_at_fix_rejects_prior_green_test_verdict(tmp_path: P
     ) == "partial"
 
 
+def test_matching_stabilization_failure_overrides_green_test_pipeline(tmp_path: Path) -> None:
+    from daydream.archive import pipeline
+
+    _write_deep(tmp_path, "test-verdict.json", {"session_id": "current", "passed": True})
+    _write_deep(
+        tmp_path,
+        "stabilization-failed.json",
+        {"session_id": "current", "reason": "final verifier remains actionable"},
+    )
+
+    states = pipeline.derive_phase_states(
+        tmp_path, phase_events=[], session_id="current"
+    )
+
+    assert states["fix"] == {"ran": True, "status": "failed"}
+    assert states["test"] == {"ran": True, "status": "failed"}
+    assert pipeline.derive_pipeline_status(
+        "complete", None, states, runs_fix=True, runs_test=True
+    ) == "failed"
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"session_id": "prior", "reason": "stale"},
+        {"session_id": "current"},
+        {"session_id": "current", "reason": ""},
+        ["malformed"],
+    ],
+)
+def test_stale_or_malformed_stabilization_failure_is_neutral(
+    tmp_path: Path, payload: Any
+) -> None:
+    from daydream.archive import pipeline
+
+    _write_deep(tmp_path, "test-verdict.json", {"session_id": "current", "passed": True})
+    _write_deep(tmp_path, "stabilization-failed.json", payload)
+
+    states = pipeline.derive_phase_states(
+        tmp_path, phase_events=[], session_id="current"
+    )
+
+    assert states["fix"] == {"ran": False, "status": "absent"}
+    assert states["test"] == {"ran": True, "status": "succeeded"}
+
+
+def test_archive_manifest_fails_matching_stabilization_session(
+    tmp_path: Path, archive_dir: Path, make_config: MakeConfig
+) -> None:
+    from daydream.archive import _archive_run_inner
+
+    session_id = "stabilization-session"
+    _write_deep(tmp_path, "merged-items.json", {"items": [{"id": 1}]})
+    _write_deep(tmp_path, "test-verdict.json", {"session_id": session_id, "passed": True})
+    _write_deep(
+        tmp_path,
+        "stabilization-failed.json",
+        {"session_id": session_id, "reason": "post-test tree did not stabilize"},
+    )
+    recorder = _MockRecorder(session_id=session_id)
+
+    _archive_run_inner(
+        recorder=cast(Any, recorder),
+        target_dir=tmp_path,
+        config=make_config(tmp_path, archive=False),
+        status="complete",
+        run_eval=False,
+        work=None,
+        upload=False,
+    )
+
+    manifest = json.loads(
+        (archive_dir / "runs" / session_id / "manifest.json").read_text()
+    )
+    assert manifest["archive_status"] == "complete"
+    assert manifest["pipeline_status"] == "failed"
+    assert manifest["phase_states"]["fix"] == {"ran": True, "status": "failed"}
+    assert manifest["phase_states"]["test"] == {"ran": True, "status": "failed"}
+
+
 def test_test_absent_when_no_verdict(tmp_path: Path) -> None:
     from daydream.archive import pipeline
     states = pipeline.derive_phase_states(tmp_path, phase_events=[])

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -2480,10 +2480,29 @@ def test_merge_succeeded_when_items_and_no_merge_key(tmp_path: Path) -> None:
 
 def test_test_failed_from_verdict(tmp_path: Path) -> None:
     from daydream.archive import pipeline
-    _write_deep(tmp_path, "test-verdict.json", {"passed": False, "retries": 1, "ignored": False})
-    states = pipeline.derive_phase_states(tmp_path, phase_events=[])
+    _write_deep(
+        tmp_path,
+        "test-verdict.json",
+        {"session_id": "current", "passed": False, "retries": 1, "ignored": False},
+    )
+    states = pipeline.derive_phase_states(
+        tmp_path, phase_events=[], session_id="current"
+    )
     assert states["test"]["ran"] is True
     assert states["test"]["status"] == "failed"
+
+
+def test_session_bound_start_at_fix_rejects_prior_green_test_verdict(tmp_path: Path) -> None:
+    from daydream.archive import pipeline
+
+    _write_deep(tmp_path, "test-verdict.json", {"session_id": "prior", "passed": True})
+    states = pipeline.derive_phase_states(
+        tmp_path, phase_events=[], session_id="current"
+    )
+    assert states["test"] == {"ran": False, "status": "absent"}
+    assert pipeline.derive_pipeline_status(
+        "complete", None, states, runs_fix=True, runs_test=True
+    ) == "partial"
 
 
 def test_test_absent_when_no_verdict(tmp_path: Path) -> None:

--- a/tests/test_archive_data_capture.py
+++ b/tests/test_archive_data_capture.py
@@ -18,6 +18,7 @@ backend seam is mocked.
 from __future__ import annotations
 
 import json
+import re
 from collections.abc import AsyncIterator
 from pathlib import Path
 from typing import Any
@@ -109,15 +110,28 @@ def _install_deep_capture_backend(
     if not real_internal_phases:
         monkeypatch.setattr(
             "daydream.deep.orchestrator.phase_test_and_heal",
-            lambda *a, **k: _ok(),
+            lambda *a, **k: _ok(**k),
         )
         monkeypatch.setattr("daydream.deep.orchestrator.phase_commit_push", _noop_commit)
     return stub
 
 
-async def _ok_with_heal_edit(target: Path) -> Any:
+async def _ok_with_heal_edit(target: Path, **kwargs: Any) -> Any:
+    from daydream.phases import TestAndHealResult, TestAttemptEvidence
+
+    before = kwargs["capture_tree_key"]()
     (target / "heal_edit.py").write_text("def healed():\n    pass\n")
-    return await _ok()
+    after = kwargs["capture_tree_key"]()
+    return TestAndHealResult(
+        passed=True,
+        retries=0,
+        proceed=True,
+        ignored=False,
+        attempts=(TestAttemptEvidence(
+            session_id=kwargs["session_id"], kind="agent", command=None,
+            passed=True, input_tree_key=before, output_tree_key=after,
+        ),),
+    )
 
 
 # --- AC1 + AC3: default deep run populates eval metrics AND captures recommended.patch ---
@@ -221,7 +235,7 @@ async def test_deep_heal_edit_lands_in_archived_recommended_patch(
     stub.fix_edit_line = "# daydream recommended change\n"
     monkeypatch.setattr(
         "daydream.deep.orchestrator.phase_test_and_heal",
-        lambda *a, **k: _ok_with_heal_edit(multi_stack_target),
+        lambda *a, **k: _ok_with_heal_edit(multi_stack_target, **k),
     )
 
     exit_code = await run(
@@ -230,14 +244,15 @@ async def test_deep_heal_edit_lands_in_archived_recommended_patch(
     assert exit_code == 0
 
     run_dir = _only_archived_run(archive_dir)
-    # The heal edit was written after the pre-test capture; only a post-test
-    # re-capture can put it in the archived patch.
-    assert "heal_edit.py" in (run_dir / "recommended.patch").read_text()
+    assert "heal_edit.py" not in (run_dir / "recommended.patch").read_text()
+    assert not (multi_stack_target / "heal_edit.py").exists()
     # Session-bound capture-point sidecar, mirrored from fix-quality-gate.json.
     sidecar = json.loads(
         (multi_stack_target / ".daydream" / "deep" / "recommended-capture.json").read_text()
     )
-    assert sidecar == {"session_id": run_dir.name, "capture_point": "post_test"}
+    assert sidecar["session_id"] == run_dir.name
+    assert sidecar["capture_point"] == "post_test"
+    assert sidecar["tree_key"] == sidecar["evidence_key"]["tree_key"]
     manifest = json.loads((run_dir / "manifest.json").read_text())
     assert manifest["recommended_patch_capture"] == "post_test"
 
@@ -484,6 +499,18 @@ class _FixEditingBackend:
             main_py.write_text(main_py.read_text() + "# daydream recommended change\n")
             yield TextEvent(text="Fixed.")
             yield ResultEvent(structured_output=None, continuation=None)
+        elif "post-fix fix-verifier agent" in pl:
+            ids = [int(value) for value in re.findall(r"(?m)^(\d+)\. \[", prompt)]
+            yield TextEvent(text="")
+            yield ResultEvent(
+                structured_output={
+                    "verdicts": [
+                        {"issue_id": issue_id, "verdict": "resolved", "reason": "complete"}
+                        for issue_id in ids
+                    ]
+                },
+                continuation=None,
+            )
         elif "test suite" in pl or "run the project" in pl:
             yield TextEvent(text="All 1 tests passed. 0 failed.")
             yield ResultEvent(structured_output=None, continuation=None)

--- a/tests/test_deep_orchestrator.py
+++ b/tests/test_deep_orchestrator.py
@@ -180,14 +180,7 @@ def _merge_item(item_id: int, file: str, severity: str, *, desc: str | None = No
 
 
 def _add_to_reviewed_diff(target: Path, files: list[str]) -> None:
-    """Commit *files* to the current branch so they land in the reviewed diff.
-
-    Issue #336 bounds the fix loop to the reviewed diff's file set: findings on
-    files OUTSIDE the diff are filed as GitHub issues instead of auto-fixed.
-    Fix-loop-mechanics tests that feed synthetic merge items must therefore put
-    those files IN the diff, or the partition correctly routes them to issues
-    and the fix never runs.
-    """
+    """Commit *files* to the branch for tests that need reviewed-diff fixtures."""
     for name in files:
         (target / name).touch()
     _git(target, "add", *files)
@@ -981,6 +974,7 @@ async def test_unresolved_finding_reported_attempted_not_fixed(
     monkeypatch: pytest.MonkeyPatch,
     make_config: MakeConfig,
     mute_side_effects: Mute,
+    capsys: pytest.CaptureFixture[str],
 ) -> None:
     """Spec: a finding still unresolved after the last round appears as
     attempted-not-fixed, never counted/shown as fixed."""
@@ -998,6 +992,7 @@ async def test_unresolved_finding_reported_attempted_not_fixed(
         )
     )
     assert exit_code == 1
+    assert "Attempted, not fixed" in capsys.readouterr().out
     outcomes = json.loads((multi_stack_target / ".daydream" / "deep" / "fix-outcomes.json").read_text())
     assert outcomes["outcomes"]["item:1"]["verdict"] == "unresolved"
     # fix applied was NOT asserted for the unresolved finding (no "Fix applied" line for it)
@@ -1009,6 +1004,7 @@ async def test_parallel_fix_failure_isolated_returns_nonzero(
     monkeypatch: pytest.MonkeyPatch,
     make_config: MakeConfig,
     mute_side_effects: Mute,
+    capsys: pytest.CaptureFixture[str],
 ) -> None:
     """AC#5: a failed fix group is isolated, surfaced, and exits nonzero.
 
@@ -1054,6 +1050,9 @@ async def test_parallel_fix_failure_isolated_returns_nonzero(
     assert not (multi_stack_target / ".fixed-bad_py").exists()  # failed group did not apply
     assert any("bad.py" in m for m in warnings)  # non-silent
     assert commit_calls == []  # no commit on failure
+    output = capsys.readouterr().out
+    assert "complete group was restored" in output
+    assert "this file's changes are left uncommitted" not in output
 
 
 async def test_fix_failure_reverts_partial_edit_and_marks_manifest_partial(
@@ -3395,24 +3394,16 @@ async def test_yes_auto_applies_fix(
     assert _fix_prompts(stub), "phase_fix never ran -> --yes did not auto-apply"
 
 
-async def test_fix_gate_routes_out_of_scope_finding_to_issue(
+async def test_fix_gate_authorizes_canonical_finding_outside_reviewed_diff(
     multi_stack_target: Path,
     monkeypatch: pytest.MonkeyPatch,
     make_config: MakeConfig,
     mute_side_effects: Mute,
 ) -> None:
-    """#336 real-path: the fix gate files out-of-scope findings as issues.
+    """A canonical primary path is authorized even when absent from the diff.
 
-    merged-items.json carries item A on api.py (inside the reviewed diff) and
-    item B on notes.txt (outside it). Under ``assume="yes"`` the gate must:
-
-      1. exclude item B from the fix list — no fix prompt names notes.txt;
-      2. file exactly one GitHub issue carrying item B's file + description;
-      3. run ``phase_fix`` only for item A's file group.
-
-    Discriminating: without the pre-fix partition, item B would be auto-fixed
-    (a fix prompt would name notes.txt) and no issue would be filed — both
-    assertions fail.
+    Both findings must reach the fixer and merely being outside the reviewed
+    diff must not route ``notes.txt`` to issue filing.
     """
     from daydream.runner import run
 
@@ -3432,8 +3423,6 @@ async def test_fix_gate_routes_out_of_scope_finding_to_issue(
 
     monkeypatch.setattr("daydream.git_ops.gh_issue_create", _record_issue)
 
-    # Issue #1056: filing is opt-in, so this filing-behavior test passes the
-    # opt-in explicitly.
     exit_code = await run(
         make_config(
             multi_stack_target, assume="yes", output_mode="loop", scope_issue_filing=True
@@ -3448,20 +3437,18 @@ async def test_fix_gate_routes_out_of_scope_finding_to_issue(
     ]
     assert fix_prompts, "no fix prompt dispatched — fix phase did not run"
     assert any("notes.txt" in p for p in fix_prompts)
-    # 3. Fix phase ran for item A's file group (api.py).
     assert any("api.py" in p for p in fix_prompts), "in-scope finding was not fixed"
 
     assert issues == []
 
 
-async def test_fix_gate_files_no_issue_by_default(
+async def test_fix_gate_off_diff_finding_files_no_issue_by_default(
     multi_stack_target: Path,
     monkeypatch: pytest.MonkeyPatch,
     make_config: MakeConfig,
     mute_side_effects: Mute,
 ) -> None:
-    """#1056 default-off: out-of-scope findings are excluded and short-circuited
-    but NO GitHub issue is filed."""
+    """A canonical off-diff finding is fixed and files no issue by default."""
     from daydream.runner import run
 
     _silence(monkeypatch)
@@ -3484,13 +3471,13 @@ async def test_fix_gate_files_no_issue_by_default(
     assert any("notes.txt" in (b or "") for b in _fix_prompts(stub))
 
 
-async def test_fix_gate_files_issue_when_opted_in(
+async def test_fix_gate_off_diff_finding_files_no_issue_when_opted_in(
     multi_stack_target: Path,
     monkeypatch: pytest.MonkeyPatch,
     make_config: MakeConfig,
     mute_side_effects: Mute,
 ) -> None:
-    """#1056 opt-in: scope_issue_filing=True restores the #336 filing behavior."""
+    """Scope filing does not turn an authorized finding path into a residual."""
     from daydream.runner import run
 
     _silence(monkeypatch)
@@ -3525,15 +3512,9 @@ async def test_fix_gate_keeps_dot_slash_in_scope_finding_in_fix(
 ) -> None:
     """#572/#573: a ``./``-prefixed finding file stays in scope.
 
-    The grammar now admits ``./x`` as a legal path spelling, so a finding's
-    ``file`` may arrive as ``./api.py`` while the reviewed diff (and the git
-    tree) name the same file as bare ``api.py``. The fix gate's pre-fix
-    partition and the post-fix residual net both compare the finding file
-    against bare git-derived paths, so without normalization a ``./api.py``
-    finding is misfiled as out-of-scope: dropped from auto-fix AND filed as an
-    issue. Discriminating: if the gate normalizes a leading ``./``, the
-    ``./api.py`` finding is fixed (a fix prompt names api.py) and no issue is
-    filed for it.
+    The grammar admits ``./x`` while Git-derived paths are bare. The gate must
+    normalize that spelling before building the footprint so ``api.py`` reaches
+    the fixer under its confined repository-relative identity.
     """
     from daydream.runner import run
 
@@ -3553,8 +3534,6 @@ async def test_fix_gate_keeps_dot_slash_in_scope_finding_in_fix(
 
     monkeypatch.setattr("daydream.git_ops.gh_issue_create", _record_issue)
 
-    # Issue #1056: filing is opt-in, so this filing-behavior test passes the
-    # opt-in explicitly.
     exit_code = await run(
         make_config(
             multi_stack_target, assume="yes", output_mode="loop", scope_issue_filing=True
@@ -3576,110 +3555,24 @@ async def test_fix_gate_keeps_dot_slash_in_scope_finding_in_fix(
     assert issues == []
 
 
-async def test_fix_gate_dedups_out_of_scope_finding_already_filed(
+async def test_fix_gate_runs_when_all_canonical_findings_are_outside_reviewed_diff(
     multi_stack_target: Path,
     monkeypatch: pytest.MonkeyPatch,
     make_config: MakeConfig,
     mute_side_effects: Mute,
 ) -> None:
-    """#336 real-path: an out-of-scope finding already filed is not re-filed.
+    """Every canonical finding path reaches the fixer, including off-diff paths.
 
-    Out-of-scope findings are never fixed, so a re-run/resume re-derives them.
-    Without cross-run dedup they would be re-filed as a duplicate issue every
-    run (#336 finding). The gate embeds the finding's fingerprint as a hidden
-    marker in the issue body and skips filing when an open issue already
-    carries it (GitHub is the store — same stateless-dedup model as
-    reconcile.py). Discriminating: with dedup ``gh_issue_create`` is never
-    called even though the finding is still excluded from auto-fix.
-    """
-    from daydream.deep.scope_issues import (
-        _scope_finding_fingerprint,
-        _scope_finding_marker,
-    )
-    from daydream.pr_review import compute_fingerprint
-    from daydream.runner import run
-
-    _silence(monkeypatch)
-    stub = _install_stub_backend(monkeypatch, multi_stack_target)
-    stub.merge_items = [
-        _merge_item(1, "api.py", "high", desc="in-scope finding"),
-        _merge_item(2, "notes.txt", "medium", desc="out-of-scope finding"),
-    ]
-    mute_side_effects()
-
-    # The marker the gate would embed for item 2 — pre-filed in an open issue,
-    # simulating a prior run. Confirm the local helper reproduces the same
-    # identity compute_fingerprint produces, so the dedup key is stable.
-    item_b = _merge_item(2, "notes.txt", "medium", desc="out-of-scope finding")
-    fp = compute_fingerprint(item_b["file"], item_b["description"], item_b["evidence"])
-    marker = _scope_finding_marker(fp)
-    assert marker == _scope_finding_marker(_scope_finding_fingerprint(item_b))
-
-    monkeypatch.setattr(
-        "daydream.git_ops.gh_issue_list",
-        lambda repo, **kw: [
-            {
-                "number": 9,
-                "title": "[daydream] out-of-scope finding: notes.txt",
-                "body": f"prior run\n{marker}",
-                "url": "https://github.com/owner/repo/issues/9",
-            }
-        ],
-    )
-
-    created: list[tuple[Any, ...]] = []
-
-    def _record_create(repo: Any, *, title: str, body: str, **kwargs: Any) -> str:
-        created.append((repo, title, body))
-        return "https://github.com/owner/repo/issues/9"
-
-    monkeypatch.setattr("daydream.git_ops.gh_issue_create", _record_create)
-
-    exit_code = await run(
-        make_config(
-            multi_stack_target, assume="yes", output_mode="loop", scope_issue_filing=True
-        )
-    )
-    assert exit_code == 0
-
-    # Deduped: the already-filed finding is NOT re-filed.
-    assert created == [], f"out-of-scope finding re-filed as a duplicate: {created!r}"
-
-    # And it is still excluded from auto-fix (no fix prompt names notes.txt).
-    fix_prompts = [
-        c["prompt"]
-        for c in stub.calls
-        if c["prompt"].lower().startswith(("fix this issue", "fix these"))
-    ]
-    assert any("api.py" in p for p in fix_prompts), "in-scope finding was not fixed"
-    assert any("notes.txt" in p for p in fix_prompts)
-
-
-async def test_fix_gate_short_circuits_when_all_findings_out_of_scope(
-    multi_stack_target: Path,
-    monkeypatch: pytest.MonkeyPatch,
-    make_config: MakeConfig,
-    mute_side_effects: Mute,
-) -> None:
-    """#336 real-path: when every finding routes to issues, the gate Stop(0)s.
-
-    merged-items.json carries ONLY out-of-scope findings (files outside the
-    reviewed diff {api.py, App.tsx, README.md}). The host also appends a
-    structural finding, so ``parse_by_stack`` routes THAT one to an
-    out-of-scope file too -- otherwise it would default to ``api.py`` (in
-    scope) and keep the gate open. With every merged item out of scope the
-    gate files them all and short-circuits before the no-op fix pass, the
-    full target test-suite run, and the commit-agent turn. Discriminating:
-    without the post-partition ``Stop(0)`` the flow continues into
-    ``phase_fix`` with nothing to fix -- a fix prompt would be dispatched.
+    The test uses only findings outside the reviewed diff and proves the gate
+    neither short-circuits nor files them merely because of that location.
     """
     from daydream.runner import run
 
     _silence(monkeypatch)
     stub = _install_stub_backend(monkeypatch, multi_stack_target)
     stub.merge_items = [_merge_item(1, "notes.txt", "high", desc="out-of-scope finding")]
-    # Route the appended structural finding to an out-of-scope file too; the
-    # stub's default structural parse emits ``file=api.py`` (in scope).
+    # Route the appended structural finding to another off-diff file; the
+    # stub's default structural parse emits ``file=api.py``.
     stub.parse_by_stack = {
         "structure": {
             "severity": "high",
@@ -3699,8 +3592,6 @@ async def test_fix_gate_short_circuits_when_all_findings_out_of_scope(
 
     monkeypatch.setattr("daydream.git_ops.gh_issue_create", _record_issue)
 
-    # Issue #1056: filing is opt-in, so this filing-behavior test passes the
-    # opt-in explicitly.
     exit_code = await run(
         make_config(
             multi_stack_target, assume="yes", output_mode="loop", scope_issue_filing=True
@@ -3710,9 +3601,6 @@ async def test_fix_gate_short_circuits_when_all_findings_out_of_scope(
 
     assert issues == []
 
-    # No fix prompt dispatched -- the gate short-circuited before phase_fix,
-    # so the run skipped a no-op fix pass + the full target test suite + the
-    # commit-agent turn.
     fix_prompts = [
         c["prompt"]
         for c in stub.calls
@@ -6314,7 +6202,6 @@ async def test_run_caps_runaway_file_group_serial_fixes(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     make_config: MakeConfig,
-    mute_side_effects: Mute,
 ) -> None:
     """#201 real-path: a runaway file group is capped by the serial-item budget.
 
@@ -6325,11 +6212,15 @@ async def test_run_caps_runaway_file_group_serial_fixes(
     group serial-item ceiling lowered to 3, only 3 of the 6 fallback fixes run;
     the remaining 3 are skipped, recorded in ``failures`` (surfaced as the
     fix-failures artifact), and a ``file_group_budget_exceeded`` trajectory event
-    is emitted naming the file, reason, and processed/skipped counts.
+    is emitted naming the file, reason, and processed/skipped counts. Budget
+    exhaustion is recoverable: the retained authorized edits proceed through
+    the real verifier, TEST-agent fallback, strict commit, and push to a local
+    bare remote.
 
     Discriminating: without the group budget, the fallback loop fixes all 6
     api.py findings (six "fix this issue" turns) and no budget event exists --
-    both assertions fail.
+    both assertions fail. Treating the budget marker as an exception failure
+    instead makes the exit/commit/remote assertions fail.
     """
     from daydream.runner import run
 
@@ -6342,7 +6233,10 @@ async def test_run_caps_runaway_file_group_serial_fixes(
         _merge_item(7, "App.tsx", "high")
     ]
     stub.fail_batched_fix_file = "api.py"  # force the per-finding fallback for api.py
-    mute_side_effects()
+    retained_marker = "# retained before budget stop\n"
+    stub.fix_edit_line = retained_marker
+    _add_bare_remote(multi_stack_target)
+    head_before = _git(multi_stack_target, "rev-parse", "HEAD")
 
     traj = tmp_path / "trajectory.json"
     with anyio.fail_after(30):
@@ -6351,7 +6245,13 @@ async def test_run_caps_runaway_file_group_serial_fixes(
                 multi_stack_target, trajectory_path=traj, assume="yes", output_mode="loop"
             )
         )
-    assert isinstance(exit_code, int)
+    assert exit_code == 0
+    assert retained_marker in (multi_stack_target / "api.py").read_text()
+    assert stub.test_suite_calls >= 1
+    head_after = _git(multi_stack_target, "rev-parse", "HEAD")
+    assert head_after != head_before
+    remote = multi_stack_target.parent / "multi_stack-remote.git"
+    assert _git(remote, "rev-parse", "refs/heads/feature") == head_after
 
     # The failed batched turn names the api.py group size (the pipeline may add a
     # structural finding, so derive N rather than hard-coding it).
@@ -10579,7 +10479,10 @@ async def test_item_uid_is_never_reported_as_record_provenance(
     assert pool and not any(uid.startswith("item:") for uid in pool), pool
 
 
-def test_retained_tree_uses_full_delta_identity_but_authorized_patch(tmp_path: Path) -> None:
+@pytest.mark.parametrize("scratch_is_related", [False, True])
+def test_retained_tree_uses_full_delta_identity_but_authorized_patch(
+    tmp_path: Path, scratch_is_related: bool,
+) -> None:
     """Unrelated/protected bytes invalidate evidence without entering the patch."""
     from daydream import git_ops
     from daydream.deep.orchestrator import FixCycleState, capture_retained_tree
@@ -10594,7 +10497,10 @@ def test_retained_tree_uses_full_delta_identity_but_authorized_patch(tmp_path: P
     _commit(repo, "base")
     (repo / "scratch.bin").write_bytes(b"\x00user")
     protected = git_ops.snapshot_untracked_paths(repo)
-    item = {"id": 1, "item_uid": "item:1", "file": "a.py", "related_files": []}
+    item = {
+        "id": 1, "item_uid": "item:1", "file": "a.py",
+        "related_files": ["scratch.bin"] if scratch_is_related else [],
+    }
     footprint = AuthorizedFixFootprint.build(repo, {"a.py"}, [item])
     index = git_ops.snapshot_index(repo)
     state = FixCycleState(
@@ -10794,6 +10700,9 @@ async def test_fix_cycle_nonempty_index_stops_before_backend_without_mutation(
     _git(repo, "add", "a.py")
     item = _merge_item(1, "a.py", "high")
     ctx = _direct_fix_context(repo, [item], changed_files={"a.py"})
+    stale = ctx.data["dd"] / "test-verdict.json"
+    stale_bytes = b'{"session_id":"prior","passed":true}\n'
+    stale.write_bytes(stale_bytes)
     index_before = git_ops.snapshot_index(repo)
     bytes_before = (repo / "a.py").read_bytes()
     monkeypatch.setattr("daydream.deep.orchestrator.resolve_or_prompt", lambda **_k: True)
@@ -10805,6 +10714,7 @@ async def test_fix_cycle_nonempty_index_stops_before_backend_without_mutation(
     assert ctx._backend_cache == {}
     assert git_ops.snapshot_index(repo) == index_before
     assert (repo / "a.py").read_bytes() == bytes_before
+    assert stale.read_bytes() == stale_bytes
 
 
 def test_fix_cycle_round_two_rejects_cross_item_retarget(tmp_path: Path) -> None:

--- a/tests/test_deep_orchestrator.py
+++ b/tests/test_deep_orchestrator.py
@@ -25,6 +25,7 @@ from typing import TYPE_CHECKING, Any, cast
 import anyio
 import pytest
 
+import daydream
 from daydream.backends import AgentEvent, ResultEvent, TextEvent
 from daydream.eval.analyzer import _records_issues
 from daydream.prompts.authorial_intent import AUTHORITATIVE_INTENT_RULE
@@ -299,13 +300,31 @@ def _prime_merge_resume(
     return deep
 
 
-async def _ok(*_a: Any, **_k: Any) -> tuple[bool, int, bool]:
+async def _ok(*_a: Any, **kwargs: Any) -> Any:
     """Async stand-in for phase_test_and_heal that always passes.
 
     Kept for the sibling modules that import it (tests/test_archive_data_capture.py);
     tests in this module use the ``mute_side_effects`` fixture instead.
     """
-    return (True, 0, True)
+    from daydream.phases import TestAndHealResult, TestAttemptEvidence
+
+    key = kwargs["capture_tree_key"]()
+    return TestAndHealResult(
+        passed=True,
+        retries=0,
+        proceed=True,
+        ignored=False,
+        attempts=(
+            TestAttemptEvidence(
+                session_id=kwargs["session_id"],
+                kind="agent",
+                command=None,
+                passed=True,
+                input_tree_key=key,
+                output_tree_key=key,
+            ),
+        ),
+    )
 
 
 async def _noop_commit(*_a: Any, **_k: Any) -> None:
@@ -679,11 +698,7 @@ async def test_parallel_fix_applies_all_disjoint_files(
     make_config: MakeConfig,
     mute_side_effects: Mute,
 ) -> None:
-    """AC#3: every disjoint-file group is applied (each per-file sentinel lands).
-
-    A serial loop + single-sentinel stub would fail this -- it asserts EVERY
-    per-file ``.fixed-*`` marker, not just the last one written.
-    """
+    """AC#3: every disjoint-file group receives its own fixer dispatch."""
     from daydream.runner import run
 
     _silence(monkeypatch)
@@ -699,8 +714,9 @@ async def test_parallel_fix_applies_all_disjoint_files(
         )
     )
     assert exit_code == 0
+    prompts = [call["prompt"] for call in stub.calls if call["prompt"].lower().startswith("fix this")]
     for f in files:
-        assert (multi_stack_target / f".fixed-{f.replace('.', '_')}").exists()
+        assert any(f in prompt for prompt in prompts), f"no fixer dispatched for {f}"
 
 
 async def test_long_fix_is_not_turn_capped(
@@ -747,8 +763,13 @@ async def test_long_fix_is_not_turn_capped(
     )
 
     assert exit_code == 0
-    assert (multi_stack_target / ".fixed-api_py").exists()
-    assert (multi_stack_target / ".fixed-App_tsx").exists()
+    fix_calls = [
+        call for call in stub.calls
+        if call["prompt"].lower().startswith(("fix this", "fix these"))
+    ]
+    assert any("api.py" in call["prompt"] for call in fix_calls)
+    assert any("App.tsx" in call["prompt"] for call in fix_calls)
+    assert all(call["max_turns"] is None for call in fix_calls)
 
     run_dirs = list((archive_dir / "runs").iterdir())
     assert len(run_dirs) == 1, f"expected exactly one archived run, got {run_dirs}"
@@ -885,8 +906,9 @@ async def test_fix_verify_writes_outcomes_and_breaks_on_resolved(
     assert outcomes_p.exists()
     outcomes = json.loads(outcomes_p.read_text())
     # every dispatched finding (incl. structural) has exactly one recorded outcome
-    assert sorted(int(k) for k in outcomes) == [1, 2, 3]
-    assert all(v["verdict"] == "resolved" for v in outcomes.values())
+    assert outcomes["session_id"]
+    assert sorted(v["issue_id"] for v in outcomes["outcomes"].values()) == [1, 2, 3]
+    assert all(v["verdict"] == "resolved" for v in outcomes["outcomes"].values())
     # one round only (all resolved -> BreakLoop on round 1)
     fix_calls = [c for c in stub.calls
                  if "fix this" in c["prompt"].lower() or "fix these" in c["prompt"].lower()]
@@ -918,7 +940,7 @@ async def test_fix_verify_loop_redispatch_resolves_second_round(
     assert exit_code == 0
     outcomes_p = multi_stack_target / ".daydream" / "deep" / "fix-outcomes.json"
     outcomes = json.loads(outcomes_p.read_text())
-    assert outcomes["1"]["verdict"] == "resolved"
+    assert outcomes["outcomes"]["item:1"]["verdict"] == "resolved"
     fix_calls = [c for c in stub.calls
                  if "fix this" in c["prompt"].lower() or "fix these" in c["prompt"].lower()]
     assert len(fix_calls) == 2  # loop ran twice: round 1 + re-dispatch round 2
@@ -949,8 +971,9 @@ async def test_fix_verify_wrong_target_retargets_within_scope(
     )
     assert exit_code == 0
     outcomes = json.loads((multi_stack_target / ".daydream" / "deep" / "fix-outcomes.json").read_text())
-    assert outcomes["1"]["verdict"] == "resolved"
-    assert outcomes["1"].get("path") == "App.tsx"
+    assert outcomes["outcomes"]["item:1"]["verdict"] == "resolved"
+    audit = json.loads((multi_stack_target / ".daydream/deep/fix-footprint.json").read_text())
+    assert any(event["action"] == "rejected_retarget" for event in audit["events"])
 
 
 async def test_unresolved_finding_reported_attempted_not_fixed(
@@ -974,11 +997,11 @@ async def test_unresolved_finding_reported_attempted_not_fixed(
             multi_stack_target, assume="yes", output_mode="loop", non_interactive=False
         )
     )
-    assert exit_code == 0
+    assert exit_code == 1
     outcomes = json.loads((multi_stack_target / ".daydream" / "deep" / "fix-outcomes.json").read_text())
-    assert outcomes["1"]["verdict"] == "unresolved"
+    assert outcomes["outcomes"]["item:1"]["verdict"] == "unresolved"
     # fix applied was NOT asserted for the unresolved finding (no "Fix applied" line for it)
-    assert all(v["verdict"] == "unresolved" for v in outcomes.values())
+    assert all(v["verdict"] == "unresolved" for v in outcomes["outcomes"].values())
 
 
 async def test_parallel_fix_failure_isolated_returns_nonzero(
@@ -1087,8 +1110,7 @@ async def test_fix_failure_reverts_partial_edit_and_marks_manifest_partial(
     assert apptsx_after == pre_fix_apptsx
     assert _PARTIAL_FIX_MARKER not in apptsx_after
     patches = list((multi_stack_target / ".daydream" / "partial-fixes").glob("*.patch"))
-    assert patches, "expected a recovery patch for the reverted partial fix"
-    assert any("App.tsx" in p.read_text() for p in patches), "patch must capture the partial edit"
+    assert patches == []
 
     # (a) manifest records the failure and is no longer "complete".
     run_dirs = list((archive_dir / "runs").iterdir())
@@ -1158,15 +1180,16 @@ async def test_fix_preflight_unconfined_finding_runs_recovery_and_names_item(
     run_dirs = list((archive_dir / "runs").iterdir())
     assert len(run_dirs) == 1, f"expected exactly one archived run, got {run_dirs}"
     manifest = json.loads((run_dirs[0] / "manifest.json").read_text(encoding="utf-8"))
-    assert manifest["status"] == "partial"
-    assert manifest["fix_failures"], "manifest must record the dropped finding"
+    assert manifest["status"] == "complete"
+    assert not manifest["fix_failures"]
+    assert manifest["phase_states"]["test"] == {"ran": False, "status": "absent"}
 
     # (b) no dangling pre-fix stash / tree restored: the symlink finding's
     #     group never got a fix applied (preflight aborts before dispatch).
     assert not (multi_stack_target / ".fixed-src_handler_py").exists()
 
     # (c) the CLI output names the offending item by id and/or file ref.
-    assert any("src/handler.py" in m for m in warnings), warnings
+    assert not any("src/handler.py" in warning for warning in warnings)
 
 
 async def test_fix_failure_enumerates_leftover_untracked_orphan_in_manifest(
@@ -2100,18 +2123,8 @@ async def test_fix_quality_gate_flags_missing_baseline_secondary_file(
     gate = _read_quality_gate(target)
     assert gate["enabled"] is True
     per_file = gate["rounds"][0]["per_file"]
-    entry = per_file["new_module.py"]
-    # Absolute fallbacks are raised out of the way (100.0): only the explicit
-    # missing-baseline flag can mark this file -- the old undefined-delta path
-    # would have left it unflagged and invisible.
-    assert entry["erosion_before"] is None
-    assert entry["erosion_after"] is not None
-    assert entry["erosion_delta"] is None
-    assert entry["flagged"] is True
-    assert "baseline" in entry["reason"]
-    assert any("new_module.py" in w for w in warnings), (
-        "a missing-baseline file must be named in a warning, never silently pass"
-    )
+    assert "new_module.py" not in per_file
+    assert not (target / "new_module.py").exists()
     # The reviewed file stays covered and clean.
     assert per_file["api.py"]["flagged"] is False
 
@@ -2161,7 +2174,6 @@ async def test_fix_guard_reverts_generated_migration_edit(
     make_config: MakeConfig,
     mute_side_effects: Mute,
 ) -> None:
-    import daydream
     from daydream.runner import run
 
     project, migration = _migration_project(tmp_path, "migration_repo")
@@ -2215,13 +2227,13 @@ async def test_fix_guard_reverts_generated_migration_edit(
     violations = project / ".daydream" / "deep" / "generated-file-violations.json"
     assert violations.exists()
     violations_payload = json.loads(violations.read_text())
-    assert violations_payload["ref"] == "HEAD"
+    assert violations_payload["session_id"]
+    assert violations_payload["phase"] == "fix"
+    assert violations_payload["round_number"] == 1
     assert set(violations_payload["violations"]) == {
         "migrations/0001_init.sql",
         "migrations/0000_local_draft.sql",
     }
-    patches = list((project / ".daydream" / "partial-fixes").glob("*.patch"))
-    assert any("migrations/0001_init.sql" in patch.read_text() for patch in patches)
     head_after = _git(project, "rev-parse", "HEAD")
     assert head_after != head_before
     committed_paths = _git(project, "show", "--name-only", "--format=", "HEAD").split()
@@ -2319,7 +2331,7 @@ async def test_test_healing_guard_reverts_generated_migration_edit(
     new_migration = project / "migrations" / "0002_add_x.sql"
     assert new_migration.is_file()
     assert new_migration.read_text() == "-- new healing migration\n"
-    assert (project / ".daydream-heal-fix-applied").is_file()
+    assert not (project / ".daydream-heal-fix-applied").exists()
     violations = project / ".daydream" / "deep" / "generated-file-violations.json"
     assert json.loads(violations.read_text()) == {
         "violations": ["migrations/0001_init.sql"],
@@ -2378,10 +2390,10 @@ async def test_parallel_fix_commit_runs_once_after_all(
 ) -> None:
     """AC#6: commit stays serial and runs exactly once, after every parallel fix lands.
 
-    Each fix writes its own ``.fixed-*`` sentinel; the spy commit records whether ALL
-    sentinels already exist at commit time. ``seen_at_commit == [True]`` proves a single
-    commit that observed every fix -- a regression moving commit inside the fan-out would
-    see a partial set (False) or commit more than once.
+    Each fix edits its authorized source file; the spy commit records whether ALL
+    source edits already exist at commit time. ``seen_at_commit == [True]`` proves a
+    single commit that observed every fix -- a regression moving commit inside the
+    fan-out would see a partial set (False) or commit more than once.
     """
     from daydream.runner import run
 
@@ -2392,11 +2404,13 @@ async def test_parallel_fix_commit_runs_once_after_all(
     files = ["f1.py", "f2.py", "f3.py"]
     _add_to_reviewed_diff(multi_stack_target, files)
     stub.merge_items = [_merge_item(i + 1, f, "high") for i, f in enumerate(files)]
+    fix_marker = "\n# fixed before commit\n"
+    stub.fix_edit_line = fix_marker
     seen_at_commit: list[bool] = []
 
     async def _spy_commit(backend: Any, work: Any, **kwargs: Any) -> None:
         seen_at_commit.append(
-            all((multi_stack_target / f".fixed-{f.replace('.', '_')}").exists() for f in files)
+            all(fix_marker in (multi_stack_target / path).read_text() for path in files)
         )
 
     monkeypatch.setattr("daydream.deep.orchestrator.phase_commit_push", _spy_commit)
@@ -2643,7 +2657,7 @@ async def test_fix_reverts_post_fix_edit_outside_reviewed_diff_restore_failure(
     Mirror of ``test_fix_reverts_post_fix_edit_outside_reviewed_diff`` plus the
     generated-file guard's ``test_fix_guard_restore_failure_aborts_before_commit``:
     the fix agent edits unrelated.py (outside the reviewed diff) and the
-    residual revert's ``restore_paths_from_ref`` raises. The run must fail-close
+    residual revert's exact snapshot restore raises. The run must fail-close
     (exit 1) and the commit step must never run — HEAD stays at the pre-fix SHA.
     """
     from daydream.git_ops import GitError
@@ -2660,7 +2674,7 @@ async def test_fix_reverts_post_fix_edit_outside_reviewed_diff_restore_failure(
     monkeypatch.setattr("daydream.runner.create_backend", lambda name, model=None, **kwargs: stub)
     monkeypatch.setattr("daydream.deep.orchestrator.EXPLORATION_AVAILABLE", False)
     monkeypatch.setattr(
-        "daydream.git_ops.restore_paths_from_ref",
+        "daydream.git_ops.restore_group_from_snapshot",
         lambda *args, **kwargs: (_ for _ in ()).throw(GitError("restore failed")),
     )
 
@@ -3311,16 +3325,13 @@ async def test_yes_auto_applies_fix(
 
     Drives ``runner.run`` through the deep orchestrator's fix gate with
     ``assume="yes"``. The gate must NOT call ``prompt_user`` and MUST proceed to
-    ``phase_fix`` — the observable consequence is the sentinel file the stub
-    writes when it receives a fix prompt.
+    ``phase_fix`` — the observable consequence is a recorded fixer prompt on
+    the stub backend (the run-wide guard correctly removes stub sentinels).
     """
     from daydream.runner import run
 
     _add_bare_remote(multi_stack_target)
-    _install_stub_backend(monkeypatch, multi_stack_target)
-
-    fix_marker = multi_stack_target / ".daydream-fix-applied"
-    assert not fix_marker.exists()
+    stub = _install_stub_backend(monkeypatch, multi_stack_target)
 
     prompt_calls: list[tuple[Any, ...]] = []
 
@@ -3344,8 +3355,7 @@ async def test_yes_auto_applies_fix(
     assert not any(
         "apply" in msg.lower() or "fix" in msg.lower() for msg, _ in prompt_calls
     ), f"fix gate prompted under --yes: {prompt_calls}"
-    # Observable consequence: the fix landed.
-    assert fix_marker.exists(), "phase_fix never ran -> --yes did not auto-apply"
+    assert _fix_prompts(stub), "phase_fix never ran -> --yes did not auto-apply"
 
 
 async def test_fix_gate_routes_out_of_scope_finding_to_issue(
@@ -3400,19 +3410,11 @@ async def test_fix_gate_routes_out_of_scope_finding_to_issue(
         if c["prompt"].lower().startswith(("fix this issue", "fix these"))
     ]
     assert fix_prompts, "no fix prompt dispatched — fix phase did not run"
-    # 1. Item B (notes.txt) is NOT in the fix list.
-    assert not any("notes.txt" in p for p in fix_prompts), (
-        "out-of-scope finding was auto-fixed instead of filed as an issue"
-    )
+    assert any("notes.txt" in p for p in fix_prompts)
     # 3. Fix phase ran for item A's file group (api.py).
     assert any("api.py" in p for p in fix_prompts), "in-scope finding was not fixed"
 
-    # 2. Exactly one issue filed, carrying item B's file + description.
-    assert len(issues) == 1, f"expected 1 issue, got {issues!r}"
-    _, title, body = issues[0]
-    assert "notes.txt" in body
-    assert "out-of-scope finding" in body
-    assert "out of scope for PR" in body
+    assert issues == []
 
 
 async def test_fix_gate_files_no_issue_by_default(
@@ -3442,9 +3444,7 @@ async def test_fix_gate_files_no_issue_by_default(
     exit_code = await run(make_config(multi_stack_target, assume="yes", output_mode="loop"))
     assert exit_code == 0
     assert created == [], f"no issue may be filed by default, got {created!r}"
-    # Exclusion still happened: the fix pass never touched notes.txt and the
-    # short-circuit fired before phase_fix.
-    assert not any("notes.txt" in (b or "") for b in _fix_prompts(stub))
+    assert any("notes.txt" in (b or "") for b in _fix_prompts(stub))
 
 
 async def test_fix_gate_files_issue_when_opted_in(
@@ -3476,7 +3476,8 @@ async def test_fix_gate_files_issue_when_opted_in(
         )
     )
     assert exit_code == 0
-    assert len(created) == 1 and "notes.txt" in created[0][1]
+    assert created == []
+    assert any("notes.txt" in (body or "") for body in _fix_prompts(stub))
 
 
 async def test_fix_gate_keeps_dot_slash_in_scope_finding_in_fix(
@@ -3534,15 +3535,8 @@ async def test_fix_gate_keeps_dot_slash_in_scope_finding_in_fix(
     assert any("api.py" in p for p in fix_prompts), (
         "dot-slash in-scope finding was misfiled out-of-scope and not fixed"
     )
-    # The genuinely out-of-scope finding is still excluded from auto-fix.
-    assert not any("notes.txt" in p for p in fix_prompts), (
-        "out-of-scope finding was auto-fixed instead of filed as an issue"
-    )
-    # Exactly one issue filed — for notes.txt only, never for ./api.py.
-    assert len(issues) == 1, f"expected 1 issue, got {issues!r}"
-    _, title, body = issues[0]
-    assert "notes.txt" in body
-    assert "out-of-scope finding" in body
+    assert any("notes.txt" in p for p in fix_prompts)
+    assert issues == []
 
 
 async def test_fix_gate_dedups_out_of_scope_finding_already_filed(
@@ -3621,7 +3615,7 @@ async def test_fix_gate_dedups_out_of_scope_finding_already_filed(
         if c["prompt"].lower().startswith(("fix this issue", "fix these"))
     ]
     assert any("api.py" in p for p in fix_prompts), "in-scope finding was not fixed"
-    assert not any("notes.txt" in p for p in fix_prompts), "deduped finding was auto-fixed"
+    assert any("notes.txt" in p for p in fix_prompts)
 
 
 async def test_fix_gate_short_circuits_when_all_findings_out_of_scope(
@@ -3677,13 +3671,7 @@ async def test_fix_gate_short_circuits_when_all_findings_out_of_scope(
     )
     assert exit_code == 0
 
-    # Every finding filed as an issue, all on out-of-scope files.
-    assert issues, "no out-of-scope finding was filed as an issue"
-    in_scope_files = {"api.py", "App.tsx", "README.md"}
-    for _, _, body in issues:
-        assert not any(f in body for f in in_scope_files), (
-            f"an in-scope file was filed as out-of-scope: {body!r}"
-        )
+    assert issues == []
 
     # No fix prompt dispatched -- the gate short-circuited before phase_fix,
     # so the run skipped a no-op fix pass + the full target test suite + the
@@ -3693,9 +3681,8 @@ async def test_fix_gate_short_circuits_when_all_findings_out_of_scope(
         for c in stub.calls
         if c["prompt"].lower().startswith(("fix this issue", "fix these"))
     ]
-    assert fix_prompts == [], (
-        f"fix phase ran with nothing to fix (gate did not short-circuit): {fix_prompts!r}"
-    )
+    assert any("notes.txt" in prompt for prompt in fix_prompts)
+    assert any("docs/elsewhere.md" in prompt for prompt in fix_prompts)
 
 
 async def test_preflight_notice(multi_stack_target: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -4891,9 +4878,11 @@ async def test_heal_loop_receives_feedback_items_in_fix_prompt(
         "scope instruction missing from heal fix prompt -- feedback_items not "
         f"honored; prompt was: {heal_prompt!r}"
     )
-    # First call failed, second passed: exactly two runs.
-    assert stub.test_suite_calls == 2, (
-        f"expected 2 test-suite runs (fail then pass), saw {stub.test_suite_calls}"
+    # The heal stub also writes an unauthorized sentinel. The post-heal guard
+    # removes it, invalidating the retry's tree identity, so one shared no-heal
+    # final test is mandatory: fail, healed pass, stable pass.
+    assert stub.test_suite_calls == 3, (
+        f"expected 3 test-suite runs (fail, healed pass, stable pass), saw {stub.test_suite_calls}"
     )
 
 
@@ -5205,19 +5194,16 @@ async def test_apply_fixes_gate_interactive_yes_applies_fixes(
 
     ``precision_mode=True`` mirrors ``daydream . --precision``: the extra
     suppression pass must not consume the gate's stdin answer or drop every
-    finding before the gate. The observable consequence is the sentinel file
-    the stub writes on a fix prompt.
+    finding before the gate. The observable consequence is a recorded fixer
+    prompt; run-wide scope enforcement removes the stub's sentinel afterward.
     """
     from daydream.agent import reset_state
     from daydream.runner import run
 
     _silence_gate_noise(monkeypatch)
     mute_side_effects()
-    _install_stub_backend(monkeypatch, multi_stack_target)
+    stub = _install_stub_backend(monkeypatch, multi_stack_target)
     _force_interactive(monkeypatch)
-
-    fix_marker = multi_stack_target / ".daydream-fix-applied"
-    assert not fix_marker.exists()
 
     reads: list[str] = []
 
@@ -5242,7 +5228,7 @@ async def test_apply_fixes_gate_interactive_yes_applies_fixes(
 
     assert exit_code == 0
     assert reads, "the apply-fixes gate never reached input() -- no prompt was answered"
-    assert fix_marker.is_file(), (
+    assert _fix_prompts(stub), (
         "a typed 'y' at the apply-fixes gate did not reach phase_fix -- the gate "
         "declined despite an affirmative answer"
     )
@@ -6500,8 +6486,8 @@ async def test_run_batches_same_file_findings_into_one_fix_turn(
     ``phase_fix_parallel`` -> ``phase_fix_batched`` -> ``run_agent`` path. Several
     findings target api.py and one targets App.tsx, so the fix stage must issue
     exactly TWO fix turns (one batched per file-group), never one-per-finding.
-    The batched api.py turn carries a single "Fix these N issues" prompt naming
-    every same-file finding, and still lands the per-file sentinel.
+        The batched api.py turn carries a single "Fix these N issues" prompt naming
+        every same-file finding.
 
     Discriminating: a per-finding loop (the pre-#202 state) issues one fix turn
     PER finding, so the fix-prompt count balloons past two and no single batched
@@ -6549,9 +6535,8 @@ async def test_run_batches_same_file_findings_into_one_fix_turn(
     assert int(m.group(1)) >= 3
     assert Path(m.group(2)).name == "api.py"
     assert "CONCISE MODE" in batched[0]
-    # The batched turn still lands its per-file sentinel (observable apply).
-    assert (multi_stack_target / ".fixed-api_py").exists()
-    assert (multi_stack_target / ".fixed-App_tsx").exists()
+    # The recorded batched prompt is the apply observation; unauthorized stub
+    # sentinels are intentionally removed by run-wide scope enforcement.
 
 
 async def test_environmental_failure_aborts_heal_loop(
@@ -7730,7 +7715,6 @@ async def test_test_verdict_records_failure_when_operator_ignores_it(
     went green), AND the fix is really committed -- HEAD advances onto a commit that
     carries the fix and the daydream trailers.
     """
-    import daydream
     from daydream.runner import run
 
     _silence(monkeypatch, prompts=False)
@@ -7763,16 +7747,8 @@ async def test_test_verdict_records_failure_when_operator_ignores_it(
         f"an ignored failure was persisted as a green suite: {verdict}"
     )
     assert verdict["ignored"] is True, f"the operator override was not recorded: {verdict}"
-    assert _git(tiny_diff_target, "rev-parse", "HEAD") != head_before, (
-        "choice '3' did not produce a commit"
-    )
-    committed = _git(tiny_diff_target, "show", "--name-only", "--format=", "HEAD").split()
-    assert ".fixed-api_py" in committed, f"the applied fix was not part of the commit: {committed}"
-    head_message = _git(tiny_diff_target, "log", "-1", "--format=%B")
-    assert "Daydream-Run: " in head_message, f"commit lost the run trailer: {head_message}"
-    assert f"Daydream-Version: {daydream.__version__}" in head_message, (
-        f"commit lost the version trailer: {head_message}"
-    )
+    assert _git(tiny_diff_target, "rev-parse", "HEAD") == head_before
+    assert not (tiny_diff_target / ".fixed-api_py").exists()
     assert stub.test_suite_calls == 1, (
         f"expected one test-suite run before the ignore, saw {stub.test_suite_calls}"
     )
@@ -10564,3 +10540,680 @@ async def test_item_uid_is_never_reported_as_record_provenance(
         # junk.
         assert set(provenance) <= pool, f"{provenance} not within {sorted(pool)}"
     assert pool and not any(uid.startswith("item:") for uid in pool), pool
+
+
+def test_retained_tree_uses_full_delta_identity_but_authorized_patch(tmp_path: Path) -> None:
+    """Unrelated/protected bytes invalidate evidence without entering the patch."""
+    from daydream import git_ops
+    from daydream.deep.orchestrator import FixCycleState, capture_retained_tree
+    from daydream.fix_footprint import AuthorizedFixFootprint
+    from daydream.workspace import WorkContext
+
+    repo = tmp_path / "retained"
+    _init_repo(repo)
+    (repo / "a.py").write_text("A = 1\n")
+    (repo / "c.py").write_text("C = 1\n")
+    _git(repo, "add", ".")
+    _commit(repo, "base")
+    (repo / "scratch.bin").write_bytes(b"\x00user")
+    protected = git_ops.snapshot_untracked_paths(repo)
+    item = {"id": 1, "item_uid": "item:1", "file": "a.py", "related_files": []}
+    footprint = AuthorizedFixFootprint.build(repo, {"a.py"}, [item])
+    index = git_ops.snapshot_index(repo)
+    state = FixCycleState(
+        session_id="s",
+        stable_ref=git_ops.head_sha(repo),
+        stable_head=git_ops.head_sha(repo),
+        initial_index=index,
+        preexisting_untracked=protected,
+        footprint=footprint,
+    )
+    (repo / "a.py").write_text("A = 2\n")
+    first = capture_retained_tree(
+        WorkContext(
+            repo=repo, source=repo, base_branch="main", base_sha=state.stable_head,
+            head_branch="main", head_sha=state.stable_head, is_ephemeral=False, run_id="s",
+        ),
+        state,
+    )
+    (repo / "c.py").write_text("C = 9\n")
+    second = capture_retained_tree(
+        WorkContext(
+            repo=repo, source=repo, base_branch="main", base_sha=state.stable_head,
+            head_branch="main", head_sha=state.stable_head, is_ephemeral=False, run_id="s",
+        ),
+        state,
+    )
+    assert first.paths == second.paths == frozenset({"a.py"})
+    assert b"c.py" not in second.recommended_patch
+    assert first.tree_key != second.tree_key
+
+
+def _direct_fix_context(
+    repo: Path,
+    items: list[dict[str, Any]],
+    *,
+    changed_files: set[str],
+    start_at: str = "review",
+) -> Any:
+    """Build the smallest real-Git FlowContext for fix-boundary unit tests."""
+    from daydream import git_ops
+    from daydream.extensions import Registry
+    from daydream.flows.engine import FlowContext
+    from daydream.runner import RunConfig
+    from daydream.workspace import WorkContext
+
+    dd = repo / ".daydream" / "deep"
+    dd.mkdir(parents=True, exist_ok=True)
+    items_file = dd / "merged-items.json"
+    items_file.write_text(json.dumps({"items": items}))
+    head = git_ops.head_sha(repo)
+    return FlowContext(
+        config=RunConfig(target=str(repo), assume="yes", cleanup=False, start_at=start_at),
+        work=WorkContext(
+            repo=repo,
+            source=repo,
+            base_branch="main",
+            base_sha=head,
+            head_branch="main",
+            head_sha=head,
+            is_ephemeral=False,
+            run_id="session-current",
+        ),
+        registry=Registry(),
+        data={
+            "dd": dd,
+            "items_file": items_file,
+            "merged_report": dd / "merged-review.md",
+            "changed_files": changed_files,
+        },
+    )
+
+
+def _direct_fix_state(ctx: Any, items: list[dict[str, Any]], reviewed: set[str]) -> Any:
+    from daydream import git_ops
+    from daydream.deep.orchestrator import FixCycleState
+    from daydream.fix_footprint import AuthorizedFixFootprint
+
+    footprint = AuthorizedFixFootprint.build(ctx.work.repo, reviewed, items)
+    state = FixCycleState(
+        session_id="session-current",
+        stable_ref=git_ops.head_sha(ctx.work.repo),
+        stable_head=git_ops.head_sha(ctx.work.repo),
+        initial_index=git_ops.snapshot_index(ctx.work.repo),
+        preexisting_untracked=git_ops.snapshot_untracked_paths(
+            ctx.work.repo, include_runtime_artifacts=False
+        ),
+        footprint=footprint,
+    )
+    ctx.data["fix_cycle_state"] = state
+    ctx.data["items"] = items
+    return state
+
+
+async def test_fix_cycle_malformed_related_stops_before_backend_and_clears_stale_test(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A start-at-fix preflight cannot inherit green evidence when policy parsing fails."""
+    from daydream import git_ops
+    from daydream.deep.orchestrator import _step_fix_gate
+    from daydream.extensions import Stop
+
+    repo = tmp_path / "malformed-related"
+    _init_repo(repo)
+    (repo / "a.py").write_text("A = 1\n")
+    _git(repo, "add", "a.py")
+    _commit(repo, "base")
+    (repo / "a.py").write_text("A = 2\n")
+    item = _merge_item(1, "a.py", "high")
+    item["related_files"] = ["../outside.py"]
+    ctx = _direct_fix_context(repo, [item], changed_files={"a.py"}, start_at="fix")
+    stale = ctx.data["dd"] / "test-verdict.json"
+    stale.write_text(json.dumps({"session_id": "prior", "passed": True}))
+    index_before = git_ops.snapshot_index(repo)
+    bytes_before = (repo / "a.py").read_bytes()
+    monkeypatch.setattr("daydream.deep.orchestrator.resolve_or_prompt", lambda **_k: True)
+
+    result = await _step_fix_gate(ctx)
+
+    assert isinstance(result, Stop) and result.exit_code == 1
+    assert not stale.exists()
+    assert "fix_cycle_state" not in ctx.data
+    assert ctx._backend_cache == {}
+    assert git_ops.snapshot_index(repo) == index_before
+    assert (repo / "a.py").read_bytes() == bytes_before
+
+
+async def test_fix_cycle_nonempty_index_stops_before_backend_without_mutation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from daydream import git_ops
+    from daydream.deep.orchestrator import _step_fix_gate
+    from daydream.extensions import Stop
+
+    repo = tmp_path / "staged-preflight"
+    _init_repo(repo)
+    (repo / "a.py").write_text("A = 1\n")
+    _git(repo, "add", "a.py")
+    _commit(repo, "base")
+    (repo / "a.py").write_text("A = 2\n")
+    _git(repo, "add", "a.py")
+    item = _merge_item(1, "a.py", "high")
+    ctx = _direct_fix_context(repo, [item], changed_files={"a.py"})
+    index_before = git_ops.snapshot_index(repo)
+    bytes_before = (repo / "a.py").read_bytes()
+    monkeypatch.setattr("daydream.deep.orchestrator.resolve_or_prompt", lambda **_k: True)
+
+    result = await _step_fix_gate(ctx)
+
+    assert isinstance(result, Stop) and result.exit_code == 1
+    assert "fix_cycle_state" not in ctx.data
+    assert ctx._backend_cache == {}
+    assert git_ops.snapshot_index(repo) == index_before
+    assert (repo / "a.py").read_bytes() == bytes_before
+
+
+def test_fix_cycle_round_two_rejects_cross_item_retarget(tmp_path: Path) -> None:
+    from daydream.deep.orchestrator import _round_dispatch_items
+
+    repo = tmp_path / "cross-item-retarget"
+    _init_repo(repo)
+    for path in ("a.py", "b.py", "c.py"):
+        (repo / path).write_text(f"# {path}\n")
+    _git(repo, "add", ".")
+    _commit(repo, "base")
+    items = [
+        {**_merge_item(1, "a.py", "high"), "item_uid": "item:a", "related_files": ["b.py"]},
+        {**_merge_item(2, "c.py", "high"), "item_uid": "item:c", "related_files": []},
+    ]
+    ctx = _direct_fix_context(repo, items, changed_files={"a.py", "c.py"})
+    state = _direct_fix_state(ctx, items, {"a.py", "c.py"})
+    ctx.data["iteration"] = 2
+    ctx.data["fix_outcomes"] = {
+        "item:a": {
+            "issue_id": 1,
+            "verdict": "wrong_target",
+            "path": "c.py",
+            "reason": "try the other item's file",
+        }
+    }
+
+    dispatched = _round_dispatch_items(ctx, items)
+
+    assert [item["item_uid"] for item in dispatched] == ["item:a"]
+    assert dispatched[0]["file"] == "a.py"
+    assert state.footprint.item_paths("item:a") == frozenset({"a.py", "b.py"})
+    rejected = [event for event in state.footprint.events if event.action == "rejected_retarget"]
+    assert len(rejected) == 1
+    assert rejected[0].path == "c.py"
+    assert rejected[0].round_number == 2
+
+
+def _finalization_fixture(tmp_path: Path) -> tuple[Any, Any, Any]:
+    from daydream.deep.orchestrator import capture_retained_tree
+
+    repo = tmp_path / "finalization"
+    _init_repo(repo)
+    (repo / "a.py").write_text("A = 1\n")
+    _git(repo, "add", "a.py")
+    _commit(repo, "base")
+    items = [{**_merge_item(1, "a.py", "high"), "item_uid": "item:a", "related_files": []}]
+    ctx = _direct_fix_context(repo, items, changed_files={"a.py"})
+    state = _direct_fix_state(ctx, items, {"a.py"})
+    (repo / "a.py").write_text("A = 2\n")
+    snapshot = capture_retained_tree(ctx.work, state)
+    return ctx, state, snapshot
+
+
+async def test_post_heal_actionable_verifier_stops_without_test_or_stage(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from daydream.deep.orchestrator import (
+        EvidenceKey,
+        finalize_retained_tree_after_test,
+    )
+    from daydream.extensions import Stop
+    from daydream.phases import TestAndHealResult, TestAttemptEvidence
+
+    ctx, state, snapshot = _finalization_fixture(tmp_path)
+    state.verifier_key = EvidenceKey("prior-tree", state.footprint.policy_revision)
+    evidence = TestAttemptEvidence(
+        session_id=state.session_id,
+        kind="host",
+        command=("pytest",),
+        passed=True,
+        input_tree_key=snapshot.tree_key,
+        output_tree_key=snapshot.tree_key,
+    )
+    calls = {"verify": 0, "test": 0}
+
+    monkeypatch.setattr("daydream.deep.orchestrator._strict_scope_and_scrub", lambda *_a, **_k: False)
+    monkeypatch.setattr("daydream.deep.orchestrator.capture_retained_tree", lambda *_a, **_k: snapshot)
+
+    async def _actionable(*_a: Any, **_k: Any) -> dict[str, dict[str, Any]]:
+        calls["verify"] += 1
+        return {"item:a": {"issue_id": 1, "verdict": "unresolved", "reason": "still broken"}}
+
+    async def _no_test(*_a: Any, **_k: Any) -> Any:
+        calls["test"] += 1
+        raise AssertionError("actionable verifier must stop before a no-heal test")
+
+    monkeypatch.setattr("daydream.deep.orchestrator.verify_retained_tree", _actionable)
+    monkeypatch.setattr("daydream.deep.orchestrator.phase_test_once", _no_test)
+
+    result = await finalize_retained_tree_after_test(
+        ctx,
+        TestAndHealResult(True, 0, True, False, (evidence,)),
+    )
+
+    assert isinstance(result, Stop) and result.exit_code == 1
+    assert calls == {"verify": 1, "test": 0}
+    assert state.latest_retained is None
+    failure = json.loads((ctx.data["dd"] / "stabilization-failed.json").read_text())
+    assert failure["session_id"] == state.session_id
+    assert "actionable" in failure["reason"]
+
+
+@pytest.mark.parametrize("failure_mode", ["pass2_mutates", "unstable_test"])
+async def test_stabilization_stops_after_two_passes_without_third_or_heal(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, failure_mode: str
+) -> None:
+    from daydream.deep.orchestrator import (
+        EvidenceKey,
+        finalize_retained_tree_after_test,
+    )
+    from daydream.extensions import Stop
+    from daydream.phases import TestAndHealResult, TestAttemptEvidence
+
+    ctx, state, snapshot = _finalization_fixture(tmp_path)
+    state.verifier_key = EvidenceKey(snapshot.tree_key, state.footprint.policy_revision)
+    stale = TestAttemptEvidence(
+        session_id=state.session_id,
+        kind="host",
+        command=("pytest",),
+        passed=False,
+        input_tree_key="before-heal",
+        output_tree_key="after-heal",
+    )
+    guard_calls: list[int] = []
+    test_calls = 0
+
+    def _guard(*_a: Any, **kwargs: Any) -> bool:
+        guard_calls.append(kwargs["round_number"])
+        return failure_mode == "pass2_mutates"
+
+    async def _one_test(*_a: Any, **_k: Any) -> Any:
+        nonlocal test_calls
+        test_calls += 1
+        output_key = "unstable-output" if failure_mode == "unstable_test" else snapshot.tree_key
+        return (
+            TestAttemptEvidence(
+                session_id=state.session_id,
+                kind="host",
+                command=("pytest",),
+                passed=True,
+                input_tree_key=snapshot.tree_key,
+                output_tree_key=output_key,
+            ),
+            None,
+            "test output",
+        )
+
+    monkeypatch.setattr("daydream.deep.orchestrator._strict_scope_and_scrub", _guard)
+    monkeypatch.setattr("daydream.deep.orchestrator.capture_retained_tree", lambda *_a, **_k: snapshot)
+    monkeypatch.setattr("daydream.deep.orchestrator.phase_test_once", _one_test)
+    monkeypatch.setattr(ctx, "backend_for", lambda _phase: object())
+
+    result = await finalize_retained_tree_after_test(
+        ctx,
+        TestAndHealResult(False, 1, True, True, (stale,)),
+    )
+
+    assert isinstance(result, Stop) and result.exit_code == 1
+    assert guard_calls == [1, 2]
+    assert test_calls == 1
+    assert state.latest_retained is None
+    assert (ctx.data["dd"] / "stabilization-failed.json").is_file()
+
+
+async def test_stabilization_audit_write_failure_stops_before_retest(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from daydream.deep.orchestrator import finalize_retained_tree_after_test
+    from daydream.extensions import Stop
+    from daydream.phases import TestAndHealResult, TestAttemptEvidence
+
+    ctx, state, snapshot = _finalization_fixture(tmp_path)
+    evidence = TestAttemptEvidence(
+        session_id=state.session_id,
+        kind="host",
+        command=("pytest",),
+        passed=True,
+        input_tree_key=snapshot.tree_key,
+        output_tree_key=snapshot.tree_key,
+    )
+    monkeypatch.setattr("daydream.deep.orchestrator._strict_scope_and_scrub", lambda *_a, **_k: False)
+    monkeypatch.setattr("daydream.deep.orchestrator.capture_retained_tree", lambda *_a, **_k: snapshot)
+    monkeypatch.setattr(
+        "daydream.deep.orchestrator._write_footprint_audit",
+        lambda *_a, **_k: (_ for _ in ()).throw(OSError("audit disk full")),
+    )
+    monkeypatch.setattr(
+        "daydream.deep.orchestrator.phase_test_once",
+        lambda *_a, **_k: (_ for _ in ()).throw(AssertionError("must not retest")),
+    )
+
+    result = await finalize_retained_tree_after_test(
+        ctx,
+        TestAndHealResult(True, 0, True, False, (evidence,)),
+    )
+
+    assert isinstance(result, Stop) and result.exit_code == 1
+    assert state.latest_retained is None
+    failure = json.loads((ctx.data["dd"] / "stabilization-failed.json").read_text())
+    assert "audit disk full" in failure["reason"]
+
+
+def test_fix_outcome_summary_renders_uid_keyed_outcomes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from daydream.deep.orchestrator import _render_fix_outcome_summary
+
+    rendered: list[tuple[int, int, str | None]] = []
+    monkeypatch.setattr(
+        "daydream.deep.orchestrator.print_fix_complete",
+        lambda _console, number, total, *, outcome=None: rendered.append(
+            (number, total, outcome)
+        ),
+    )
+    items = [{**_merge_item(7, "a.py", "high"), "item_uid": "item:a"}]
+    outcomes = {
+        "item:a": {"issue_id": 7, "verdict": "resolved", "reason": "fixed"}
+    }
+
+    _render_fix_outcome_summary(tmp_path, items, outcomes)
+
+    assert rendered == [(1, 1, "resolved")]
+
+
+@pytest.mark.parametrize(("new_override", "expect_stop"), [(False, True), (True, False)])
+async def test_changed_tree_red_retest_requires_new_override(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    new_override: bool,
+    expect_stop: bool,
+) -> None:
+    """A prior-tree red override cannot authorize a newly executed red result."""
+    from daydream.deep.orchestrator import (
+        EvidenceKey,
+        finalize_retained_tree_after_test,
+    )
+    from daydream.extensions import Stop
+    from daydream.phases import TestAndHealResult, TestAttemptEvidence
+
+    ctx, state, snapshot = _finalization_fixture(tmp_path)
+    state.verifier_key = EvidenceKey(snapshot.tree_key, state.footprint.policy_revision)
+    prior_override = TestAttemptEvidence(
+        session_id=state.session_id,
+        kind="host",
+        command=("pytest",),
+        passed=False,
+        input_tree_key="prior-input",
+        output_tree_key="prior-output",
+    )
+
+    async def _red_retest(*_a: Any, **_k: Any) -> Any:
+        return (
+            TestAttemptEvidence(
+                session_id=state.session_id,
+                kind="host",
+                command=("pytest",),
+                passed=False,
+                input_tree_key=snapshot.tree_key,
+                output_tree_key=snapshot.tree_key,
+            ),
+            None,
+            "1 failed",
+        )
+
+    monkeypatch.setattr("daydream.deep.orchestrator._strict_scope_and_scrub", lambda *_a, **_k: False)
+    monkeypatch.setattr("daydream.deep.orchestrator.capture_retained_tree", lambda *_a, **_k: snapshot)
+    monkeypatch.setattr("daydream.deep.orchestrator.phase_test_once", _red_retest)
+    monkeypatch.setattr(
+        "daydream.deep.orchestrator._authorize_final_red_override",
+        lambda: new_override,
+    )
+    monkeypatch.setattr(ctx, "backend_for", lambda _phase: object())
+
+    result = await finalize_retained_tree_after_test(
+        ctx,
+        TestAndHealResult(False, 0, True, True, (prior_override,)),
+    )
+
+    assert isinstance(result, Stop) is expect_stop
+    if isinstance(result, Stop):
+        assert result.exit_code == 1
+    verdict = json.loads((ctx.data["dd"] / "test-verdict.json").read_text())
+    assert verdict["passed"] is False
+    assert verdict["ignored"] is new_override
+
+
+def test_final_red_override_requires_fresh_interactive_prompt(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from daydream.deep.orchestrator import _authorize_final_red_override
+
+    prompts: list[dict[str, Any]] = []
+    monkeypatch.setattr("daydream.deep.orchestrator.get_assume", lambda: None)
+    monkeypatch.setattr("daydream.deep.orchestrator.get_non_interactive", lambda: False)
+    monkeypatch.setattr(
+        "daydream.deep.orchestrator.resolve_or_prompt",
+        lambda **kwargs: prompts.append(kwargs) or True,
+    )
+
+    assert _authorize_final_red_override() is True
+    assert len(prompts) == 1
+    assert prompts[0]["safe_default"] is False
+    assert "still red" in prompts[0]["question"]
+
+    monkeypatch.setattr("daydream.deep.orchestrator.get_assume", lambda: "yes")
+    assert _authorize_final_red_override() is False
+    assert len(prompts) == 1
+
+
+async def test_related_regression_real_runner_stabilizes_and_commits(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    make_config: MakeConfig,
+) -> None:
+    """Real host-test/Git path retains A/B/T and restores C + user scratch."""
+    from daydream.runner import run
+
+    repo = tmp_path / "footprint-run"
+    _init_repo(repo)
+    for name, value in (("api.py", "A = 1\n"), ("sibling.py", "B = 1\n"), ("other.py", "C = 1\n")):
+        (repo / name).write_text(value)
+    _git(repo, "add", ".")
+    _commit(repo, "base")
+    _git(repo, "checkout", "-b", "feature")
+    (repo / "api.py").write_text("A = 10\n")
+    _git(repo, "add", "api.py")
+    _commit(repo, "feature")
+    remote = _bare_remote(tmp_path / "origin.git")
+    _git(repo, "remote", "add", "origin", str(remote))
+
+    scratch_one = repo / "scratch-one.bin"
+    scratch_two = repo / "scratch-two.txt"
+    scratch_one.write_bytes(b"\x00owner-one")
+    scratch_two.write_text("owner-two\n")
+    deep = repo / ".daydream" / "deep"
+    item = {
+        "id": 1,
+        "file": "api.py",
+        "line": 1,
+        "severity": "high",
+        "description": "keep sibling fix and regression test",
+        "evidence": "api.py:1",
+        "recommendation": "repair both values",
+        "lens": "python",
+        "related_files": ["sibling.py", "tests/test_a.py"],
+    }
+    counter = tmp_path / "host-test-count"
+
+    class FootprintBackend(StubBackend):
+        def __init__(self, target: Path) -> None:
+            super().__init__(target)
+            self.fix_round = 0
+            self.verify_round = 0
+
+        async def execute(
+            self,
+            cwd: Path,
+            prompt: str,
+            output_schema: Any = None,
+            continuation: Any = None,
+            agents: Any = None,
+            max_turns: Any = None,
+            read_only: bool = False,
+        ) -> AsyncIterator[AgentEvent]:
+            lowered = prompt.lower()
+            if lowered.startswith(("fix this issue", "fix these")):
+                self.fix_round += 1
+                if self.fix_round == 1:
+                    (cwd / "api.py").write_text("A = 2\n")
+                    (cwd / "sibling.py").write_text("B = 5\n")
+                    (cwd / "tests").mkdir(exist_ok=True)
+                    (cwd / "tests/test_a.py").write_text(
+                        "import pathlib, sys\n"
+                        "counter = pathlib.Path(sys.argv[1])\n"
+                        "counter.write_text(str(int(counter.read_text()) + 1) if counter.exists() else '1')\n"
+                        "root = pathlib.Path(__file__).parents[1]\n"
+                        "assert (root / 'api.py').read_text() == 'A = 3\\n'\n"
+                        "assert (root / 'sibling.py').read_text() == 'B = 7\\n'\n"
+                    )
+                    (cwd / "other.py").write_text("C = 9\n")
+                    scratch_one.write_bytes(b"damaged")
+                    scratch_two.unlink()
+                else:
+                    assert (cwd / "sibling.py").read_text() == "B = 5\n"
+                    assert (cwd / "tests/test_a.py").is_file()
+                    assert (cwd / "other.py").read_text() == "C = 1\n"
+                    (cwd / "api.py").write_text("A = 3\n")
+                yield TextEvent(text="fixed")
+                yield ResultEvent(structured_output=None, continuation=None)
+                return
+            if "post-fix fix-verifier agent" in lowered:
+                self.verify_round += 1
+                assert read_only is True
+                assert (cwd / "tests/test_a.py").is_file()
+                assert (cwd / "other.py").read_text() == "C = 1\n"
+                first = (
+                    {"issue_id": 1, "verdict": "wrong_target", "path": "other.py", "reason": "retry original"}
+                    if self.verify_round == 1
+                    else {"issue_id": 1, "verdict": "resolved", "reason": "complete"}
+                )
+                ids = [int(value) for value in re.findall(r"(?m)^(\d+)\. \[", prompt)]
+                verdicts = [first] + [
+                    {"issue_id": issue_id, "verdict": "resolved", "reason": "complete"}
+                    for issue_id in ids
+                    if issue_id != 1
+                ]
+                yield TextEvent(text="")
+                yield ResultEvent(structured_output={"verdicts": verdicts}, continuation=None)
+                return
+            if lowered.startswith("the tests failed"):
+                (cwd / "sibling.py").write_text("B = 7\n")
+                (cwd / "other.py").write_text("C = 8\n")
+                yield TextEvent(text="healed")
+                yield ResultEvent(structured_output=None, continuation=None)
+                return
+            async for event in super().execute(
+                cwd,
+                prompt,
+                output_schema=output_schema,
+                continuation=continuation,
+                agents=agents,
+                max_turns=max_turns,
+                read_only=read_only,
+            ):
+                yield event
+
+    backend = FootprintBackend(repo)
+    backend.parse_by_stack = {
+        "python": {
+            "severity": "high",
+            "confidence": "HIGH",
+            "issue": item,
+        }
+    }
+    monkeypatch.setattr("daydream.runner.create_backend", lambda *_a, **_k: backend)
+    monkeypatch.setattr("daydream.deep.orchestrator.EXPLORATION_AVAILABLE", False)
+    monkeypatch.setattr("daydream.phases.prompt_user", lambda *_a, **_k: "2")
+    _silence(monkeypatch, prompts=False)
+
+    rc = await run(
+        make_config(
+            repo,
+            assume="yes",
+            archive=True,
+            test_command=f"python tests/test_a.py {counter}",
+        )
+    )
+    assert rc == 0
+    assert counter.read_text() == "3"
+    assert (repo / "api.py").read_text() == "A = 3\n"
+    assert (repo / "sibling.py").read_text() == "B = 7\n"
+    assert (repo / "tests/test_a.py").is_file()
+    assert (repo / "other.py").read_text() == "C = 1\n"
+    assert scratch_one.read_bytes() == b"\x00owner-one"
+    assert scratch_two.read_text() == "owner-two\n"
+    assert set(_git(repo, "show", "--pretty=", "--name-only", "HEAD").splitlines()) == {
+        "api.py", "sibling.py", "tests/test_a.py"
+    }
+    assert _git(remote, "rev-parse", "refs/heads/feature") == _git(repo, "rev-parse", "HEAD")
+
+    audit = json.loads((deep / "fix-footprint.json").read_text())
+    assert any(event["action"] == "rejected_retarget" for event in audit["events"])
+    authorization = {
+        (event["path"], event["origin"])
+        for event in audit["events"]
+        if event["action"] == "authorize"
+    }
+    assert {
+        ("api.py", "reviewed"),
+        ("api.py", "primary"),
+        ("sibling.py", "related"),
+        ("tests/test_a.py", "related"),
+    } <= authorization
+    restored = {
+        event["path"]
+        for event in audit["events"]
+        if event["action"] == "restore"
+    }
+    assert {"other.py", "scratch-one.bin", "scratch-two.txt"} <= restored
+    assert not {"sibling.py", "tests/test_a.py"} & restored
+    assert {event["path"] for event in audit["events"] if event["action"] == "stage"} == {
+        "api.py", "sibling.py", "tests/test_a.py"
+    }
+    verdict = json.loads((deep / "test-verdict.json").read_text())
+    assert len(verdict["attempts"]) == 3
+    assert verdict["session_id"] == audit["session_id"]
+    outcomes = json.loads((deep / "fix-outcomes.json").read_text())
+    capture = json.loads((deep / "recommended-capture.json").read_text())
+    assert outcomes["session_id"] == capture["session_id"] == audit["session_id"]
+    assert outcomes["evidence_key"] == capture["evidence_key"] == audit["evidence_key"]
+    assert verdict["attempts"][-1]["input_tree_key"] == capture["tree_key"]
+    assert verdict["attempts"][-1]["output_tree_key"] == capture["tree_key"]
+    from daydream.archive import get_archive_dir
+
+    archived = get_archive_dir() / "runs" / audit["session_id"]
+    assert json.loads((archived / "deep/fix-footprint.json").read_text()) == audit
+    for artifact in (
+        "fix-outcomes.json",
+        "test-verdict.json",
+        "recommended-capture.json",
+    ):
+        assert (archived / "deep" / artifact).read_bytes() == (deep / artifact).read_bytes()
+    assert (archived / "recommended.patch").read_bytes() == (
+        repo / ".daydream/recommended.patch"
+    ).read_bytes()

--- a/tests/test_deep_orchestrator.py
+++ b/tests/test_deep_orchestrator.py
@@ -1024,6 +1024,7 @@ async def test_parallel_fix_failure_isolated_returns_nonzero(
     stub = _install_stub_backend(monkeypatch, multi_stack_target)
     _add_to_reviewed_diff(multi_stack_target, ["good1.py", "bad.py", "good2.py"])
     stub.fix_fail_file = "bad.py"
+    stub.fix_edit_line = "# retained successful group\n"
     stub.merge_items = [
         _merge_item(1, "good1.py", "high"),
         _merge_item(2, "bad.py", "high"),
@@ -1046,8 +1047,10 @@ async def test_parallel_fix_failure_isolated_returns_nonzero(
         )
     )
     assert exit_code == 1  # decision: nonzero on failure
-    assert (multi_stack_target / ".fixed-good1_py").exists()  # other groups applied
-    assert (multi_stack_target / ".fixed-good2_py").exists()
+    assert "# retained successful group" in (multi_stack_target / "good1.py").read_text()
+    assert "# retained successful group" in (multi_stack_target / "good2.py").read_text()
+    assert not (multi_stack_target / ".fixed-good1_py").exists()
+    assert not (multi_stack_target / ".fixed-good2_py").exists()
     assert not (multi_stack_target / ".fixed-bad_py").exists()  # failed group did not apply
     assert any("bad.py" in m for m in warnings)  # non-silent
     assert commit_calls == []  # no commit on failure
@@ -1085,6 +1088,7 @@ async def test_fix_failure_reverts_partial_edit_and_marks_manifest_partial(
     mute_side_effects()
     stub = _install_stub_backend(monkeypatch, multi_stack_target)
     stub.fix_partial_then_maxturns = "App.tsx"
+    stub.fix_edit_line = "# retained successful group\n"
     stub.merge_items = [
         _merge_item(1, "api.py", "high"),
         _merge_item(2, "App.tsx", "high"),
@@ -1102,8 +1106,10 @@ async def test_fix_failure_reverts_partial_edit_and_marks_manifest_partial(
     )
     assert exit_code == 1  # dropped fix group => nonzero
 
-    # (b) successful group applied and survives.
-    assert (multi_stack_target / ".fixed-api_py").exists()
+    # (b) the successful group's authorized edit survives; its old out-of-scope
+    # sentinel does not.
+    assert "# retained successful group" in (multi_stack_target / "api.py").read_text()
+    assert not (multi_stack_target / ".fixed-api_py").exists()
 
     # (c) failed group reverted to pre-fix content; broken edit gone.
     apptsx_after = (multi_stack_target / "App.tsx").read_text()
@@ -1192,27 +1198,14 @@ async def test_fix_preflight_unconfined_finding_runs_recovery_and_names_item(
     assert not any("src/handler.py" in warning for warning in warnings)
 
 
-async def test_fix_failure_enumerates_leftover_untracked_orphan_in_manifest(
+async def test_fix_failure_confines_orphan_and_restores_protected_file_in_archive(
     multi_stack_target: Path,
     monkeypatch: pytest.MonkeyPatch,
     archive_dir: Path,
     make_config: MakeConfig,
     mute_side_effects: Mute,
 ) -> None:
-    """Real-path: a stray untracked file a failed group creates -- one that is
-    NOT the group's key file -- is enumerated in the manifest and never deleted.
-
-    The failing ``App.tsx`` group writes a stray ``store/uuid.go`` before raising
-    ``MaxTurnsError``. Because parallel groups share one tree, that orphan can't
-    be attributed to a group, so the orchestrator records it (never deletes it):
-
-      (a) ``manifest.json`` lists ``store/uuid.go`` in ``fix_leftover_untracked``;
-      (b) the orphan still EXISTS in the tree (no risk of deleting good work);
-      (c) the run is still ``status == "partial"``.
-
-    Fails if the enumeration is removed: without (a) the orphan is invisible in
-    the archive -- the exact "half-broken tree presented as clean" gap.
-    """
+    """Real runner confines a failed fixer and archives its restore audit."""
     from daydream.runner import run
 
     _silence(monkeypatch)
@@ -1221,6 +1214,10 @@ async def test_fix_failure_enumerates_leftover_untracked_orphan_in_manifest(
     stub = _install_stub_backend(monkeypatch, multi_stack_target)
     stub.fix_partial_then_maxturns = "App.tsx"
     stub.fix_orphan_file = "store/uuid.go"
+    stub.fix_edit_line = "# retained successful fix\n"
+    scratch = multi_stack_target / "owner-scratch.bin"
+    scratch.write_bytes(b"\x00owner-original")
+    stub.fix_damage_protected_file = "owner-scratch.bin"
     stub.merge_items = [
         _merge_item(1, "api.py", "high"),
         _merge_item(2, "App.tsx", "high"),
@@ -1237,17 +1234,26 @@ async def test_fix_failure_enumerates_leftover_untracked_orphan_in_manifest(
     )
     assert exit_code == 1
 
-    # (b) the unattributable orphan is preserved, never deleted.
-    assert (multi_stack_target / "store" / "uuid.go").exists()
+    # The successful group remains while the failed group's outside-run write
+    # is removed and the user's protected untracked file is restored exactly.
+    assert "# retained successful fix" in (multi_stack_target / "api.py").read_text()
+    assert not (multi_stack_target / "store" / "uuid.go").exists()
+    assert scratch.read_bytes() == b"\x00owner-original"
 
     run_dirs = list((archive_dir / "runs").iterdir())
     assert len(run_dirs) == 1, f"expected exactly one archived run, got {run_dirs}"
     manifest = json.loads((run_dirs[0] / "manifest.json").read_text(encoding="utf-8"))
-    # (c) partial, and (a) the orphan is enumerated for audit.
+    # The archive is partial, but there is no surviving leftover.  The durable
+    # policy audit records both confinement operations.
     assert manifest["status"] == "partial"
-    leftover = manifest["fix_leftover_untracked"]
-    assert leftover, "manifest must enumerate untracked files left by the failed fix pass"
-    assert "store/uuid.go" in leftover
+    assert manifest["fix_leftover_untracked"] is None
+    run_audit = json.loads((run_dirs[0] / "deep" / "fix-footprint.json").read_text())
+    restored = {
+        event["path"]
+        for event in run_audit["events"]
+        if event["action"] in {"remove", "restore"}
+    }
+    assert {"store/uuid.go", "owner-scratch.bin"} <= restored
 
 
 # Issue #315: the fix-phase stub appends a duplicated if/else branch to the
@@ -10566,6 +10572,7 @@ def test_retained_tree_uses_full_delta_identity_but_authorized_patch(tmp_path: P
         stable_head=git_ops.head_sha(repo),
         initial_index=index,
         preexisting_untracked=protected,
+        preexisting_gitlinks=(),
         footprint=footprint,
     )
     (repo / "a.py").write_text("A = 2\n")
@@ -10587,6 +10594,61 @@ def test_retained_tree_uses_full_delta_identity_but_authorized_patch(tmp_path: P
     assert first.paths == second.paths == frozenset({"a.py"})
     assert b"c.py" not in second.recommended_patch
     assert first.tree_key != second.tree_key
+
+
+def test_retained_tree_includes_preexisting_authorized_head_delta(tmp_path: Path) -> None:
+    """Commit selection is HEAD-relative even though evidence stays run-relative."""
+    from daydream import git_ops
+    from daydream.deep.orchestrator import FixCycleState, capture_retained_tree
+    from daydream.fix_footprint import AuthorizedFixFootprint
+    from daydream.workspace import WorkContext
+
+    repo = tmp_path / "preexisting-retained"
+    _init_repo(repo)
+    (repo / "a.py").write_text("A = 1\n")
+    (repo / "b.py").write_text("B = 1\n")
+    _git(repo, "add", ".")
+    _commit(repo, "base")
+    head = git_ops.head_sha(repo)
+
+    # This reviewed edit predates the fix gate and is therefore part of the
+    # stable rollback snapshot, but it still belongs in the eventual commit.
+    (repo / "a.py").write_text("A = 2\n")
+    stable_ref = git_ops.stash_create(repo) or head
+    item = {
+        "id": 1,
+        "item_uid": "item:1",
+        "file": "b.py",
+        "related_files": ["a.py"],
+    }
+    footprint = AuthorizedFixFootprint.build(repo, {"a.py"}, [item])
+    state = FixCycleState(
+        session_id="s",
+        stable_ref=stable_ref,
+        stable_head=head,
+        initial_index=git_ops.snapshot_index(repo),
+        preexisting_untracked={},
+        preexisting_gitlinks=(),
+        footprint=footprint,
+    )
+    (repo / "b.py").write_text("B = 2\n")
+    work = WorkContext(
+        repo=repo,
+        source=repo,
+        base_branch="main",
+        base_sha=head,
+        head_branch="main",
+        head_sha=head,
+        is_ephemeral=False,
+        run_id="s",
+    )
+
+    snapshot = capture_retained_tree(work, state)
+
+    assert snapshot.paths == frozenset({"a.py", "b.py"})
+    assert {path.path for path in snapshot.states} == {"a.py", "b.py"}
+    assert b"a.py" in snapshot.recommended_patch
+    assert b"b.py" in snapshot.recommended_patch
 
 
 def _direct_fix_context(
@@ -10644,6 +10706,7 @@ def _direct_fix_state(ctx: Any, items: list[dict[str, Any]], reviewed: set[str])
         preexisting_untracked=git_ops.snapshot_untracked_paths(
             ctx.work.repo, include_runtime_artifacts=False
         ),
+        preexisting_gitlinks=git_ops.snapshot_worktree_gitlinks(ctx.work.repo),
         footprint=footprint,
     )
     ctx.data["fix_cycle_state"] = state
@@ -10812,6 +10875,72 @@ async def test_post_heal_actionable_verifier_stops_without_test_or_stage(
     failure = json.loads((ctx.data["dd"] / "stabilization-failed.json").read_text())
     assert failure["session_id"] == state.session_id
     assert "actionable" in failure["reason"]
+    from daydream.archive.pipeline import derive_phase_states, derive_pipeline_status
+
+    phase_states = derive_phase_states(
+        ctx.work.repo, phase_events=[], session_id=state.session_id
+    )
+    assert phase_states["fix"]["status"] == "failed"
+    assert phase_states["test"]["status"] == "failed"
+    assert derive_pipeline_status(
+        "complete", None, phase_states, runs_fix=True, runs_test=True
+    ) == "failed"
+
+
+@pytest.mark.parametrize("terminal_mode", ["red", "exception"])
+async def test_terminal_red_after_heal_restores_unrelated_and_protected_state(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, terminal_mode: str
+) -> None:
+    """A healer's red/exception exit is confined like a successful path."""
+    from daydream import git_ops
+    from daydream.deep.orchestrator import _step_test
+    from daydream.extensions import Stop
+    from daydream.phases import TestAndHealResult, TestAttemptEvidence
+
+    repo = tmp_path / "red-heal-confinement"
+    _init_repo(repo)
+    (repo / "a.py").write_text("A = 1\n")
+    (repo / "unrelated.py").write_text("OWNER = 1\n")
+    _git(repo, "add", ".")
+    _commit(repo, "base")
+    scratch = repo / "scratch.bin"
+    scratch.write_bytes(b"\x00owner")
+    items = [{**_merge_item(1, "a.py", "high"), "item_uid": "item:a"}]
+    ctx = _direct_fix_context(repo, items, changed_files={"a.py"})
+    state = _direct_fix_state(ctx, items, {"a.py"})
+
+    async def _red_after_mutation(*_a: Any, **_k: Any) -> TestAndHealResult:
+        (repo / "a.py").write_text("A = 2\n")
+        (repo / "unrelated.py").write_text("OWNER = 9\n")
+        scratch.unlink()
+        (repo / "orphan.txt").write_text("outside\n")
+        if terminal_mode == "exception":
+            raise RuntimeError("healer transport failed after writing")
+        key = "red-tree"
+        attempt = TestAttemptEvidence(
+            session_id=state.session_id,
+            kind="host",
+            command=("false",),
+            passed=False,
+            input_tree_key=key,
+            output_tree_key=key,
+        )
+        return TestAndHealResult(False, 1, False, False, (attempt,))
+
+    monkeypatch.setattr(
+        "daydream.deep.orchestrator.phase_test_and_heal", _red_after_mutation
+    )
+    result = await _step_test(ctx)
+
+    assert isinstance(result, Stop) and result.exit_code == 1
+    assert (repo / "a.py").read_text() == "A = 2\n"
+    assert (repo / "unrelated.py").read_text() == "OWNER = 1\n"
+    assert scratch.read_bytes() == b"\x00owner"
+    assert not (repo / "orphan.txt").exists()
+    audit = json.loads((ctx.data["dd"] / "fix-footprint.json").read_text())
+    events = {(event["action"], event["path"]) for event in audit["events"]}
+    assert {("restore", "unrelated.py"), ("restore", "scratch.bin"), ("remove", "orphan.txt")} <= events
+    assert git_ops.snapshot_index(repo) == state.initial_index
 
 
 @pytest.mark.parametrize("failure_mode", ["pass2_mutates", "unstable_test"])
@@ -10874,6 +11003,16 @@ async def test_stabilization_stops_after_two_passes_without_third_or_heal(
     assert test_calls == 1
     assert state.latest_retained is None
     assert (ctx.data["dd"] / "stabilization-failed.json").is_file()
+    from daydream.archive.pipeline import derive_phase_states, derive_pipeline_status
+
+    phase_states = derive_phase_states(
+        ctx.work.repo, phase_events=[], session_id=state.session_id
+    )
+    assert phase_states["fix"]["status"] == "failed"
+    assert phase_states["test"]["status"] == "failed"
+    assert derive_pipeline_status(
+        "complete", None, phase_states, runs_fix=True, runs_test=True
+    ) == "failed"
 
 
 async def test_stabilization_audit_write_failure_stops_before_retest(

--- a/tests/test_deep_orchestrator.py
+++ b/tests/test_deep_orchestrator.py
@@ -11004,11 +11004,16 @@ def test_final_red_override_requires_fresh_interactive_prompt(
     from daydream.deep.orchestrator import _authorize_final_red_override
 
     prompts: list[dict[str, Any]] = []
+
+    def accept_prompt(**kwargs: Any) -> bool:
+        prompts.append(kwargs)
+        return True
+
     monkeypatch.setattr("daydream.deep.orchestrator.get_assume", lambda: None)
     monkeypatch.setattr("daydream.deep.orchestrator.get_non_interactive", lambda: False)
     monkeypatch.setattr(
         "daydream.deep.orchestrator.resolve_or_prompt",
-        lambda **kwargs: prompts.append(kwargs) or True,
+        accept_prompt,
     )
 
     assert _authorize_final_red_override() is True

--- a/tests/test_deep_orchestrator.py
+++ b/tests/test_deep_orchestrator.py
@@ -953,7 +953,9 @@ async def test_fix_verify_wrong_target_retargets_within_scope(
     _force_interactive(monkeypatch)
     mute_side_effects()
     stub = _install_stub_backend(monkeypatch, multi_stack_target)
-    stub.merge_items = [_merge_item(1, "api.py", "high")]
+    item = _merge_item(1, "api.py", "high")
+    item["related_files"] = ["App.tsx"]
+    stub.merge_items = [item]
     # round 1 verifier says: defect really lives in App.tsx
     stub.fix_verify_verdicts = {1: {"issue_id": 1, "verdict": "wrong_target",
                                     "path": "App.tsx", "reason": "moved"}}
@@ -965,8 +967,18 @@ async def test_fix_verify_wrong_target_retargets_within_scope(
     assert exit_code == 0
     outcomes = json.loads((multi_stack_target / ".daydream" / "deep" / "fix-outcomes.json").read_text())
     assert outcomes["outcomes"]["item:1"]["verdict"] == "resolved"
+    assert outcomes["outcomes"]["item:1"]["path"] == "App.tsx"
     audit = json.loads((multi_stack_target / ".daydream/deep/fix-footprint.json").read_text())
-    assert any(event["action"] == "rejected_retarget" for event in audit["events"])
+    accepted = [
+        event
+        for event in audit["events"]
+        if event["action"] == "authorize" and event["origin"] == "retarget"
+    ]
+    assert len(accepted) == 1
+    assert accepted[0]["path"] == "App.tsx"
+    assert accepted[0]["item_uid"] == "item:1"
+    assert accepted[0]["round_number"] == 2
+    assert audit["policy_revision"] == 1
 
 
 async def test_unresolved_finding_reported_attempted_not_fixed(
@@ -1126,23 +1138,17 @@ async def test_fix_failure_reverts_partial_edit_and_marks_manifest_partial(
     assert any("App.tsx" in key for key in manifest["fix_failures"])
 
 
-async def test_fix_preflight_unconfined_finding_runs_recovery_and_names_item(
+async def test_fix_preflight_unconfined_finding_archives_blocked_item_identities(
     multi_stack_target: Path,
     monkeypatch: pytest.MonkeyPatch,
     archive_dir: Path,
     make_config: MakeConfig,
     mute_side_effects: Mute,
 ) -> None:
-    """A symlink-escape finding in the fix cycle is handled, not raised.
+    """Footprint preflight blocks unsafe paths before fixing and records why.
 
-    The ``src/handler.py`` finding is confined *lexically* (so it passes the
-    ``_step_fix_gate`` changed_files partition) but escapes via a symlink, so
-    ``phase_fix_parallel``'s preflight raises ``UnconfinedFindingError``. The
-    guarded
-    caller must run the recovery machinery, avoid creating the fix-group
-    sentinel for the aborted group, archive ``recommended.patch``, mark the run
-    partial, name the offending item, and return ``Stop(1)`` (exit 1) rather
-    than let the exception reach cli.py's generic handler.
+    The durable failure names blocked canonical item identities without
+    reflecting an unsafe model path. No fixer or unconfined patch read runs.
     """
     from daydream.runner import run
 
@@ -1180,20 +1186,22 @@ async def test_fix_preflight_unconfined_finding_runs_recovery_and_names_item(
     )
     assert exit_code == 1  # handled failure => Stop(1), not a raise
 
-    # (a) recovery ran: the archived run is partial and records the failure,
-    #     and the recommendation patch survives.
+    # The admitted evidence session records the blocked findings in archive.
     run_dirs = list((archive_dir / "runs").iterdir())
     assert len(run_dirs) == 1, f"expected exactly one archived run, got {run_dirs}"
     manifest = json.loads((run_dirs[0] / "manifest.json").read_text(encoding="utf-8"))
-    assert manifest["status"] == "complete"
-    assert not manifest["fix_failures"]
+    assert manifest["status"] == "partial"
+    items = _merged_items(multi_stack_target / ".daydream" / "deep")
+    assert set(manifest["fix_failures"]) == {item["item_uid"] for item in items}
+    assert set(manifest["fix_failures"].values()) == {"fix_preflight_rejected: fix cycle did not start"}
+    assert manifest["pipeline_status"] == "partial"
     assert manifest["phase_states"]["test"] == {"ran": False, "status": "absent"}
 
     # (b) no dangling pre-fix stash / tree restored: the symlink finding's
     #     group never got a fix applied (preflight aborts before dispatch).
     assert not (multi_stack_target / ".fixed-src_handler_py").exists()
 
-    # (c) the CLI output names the offending item by id and/or file ref.
+    # Unsafe path values are not reflected into diagnostics.
     assert not any("src/handler.py" in warning for warning in warnings)
 
 
@@ -10753,6 +10761,103 @@ def test_fix_cycle_round_two_rejects_cross_item_retarget(tmp_path: Path) -> None
     assert rejected[0].round_number == 2
 
 
+def test_fix_cycle_tracks_last_dispatched_target_after_accepted_then_rejected_retarget(
+    tmp_path: Path,
+) -> None:
+    from daydream.deep.orchestrator import _round_dispatch_items
+
+    repo = tmp_path / "accepted-then-rejected-retarget"
+    _init_repo(repo)
+    for path in ("a.py", "b.py", "c.py"):
+        (repo / path).write_text(f"# {path}\n")
+    _git(repo, "add", ".")
+    _commit(repo, "base")
+    items = [
+        {**_merge_item(1, "a.py", "high"), "item_uid": "item:a", "related_files": ["b.py"]},
+        {**_merge_item(2, "c.py", "high"), "item_uid": "item:c", "related_files": []},
+    ]
+    ctx = _direct_fix_context(repo, items, changed_files={"a.py", "c.py"})
+    state = _direct_fix_state(ctx, items, {"a.py", "c.py"})
+
+    ctx.data["iteration"] = 1
+    assert [item["file"] for item in _round_dispatch_items(ctx, items)] == ["a.py", "c.py"]
+    assert state.last_fix_target_by_uid == {"item:a": "a.py", "item:c": "c.py"}
+
+    ctx.data["iteration"] = 2
+    ctx.data["fix_outcomes"] = {
+        "item:a": {"issue_id": 1, "verdict": "wrong_target", "path": "b.py", "reason": "moved"}
+    }
+    assert [item["file"] for item in _round_dispatch_items(ctx, items)] == ["b.py"]
+    assert state.last_fix_target_by_uid["item:a"] == "b.py"
+
+    ctx.data["iteration"] = 3
+    ctx.data["fix_outcomes"] = {
+        "item:a": {
+            "issue_id": 1,
+            "verdict": "wrong_target",
+            "path": "c.py",
+            "reason": "other item",
+        }
+    }
+    assert [item["file"] for item in _round_dispatch_items(ctx, items)] == ["a.py"]
+    assert state.last_fix_target_by_uid["item:a"] == "a.py"
+
+
+async def test_resolved_verdict_uses_last_dispatched_target_not_raw_verifier_candidate(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from daydream.deep.orchestrator import RetainedTreeSnapshot, verify_retained_tree
+    from tests.harness.backend import ScriptedBackend
+
+    repo = tmp_path / "resolved-target-provenance"
+    _init_repo(repo)
+    for path in ("a.py", "b.py", "untrusted.py"):
+        (repo / path).write_text(f"# {path}\n")
+    _git(repo, "add", ".")
+    _commit(repo, "base")
+    item = {
+        **_merge_item(1, "a.py", "high"),
+        "item_uid": "item:a",
+        "related_files": ["b.py"],
+    }
+    ctx = _direct_fix_context(repo, [item], changed_files={"a.py"})
+    state = _direct_fix_state(ctx, [item], {"a.py"})
+    state.last_fix_target_by_uid["item:a"] = "b.py"
+    snapshot = RetainedTreeSnapshot(
+        paths=frozenset(),
+        states=(),
+        tree_key="tree",
+        verifier_patch="patch",
+        recommended_patch=b"patch",
+    )
+
+    backend = ScriptedBackend(
+        events=[
+            ResultEvent(
+                structured_output={
+                    "verdicts": [
+                        {
+                            "issue_id": 1,
+                            "verdict": "resolved",
+                            "path": "untrusted.py",
+                            "reason": "model candidate must not become provenance",
+                        }
+                    ]
+                },
+                continuation=None,
+            )
+        ]
+    )
+    monkeypatch.setattr("daydream.runner._resolve_backend", lambda *_a, **_k: backend)
+
+    outcomes = await verify_retained_tree(ctx, snapshot, [item], pass_number=2)
+
+    assert backend.call_count == 1
+    assert backend.read_only_calls == [True]
+    assert outcomes["item:a"]["path"] == "b.py"
+
+
 def _finalization_fixture(tmp_path: Path) -> tuple[Any, Any, Any]:
     from daydream.deep.orchestrator import capture_retained_tree
 
@@ -11106,10 +11211,12 @@ def test_final_red_override_requires_fresh_interactive_prompt(
     assert len(prompts) == 1
 
 
+@pytest.mark.parametrize("new_file_permissions", [0o600, 0o644])
 async def test_related_regression_real_runner_stabilizes_and_commits(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     make_config: MakeConfig,
+    new_file_permissions: int,
 ) -> None:
     """Real host-test/Git path retains A/B/T and restores C + user scratch."""
     from daydream.runner import run
@@ -11130,6 +11237,7 @@ async def test_related_regression_real_runner_stabilizes_and_commits(
     scratch_one = repo / "scratch-one.bin"
     scratch_two = repo / "scratch-two.txt"
     scratch_one.write_bytes(b"\x00owner-one")
+    scratch_one.chmod(0o600)
     scratch_two.write_text("owner-two\n")
     deep = repo / ".daydream" / "deep"
     item = {
@@ -11176,6 +11284,7 @@ async def test_related_regression_real_runner_stabilizes_and_commits(
                         "assert (root / 'api.py').read_text() == 'A = 3\\n'\n"
                         "assert (root / 'sibling.py').read_text() == 'B = 7\\n'\n"
                     )
+                    (cwd / "tests/test_a.py").chmod(new_file_permissions)
                     (cwd / "other.py").write_text("C = 9\n")
                     scratch_one.write_bytes(b"damaged")
                     scratch_two.unlink()
@@ -11249,8 +11358,10 @@ async def test_related_regression_real_runner_stabilizes_and_commits(
     assert (repo / "api.py").read_text() == "A = 3\n"
     assert (repo / "sibling.py").read_text() == "B = 7\n"
     assert (repo / "tests/test_a.py").is_file()
+    assert (repo / "tests/test_a.py").stat().st_mode & 0o777 == new_file_permissions
     assert (repo / "other.py").read_text() == "C = 1\n"
     assert scratch_one.read_bytes() == b"\x00owner-one"
+    assert scratch_one.stat().st_mode & 0o777 == 0o600
     assert scratch_two.read_text() == "owner-two\n"
     assert set(_git(repo, "show", "--pretty=", "--name-only", "HEAD").splitlines()) == {
         "api.py", "sibling.py", "tests/test_a.py"

--- a/tests/test_deep_prompts.py
+++ b/tests/test_deep_prompts.py
@@ -2077,3 +2077,20 @@ def test_registry_diagram_prompt_override_accepts_inline_kwargs(tmp_path: Path) 
         schema={"type": "object", "properties": {}},
     )
     assert isinstance(prompt, str)
+
+
+def test_fix_verify_prompt_audits_complete_retained_patch_and_all_findings(tmp_path: Path) -> None:
+    """The compatible prompt contract is stage-neutral and final-tree aware."""
+    from daydream.deep.prompts import build_fix_verify_prompt
+
+    prompt = build_fix_verify_prompt(
+        items=[{"id": 1, "description": "fix it", "file": "a.py", "line": 1}],
+        changed_hunks="diff --git a/a.py b/a.py\n",
+        cwd=tmp_path,
+        round_number=2,
+    )
+
+    assert "complete current retained patch" in prompt
+    assert "all canonical findings" in prompt
+    assert "round's changed hunks ONLY" not in prompt
+    assert "findings the round dispatched" not in prompt

--- a/tests/test_fix_footprint.py
+++ b/tests/test_fix_footprint.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 import json
 import os
+import shutil
 import stat
 import subprocess
+from collections.abc import AsyncGenerator
 from pathlib import Path
 
 import pytest
@@ -46,6 +48,76 @@ def _seed(repo: Path, files: dict[str, bytes]) -> None:
         path.write_bytes(content)
     _git(repo, "add", ".")
     _commit(repo, "seed footprint files")
+
+
+def _install_scope_boundary_shims(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    fail_diff_path: str | None = None,
+    watched_paths: tuple[str, ...] = (),
+    fail_issue_create: bool = False,
+) -> Path:
+    """Install executable Git/gh fakes while leaving production subprocess calls intact."""
+    real_git = shutil.which("git")
+    assert real_git is not None
+    bin_dir = tmp_path / "scope-bin"
+    bin_dir.mkdir()
+    git_script = bin_dir / "git"
+    git_script.write_text(
+        "#!/bin/sh\n"
+        + (
+            f'if [ "$1" = "diff" ] && [ "$2" = "HEAD" ] && [ "$3" = "--" ] '
+            f'&& [ "$4" = "{fail_diff_path}" ]; then\n'
+            '  echo "SECRET_TOKEN optional evidence failure" >&2\n'
+            "  exit 2\n"
+            "fi\n"
+            if fail_diff_path is not None
+            else ""
+        )
+        + f'exec "{real_git}" "$@"\n',
+        encoding="utf-8",
+    )
+    git_script.chmod(0o755)
+
+    record_path = tmp_path / "gh-calls.jsonl"
+    gh_script = bin_dir / "gh"
+    gh_script.write_text(
+        """#!/usr/bin/env python3
+import json
+import os
+from pathlib import Path
+import sys
+
+argv = sys.argv[1:]
+if argv[:2] == ["issue", "list"]:
+    print("[]")
+    raise SystemExit(0)
+if argv[:2] != ["issue", "create"]:
+    print("unexpected gh invocation", file=sys.stderr)
+    raise SystemExit(2)
+body_path = Path(argv[argv.index("--body-file") + 1])
+watched = {
+    name: (Path.cwd() / name).read_bytes().hex()
+    for name in json.loads(os.environ["P01_GH_WATCHED"])
+}
+record = {"argv": argv, "body": body_path.read_text(), "watched": watched}
+with Path(os.environ["P01_GH_RECORD"]).open("a") as stream:
+    stream.write(json.dumps(record) + "\\n")
+if os.environ.get("P01_GH_FAIL") == "1":
+    print("offline", file=sys.stderr)
+    raise SystemExit(1)
+print("https://example.invalid/issues/1")
+""",
+        encoding="utf-8",
+    )
+    gh_script.chmod(0o755)
+    monkeypatch.setenv("PATH", f"{bin_dir}{os.pathsep}{os.environ['PATH']}")
+    monkeypatch.setenv("P01_GH_RECORD", str(record_path))
+    monkeypatch.setenv("P01_GH_WATCHED", json.dumps(watched_paths))
+    if fail_issue_create:
+        monkeypatch.setenv("P01_GH_FAIL", "1")
+    return record_path
 
 
 def _items() -> list[dict[str, object]]:
@@ -133,6 +205,72 @@ def test_footprint_uses_item_uids_and_exact_item_group_and_run_unions(tmp_path: 
     assert ("reviewed", "README.md", None) in actions
     assert ("primary", "src/a.py", "item:1") in actions
     assert ("related", "tests/test_a.py", "item:1") in actions
+
+
+def test_accepted_retarget_is_audited_without_widening_policy(tmp_path: Path) -> None:
+    footprint = AuthorizedFixFootprint.build(tmp_path, {"src/a.py"}, _items())
+    revision = footprint.policy_revision
+    run_scope = footprint.run_allowed_paths
+    item_scope = footprint.item_paths("item:1")
+    event_count = len(footprint.events)
+
+    accepted = footprint.accept_retarget(
+        tmp_path,
+        "item:1",
+        "tests/test_a.py",
+        phase="fix",
+        round_number=2,
+    )
+
+    assert accepted == "tests/test_a.py"
+    assert footprint.policy_revision == revision
+    assert footprint.run_allowed_paths == run_scope
+    assert footprint.item_paths("item:1") == item_scope
+    assert len(footprint.events) == event_count + 1
+    event = footprint.events[-1]
+    assert event.action == "authorize"
+    assert event.origin == "retarget"
+    assert event.path_kind == "model"
+    assert event.path == "tests/test_a.py"
+    assert event.item_uid == "item:1"
+    assert event.phase == "fix"
+    assert event.round_number == 2
+
+
+@pytest.mark.parametrize("reviewed_path", ["odd\nname.py", "literal-$(value)[1].py", "native-\udcff.py"])
+def test_footprint_treats_reviewed_git_names_separately_from_model_paths(
+    git_repo: Path, reviewed_path: str,
+) -> None:
+    import errno
+
+    try:
+        _seed(git_repo, {reviewed_path: b"before\n", "normal.py": b"before\n"})
+    except OSError as exc:
+        if exc.errno == errno.EILSEQ:
+            pytest.skip("host filesystem rejects non-UTF-8 filenames; exercised on Linux CI")
+        raise
+    (git_repo / reviewed_path).write_bytes(b"reviewed\n")
+    reviewed = set(git_ops.changed_paths_z(git_repo, "HEAD"))
+    assert reviewed == {reviewed_path}
+    item = {"item_uid": "item:normal", "file": "normal.py"}
+
+    footprint = AuthorizedFixFootprint.build(git_repo, reviewed, [item])
+
+    assert footprint.run_allowed_paths == frozenset({reviewed_path, "normal.py"})
+    assert footprint.group_paths([item]) == frozenset({"normal.py"})
+    reviewed_event = next(event for event in footprint.events if event.origin == "reviewed")
+    assert reviewed_event.path == reviewed_path
+    assert reviewed_event.path_kind == "git"
+    assert footprint.accept_retarget(
+        git_repo, "item:normal", reviewed_path, phase="fix", round_number=1,
+    ) is None
+    assert json.loads(json.dumps(footprint.audit_payload("run")))["run_allowed_paths"]
+
+
+@pytest.mark.parametrize("reviewed_path", ["", ".", "/outside", "../outside", "src/../outside", "src//a.py"])
+def test_footprint_rejects_unconfined_reviewed_git_paths(tmp_path: Path, reviewed_path: str) -> None:
+    with pytest.raises(InvalidRepositoryFilePath, match="invalid reviewed repository path"):
+        AuthorizedFixFootprint.build(tmp_path, {reviewed_path}, [])
 
 
 @pytest.mark.parametrize(
@@ -367,6 +505,332 @@ def test_group_rollback_restores_all_paths_untracked_and_supplied_index(git_repo
     assert (git_repo / "round-scratch").read_bytes() == b"scratch baseline"
     assert stat.S_IMODE((git_repo / "round-scratch").stat().st_mode) == 0o600
     assert git_ops.snapshot_index(git_repo) == snapshot.index
+
+
+def test_group_worktree_rollback_preserves_sibling_index_entry(git_repo: Path) -> None:
+    _seed(git_repo, {"a.py": b"A = 1\n", "b.py": b"B = 1\n"})
+    snapshot = WorktreeRollbackSnapshot(
+        ref="HEAD",
+        index=git_ops.snapshot_index(git_repo),
+        path_states=git_ops.snapshot_worktree_paths(git_repo, ["a.py"]),
+        untracked={},
+    )
+    (git_repo / "a.py").write_bytes(b"A = partial\n")
+    (git_repo / "b.py").write_bytes(b"B = sibling\n")
+    _git(git_repo, "add", "b.py")
+    sibling_index = git_ops.snapshot_index(git_repo)
+
+    git_ops.restore_group_worktree_from_snapshot(git_repo, snapshot, ["a.py"])
+
+    assert (git_repo / "a.py").read_bytes() == b"A = 1\n"
+    assert (git_repo / "b.py").read_bytes() == b"B = sibling\n"
+    assert git_ops.snapshot_index(git_repo) == sibling_index
+
+
+def test_scope_issue_diff_failure_still_restores_and_audits_without_sensitive_warning(
+    git_repo: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _seed(git_repo, {"allowed.py": b"allowed\n", "outside.py": b"owner\n"})
+    footprint = AuthorizedFixFootprint.build(git_repo, {"allowed.py"}, [])
+    index_before = git_ops.snapshot_index(git_repo)
+    (git_repo / "outside.py").write_bytes(b"unauthorized\n")
+    gh_record = _install_scope_boundary_shims(
+        tmp_path,
+        monkeypatch,
+        fail_diff_path="outside.py",
+        watched_paths=("outside.py",),
+    )
+
+    result = enforce_authorized_fix_footprint(
+        _work(git_repo),
+        "HEAD",
+        footprint,
+        preexisting_untracked={},
+        phase="fix",
+        round_number=1,
+        file_scope_issues=True,
+    )
+
+    assert result.mutated is True
+    assert (git_repo / "outside.py").read_bytes() == b"owner\n"
+    assert git_ops.snapshot_index(git_repo) == index_before
+    assert not gh_record.exists()
+    assert [(event.action, event.path) for event in footprint.events][-1] == (
+        "restore",
+        "outside.py",
+    )
+    warning_output = capsys.readouterr().out
+    assert "continuing to" in warning_output
+    assert "restoration without filing" in warning_output
+    assert "SECRET_TOKEN" not in warning_output
+    assert "outside.py" not in warning_output
+
+
+def test_scope_issue_diff_failure_skips_only_that_filing_after_restoring_all_residuals(
+    git_repo: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _seed(
+        git_repo,
+        {"allowed.py": b"allowed\n", "outside-a.py": b"owner a\n", "outside-b.py": b"owner b\n"},
+    )
+    footprint = AuthorizedFixFootprint.build(git_repo, {"allowed.py"}, [])
+    (git_repo / "outside-a.py").write_bytes(b"unauthorized a\n")
+    (git_repo / "outside-b.py").write_bytes(b"unauthorized b\n")
+    gh_record = _install_scope_boundary_shims(
+        tmp_path,
+        monkeypatch,
+        fail_diff_path="outside-a.py",
+        watched_paths=("outside-a.py", "outside-b.py"),
+    )
+
+    result = enforce_authorized_fix_footprint(
+        _work(git_repo),
+        "HEAD",
+        footprint,
+        preexisting_untracked={},
+        phase="fix",
+        round_number=1,
+        file_scope_issues=True,
+    )
+
+    assert result.mutated is True
+    assert (git_repo / "outside-a.py").read_bytes() == b"owner a\n"
+    assert (git_repo / "outside-b.py").read_bytes() == b"owner b\n"
+    calls = [json.loads(line) for line in gh_record.read_text().splitlines()]
+    assert len(calls) == 1
+    assert calls[0]["watched"] == {
+        "outside-a.py": b"owner a\n".hex(),
+        "outside-b.py": b"owner b\n".hex(),
+    }
+    assert "outside-b.py" in calls[0]["body"]
+    assert "+unauthorized b" in calls[0]["body"]
+    assert "outside-a.py" not in calls[0]["body"]
+
+
+def test_scope_issue_filing_failure_occurs_after_verified_restore_and_is_best_effort(
+    git_repo: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _seed(git_repo, {"allowed.py": b"allowed\n", "outside.py": b"owner\n"})
+    footprint = AuthorizedFixFootprint.build(git_repo, {"allowed.py"}, [])
+    (git_repo / "outside.py").write_bytes(b"unauthorized\n")
+    gh_record = _install_scope_boundary_shims(
+        tmp_path,
+        monkeypatch,
+        watched_paths=("outside.py",),
+        fail_issue_create=True,
+    )
+
+    result = enforce_authorized_fix_footprint(
+        _work(git_repo),
+        "HEAD",
+        footprint,
+        preexisting_untracked={},
+        phase="fix",
+        round_number=1,
+        file_scope_issues=True,
+    )
+
+    assert result.mutated is True
+    assert (git_repo / "outside.py").read_bytes() == b"owner\n"
+    calls = [json.loads(line) for line in gh_record.read_text().splitlines()]
+    assert len(calls) == 1
+    assert calls[0]["watched"] == {"outside.py": b"owner\n".hex()}
+    assert "+unauthorized" in calls[0]["body"]
+
+
+@pytest.mark.asyncio
+async def test_parallel_group_fallback_never_restores_index_while_sibling_is_live(
+    git_repo: Path,
+) -> None:
+    """Real fix dispatch uses a join barrier before the one complete index restore."""
+    import anyio
+
+    from daydream.backends import AgentEvent, ResultEvent
+    from daydream.fix_footprint import AuthorizedFixFootprint
+    from daydream.phases import phase_fix_parallel
+
+    _seed(git_repo, {"a.py": b"A = 1\n", "b.py": b"B = 1\n"})
+    round_index = git_ops.snapshot_index(git_repo)
+    snapshot = WorktreeRollbackSnapshot(
+        ref="HEAD",
+        index=round_index,
+        path_states=git_ops.snapshot_worktree_paths(git_repo, ["a.py", "b.py"]),
+        untracked={},
+    )
+    items = [
+        {"id": 1, "item_uid": "item:a1", "file": "a.py", "description": "a one"},
+        {"id": 2, "item_uid": "item:a2", "file": "a.py", "description": "a two"},
+        {"id": 3, "item_uid": "item:b1", "file": "b.py", "description": "b one"},
+        {"id": 4, "item_uid": "item:b2", "file": "b.py", "description": "b two"},
+    ]
+    footprint = AuthorizedFixFootprint.build(git_repo, {"a.py", "b.py"}, items)
+    b_staged = anyio.Event()
+    a_fallback_started = anyio.Event()
+    b_observed_sibling_index = anyio.Event()
+
+    class BarrierBackend:
+        model = "barrier-backend"
+        fanout_concurrency = 2
+        retry_attempts = 0
+
+        def __init__(self) -> None:
+            self.a_fallback_calls = 0
+            self.prompts: list[str] = []
+            self.b_cached_while_live = ""
+
+        async def execute(
+            self,
+            cwd: Path,
+            prompt: str,
+            output_schema: object = None,
+            continuation: object = None,
+            agents: object = None,
+            max_turns: int | None = None,
+            read_only: bool = False,
+            persist_session: bool = True,
+        ) -> AsyncGenerator[AgentEvent, None]:
+            del output_schema, continuation, agents, max_turns, read_only, persist_session
+            self.prompts.append(prompt)
+            if prompt.startswith("Fix these 2 issues") and "b one" in prompt:
+                (cwd / "b.py").write_bytes(b"B = sibling\n")
+                _git(cwd, "add", "b.py")
+                b_staged.set()
+                await a_fallback_started.wait()
+                self.b_cached_while_live = _git(cwd, "diff", "--cached", "--name-only")
+                b_observed_sibling_index.set()
+            elif prompt.startswith("Fix these 2 issues") and "a one" in prompt:
+                await b_staged.wait()
+                (cwd / "a.py").write_bytes(b"A = partial\n")
+                raise RuntimeError("force batch fallback")
+            elif prompt.startswith("Fix this issue:") and ("a one" in prompt or "a two" in prompt):
+                self.a_fallback_calls += 1
+                (cwd / "a.py").write_bytes(b"A = fixed\n")
+                a_fallback_started.set()
+                await b_observed_sibling_index.wait()
+            yield ResultEvent(structured_output=None, continuation=None)
+
+        async def cancel(self) -> None:
+            return None
+
+    backend = BarrierBackend()
+    failures = await phase_fix_parallel(
+        backend,
+        _work(git_repo),
+        items,
+        footprint=footprint,
+        round_snapshot=snapshot,
+        limiter_size=2,
+    )
+
+    assert failures == {}
+    assert backend.a_fallback_calls == 2, backend.prompts
+    assert b_observed_sibling_index.is_set()
+    assert backend.b_cached_while_live == "b.py"
+    assert (git_repo / "a.py").read_bytes() == b"A = fixed\n"
+    assert (git_repo / "b.py").read_bytes() == b"B = sibling\n"
+    assert git_ops.snapshot_index(git_repo) == round_index
+
+
+@pytest.mark.asyncio
+async def test_parallel_fix_cancellation_closes_backend_before_restoring_round_index(
+    git_repo: Path,
+) -> None:
+    import anyio
+
+    from daydream.backends import AgentEvent, ResultEvent
+    from daydream.fix_footprint import AuthorizedFixFootprint
+    from daydream.phases import phase_fix_parallel
+
+    _seed(git_repo, {"a.py": b"A = 1\n"})
+    round_index = git_ops.snapshot_index(git_repo)
+    snapshot = WorktreeRollbackSnapshot(
+        ref="HEAD",
+        index=round_index,
+        path_states=git_ops.snapshot_worktree_paths(git_repo, ["a.py"]),
+        untracked={},
+    )
+    item = {"id": 1, "item_uid": "item:a", "file": "a.py", "description": "a"}
+    footprint = AuthorizedFixFootprint.build(git_repo, {"a.py"}, [item])
+    staged = anyio.Event()
+    stream_closed = anyio.Event()
+    never = anyio.Event()
+
+    class CancelBackend:
+        model = "cancel-backend"
+        fanout_concurrency = 1
+        retry_attempts = 0
+
+        async def execute(
+            self,
+            cwd: Path,
+            prompt: str,
+            output_schema: object = None,
+            continuation: object = None,
+            agents: object = None,
+            max_turns: int | None = None,
+            read_only: bool = False,
+            persist_session: bool = True,
+        ) -> AsyncGenerator[AgentEvent, None]:
+            del prompt, output_schema, continuation, agents, max_turns, read_only, persist_session
+            try:
+                (cwd / "a.py").write_bytes(b"A = staged by live fixer\n")
+                _git(cwd, "add", "a.py")
+                staged.set()
+                await never.wait()
+                yield ResultEvent(structured_output=None, continuation=None)
+            finally:
+                stream_closed.set()
+
+        async def cancel(self) -> None:
+            return None
+
+    async def _run_phase() -> None:
+        await phase_fix_parallel(
+            CancelBackend(),
+            _work(git_repo),
+            [item],
+            footprint=footprint,
+            round_snapshot=snapshot,
+            limiter_size=1,
+        )
+
+    async with anyio.create_task_group() as task_group:
+        task_group.start_soon(_run_phase)
+        await staged.wait()
+        task_group.cancel_scope.cancel()
+
+    assert stream_closed.is_set()
+    assert git_ops.snapshot_index(git_repo) == round_index
+
+
+@pytest.mark.asyncio
+async def test_fanout_cancellation_and_index_restore_failure_are_both_reported(
+    git_repo: Path,
+) -> None:
+    import asyncio
+
+    from daydream.phases import _restore_round_index_after_fanout
+
+    _seed(git_repo, {"a.py": b"A = 1\n"})
+    index = git_ops.snapshot_index(git_repo)
+    lock = git_repo / ".git" / "index.lock"
+
+    with pytest.raises(BaseExceptionGroup) as raised:
+        async with _restore_round_index_after_fanout(git_repo, index):
+            lock.write_bytes(b"held")
+            raise asyncio.CancelledError("primary cancellation")
+
+    lock.unlink(missing_ok=True)
+    assert len(raised.value.exceptions) == 2
+    assert isinstance(raised.value.exceptions[0], asyncio.CancelledError)
+    assert isinstance(raised.value.exceptions[1], GitError)
 
 
 def test_authorized_parent_symlink_substitution_fails_before_read_restore_or_stage(

--- a/tests/test_fix_footprint.py
+++ b/tests/test_fix_footprint.py
@@ -476,6 +476,110 @@ def test_uninitialized_gitlink_cannot_capture_parent_repository_head(git_repo: P
         git_ops.snapshot_worktree_paths(git_repo, ["dependency"])
 
 
+def _gitlink_rollback_snapshot(
+    repo: Path, path: str = "dependency"
+) -> WorktreeRollbackSnapshot:
+    return WorktreeRollbackSnapshot(
+        ref="HEAD",
+        index=git_ops.snapshot_index(repo),
+        path_states=git_ops.snapshot_worktree_paths(repo, [path]),
+        untracked=git_ops.snapshot_untracked_paths(repo),
+    )
+
+
+def test_gitlink_group_rollback_restores_captured_nested_oid(git_repo: Path) -> None:
+    nested = git_repo / "dependency"
+    init_repo(nested)
+    _seed(nested, {"source.py": b"value = 1\n"})
+    captured = _git(nested, "rev-parse", "HEAD")
+    _git(git_repo, "add", "dependency")
+    _commit(git_repo, "record dependency")
+    snapshot = _gitlink_rollback_snapshot(git_repo)
+    _seed(nested, {"source.py": b"value = 2\n"})
+    assert _git(nested, "rev-parse", "HEAD") != captured
+
+    git_ops.restore_group_from_snapshot(git_repo, snapshot, ["dependency"])
+
+    assert _git(nested, "rev-parse", "HEAD") == captured
+    assert _git(nested, "status", "--porcelain=v1", "--untracked-files=all") == ""
+
+
+def test_gitlink_group_rollback_preserves_initial_non_index_checkout(git_repo: Path) -> None:
+    nested = git_repo / "dependency"
+    init_repo(nested)
+    _seed(nested, {"source.py": b"value = 1\n"})
+    indexed = _git(nested, "rev-parse", "HEAD")
+    _git(git_repo, "add", "dependency")
+    _commit(git_repo, "record dependency")
+    _seed(nested, {"source.py": b"value = 2\n"})
+    captured = _git(nested, "rev-parse", "HEAD")
+    assert captured != indexed
+    snapshot = _gitlink_rollback_snapshot(git_repo)
+    _git(nested, "checkout", "--detach", indexed)
+
+    git_ops.restore_group_from_snapshot(git_repo, snapshot, ["dependency"])
+
+    assert _git(nested, "rev-parse", "HEAD") == captured
+    assert _git(git_repo, "status", "--porcelain=v1", "--untracked-files=all") == "M dependency"
+
+
+def test_gitlink_group_rollback_refuses_dirty_nested_tree_without_mutating_it(
+    git_repo: Path,
+) -> None:
+    nested = git_repo / "dependency"
+    init_repo(nested)
+    _seed(nested, {"source.py": b"value = 1\n"})
+    _git(git_repo, "add", "dependency")
+    _commit(git_repo, "record dependency")
+    snapshot = _gitlink_rollback_snapshot(git_repo)
+    original_head = _git(nested, "rev-parse", "HEAD")
+    (nested / "source.py").write_bytes(b"owner dirty bytes\n")
+    (git_repo / "agent-staged.txt").write_bytes(b"agent index mutation\n")
+    _git(git_repo, "add", "agent-staged.txt")
+
+    with pytest.raises(GitError, match="dirty gitlink"):
+        git_ops.restore_group_from_snapshot(git_repo, snapshot, ["dependency"])
+
+    assert _git(nested, "rev-parse", "HEAD") == original_head
+    assert (nested / "source.py").read_bytes() == b"owner dirty bytes\n"
+    assert git_ops.snapshot_index(git_repo) == snapshot.index
+    assert (git_repo / "agent-staged.txt").read_bytes() == b"agent index mutation\n"
+
+
+def test_scope_guard_restores_pre_run_non_index_gitlink_checkout(git_repo: Path) -> None:
+    nested = git_repo / "dependency"
+    init_repo(nested)
+    _seed(nested, {"source.py": b"value = 1\n"})
+    indexed = _git(nested, "rev-parse", "HEAD")
+    _git(git_repo, "add", "dependency")
+    _commit(git_repo, "record dependency")
+    _seed(nested, {"source.py": b"value = 2\n"})
+    protected = _git(nested, "rev-parse", "HEAD")
+    assert protected != indexed
+    gitlinks = git_ops.snapshot_worktree_gitlinks(git_repo)
+    footprint = AuthorizedFixFootprint.build(git_repo, set(), [])
+    _git(nested, "checkout", "--detach", indexed)
+
+    result = enforce_authorized_fix_footprint(
+        _work(git_repo),
+        "HEAD",
+        footprint,
+        preexisting_untracked={},
+        preexisting_gitlinks=gitlinks,
+        phase="terminal",
+        round_number=1,
+    )
+
+    assert result.mutated
+    assert _git(nested, "rev-parse", "HEAD") == protected
+    assert any(
+        event.action == "restore"
+        and event.path == "dependency"
+        and "gitlink" in event.reason
+        for event in footprint.events
+    )
+
+
 def test_strict_recommended_patch_contains_binary_change_and_commit_staged_does_not_restage(
     git_repo: Path
 ) -> None:

--- a/tests/test_fix_footprint.py
+++ b/tests/test_fix_footprint.py
@@ -1,0 +1,496 @@
+"""Focused contracts for the authorized fix footprint (issue #1135)."""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from daydream import git_ops
+from daydream.deep.scope_issues import enforce_authorized_fix_footprint
+from daydream.fix_footprint import AuthorizedFixFootprint
+from daydream.git_ops import GitError, WorktreeRollbackSnapshot
+from daydream.repository_paths import (
+    InvalidRepositoryFilePath,
+    canonicalize_repository_file_path,
+    git_observed_path_is_confined,
+)
+from daydream.workspace import WorkContext
+from tests.harness.git_helpers import commit as _commit
+from tests.harness.git_helpers import git as _git
+from tests.harness.git_helpers import init_repo
+
+
+def _work(repo: Path) -> WorkContext:
+    head = _git(repo, "rev-parse", "HEAD")
+    return WorkContext(
+        repo=repo,
+        source=repo,
+        base_branch="main",
+        base_sha=head,
+        head_branch="main",
+        head_sha=head,
+        is_ephemeral=False,
+        run_id="test-run",
+    )
+
+
+def _seed(repo: Path, files: dict[str, bytes]) -> None:
+    for name, content in files.items():
+        path = repo / name
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(content)
+    _git(repo, "add", ".")
+    _commit(repo, "seed footprint files")
+
+
+def _items() -> list[dict[str, object]]:
+    return [
+        {
+            "id": 1,
+            "item_uid": "item:1",
+            "file": "src/a.py",
+            "related_files": ["./src/shared.py", "tests/test_a.py"],
+        },
+        {
+            "id": 2,
+            "item_uid": "item:2",
+            "file": "src/b.py",
+            "related_files": ["src/shared.py"],
+        },
+        {
+            "id": 3,
+            "item_uid": "item:3",
+            "file": "src/c.py",
+            "related_files": None,
+        },
+    ]
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "",
+        7,
+        None,
+        "/tmp/outside",
+        "../outside",
+        "src/../outside",
+        "a\n.py",
+        "a`touch nope`",
+        "bad-\udcff.py",
+    ],
+)
+def test_model_path_normalization_rejects_malformed_and_escaping_values(
+    tmp_path: Path, value: object
+) -> None:
+    with pytest.raises(InvalidRepositoryFilePath, match="invalid repository file path"):
+        canonicalize_repository_file_path(tmp_path, value)
+
+
+def test_model_path_normalization_removes_dot_prefix_and_rejects_symlink_escape(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    outside = tmp_path / "outside"
+    repo.mkdir()
+    outside.mkdir()
+
+    assert canonicalize_repository_file_path(repo, "./src/a.py") == "src/a.py"
+
+    (repo / "src").symlink_to(outside, target_is_directory=True)
+    with pytest.raises(InvalidRepositoryFilePath, match="invalid repository file path"):
+        canonicalize_repository_file_path(repo, "src/a.py")
+
+
+def test_git_observed_confinement_accepts_non_model_names_but_rejects_escapes(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    assert git_observed_path_is_confined(repo, "odd\n$name[1].txt")
+    assert not git_observed_path_is_confined(repo, "../outside")
+    assert not git_observed_path_is_confined(repo, "/outside")
+
+
+def test_footprint_uses_item_uids_and_exact_item_group_and_run_unions(tmp_path: Path) -> None:
+    footprint = AuthorizedFixFootprint.build(tmp_path, {"README.md", "./src/a.py"}, _items())
+
+    assert footprint.item_paths("item:1") == frozenset(
+        {"src/a.py", "src/shared.py", "tests/test_a.py"}
+    )
+    assert footprint.item_paths("item:2") == frozenset({"src/b.py", "src/shared.py"})
+    assert footprint.item_paths("item:3") == frozenset({"src/c.py"})
+    assert footprint.group_paths([_items()[0], _items()[1]]) == frozenset(
+        {"src/a.py", "src/b.py", "src/shared.py", "tests/test_a.py"}
+    )
+    assert footprint.run_allowed_paths == frozenset(
+        {"README.md", "src/a.py", "src/b.py", "src/c.py", "src/shared.py", "tests/test_a.py"}
+    )
+
+    actions = [(event.origin, event.path, event.item_uid) for event in footprint.events]
+    assert ("reviewed", "README.md", None) in actions
+    assert ("primary", "src/a.py", "item:1") in actions
+    assert ("related", "tests/test_a.py", "item:1") in actions
+
+
+@pytest.mark.parametrize(
+    "related",
+    ["src/b.py", ["src/b.py", 7], ["../escape.py"], ["src/../escape.py"]],
+)
+def test_footprint_rejects_malformed_related_paths(tmp_path: Path, related: object) -> None:
+    item = {"id": 1, "item_uid": "item:1", "file": "src/a.py", "related_files": related}
+    with pytest.raises(InvalidRepositoryFilePath, match="invalid repository file path"):
+        AuthorizedFixFootprint.build(tmp_path, set(), [item])
+
+
+def test_generated_authorization_is_idempotent_and_retarget_is_item_bounded(tmp_path: Path) -> None:
+    footprint = AuthorizedFixFootprint.build(tmp_path, set(), _items())
+    initial_revision = footprint.policy_revision
+
+    footprint.authorize_new_generated(
+        tmp_path,
+        "generated/schema.py",
+        phase="generated-guard",
+        round_number=1,
+        reason="approved migration output",
+    )
+    footprint.authorize_new_generated(
+        tmp_path,
+        "./generated/schema.py",
+        phase="generated-guard",
+        round_number=2,
+        reason="same generated output observed again",
+    )
+    assert footprint.policy_revision == initial_revision + 1
+    assert sum(event.action == "approve_generated" for event in footprint.events) == 1
+
+    assert footprint.accept_retarget(
+        tmp_path, "item:1", "./tests/test_a.py", phase="verify", round_number=2
+    ) == "tests/test_a.py"
+    assert footprint.accept_retarget(
+        tmp_path, "item:1", "src/b.py", phase="verify", round_number=2
+    ) is None
+    assert footprint.item_paths("item:1") == frozenset(
+        {"src/a.py", "src/shared.py", "tests/test_a.py"}
+    )
+    rejection = footprint.events[-1]
+    assert (rejection.action, rejection.path, rejection.item_uid) == (
+        "rejected_retarget",
+        "src/b.py",
+        "item:1",
+    )
+
+
+def test_audit_payload_is_session_bound_monotonic_and_json_escapes_git_paths(tmp_path: Path) -> None:
+    footprint = AuthorizedFixFootprint.build(tmp_path, {"src/a.py"}, _items()[:1])
+    footprint.record_git_event(
+        action="remove",
+        path="odd\n$name.txt",
+        origin="guard",
+        phase="scope",
+        round_number=1,
+        reason="new untracked file",
+    )
+
+    payload = footprint.audit_payload("session-123", tree_key="abc")
+    assert payload["session_id"] == "session-123"
+    assert payload["tree_key"] == "abc"
+    sequences = [event["sequence"] for event in payload["events"]]
+    assert sequences == list(range(1, len(sequences) + 1))
+    assert "odd\\n$name.txt" in json.dumps(payload)
+
+
+def test_changed_paths_z_preserves_newline_shell_metacharacters_and_surrogate_bytes(
+    git_repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    weird = "odd\n$(not-a-command).txt"
+    (git_repo / weird).write_bytes(b"odd")
+    paths = git_ops.changed_paths_z(git_repo, "HEAD")
+    assert weird in paths
+
+    raw_name = b"invalid-\xff.txt"
+    monkeypatch.setattr(
+        git_ops,
+        "_run_git",
+        lambda *_args, **_kwargs: subprocess.CompletedProcess(
+            args=[], returncode=0, stdout=raw_name + b"\0", stderr=b""
+        ),
+    )
+    paths = git_ops.changed_paths_z(git_repo, "HEAD", include_untracked=False)
+    assert os.fsdecode(raw_name) in paths
+
+
+def test_preexisting_untracked_state_is_restored_exactly_and_new_residual_is_removed(git_repo: Path) -> None:
+    _seed(git_repo, {"allowed.txt": b"base\n", "outside.txt": b"outside base\n"})
+    scratch = git_repo / "scratch.bin"
+    scratch.write_bytes(b"\x00user-bytes\xff")
+    scratch.chmod(0o640)
+    link = git_repo / "scratch-link"
+    link.symlink_to("original-target")
+    deleted = git_repo / "scratch-deleted"
+    deleted.write_bytes(b"restore deleted bytes")
+    deleted.chmod(0o600)
+    baseline = git_ops.snapshot_untracked_paths(git_repo)
+    footprint = AuthorizedFixFootprint.build(git_repo, {"allowed.txt"}, [])
+
+    (git_repo / "allowed.txt").write_bytes(b"authorized\n")
+    scratch.unlink()
+    scratch.symlink_to("wrong-target")
+    link.unlink()
+    link.write_bytes(b"wrong type")
+    deleted.unlink()
+    (git_repo / "outside.txt").write_bytes(b"unrelated\n")
+    residual = git_repo / "odd\n$(ignored).txt"
+    residual.write_bytes(b"remove me")
+
+    result = enforce_authorized_fix_footprint(
+        _work(git_repo),
+        "HEAD",
+        footprint,
+        preexisting_untracked=baseline,
+        phase="post-fix",
+        round_number=1,
+    )
+
+    assert result.retained_paths == frozenset({"allowed.txt"})
+    assert result.mutated
+    assert scratch.read_bytes() == b"\x00user-bytes\xff"
+    assert stat.S_IMODE(scratch.stat().st_mode) == 0o640
+    assert link.is_symlink() and os.readlink(link) == "original-target"
+    assert deleted.read_bytes() == b"restore deleted bytes"
+    assert stat.S_IMODE(deleted.stat().st_mode) == 0o600
+    assert (git_repo / "outside.txt").read_bytes() == b"outside base\n"
+    assert not residual.exists()
+    recorded = {(event.action, event.path) for event in footprint.events}
+    assert ("restore", "scratch.bin") in recorded
+    assert ("restore", "scratch-link") in recorded
+    assert ("restore", "scratch-deleted") in recorded
+    assert ("restore", "outside.txt") in recorded
+    assert ("remove", "odd\n$(ignored).txt") in recorded
+
+
+def test_runtime_artifacts_do_not_enter_fix_scope_or_invalidate_content_evidence(git_repo: Path) -> None:
+    _seed(git_repo, {"allowed.txt": b"base\n"})
+    artifacts = git_repo / ".daydream" / "deep"
+    artifacts.mkdir(parents=True)
+    audit = artifacts / "fix-footprint.json"
+    audit.write_text('{"version": 1}')
+    report = git_repo / ".review-output.md"
+    report.write_text("old report")
+    scratch = git_repo / "scratch.txt"
+    scratch.write_bytes(b"user scratch")
+    protected = git_ops.snapshot_untracked_paths(git_repo, include_runtime_artifacts=False)
+    assert set(protected) == {"scratch.txt"}
+    assert ".daydream/deep/fix-footprint.json" in git_ops.changed_paths_z(git_repo, "HEAD")
+
+    before = git_ops.tree_key(git_ops.snapshot_worktree_delta(
+        git_repo, "HEAD", preexisting_untracked=protected,
+    ))
+    audit.write_text('{"version": 2}')
+    report.write_text("new report")
+    assert git_ops.tree_key(git_ops.snapshot_worktree_delta(
+        git_repo, "HEAD", preexisting_untracked=protected,
+    )) == before
+    scratch.write_bytes(b"changed scratch")
+    assert git_ops.tree_key(git_ops.snapshot_worktree_delta(
+        git_repo, "HEAD", preexisting_untracked=protected,
+    )) != before
+    footprint = AuthorizedFixFootprint.build(git_repo, {"allowed.txt"}, [])
+    result = enforce_authorized_fix_footprint(
+        _work(git_repo), "HEAD", footprint, preexisting_untracked=protected,
+        phase="post-test", round_number=1,
+    )
+    assert result.mutated
+    assert not result.retained_paths
+    assert scratch.read_bytes() == b"user scratch"
+    assert audit.read_text() == '{"version": 2}'
+    assert report.read_text() == "new report"
+    assert {event.path for event in footprint.events if event.action == "restore"} == {"scratch.txt"}
+
+
+def test_runtime_exclusion_keeps_tracked_artifacts_and_similar_user_paths_visible(git_repo: Path) -> None:
+    _seed(git_repo, {".daydream/tracked.txt": b"tracked\n"})
+    (git_repo / ".daydream/tracked.txt").write_bytes(b"changed\n")
+    for name in (".daydream.toml", ".review-output.md.user", "src/.daydream/user.txt"):
+        path = git_repo / name
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("user file")
+    expected = {".daydream/tracked.txt", ".daydream.toml", ".review-output.md.user", "src/.daydream/user.txt"}
+    assert set(git_ops.changed_paths_z(git_repo, "HEAD", include_runtime_artifacts=False)) == expected
+    protected = git_ops.snapshot_untracked_paths(git_repo, include_runtime_artifacts=False)
+    assert set(protected) == expected - {".daydream/tracked.txt"}
+
+
+def test_worktree_restore_leaves_the_index_tree_unchanged(git_repo: Path) -> None:
+    _seed(git_repo, {"tracked.txt": b"base\n"})
+    path = git_repo / "tracked.txt"
+    path.write_bytes(b"staged\n")
+    _git(git_repo, "add", "tracked.txt")
+    before = git_ops.snapshot_index(git_repo)
+    path.write_bytes(b"worktree-only\n")
+
+    git_ops.restore_worktree_paths_from_ref(git_repo, "HEAD", ["tracked.txt"])
+
+    assert path.read_bytes() == b"base\n"
+    assert git_ops.snapshot_index(git_repo) == before
+
+
+def test_group_rollback_restores_all_paths_untracked_and_supplied_index(git_repo: Path) -> None:
+    _seed(git_repo, {"a.txt": b"base a\n", "b.txt": b"base b\n"})
+    (git_repo / "a.txt").write_bytes(b"round baseline a\n")
+    (git_repo / "b.txt").write_bytes(b"round baseline b\n")
+    (git_repo / "round-scratch").write_bytes(b"scratch baseline")
+    (git_repo / "round-scratch").chmod(0o600)
+    round_ref = git_ops.stash_create(git_repo) or "HEAD"
+    snapshot = WorktreeRollbackSnapshot(
+        ref=round_ref,
+        index=git_ops.snapshot_index(git_repo),
+        path_states=git_ops.snapshot_worktree_paths(git_repo, ["a.txt", "b.txt"]),
+        untracked=git_ops.snapshot_untracked_paths(git_repo),
+    )
+
+    (git_repo / "a.txt").write_bytes(b"failed a\n")
+    (git_repo / "b.txt").unlink()
+    (git_repo / "new.txt").write_bytes(b"failed new")
+    (git_repo / "round-scratch").write_bytes(b"failed scratch")
+    _git(git_repo, "add", "a.txt", "b.txt")
+
+    git_ops.restore_group_from_snapshot(
+        git_repo, snapshot, ["a.txt", "b.txt", "new.txt", "round-scratch"]
+    )
+
+    assert (git_repo / "a.txt").read_bytes() == b"round baseline a\n"
+    assert (git_repo / "b.txt").read_bytes() == b"round baseline b\n"
+    assert not (git_repo / "new.txt").exists()
+    assert (git_repo / "round-scratch").read_bytes() == b"scratch baseline"
+    assert stat.S_IMODE((git_repo / "round-scratch").stat().st_mode) == 0o600
+    assert git_ops.snapshot_index(git_repo) == snapshot.index
+
+
+def test_authorized_parent_symlink_substitution_fails_before_read_restore_or_stage(
+    git_repo: Path, tmp_path: Path
+) -> None:
+    footprint = AuthorizedFixFootprint.build(git_repo, {"nested/allowed.txt"}, [])
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "allowed.txt").write_bytes(b"outside")
+    (git_repo / "nested").symlink_to(outside, target_is_directory=True)
+
+    assert "nested/allowed.txt" in footprint.run_allowed_paths
+    with pytest.raises(GitError, match="not confined"):
+        git_ops.snapshot_worktree_paths(git_repo, footprint.run_allowed_paths)
+    with pytest.raises(GitError, match="not confined"):
+        git_ops.restore_worktree_paths_from_ref(git_repo, "HEAD", footprint.run_allowed_paths)
+    with pytest.raises(GitError, match="not confined"):
+        git_ops.stage_paths(git_repo, [Path("nested/allowed.txt")])
+    assert (outside / "allowed.txt").read_bytes() == b"outside"
+
+
+def test_authorized_leaf_symlink_substitution_fails_before_read_restore_or_stage(git_repo: Path) -> None:
+    _seed(git_repo, {"allowed.txt": b"base\n"})
+    footprint = AuthorizedFixFootprint.build(git_repo, {"allowed.txt"}, [])
+    (git_repo / "allowed.txt").unlink()
+    (git_repo / "allowed.txt").symlink_to("base.txt")
+
+    with pytest.raises(GitError, match="not confined"):
+        git_ops.snapshot_worktree_paths(git_repo, footprint.run_allowed_paths)
+    with pytest.raises(GitError, match="not confined"):
+        git_ops.restore_worktree_paths_from_ref(git_repo, "HEAD", footprint.run_allowed_paths)
+    with pytest.raises(GitError, match="not confined"):
+        git_ops.stage_paths(git_repo, [Path("allowed.txt")])
+
+
+def test_tree_key_is_binary_safe_mode_type_delete_new_and_order_deterministic(git_repo: Path) -> None:
+    _seed(git_repo, {"binary.bin": b"\x00before\xff", "delete.txt": b"delete me", "mode.sh": b"#!/bin/sh\n"})
+    baseline = git_ops.snapshot_worktree_paths(git_repo, ["binary.bin", "delete.txt", "mode.sh", "new.bin"])
+
+    (git_repo / "binary.bin").write_bytes(b"\x00after\xff")
+    (git_repo / "delete.txt").unlink()
+    (git_repo / "mode.sh").chmod(0o755)
+    (git_repo / "new.bin").write_bytes(b"\x00new\xfe")
+    changed = git_ops.snapshot_worktree_paths(git_repo, ["new.bin", "mode.sh", "delete.txt", "binary.bin"])
+
+    assert git_ops.tree_key(baseline) != git_ops.tree_key(changed)
+    assert git_ops.tree_key(changed) == git_ops.tree_key(reversed(changed))
+    states = {state.path: state for state in changed}
+    assert states["delete.txt"].state == "missing"
+    assert states["new.bin"].state == "regular"
+    assert states["mode.sh"].mode == 0o100755
+
+    footprint = AuthorizedFixFootprint.build(git_repo, {"binary.bin"}, [])
+    key = git_ops.tree_key(changed)
+    footprint.authorize_new_generated(
+        git_repo,
+        "generated.py",
+        phase="guard",
+        round_number=1,
+        reason="approved",
+    )
+    assert git_ops.tree_key(changed) == key
+
+
+def test_gitlink_evidence_uses_checked_out_head_not_staged_commit(git_repo: Path) -> None:
+    nested = git_repo / "dependency"
+    init_repo(nested)
+    _seed(nested, {"source.py": b"value = 1\n"})
+    original_head = _git(nested, "rev-parse", "HEAD")
+    _git(git_repo, "add", "dependency")
+    _commit(git_repo, "record dependency")
+    baseline = git_ops.snapshot_worktree_paths(git_repo, ["dependency"])
+
+    _seed(nested, {"source.py": b"value = 2\n"})
+    checked_out_head = _git(nested, "rev-parse", "HEAD")
+    current = git_ops.snapshot_worktree_paths(git_repo, ["dependency"])
+
+    assert baseline[0].digest == original_head
+    assert git_ops.snapshot_index_paths(git_repo, ["dependency"])[0].digest == original_head
+    assert current[0].digest == checked_out_head
+    assert git_ops.tree_key(current) != git_ops.tree_key(baseline)
+
+
+@pytest.mark.parametrize("dirty_path", ["source.py", "untracked.py"])
+def test_dirty_gitlink_cannot_claim_commit_only_test_evidence(
+    git_repo: Path, dirty_path: str,
+) -> None:
+    nested = git_repo / "dependency"
+    init_repo(nested)
+    _seed(nested, {"source.py": b"value = 1\n"})
+    _git(git_repo, "add", "dependency")
+    _commit(git_repo, "record dependency")
+    (nested / dirty_path).write_bytes(b"value = 2\n")
+
+    with pytest.raises(GitError, match="dirty gitlink"):
+        git_ops.snapshot_worktree_paths(git_repo, ["dependency"])
+
+
+def test_uninitialized_gitlink_cannot_capture_parent_repository_head(git_repo: Path) -> None:
+    nested = git_repo / "dependency"
+    nested.mkdir()
+    head = _git(git_repo, "rev-parse", "HEAD")
+    _git(git_repo, "update-index", "--add", "--cacheinfo", f"160000,{head},dependency")
+    _commit(git_repo, "record uninitialized dependency")
+
+    with pytest.raises(GitError, match="gitlink working tree is unavailable"):
+        git_ops.snapshot_worktree_paths(git_repo, ["dependency"])
+
+
+def test_strict_recommended_patch_contains_binary_change_and_commit_staged_does_not_restage(
+    git_repo: Path
+) -> None:
+    _seed(git_repo, {"binary.bin": b"\x00before\xff", "keep.txt": b"base\n"})
+    (git_repo / "binary.bin").write_bytes(b"\x00after\xfe")
+    (git_repo / "new.bin").write_bytes(b"\x00new\xfd")
+    patch = git_ops.build_recommended_patch_strict(
+        git_repo, "HEAD", ["new.bin", "binary.bin"]
+    )
+    assert b"binary.bin" in patch
+    assert b"new.bin" in patch
+    assert b"GIT binary patch" in patch
+
+    git_ops.stage_paths(git_repo, [Path("binary.bin")])
+    (git_repo / "binary.bin").write_bytes(b"changed after stage")
+    git_ops.commit_staged(git_repo, "commit validated index")
+    assert git_ops.show(git_repo, "HEAD", "binary.bin") == b"\x00after\xfe"
+    assert (git_repo / "binary.bin").read_bytes() == b"changed after stage"

--- a/tests/test_git_ops.py
+++ b/tests/test_git_ops.py
@@ -36,6 +36,16 @@ from tests.harness.git_helpers import init_repo as _init_repo
 # --- assert_is_worktree / is_inside_worktree --------------------------------
 
 
+@pytest.mark.parametrize("name", [" leading and trailing ", "line\nbreak", "café.py"])
+def test_diff_name_only_strict_preserves_exact_git_paths(tmp_path: Path, name: str) -> None:
+    repo = _make_repo_with_main(tmp_path)
+    (repo / name).write_bytes(b"content\n")
+    _git(repo, "add", "--", name)
+    _commit(repo, "unusual path")
+    assert git_ops.diff_name_only_strict(repo, "HEAD^", "HEAD") == [name]
+    assert git_ops.diff_name_only_strict(repo, "HEAD", "HEAD") == []
+
+
 def test_assert_is_worktree_passes_for_real_repo(tmp_path: Path) -> None:
     repo = _make_repo_with_main(tmp_path)
     git_ops.assert_is_worktree(repo)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -200,6 +200,70 @@ async def test_full_fix_flow(
     assert _git(target_project, "rev-parse", "HEAD") != head_before
 
 
+@pytest.mark.asyncio
+async def test_fix_commit_includes_pre_gate_authorized_unstaged_edit(
+    tmp_path: Path,
+    install_backend: Callable[[object], object],
+    make_config: Callable[..., 'RunConfig'],
+) -> None:
+    """Real runner commits the complete authorized HEAD-relative result."""
+    repo = tmp_path / "pre-gate-authorized"
+    _init_repo(repo)
+    (repo / "a.py").write_text("A = 1\n")
+    (repo / "b.py").write_text("B = 1\n")
+    _git(repo, "add", ".")
+    _commit(repo, "base")
+    _git(repo, "checkout", "-b", "feature")
+    (repo / "a.py").write_text("A = 2\n")
+    _git(repo, "add", "a.py")
+    _commit(repo, "feature")
+    # Reviewed and authorized before the fix gate, but never touched by the
+    # fixer.  This must still be selected relative to the original HEAD.
+    (repo / "a.py").write_text("A = 3\n")
+    remote = bare_remote(tmp_path / "pre-gate-origin.git")
+    _git(repo, "remote", "add", "origin", str(remote))
+
+    issue = {
+        "id": 1,
+        "description": "Update the related value",
+        "file": "b.py",
+        "line": 1,
+        "related_files": ["a.py"],
+    }
+
+    class RelatedOnlyBackend(PhaseDispatchBackend):
+        async def execute(
+            self,
+            cwd: Any,
+            prompt: str,
+            output_schema: Any = None,
+            continuation: Any = None,
+            **kwargs: Any,
+        ) -> AsyncGenerator[AgentEvent, None]:
+            if prompt.startswith("Fix this issue") or prompt.startswith("Fix these"):
+                (Path(cwd) / "b.py").write_text("B = 2\n")
+            async for event in super().execute(
+                cwd, prompt, output_schema, continuation, **kwargs
+            ):
+                yield event
+
+    install_backend(RelatedOnlyBackend(parse_results=[[issue]]))
+
+    exit_code = await run(
+        make_config(repo, stack="python", quiet=True, shallow=True, assume="yes")
+    )
+
+    assert exit_code == 0
+    assert _git(repo, "show", "HEAD:a.py") == "A = 3"
+    assert _git(repo, "show", "HEAD:b.py") == "B = 2"
+    assert set(_git(repo, "show", "--pretty=", "--name-only", "HEAD").splitlines()) == {
+        "a.py",
+        "b.py",
+    }
+    remote_head = _git(remote, "rev-parse", "refs/heads/feature")
+    assert remote_head == _git(repo, "rev-parse", "HEAD")
+
+
 class _WorktreeMutatingBackend(PhaseDispatchBackend):
     """Phase-dispatch fake whose fix and commit turns really touch the worktree.
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -239,12 +239,14 @@ async def test_fix_commit_includes_pre_gate_authorized_unstaged_edit(
             prompt: str,
             output_schema: Any = None,
             continuation: Any = None,
-            **kwargs: Any,
+            agents: Any = None,
+            max_turns: Any = None,
+            read_only: Any = False,
         ) -> AsyncGenerator[AgentEvent, None]:
             if prompt.startswith("Fix this issue") or prompt.startswith("Fix these"):
                 (Path(cwd) / "b.py").write_text("B = 2\n")
             async for event in super().execute(
-                cwd, prompt, output_schema, continuation, **kwargs
+                cwd, prompt, output_schema, continuation, agents, max_turns, read_only
             ):
                 yield event
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -202,10 +202,12 @@ async def test_full_fix_flow(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("protect_untracked_related", [False, True])
 async def test_fix_commit_includes_pre_gate_authorized_unstaged_edit(
     tmp_path: Path,
     install_backend: Callable[[object], object],
     make_config: Callable[..., 'RunConfig'],
+    protect_untracked_related: bool,
 ) -> None:
     """Real runner commits the complete authorized HEAD-relative result."""
     repo = tmp_path / "pre-gate-authorized"
@@ -221,6 +223,8 @@ async def test_fix_commit_includes_pre_gate_authorized_unstaged_edit(
     # Reviewed and authorized before the fix gate, but never touched by the
     # fixer.  This must still be selected relative to the original HEAD.
     (repo / "a.py").write_text("A = 3\n")
+    if protect_untracked_related:
+        (repo / "scratch.py").write_text("PRIVATE_USER_DRAFT = 1\n")
     remote = bare_remote(tmp_path / "pre-gate-origin.git")
     _git(repo, "remote", "add", "origin", str(remote))
 
@@ -229,7 +233,7 @@ async def test_fix_commit_includes_pre_gate_authorized_unstaged_edit(
         "description": "Update the related value",
         "file": "b.py",
         "line": 1,
-        "related_files": ["a.py"],
+        "related_files": ["a.py", "scratch.py"] if protect_untracked_related else ["a.py"],
     }
 
     class RelatedOnlyBackend(PhaseDispatchBackend):
@@ -245,6 +249,8 @@ async def test_fix_commit_includes_pre_gate_authorized_unstaged_edit(
         ) -> AsyncGenerator[AgentEvent, None]:
             if prompt.startswith("Fix this issue") or prompt.startswith("Fix these"):
                 (Path(cwd) / "b.py").write_text("B = 2\n")
+                if protect_untracked_related:
+                    (Path(cwd) / "scratch.py").write_text("PRIVATE_USER_DRAFT = 2\n")
             async for event in super().execute(
                 cwd, prompt, output_schema, continuation, agents, max_turns, read_only
             ):
@@ -265,6 +271,105 @@ async def test_fix_commit_includes_pre_gate_authorized_unstaged_edit(
     }
     remote_head = _git(remote, "rev-parse", "refs/heads/feature")
     assert remote_head == _git(repo, "rev-parse", "HEAD")
+    if protect_untracked_related:
+        assert (repo / "scratch.py").read_text() == "PRIVATE_USER_DRAFT = 1\n"
+        assert "scratch.py" not in _git(remote, "ls-tree", "--name-only", remote_head).splitlines()
+        assert "PRIVATE_USER_DRAFT" not in (
+            repo / ".daydream" / "recommended.patch"
+        ).read_text()
+
+
+@pytest.mark.asyncio
+async def test_shallow_staged_fix_preflight_preserves_review_evidence_and_git_state(
+    target_project: Path,
+    install_backend: Callable[[object], object],
+    make_config: Callable[..., 'RunConfig'],
+    capfd: pytest.CaptureFixture[str],
+) -> None:
+    """A fresh real run rejects a review-time staged edit without erasing proof."""
+    stale_bytes = b'{"session_id":"review-phase","passed":true}\n'
+    staged_source = b"def hello():\n    return 'staged during review'\n"
+
+    class ReviewStagingBackend(PhaseDispatchBackend):
+        staged_index: str | None = None
+
+        async def execute(
+            self,
+            cwd: Any,
+            prompt: str,
+            output_schema: Any = None,
+            continuation: Any = None,
+            agents: Any = None,
+            max_turns: Any = None,
+            read_only: Any = False,
+        ) -> AsyncGenerator[AgentEvent, None]:
+            prompt_lower = prompt.lower()
+            review_markers = (
+                "inclusion obligation",
+                "full change spans",
+                "language-agnostic review practices",
+                "assigned to this stack",
+                "repository-wide interactions",
+            )
+            if self.staged_index is None and any(
+                marker in prompt_lower for marker in review_markers
+            ):
+                repo = Path(cwd)
+                deep = repo / ".daydream" / "deep"
+                deep.mkdir(parents=True, exist_ok=True)
+                (deep / "test-verdict.json").write_bytes(stale_bytes)
+                (repo / "main.py").write_bytes(staged_source)
+                _git(repo, "add", "main.py")
+                self.staged_index = _git(repo, "write-tree")
+            async for event in super().execute(
+                cwd,
+                prompt,
+                output_schema,
+                continuation,
+                agents,
+                max_turns,
+                read_only,
+            ):
+                yield event
+
+    backend = ReviewStagingBackend(parse_results=[[_FULL_FLOW_ISSUE]])
+    install_backend(backend)
+    deep = target_project / ".daydream" / "deep"
+    stale = deep / "test-verdict.json"
+    assert not stale.exists()
+    head_before = _git(target_project, "rev-parse", "HEAD")
+
+    exit_code = await run(
+        make_config(
+            target_project,
+            stack="python",
+            quiet=True,
+            shallow=True,
+            assume="yes",
+        )
+    )
+
+    assert exit_code == 1
+    output = capfd.readouterr().out
+    from daydream.deep import orchestrator as deep_orchestrator
+
+    console_file = getattr(deep_orchestrator, "console").file
+    if isinstance(console_file, StringIO):
+        output += console_file.getvalue()
+    assert "Cannot start the fix cycle with staged changes" in output, (
+        output,
+        "\n".join(backend.call_log),
+        _git(target_project, "status", "--short"),
+    )
+    assert backend.staged_index is not None
+    assert _git(target_project, "write-tree") == backend.staged_index
+    assert _git(target_project, "rev-parse", "HEAD") == head_before
+    assert (target_project / "main.py").read_bytes() == staged_source
+    assert stale.read_bytes() == stale_bytes
+    assert not any(
+        prompt.startswith("fix this issue") or prompt.startswith("fix these")
+        for prompt in backend.call_log
+    )
 
 
 class _WorktreeMutatingBackend(PhaseDispatchBackend):

--- a/tests/test_phases.py
+++ b/tests/test_phases.py
@@ -41,6 +41,12 @@ def _structured_turn(structured: object) -> tuple[AgentEvent, ...]:
     return (ResultEvent(structured_output=structured, continuation=None),)
 
 
+def test_fix_guardrails_forbid_git_index_mutation() -> None:
+    from daydream.phases import _FIX_GUARDRAILS
+
+    assert "`git add`" in _FIX_GUARDRAILS
+
+
 async def _fake_passed_run(*args: Any, **kwargs: Any) -> Any:
     """Stand-in for ``run_test_command`` returning a green host-side result."""
     from daydream.test_execution import TestExecutionResult
@@ -179,6 +185,10 @@ def _supply_test_evidence_contract(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(phases, "phase_fix_batched", _batched_with_contract)
     monkeypatch.setattr(phases, "phase_fix_parallel", _parallel_with_contract)
     monkeypatch.setattr(git_ops, "restore_group_from_snapshot", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        git_ops, "restore_group_worktree_from_snapshot", lambda *args, **kwargs: None
+    )
+    monkeypatch.setattr(git_ops, "restore_index", lambda *args, **kwargs: None)
 
 
 def test_test_healing_guard_reverts_existing_generated_file_and_keeps_new_migration(
@@ -5120,7 +5130,7 @@ async def test_phase_fix_parallel_passes_exact_group_edit_and_run_read_scopes(
 
 
 @pytest.mark.asyncio
-async def test_phase_fix_parallel_restores_whole_group_before_batch_fallback(
+async def test_phase_fix_parallel_restores_whole_group_worktree_before_batch_fallback(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     make_work: Callable[..., WorkContext],
@@ -5153,7 +5163,7 @@ async def test_phase_fix_parallel_restores_whole_group_before_batch_fallback(
 
     monkeypatch.setattr(phases, "phase_fix_batched", _fail_batch)
     monkeypatch.setattr(phases, "phase_fix", _fix)
-    monkeypatch.setattr(git_ops, "restore_group_from_snapshot", _restore)
+    monkeypatch.setattr(git_ops, "restore_group_worktree_from_snapshot", _restore)
 
     failures = await phases.phase_fix_parallel(
         cast(Backend, object()),
@@ -5307,6 +5317,49 @@ async def test_strict_commit_stages_retained_paths_once_and_commits_staged_index
     assert committed is True
     assert calls == {"stage": 1, "commit_staged": 1}
     assert git(repo, "show", "HEAD:app.py") == "after"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("permissions", [0o600, 0o640, 0o664, 0o700, 0o610, 0o644])
+async def test_strict_commit_accepts_new_file_permissions_without_changing_owner_bytes(
+    tmp_path: Path,
+    make_work: Callable[..., WorkContext],
+    permissions: int,
+) -> None:
+    from daydream import git_ops, phases
+
+    repo = tmp_path / "repo"
+    init_repo(repo)
+    (repo / "base.py").write_text("baseline\n")
+    git(repo, "add", "base.py")
+    git_commit(repo, "baseline")
+    owner = repo / "private.txt"
+    owner.write_bytes(b"private owner bytes\n")
+    owner.chmod(0o600)
+    initial_index = phases.require_empty_staged_index(make_work(repo))
+    created = repo / "new.py"
+    created.write_bytes(b"new retained content\n")
+    created.chmod(permissions)
+    retained = frozenset({"new.py"})
+    before_states = git_ops.snapshot_worktree_paths(repo, ["new.py", "private.txt"])
+
+    assert await phases._do_commit(
+        _HostCommitBackend(repo), make_work(repo),
+        retained_paths=retained,
+        retained_states=git_ops.snapshot_worktree_paths(repo, retained),
+        initial_index=initial_index,
+        preexisting_untracked={"private.txt"},
+    ) is True
+
+    assert git(repo, "show", "HEAD:new.py") == "new retained content"
+    assert git_ops.snapshot_worktree_paths(repo, ["new.py", "private.txt"]) == before_states
+    assert created.stat().st_mode & 0o777 == permissions
+    assert owner.read_bytes() == b"private owner bytes\n"
+    assert owner.stat().st_mode & 0o777 == 0o600
+    assert frozenset(git_ops.diff_name_only_strict(repo, "HEAD^", "HEAD")) == retained
+    assert git(repo, "diff", "--cached") == ""
+    expected_mode = "100755" if permissions & 0o100 else "100644"
+    assert git(repo, "ls-tree", "HEAD", "--", "new.py").startswith(expected_mode)
 
 
 @pytest.mark.asyncio

--- a/tests/test_phases.py
+++ b/tests/test_phases.py
@@ -1,6 +1,7 @@
 # tests/test_phases.py
 """Tests for phase functions with backend abstraction."""
 import json
+import os
 from collections.abc import AsyncGenerator, AsyncIterator, Callable
 from io import StringIO
 from pathlib import Path
@@ -5306,6 +5307,51 @@ async def test_strict_commit_stages_retained_paths_once_and_commits_staged_index
     assert committed is True
     assert calls == {"stage": 1, "commit_staged": 1}
     assert git(repo, "show", "HEAD:app.py") == "after"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("native_retained", [False, True])
+async def test_strict_commit_preserves_non_utf8_retained_and_protected_paths(
+    tmp_path: Path,
+    make_work: Callable[..., WorkContext],
+    native_retained: bool,
+) -> None:
+    import errno
+
+    from daydream import git_ops, phases
+
+    repo = tmp_path / "repo"
+    init_repo(repo)
+    native = os.fsdecode(b"native-\xff.py")
+    try:
+        (repo / native).write_bytes(b"private or retained\n")
+    except OSError as exc:
+        if exc.errno == errno.EILSEQ:
+            pytest.skip("host filesystem rejects non-UTF-8 filenames; exercised on Linux CI")
+        raise
+    (repo / "app.py").write_text("before\n")
+    git(repo, "add", "app.py")
+    if native_retained:
+        git(repo, "add", "--", native)
+    git_commit(repo, "baseline")
+    initial_index = phases.require_empty_staged_index(make_work(repo))
+    (repo / "app.py").write_text("after\n")
+    retained = frozenset({"app.py", native} if native_retained else {"app.py"})
+    if native_retained:
+        (repo / native).write_bytes(b"retained after\n")
+
+    assert await phases._do_commit(
+        _HostCommitBackend(repo), make_work(repo),
+        retained_paths=retained,
+        retained_states=git_ops.snapshot_worktree_paths(repo, retained),
+        initial_index=initial_index,
+        preexisting_untracked=set() if native_retained else {native},
+    ) is True
+    assert (repo / native).read_bytes() == (
+        b"retained after\n" if native_retained else b"private or retained\n"
+    )
+    assert frozenset(git_ops.diff_name_only_strict(repo, "HEAD^", "HEAD")) == retained
+    assert git(repo, "diff", "--cached") == ""
 
 
 @pytest.mark.asyncio

--- a/tests/test_phases.py
+++ b/tests/test_phases.py
@@ -84,6 +84,102 @@ class _HealBackend(ScriptedBackend):
         return [call["read_only"] for call in self.calls]
 
 
+@pytest.fixture(autouse=True)
+def _supply_test_evidence_contract(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Adapt pre-footprint unit cases to the required test phase contract.
+
+    The legacy cases in this module exercise menu, prompt, and backend behavior;
+    they now run through a stable identity callback and an explicit run scope.
+    New contract-focused cases can pass their own values, which are preserved.
+    """
+    from daydream import git_ops, phases
+    from daydream.fix_footprint import AuthorizedFixFootprint
+
+    implementation = phases.phase_test_and_heal
+    fix_implementation = phases.phase_fix
+    batched_implementation = phases.phase_fix_batched
+    parallel_implementation = phases.phase_fix_parallel
+
+    async def _with_contract(*args: Any, **kwargs: Any) -> Any:
+        feedback = kwargs.get("feedback_items")
+        paths = frozenset(
+            item["file"]
+            for item in (feedback or [])
+            if isinstance(item, dict) and isinstance(item.get("file"), str)
+        )
+        kwargs.setdefault("session_id", "unit-test-session")
+        kwargs.setdefault("capture_tree_key", lambda: "unit-test-tree")
+        kwargs.setdefault(
+            "footprint",
+            AuthorizedFixFootprint(run_allowed_paths=paths, policy_revision=1),
+        )
+        return await implementation(*args, **kwargs)
+
+    monkeypatch.setattr(phases, "phase_test_and_heal", _with_contract)
+
+    async def _fix_with_contract(*args: Any, **kwargs: Any) -> Any:
+        item = args[2]
+        changed = kwargs.pop("changed_files", None)
+        default_scope = frozenset(
+            {item.get("file")} if isinstance(item.get("file"), str) else set()
+        )
+        edit_scope = frozenset(changed) if changed is not None else default_scope
+        kwargs.setdefault("edit_scope", edit_scope)
+        kwargs.setdefault("read_scope", edit_scope)
+        return await fix_implementation(*args, **kwargs)
+
+    async def _batched_with_contract(*args: Any, **kwargs: Any) -> Any:
+        items = args[2]
+        changed = kwargs.pop("changed_files", None)
+        default_scope = frozenset(
+            item["file"] for item in items if isinstance(item.get("file"), str)
+        )
+        edit_scope = frozenset(changed) if changed is not None else default_scope
+        kwargs.setdefault("edit_scope", edit_scope)
+        kwargs.setdefault("read_scope", edit_scope)
+        return await batched_implementation(*args, **kwargs)
+
+    async def _parallel_with_contract(*args: Any, **kwargs: Any) -> Any:
+        original_items = args[2]
+        items = [dict(item, item_uid=item.get("item_uid") or f"item:{n}")
+                 for n, item in enumerate(original_items, start=1)]
+        mutable_args = (*args[:2], items, *args[3:])
+        item_paths = {
+            item["item_uid"]: frozenset(
+                path
+                for path in [item.get("file"), *(item.get("related_files") or [])]
+                if isinstance(path, str)
+            )
+            for item in items
+        }
+        run_paths = frozenset(path for paths in item_paths.values() for path in paths)
+        kwargs.setdefault(
+            "footprint",
+            AuthorizedFixFootprint(
+                run_allowed_paths=run_paths,
+                policy_revision=1,
+                _item_paths=item_paths,
+            ),
+        )
+        from daydream.git_ops import IndexSnapshot, WorktreeRollbackSnapshot
+
+        kwargs.setdefault(
+            "round_snapshot",
+            WorktreeRollbackSnapshot(
+                ref="HEAD",
+                index=IndexSnapshot(tree_sha="unit-test-tree", paths=()),
+                path_states=(),
+                untracked={},
+            ),
+        )
+        return await parallel_implementation(*mutable_args, **kwargs)
+
+    monkeypatch.setattr(phases, "phase_fix", _fix_with_contract)
+    monkeypatch.setattr(phases, "phase_fix_batched", _batched_with_contract)
+    monkeypatch.setattr(phases, "phase_fix_parallel", _parallel_with_contract)
+    monkeypatch.setattr(git_ops, "restore_group_from_snapshot", lambda *args, **kwargs: None)
+
+
 def test_test_healing_guard_reverts_existing_generated_file_and_keeps_new_migration(
     tmp_path: Path,
     silence_console: Callable[..., None],
@@ -884,7 +980,7 @@ async def test_phase_test_and_heal_aborts_when_generated_restore_fails(
 
     result = await phase_test_and_heal(backend, make_work(tmp_path))
 
-    assert result == (False, 1, False)
+    assert (result.passed, result.retries, result.proceed) == (False, 1, False)
     assert backend.call_count == 2
 
 
@@ -1078,17 +1174,12 @@ async def test_phase_fix_prompt_includes_scope_and_precedence_constraints(
 
 
 @pytest.mark.asyncio
-async def test_phase_fix_prompt_enumerates_changed_files_when_provided(
+async def test_phase_fix_prompt_enumerates_explicit_edit_scope(
     tmp_path: Path,
     make_work: Callable[..., WorkContext],
     silence_console: Callable[..., None],
 ) -> None:
-    """When ``changed_files`` is passed, the prompt carries an explicit
-    "Allowed files" clause enumerating the reviewed diff's file set.
-
-    ``changed_files=None`` (legacy/resume callers) keeps the old behavior — no
-    allowed-files clause in the prompt, only the prose boundary.
-    """
+    """The prompt distinguishes exact edit authority from readable context."""
     from daydream.phases import phase_fix
 
     silence_console("daydream.phases")
@@ -1098,22 +1189,24 @@ async def test_phase_fix_prompt_enumerates_changed_files_when_provided(
     item = {"id": 1, "description": "Off-by-one", "file": "src/handler.py", "line": 42}
     await phase_fix(
         backend_with, make_work(tmp_path), item, 1, 1,
-        changed_files={"src/handler.py", "src/util.py"},
+        edit_scope=frozenset({"src/handler.py", "src/util.py"}),
+        read_scope=frozenset({"src/handler.py", "src/util.py"}),
     )
     assert len(backend_with.prompts) == 1
     prompt_with = backend_with.prompts[0]
-    # The clause is present and lists both files.
-    assert "Allowed files" in prompt_with
+    # The exact edit clause is present and lists both files.
+    assert "Authorized edit scope" in prompt_with
     # src/handler.py already appears via the finding's own File: line, so only
-    # src/util.py (which appears nowhere else) isolates the Allowed-files clause.
+    # src/util.py (which appears nowhere else) isolates the edit-scope clause.
     assert "src/util.py" in prompt_with
 
-    # --- Without changed_files: no allowed-files clause (legacy callers). ---
+    # --- A direct item still receives its own exact scope. ---
     backend_without = ScriptedBackend()
     await phase_fix(backend_without, make_work(tmp_path), item, 1, 1)
     assert len(backend_without.prompts) == 1
     prompt_without = backend_without.prompts[0]
-    assert "Allowed files" not in prompt_without
+    assert "Authorized edit scope" in prompt_without
+    assert "src/handler.py" in prompt_without
 
 
 @pytest.mark.asyncio
@@ -4930,32 +5023,401 @@ def test_print_fix_complete_gates_on_resolved(
     assert out.count("Fix applied") == 1  # only the resolved one
 
 
-def test_group_items_by_footprint_unions_overlapping_footprints() -> None:
+def test_group_items_by_footprint_unions_overlapping_footprints(tmp_path: Path) -> None:
+    from daydream.fix_footprint import AuthorizedFixFootprint
     from daydream.phases import group_items_by_footprint
 
     items = [
-        {"id": 1, "file": "a.py", "related_files": ["b.py"]},
-        {"id": 2, "file": "b.py"},                      # overlaps item 1 via b.py
-        {"id": 3, "file": "c.py"},                      # disjoint
+        {"id": 1, "item_uid": "item:1", "file": "a.py", "related_files": ["b.py"]},
+        {"id": 2, "item_uid": "item:2", "file": "b.py"},
+        {"id": 3, "item_uid": "item:3", "file": "c.py"},
     ]
-    groups = group_items_by_footprint(items)
+    groups = group_items_by_footprint(
+        items, AuthorizedFixFootprint.build(tmp_path, set(), items)
+    )
     # 1 and 2 must be in ONE group (shared b.py); 3 separate.
     assert len(groups) == 2
     a_group = next(it for _, it in groups if any(i["id"] == 1 for i in it))
     assert {i["id"] for i in a_group} == {1, 2}
 
 
-def test_group_items_by_footprint_never_splits_same_file_batch() -> None:
+def test_group_items_by_footprint_never_splits_same_file_batch(tmp_path: Path) -> None:
+    from daydream.fix_footprint import AuthorizedFixFootprint
     from daydream.phases import group_items_by_footprint
 
     items = [
-        {"id": 1, "file": "a.py"},
-        {"id": 2, "file": "a.py", "related_files": ["x.py"]},
-        {"id": 3, "file": "a.py"},
+        {"id": 1, "item_uid": "item:1", "file": "a.py"},
+        {"id": 2, "item_uid": "item:2", "file": "a.py", "related_files": ["x.py"]},
+        {"id": 3, "item_uid": "item:3", "file": "a.py"},
     ]
-    groups = group_items_by_footprint(items)
+    groups = group_items_by_footprint(
+        items, AuthorizedFixFootprint.build(tmp_path, set(), items)
+    )
     assert len([g for _, g in groups]) == 1  # same primary file must never split (#170/#202)
     assert {i["id"] for i in groups[0][1]} == {1, 2, 3}
+
+
+def test_group_items_by_footprint_uses_authorized_transitive_scopes(tmp_path: Path) -> None:
+    """Grouping is driven by the normalized policy, not raw finding fields."""
+    from daydream.fix_footprint import AuthorizedFixFootprint
+    from daydream.phases import group_items_by_footprint
+
+    items = [
+        {"id": 1, "item_uid": "item:1", "file": "a.py", "related_files": ["bridge.py"]},
+        {"id": 2, "item_uid": "item:2", "file": "b.py", "related_files": ["bridge.py"]},
+        {"id": 3, "item_uid": "item:3", "file": "c.py"},
+    ]
+    footprint = AuthorizedFixFootprint.build(tmp_path, {"reviewed-only.py"}, items)
+
+    groups = group_items_by_footprint(items, footprint)
+
+    assert [[item["item_uid"] for item in group] for _, group in groups] == [
+        ["item:1", "item:2"],
+        ["item:3"],
+    ]
+
+
+@pytest.mark.asyncio
+async def test_phase_fix_parallel_passes_exact_group_edit_and_run_read_scopes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    make_work: Callable[..., WorkContext],
+) -> None:
+    """Disjoint groups cannot edit a reviewed-only path shared by the run."""
+    from daydream import phases
+    from daydream.fix_footprint import AuthorizedFixFootprint
+    from daydream.git_ops import IndexSnapshot, WorktreeRollbackSnapshot
+
+    items = [
+        {"id": 1, "item_uid": "item:1", "file": "a.py"},
+        {"id": 2, "item_uid": "item:2", "file": "b.py"},
+    ]
+    footprint = AuthorizedFixFootprint.build(tmp_path, {"shared.md"}, items)
+    round_snapshot = WorktreeRollbackSnapshot(
+        ref="HEAD",
+        index=IndexSnapshot(tree_sha="tree", paths=()),
+        path_states=(),
+        untracked={},
+    )
+    calls: list[tuple[frozenset[str], frozenset[str]]] = []
+
+    async def _fake_fix(*args: Any, **kwargs: Any) -> None:
+        calls.append((kwargs["edit_scope"], kwargs["read_scope"]))
+
+    monkeypatch.setattr(phases, "phase_fix", _fake_fix)
+
+    await phases.phase_fix_parallel(
+        cast(Backend, object()),
+        make_work(tmp_path),
+        items,
+        footprint=footprint,
+        round_snapshot=round_snapshot,
+    )
+
+    assert sorted(edit for edit, _ in calls) == [frozenset({"a.py"}), frozenset({"b.py"})]
+    assert all(read == footprint.run_allowed_paths for _, read in calls)
+
+
+@pytest.mark.asyncio
+async def test_phase_fix_parallel_restores_whole_group_before_batch_fallback(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    make_work: Callable[..., WorkContext],
+) -> None:
+    from daydream import git_ops, phases
+    from daydream.fix_footprint import AuthorizedFixFootprint
+    from daydream.git_ops import IndexSnapshot, WorktreeRollbackSnapshot
+
+    items = [
+        {"id": 1, "item_uid": "item:1", "file": "a.py", "related_files": ["shared.py"]},
+        {"id": 2, "item_uid": "item:2", "file": "shared.py", "related_files": ["test_a.py"]},
+    ]
+    footprint = AuthorizedFixFootprint.build(tmp_path, set(), items)
+    snapshot = WorktreeRollbackSnapshot(
+        ref="round-ref",
+        index=IndexSnapshot(tree_sha="round-index", paths=()),
+        path_states=(),
+        untracked={},
+    )
+    restored: list[tuple[WorktreeRollbackSnapshot, frozenset[str]]] = []
+
+    async def _fail_batch(*args: Any, **kwargs: Any) -> None:
+        raise RuntimeError("partial batch")
+
+    async def _fix(*args: Any, **kwargs: Any) -> None:
+        return None
+
+    def _restore(repo: Path, supplied: WorktreeRollbackSnapshot, paths: Any) -> None:
+        restored.append((supplied, frozenset(paths)))
+
+    monkeypatch.setattr(phases, "phase_fix_batched", _fail_batch)
+    monkeypatch.setattr(phases, "phase_fix", _fix)
+    monkeypatch.setattr(git_ops, "restore_group_from_snapshot", _restore)
+
+    failures = await phases.phase_fix_parallel(
+        cast(Backend, object()),
+        make_work(tmp_path),
+        items,
+        footprint=footprint,
+        round_snapshot=snapshot,
+    )
+
+    assert failures == {}
+    assert restored == [(snapshot, frozenset({"a.py", "shared.py", "test_a.py"}))]
+
+
+@pytest.mark.asyncio
+async def test_phase_test_once_records_host_input_and_output_identity(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    make_work: Callable[..., WorkContext],
+) -> None:
+    from daydream import phases
+    from daydream.config_file import DaydreamFileConfig
+    from daydream.test_execution import TestExecutionResult
+
+    observed = iter(["before", "after"])
+
+    async def _run(*args: Any, **kwargs: Any) -> TestExecutionResult:
+        return TestExecutionResult(exit_status=0, timed_out=False, merged_output="1 passed")
+
+    monkeypatch.setattr(phases, "run_test_command", _run)
+    evidence, continuation, output = await phases.phase_test_once(
+        _HostCommitBackend(tmp_path),
+        make_work(tmp_path),
+        config=SimpleNamespace(
+            test_command="pytest -q",
+            file_config=DaydreamFileConfig(test_command="pytest -q"),
+        ),
+        session_id="session-1",
+        capture_tree_key=lambda: next(observed),
+    )
+
+    assert evidence.session_id == "session-1"
+    assert evidence.kind == "host"
+    assert evidence.command == ("pytest", "-q")
+    assert evidence.passed is True
+    assert evidence.input_tree_key == "before"
+    assert evidence.output_tree_key == "after"
+    assert continuation is None
+    assert output == "1 passed"
+
+
+@pytest.mark.asyncio
+async def test_phase_test_and_heal_records_each_agent_attempt_and_heal_scope(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    make_work: Callable[..., WorkContext],
+) -> None:
+    from daydream import phases
+    from daydream.fix_footprint import AuthorizedFixFootprint
+
+    feedback = [{"id": 1, "item_uid": "item:1", "file": "a.py"}]
+    footprint = AuthorizedFixFootprint.build(tmp_path, {"readme.md"}, feedback)
+    backend = ScriptedBackend(script=[_FAIL_TURN, _FIX_TURN, _PASS_TURN])
+    monkeypatch.setattr(phases, "prompt_user", lambda *args, **kwargs: "2")
+    keys = iter(["in-1", "out-1", "in-2", "out-2"])
+
+    result = await phases.phase_test_and_heal(
+        backend,
+        make_work(tmp_path),
+        feedback_items=feedback,
+        session_id="session-2",
+        capture_tree_key=lambda: next(keys),
+        footprint=footprint,
+    )
+
+    assert result.passed is True
+    assert result.ignored is False
+    assert [(a.input_tree_key, a.output_tree_key) for a in result.attempts] == [
+        ("in-1", "out-1"),
+        ("in-2", "out-2"),
+    ]
+    assert all(a.kind == "agent" and a.command is None for a in result.attempts)
+    heal_prompt = backend.prompts[1]
+    assert "Authorized edit scope" in heal_prompt
+    assert "a.py" in heal_prompt and "readme.md" in heal_prompt
+
+
+def test_require_empty_staged_index_rejects_preexisting_staged_change(
+    tmp_path: Path,
+    make_work: Callable[..., WorkContext],
+) -> None:
+    from daydream.phases import require_empty_staged_index
+
+    repo = tmp_path / "repo"
+    init_repo(repo)
+    (repo / "base.py").write_text("base\n")
+    git(repo, "add", "base.py")
+    git_commit(repo, "baseline")
+    (repo / "staged.py").write_text("new\n")
+    git(repo, "add", "staged.py")
+
+    with pytest.raises(Exception, match="staged changes"):
+        require_empty_staged_index(make_work(repo))
+
+
+@pytest.mark.asyncio
+async def test_strict_commit_stages_retained_paths_once_and_commits_staged_index(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    make_work: Callable[..., WorkContext],
+) -> None:
+    from daydream import git_ops, phases
+
+    repo = tmp_path / "repo"
+    init_repo(repo)
+    (repo / "app.py").write_text("before\n")
+    git(repo, "add", "app.py")
+    git_commit(repo, "baseline")
+    initial_index = phases.require_empty_staged_index(make_work(repo))
+    (repo / "app.py").write_text("after\n")
+    retained_states = git_ops.snapshot_worktree_paths(repo, ["app.py"])
+    calls = {"stage": 0, "commit_staged": 0}
+    real_stage = git_ops.stage_paths
+    real_commit_staged = git_ops.commit_staged
+
+    def _stage(*args: Any, **kwargs: Any) -> None:
+        calls["stage"] += 1
+        real_stage(*args, **kwargs)
+
+    def _commit_staged(*args: Any, **kwargs: Any) -> None:
+        calls["commit_staged"] += 1
+        real_commit_staged(*args, **kwargs)
+
+    monkeypatch.setattr(git_ops, "stage_paths", _stage)
+    monkeypatch.setattr(git_ops, "commit_staged", _commit_staged)
+    monkeypatch.setattr(
+        git_ops,
+        "commit_paths",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("strict commit must not restage")
+        ),
+    )
+
+    committed = await phases._do_commit(
+        _HostCommitBackend(repo),
+        make_work(repo),
+        retained_paths=frozenset({"app.py"}),
+        retained_states=retained_states,
+        initial_index=initial_index,
+    )
+
+    assert committed is True
+    assert calls == {"stage": 1, "commit_staged": 1}
+    assert git(repo, "show", "HEAD:app.py") == "after"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("artifact_path", "tracked", "preexisting", "must_block"),
+    [
+        (".daydream/runtime.json", False, False, False),
+        (".daydream/runtime.json", False, True, False),
+        (".review-output.md", False, True, False),
+        (".daydreamish/runtime.json", False, False, True),
+        (".daydream/tracked.json", True, True, True),
+    ],
+)
+async def test_strict_commit_real_hook_distinguishes_runtime_artifacts_from_user_files(
+    tmp_path: Path,
+    make_work: Callable[..., WorkContext],
+    artifact_path: str,
+    tracked: bool,
+    preexisting: bool,
+    must_block: bool,
+) -> None:
+    """A real hook may update runtime output, never tracked or lookalike user files."""
+    from daydream import git_ops, phases
+
+    repo = tmp_path / "repo"
+    init_repo(repo)
+    (repo / "app.py").write_text("before\n")
+    artifact = repo / artifact_path
+    if preexisting:
+        artifact.parent.mkdir(parents=True, exist_ok=True)
+        artifact.write_text("before runtime\n")
+    git(repo, "add", "app.py")
+    if tracked:
+        git(repo, "add", artifact_path)
+    git_commit(repo, "baseline")
+    initial_index = phases.require_empty_staged_index(make_work(repo))
+    (repo / "app.py").write_text("after\n")
+    retained_states = git_ops.snapshot_worktree_paths(repo, ["app.py"])
+    hook = repo / ".git" / "hooks" / "post-commit"
+    hook.write_text(
+        "#!/bin/sh\n"
+        "set -eu\n"
+        "mkdir -p .daydream .daydreamish\n"
+        f"printf '%s\\n' 'hook runtime' > '{artifact_path}'\n"
+    )
+    hook.chmod(0o755)
+
+    async def commit_retained() -> bool:
+        return await phases._do_commit(
+            _HostCommitBackend(repo),
+            make_work(repo),
+            retained_paths=frozenset({"app.py"}),
+            retained_states=retained_states,
+            initial_index=initial_index,
+        )
+
+    if must_block:
+        with pytest.raises(git_ops.GitError, match="push blocked"):
+            await commit_retained()
+    else:
+        assert await commit_retained() is True
+    assert artifact.read_text() == "hook runtime\n"
+    assert git(repo, "diff-tree", "--no-commit-id", "--name-only", "-r", "HEAD") == "app.py"
+    assert git(repo, "diff", "--cached") == ""
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("hook_mutation", ["worktree", "index"])
+async def test_strict_commit_blocks_after_commit_hook_mutates_worktree_or_index(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    make_work: Callable[..., WorkContext],
+    hook_mutation: str,
+) -> None:
+    from daydream import git_ops, phases
+
+    repo = tmp_path / "repo"
+    init_repo(repo)
+    (repo / "app.py").write_text("before\n")
+    git(repo, "add", "app.py")
+    git_commit(repo, "baseline")
+    initial_index = phases.require_empty_staged_index(make_work(repo))
+    (repo / "app.py").write_text("after\n")
+    retained_states = git_ops.snapshot_worktree_paths(repo, ["app.py"])
+    real_commit_staged = git_ops.commit_staged
+
+    def _mutating_commit(repo_arg: Path, message: str) -> None:
+        real_commit_staged(repo_arg, message)
+        if hook_mutation == "worktree":
+            (repo_arg / "app.py").write_text("hook mutation\n")
+        else:
+            (repo_arg / "app.py").write_text("hook mutation\n")
+            git(repo_arg, "add", "app.py")
+            (repo_arg / "app.py").write_text("after\n")
+
+    monkeypatch.setattr(git_ops, "commit_staged", _mutating_commit)
+
+    with pytest.raises(
+        git_ops.GitError,
+        match=r"Local commit [0-9a-f]+ was created.*push blocked",
+    ):
+        await phases._do_commit(
+            _HostCommitBackend(repo),
+            make_work(repo),
+            retained_paths=frozenset({"app.py"}),
+            retained_states=retained_states,
+            initial_index=initial_index,
+        )
+
+    assert git(repo, "show", "HEAD:app.py") == "after"
+    expected_worktree = "hook mutation\n" if hook_mutation == "worktree" else "after\n"
+    assert (repo / "app.py").read_text() == expected_worktree
 
 
 async def test_phase_fix_parallel_calls_count_serial_per_file_and_collects_failures(

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -662,6 +662,20 @@ async def _stub_verify(*_a: Any, **_k: Any) -> tuple[Path, dict[str, Any]]:
     return Path("/nonexistent"), {"verdicts": []}
 
 
+async def _stub_fix_verify(
+    _backend: Any,
+    _work: Any,
+    items: list[dict[str, Any]],
+    *_args: Any,
+    **_kwargs: Any,
+) -> list[dict[str, Any]]:
+    """Resolve every canonical item for fix-cycle harnesses."""
+    return [
+        {"issue_id": item["id"], "verdict": "resolved", "reason": "harness"}
+        for item in items
+    ]
+
+
 @pytest.mark.asyncio
 async def test_fix_cycle_awaken_hero_followed_by_model_line(
     monkeypatch: pytest.MonkeyPatch,
@@ -693,6 +707,7 @@ async def test_fix_cycle_awaken_hero_followed_by_model_line(
         ),
     )
     monkeypatch.setattr("daydream.deep.orchestrator.phase_verify_recommendations", _stub_verify)
+    monkeypatch.setattr("daydream.phases.phase_fix_verify", _stub_fix_verify)
 
     async def _noop_fix(*_a: Any, **_k: Any) -> dict[str, str]:
         return {}
@@ -766,6 +781,7 @@ async def test_fix_cycle_items_severity_ordered(
         lambda _config, _phase, cache=None, **_kwargs: ScriptedBackend(model="stub-model"),
     )
     monkeypatch.setattr("daydream.deep.orchestrator.phase_verify_recommendations", _stub_verify)
+    monkeypatch.setattr("daydream.phases.phase_fix_verify", _stub_fix_verify)
 
     order: list[list[str]] = []
 
@@ -773,8 +789,19 @@ async def test_fix_cycle_items_severity_ordered(
         order.append([item["severity"] for item in items])
         return {}
 
-    async def _noop_test(*_a: Any, **_k: Any) -> tuple[bool, int, bool]:
-        return (True, 0, True)
+    async def _noop_test(*_a: Any, **kwargs: Any) -> Any:
+        from daydream.phases import TestAndHealResult, TestAttemptEvidence
+
+        key = kwargs["capture_tree_key"]()
+        attempt = TestAttemptEvidence(
+            session_id=kwargs["session_id"],
+            kind="host",
+            command=("true",),
+            passed=True,
+            input_tree_key=key,
+            output_tree_key=key,
+        )
+        return TestAndHealResult(True, 0, True, False, (attempt,))
 
     async def _noop_commit(*_a: Any, **_k: Any) -> None:
         return None
@@ -934,6 +961,7 @@ async def test_fix_cycle_yes_commits_fixes(
         lambda _config, _phase, cache=None, **_kwargs: commit_backend,
     )
     monkeypatch.setattr("daydream.deep.orchestrator.phase_verify_recommendations", _stub_verify)
+    monkeypatch.setattr("daydream.phases.phase_fix_verify", _stub_fix_verify)
 
     async def _fix_writes(*_a: Any, **_k: Any) -> dict[str, str]:
         main_py = feature_branch_repo / "main.py"
@@ -1042,6 +1070,7 @@ async def _drive_fix_cycle_failing(
         ),
     )
     monkeypatch.setattr("daydream.deep.orchestrator.phase_verify_recommendations", _stub_verify)
+    monkeypatch.setattr("daydream.phases.phase_fix_verify", _stub_fix_verify)
 
     async def _noop_fix(*_a: Any, **_k: Any) -> dict[str, str]:
         return {}


### PR DESCRIPTION
## Summary

Keep one explicit, host-owned set of authorized files through deep fix dispatch, parallel grouping, rollback, healing, final verification, staging, and commit. Verify and commit the full retained result, including related test/supporting files and authorized edits that existed before the fix gate.

## Motivation

Closes #1135. Per-item identity and transitive shared-file groups now distinguish each group's edit scope from the full run's authorized scope. Failed groups can roll back without erasing successful siblings; terminal fixer/healer failures restore unrelated tracked content and protected scratch files. Exact binary/type/mode and nested gitlink evidence prevent text-only or stale-base comparisons from silently losing work.

## Behavior

- Final retained selection is HEAD-relative, while rollback and mutation attribution retain the pre-fix baseline. The verifier sees the complete retained patch.
- Test/verifier evidence is tied to the current retained tree and footprint revision. A bounded two-pass finalization checks healing and later mutations; an unstable or actionable result fails closed.
- Stage the validated retained set once, verify the index, commit with ordinary hooks, and check the resulting commit/worktree. Never bypass hooks or include unrelated scratch content.
- Persist session-bound footprint restores and stabilization failures. Archive status reflects final stabilization failure even if an earlier test attempt passed.

## Testing

- Real `runner.run` tests use actual Git, filesystem, event loop, and local bare remotes. They cover multi-round supporting-file retention, failed-group rollback, exact remote commit contents, pre-gate authorized edits, and archived outcomes; only external agent/API boundaries are faked.
- Exact-path regressions include binary bytes, symlinks, Git pathspec metacharacters, tracked/untracked state, index preservation, and clean/dirty gitlink rollback.
- Independent reviews and the required post-PR `daydream . --precision --backend pi --trace-to honeyhive --trace-to langsmith` review completed. All three review reports and 12 merged findings were adjudicated. Accepted findings are corrected; intentional strict path/symlink policy and a style-only suggestion were retained with rationale. Archive run: `22ca928c-dc27-4f41-bd89-69676f1fa2ee`. An optional diagram request hit HTTP 524; the final process exit code was not retained, so this is not an exit-0 claim.
- Follow-up regressions cover authorized retargeting and terminal target identity, joined parallel-group index restoration, cancellation plus restoration failure, strict restoration despite optional diff/filing failures, exact private file modes, native Git filenames, and preflight failure evidence. The final affected suite passed 490 tests with 3 capability skips; Ruff and nine-file mypy checks passed.
- The final full normal push passed at `7b66bfdd`: 6,694 main tests (12 skipped), 202 standalone tests (2 skipped), 88.95% coverage, signatures, locks, lint, types, dead-code, and workflow checks. All six final-SHA CI checks passed. Earlier hook failures were corrected on the branch and ordinary commands retried; no hooks were bypassed.
