### PR TITLE
fix: validate benchmark snapshot scope and base provenance

### DIFF
--- a/daydream/benchmark/cli.py
+++ b/daydream/benchmark/cli.py
@@ -61,7 +61,8 @@ def _build_benchmark_parser() -> argparse.ArgumentParser:
     build_p.add_argument("--daydream-wheel", required=True, type=Path, help="wheel for this Daydream version")
 
     upgrade_p = sub.add_parser(
-        "upgrade", help="deterministically upgrade legacy case documents (finding_id + schema_version)"
+        "upgrade",
+        help="upgrade legacy cases and verify ready-snapshot base provenance",
     )
     upgrade_p.add_argument("dir", type=Path, help="workspace directory")
     upgrade_p.add_argument("--dry-run", action="store_true", help="report the upgrade without writing")
@@ -251,9 +252,13 @@ def _handle_benchmark_status(dir_path: Path) -> int:
     print(f"ledger entries: {len(status.ledger.pull_requests)}")
     for summary in status.case_snapshots:
         head = summary.get("head_prefix") or "-"
+        snapshot_status = summary.get("snapshot_status", "imported")
+        reason = summary.get("error_reason") or ""
+        if reason:
+            snapshot_status += f" ({reason})"
         print(
             f"  case {summary.get('case_id', '')}: "
-            f"snapshot {summary.get('snapshot_status', 'imported')} @ {head}"
+            f"snapshot {snapshot_status} @ {head}"
         )
     return 0
 
@@ -295,7 +300,7 @@ def _handle_benchmark_build_harbor(args: argparse.Namespace) -> int:
 
 
 def _handle_benchmark_upgrade(args: argparse.Namespace) -> int:
-    """Deterministically upgrade legacy v1 case documents to v2 in place.
+    """Upgrade legacy cases and verify ready-snapshot base provenance in place.
 
     Prints the per-case report plus any surfaced errors. Returns ``0`` on a
     successful upgrade (including an idempotent no-op second run) and ``1``

--- a/daydream/benchmark/github_import.py
+++ b/daydream/benchmark/github_import.py
@@ -1807,6 +1807,17 @@ def _retired_snapshot_bundles(
             raw = storage.load_yaml_strict(
                 storage.resolve_authoring_path(root, row["case_file"])
             )
+            prior_snapshot = raw.get("snapshot") if isinstance(raw, dict) else None
+            if (
+                isinstance(prior_snapshot, dict)
+                and prior_snapshot.get("status") == "ready"
+                and "base_resolution" not in prior_snapshot
+            ):
+                raise storage.WorkspaceCorrupt(
+                    f"{root}: prior ready case {case_id} is missing snapshot.base_resolution; "
+                    "run `daydream benchmark upgrade <workspace>` for this workspace "
+                    "before refreshing"
+                )
             try:
                 old_docs[case_id] = schema.CaseDocument.model_validate(
                     schema._schema_ready(raw)

--- a/daydream/benchmark/github_import.py
+++ b/daydream/benchmark/github_import.py
@@ -1630,6 +1630,10 @@ def _case_materialize(
             curation = dict(prior_curations[case_id])
         if root is not None and origin_url is not None and base_sha and head_sha:
             policy = "final_pr_head" if head_token == "final" else "explicit_head"
+            if policy == "explicit_head" and pull_request.changed_files is None:
+                raise git_ops.GitError(
+                    f"PR {number} explicit-head freeze requires a complete changed-files inventory"
+                )
             snapshot_doc, bundle_bytes = snapshot.freeze_one(
                 root,
                 repo_slug,
@@ -1638,6 +1642,7 @@ def _case_materialize(
                 head_sha=head_sha,
                 policy=policy,
                 requested_head=head_token,
+                pr_changed_files=frozenset(pull_request.changed_files or ()),
                 origin_url=origin_url,
             )
             if snapshot_doc.get("status") == "ready" and bundle_bytes is not None:
@@ -1658,6 +1663,12 @@ def _case_materialize(
                     f"PR {number} freeze of curated case {case_id} is unreplayable "
                     f"({error.get('reason')}): {error.get('detail')}"
                 )
+            elif snapshot_doc.get("status") == "unreplayable" and curation.get("state") != "excluded":
+                curation["state"] = "unreplayable"
+                curation["snapshot_attested"] = False
+                curation["clean_attested"] = False
+                curation["gold_status"] = "findings" if curation.get("findings") else None
+                cu._invalidate_task_spec_approval(curation)
             # Strict authoring anchors: derived from the authenticated mirror
             # (the same one the freeze just populated) immediately before
             # projection. Derivation mutates the typed doc's evidence records
@@ -2033,7 +2044,19 @@ def _import_one_pr(
     prior_sig, prior_task_sig, prior_curations, prior_candidates, import_file, prior_pinned, \
         prior_policy, prior_facts, prior_requested_heads = _prior_import_state(root, raw, number)
     try:
-        doc = fetch_and_normalize(root, repo, number)
+        # Refresh/re-import never orphans a previously pinned case. The same
+        # union also decides whether a complete PR-file inventory is required:
+        # a newly final-only refresh must still protect a retained explicit head.
+        materialize_heads = requested_heads
+        if prior_requested_heads:
+            materialize_heads = list(dict.fromkeys([*prior_requested_heads, *requested_heads]))
+        include_changed_files = any(head != "final" for head in materialize_heads)
+        doc = fetch_and_normalize(
+            root,
+            repo,
+            number,
+            include_changed_files=include_changed_files,
+        )
         # Head-immutable task input: an existing final_pr_head case pins the
         # refreshed doc's head to its snapshot.original_head_sha, so a live
         # head advance neither re-anchors the case nor flips the task-input
@@ -2132,9 +2155,6 @@ def _import_one_pr(
         # Refresh/re-import never orphans a previously pinned case: materialize
         # the union of the prior ledger heads and the newly-requested heads so
         # _stamp_fetched's cases[] rewrite keeps every curated case indexed.
-        materialize_heads = requested_heads
-        if prior_requested_heads:
-            materialize_heads = list(dict.fromkeys([*prior_requested_heads, *requested_heads]))
         cases, bundle_rels = _case_materialize(
             doc, number, materialize_heads, import_file, import_sha256,
             root=root, repo_slug=repo, origin_url=origin_url,
@@ -2264,6 +2284,8 @@ def fetch_and_normalize(
     root: Path,
     owner_repo: str,
     number: int,
+    *,
+    include_changed_files: bool = False,
 ) -> schema.ImportDocument:
     """Fetch one PR's full evidence set through REST and normalize it.
 
@@ -2284,6 +2306,12 @@ def fetch_and_normalize(
     silent default.
     """
     header = _fetch_with_retry(root, owner_repo, number)
+    changed_files = None
+    if include_changed_files:
+        changed_files = _normalize_changed_files(
+            header,
+            _rest(root, f"repos/{owner_repo}/pulls/{number}/files"),
+        )
 
     review_records = _rest(root, f"repos/{owner_repo}/pulls/{number}/reviews")
     inline_records = [_evidence_from_inline(raw) for raw in _rest(root, f"repos/{owner_repo}/pulls/{number}/comments")]
@@ -2319,6 +2347,7 @@ def fetch_and_normalize(
         "merged_at": header.get("merged_at"),
         "closed_at": header.get("closed_at"),
         "author": _as_author(header),
+        "changed_files": changed_files,
     }
     import_doc = {
         "schema_version": 1,
@@ -2336,3 +2365,51 @@ def fetch_and_normalize(
             },
         }
     )
+
+
+def _normalize_changed_files(header: dict[str, Any], rows: list[Any]) -> list[str]:
+    """Return a complete canonical PR path inventory or fail closed."""
+    expected = header.get("changed_files")
+    if not isinstance(expected, int) or isinstance(expected, bool) or expected < 0:
+        raise git_ops.GitError("PR changed_files count is missing or malformed")
+    if expected > 3000:
+        raise git_ops.GitError(
+            f"PR changed_files count {expected} exceeds the 3000-file API inventory limit"
+        )
+    if len(rows) != expected:
+        raise git_ops.GitError(
+            f"PR changed_files inventory count mismatch: header={expected}, rows={len(rows)}"
+        )
+
+    current_names: set[str] = set()
+    all_names: set[str] = set()
+    for index, row in enumerate(rows):
+        if not isinstance(row, dict):
+            raise git_ops.GitError(f"PR changed_files row {index} is not an object")
+        try:
+            current = schema.exact_git_tree_path(row.get("filename"))
+        except ValueError as exc:
+            raise git_ops.GitError(f"PR changed_files row {index} has invalid filename: {exc}") from exc
+        if current in current_names:
+            raise git_ops.GitError(f"PR changed_files inventory repeats filename {current!r}")
+        current_names.add(current)
+        all_names.add(current)
+
+        status = row.get("status")
+        previous = row.get("previous_filename")
+        if status in ("renamed", "copied") and previous is None:
+            raise git_ops.GitError(
+                f"PR changed_files {status} row {index} is missing previous_filename"
+            )
+        if status not in ("renamed", "copied") and previous is not None:
+            raise git_ops.GitError(
+                f"PR changed_files row {index} has unexpected previous_filename"
+            )
+        if previous is not None:
+            try:
+                all_names.add(schema.exact_git_tree_path(previous))
+            except ValueError as exc:
+                raise git_ops.GitError(
+                    f"PR changed_files row {index} has invalid previous_filename: {exc}"
+                ) from exc
+    return sorted(all_names)

--- a/daydream/benchmark/github_import.py
+++ b/daydream/benchmark/github_import.py
@@ -1767,6 +1767,91 @@ def _case_materialize(
     return out, bundle_drops
 
 
+def _retired_snapshot_bundles(
+    root: Path,
+    manifest: dict[str, Any],
+    number: int,
+    new_cases: list[tuple[str, str, dict[str, Any]]],
+) -> list[tuple[str, str]]:
+    """Return unshared prior ready bundles retired by this case rewrite.
+
+    Only a case that changes from a prior ``ready`` snapshot to a non-ready
+    snapshot contributes a candidate. A bundle still referenced by any ready
+    case in the post-transaction workspace is retained. Returned digests bind
+    :meth:`storage.Transaction.retire` to the exact prior bytes.
+    """
+    entry = _manifest_entry(manifest, number)
+    if entry is None or entry.get("import_state") != "fetched":
+        return []
+    new_by_id = {case_id: case_doc for case_id, _, case_doc in new_cases}
+    transitioned = {
+        case_id
+        for case_id, case_doc in new_by_id.items()
+        if (case_doc.get("snapshot") or {}).get("status") != "ready"
+    }
+    if not transitioned:
+        return []
+    rows_by_id: dict[str, dict[str, Any]] = {}
+    for row in manifest.get("cases", []):
+        if isinstance(row, dict) and isinstance(row.get("case_id"), str):
+            rows_by_id[row["case_id"]] = row
+    old_docs: dict[str, schema.CaseDocument] = {}
+
+    def old_doc(case_id: str) -> schema.CaseDocument:
+        if case_id not in old_docs:
+            row = rows_by_id.get(case_id)
+            if not isinstance(row, dict) or not isinstance(row.get("case_file"), str):
+                raise storage.WorkspaceCorrupt(
+                    f"{root}: prior case {case_id} has no indexed case file"
+                )
+            raw = storage.load_yaml_strict(
+                storage.resolve_authoring_path(root, row["case_file"])
+            )
+            try:
+                old_docs[case_id] = schema.CaseDocument.model_validate(
+                    schema._schema_ready(raw)
+                )
+            except Exception as exc:
+                raise storage.WorkspaceCorrupt(
+                    f"{root}: prior case {case_id} is not a valid case document"
+                ) from exc
+        return old_docs[case_id]
+
+    candidates: dict[str, str] = {}
+    for case_id in entry.get("case_ids", []):
+        if case_id not in transitioned:
+            continue
+        prior_snapshot = old_doc(case_id).snapshot
+        if not isinstance(prior_snapshot, schema.SnapshotReady):
+            continue
+        previous = candidates.get(prior_snapshot.bundle_file)
+        if previous is not None and previous != prior_snapshot.bundle_sha256:
+            raise storage.WorkspaceCorrupt(
+                f"{root}: shared prior bundle has conflicting recorded digests"
+            )
+        candidates[prior_snapshot.bundle_file] = prior_snapshot.bundle_sha256
+
+    if not candidates:
+        return []
+    retained_refs = {
+        str((case_doc.get("snapshot") or {}).get("bundle_file"))
+        for case_doc in new_by_id.values()
+        if (case_doc.get("snapshot") or {}).get("status") == "ready"
+        and (case_doc.get("snapshot") or {}).get("bundle_file")
+    }
+    for case_id in rows_by_id:
+        if case_id in new_by_id:
+            continue
+        snapshot = old_doc(case_id).snapshot
+        if isinstance(snapshot, schema.SnapshotReady):
+            retained_refs.add(snapshot.bundle_file)
+    return sorted(
+        (bundle_file, digest)
+        for bundle_file, digest in candidates.items()
+        if bundle_file not in retained_refs
+    )
+
+
 def _ledger_replace(raw: dict[str, Any], entry: dict[str, Any]) -> None:
     """Replace (or append) one ``pull_requests[]`` entry, keeping stable order."""
     raw["pull_requests"] = [
@@ -2169,6 +2254,7 @@ def _import_one_pr(
             prior_facts=prior_facts,
             changed_ids=changed_ids, task_input_changed=task_input_changed,
         )
+        retired_bundles = _retired_snapshot_bundles(root, raw, number, cases)
         # Re-serialize the mutated doc (authoring anchors derived on the typed
         # evidence records during materialization), recompute the fetch payload
         # digest over the same blocks, and keep every digest in lockstep.
@@ -2181,6 +2267,8 @@ def _import_one_pr(
         for _, _, case_doc in cases:
             case_doc["source"]["import_sha256"] = import_sha256
         with storage.Transaction(root, op_id=f"import-{number}", kind="import") as tx:
+            for rel, digest in retired_bundles:
+                tx.retire(rel, expected_sha256=digest)
             tx.stage(import_file, import_bytes)
             for rel, content in bundle_rels:
                 tx.stage(rel, content)
@@ -2375,6 +2463,15 @@ def fetch_and_normalize(
 
 def _normalize_changed_files(header: dict[str, Any], rows: list[Any]) -> list[str]:
     """Return a complete canonical PR path inventory or fail closed."""
+    valid_statuses = {
+        "added",
+        "removed",
+        "modified",
+        "renamed",
+        "copied",
+        "changed",
+        "unchanged",
+    }
     expected = header.get("changed_files")
     if not isinstance(expected, int) or isinstance(expected, bool) or expected < 0:
         raise git_ops.GitError("PR changed_files count is missing or malformed")
@@ -2402,6 +2499,10 @@ def _normalize_changed_files(header: dict[str, Any], rows: list[Any]) -> list[st
         all_names.add(current)
 
         status = row.get("status")
+        if not isinstance(status, str) or status not in valid_statuses:
+            raise git_ops.GitError(
+                f"PR changed_files row {index} has missing or unsupported status"
+            )
         previous = row.get("previous_filename")
         if status in ("renamed", "copied") and previous is None:
             raise git_ops.GitError(

--- a/daydream/benchmark/migrate.py
+++ b/daydream/benchmark/migrate.py
@@ -5,11 +5,11 @@ Issue #806 hardened the authoring schemas and made ``finding_id`` case-scoped
 :func:`daydream.benchmark.schema.derive_finding_id`, gated on
 ``CaseDocument.schema_version == 2`` so pre-change v1 workspaces stay loadable.
 This module deterministically re-derives ``finding_id`` for every v1 case and
-bumps its ``schema_version`` to 2, mutating only those two fields and never
-touching authored content. It also repairs legacy snapshot provenance:
-imported snapshots preserve their sole base candidate, while ready snapshots
-gain the merge-base marker only after local Git objects prove their requested
-tip, merge base, and trees.
+bumps its ``schema_version`` to 2 without touching authored content. It also
+repairs the legacy producer's draft/unreplayable state pairing and snapshot
+provenance: imported snapshots preserve their sole base candidate, while ready
+snapshots gain the merge-base marker only after local Git objects prove their
+requested tip, merge base, and trees.
 
 Invalid data is **never** silently rewritten: a case that fails to load or
 validate is surfaced in ``UpgradeReport.errors`` and left byte-unchanged.
@@ -24,7 +24,7 @@ from typing import Any
 import yaml
 
 from daydream import git_ops
-from daydream.benchmark import schema, snapshot, storage
+from daydream.benchmark import curation, schema, snapshot, storage
 
 
 @dataclass
@@ -108,6 +108,27 @@ def _repair_ready_base_provenance(root: Path, doc: dict[str, Any]) -> bool:
     return True
 
 
+def _repair_legacy_unreplayable_curation(doc: dict[str, Any]) -> bool:
+    """Repair the legacy producer's draft/unreplayable state pairing."""
+    raw_snapshot = doc.get("snapshot")
+    raw_curation = doc.get("curation")
+    if (
+        not isinstance(raw_snapshot, dict)
+        or raw_snapshot.get("status") != "unreplayable"
+        or not isinstance(raw_curation, dict)
+        or raw_curation.get("state") != "draft"
+    ):
+        return False
+    repaired = dict(raw_curation)
+    repaired["state"] = "unreplayable"
+    repaired["snapshot_attested"] = False
+    repaired["clean_attested"] = False
+    repaired["gold_status"] = "findings" if repaired.get("findings") else None
+    curation._invalidate_task_spec_approval(repaired)
+    doc["curation"] = repaired
+    return True
+
+
 def _upgrade_case(raw: dict[str, Any], case_id: str) -> tuple[dict[str, Any], int]:
     """Return a copy of *raw* with case-scoped finding ids and schema_version 2.
 
@@ -136,10 +157,12 @@ def _upgrade_case(raw: dict[str, Any], case_id: str) -> tuple[dict[str, Any], in
 def migrate_workspace(root: Path, *, dry_run: bool = False) -> UpgradeReport:
     """Deterministically upgrade every v1 case in the workspace to v2.
 
-    Recomputes case-scoped ``finding_id`` and bumps ``schema_version`` to 2,
-    writing changed cases atomically through ``storage.Transaction``. When
-    *dry_run* is True the report is computed without writing. Invalid cases are
-    recorded in ``report.errors`` and left byte-unchanged.
+    Recomputes case-scoped ``finding_id``, bumps ``schema_version`` to 2, and
+    repairs the legacy producer's draft/unreplayable curation pairing, writing
+    changed cases atomically through ``storage.Transaction``. When *dry_run* is
+    True the report is computed without writing. Every unchanged v2 case is
+    still validated; invalid cases are recorded in ``report.errors`` and left
+    byte-unchanged.
 
     The migration's writes run under the workspace lock so they serialize
     against concurrent curators — otherwise a curator mutation and a migration
@@ -167,15 +190,16 @@ def _migrate_workspace_unlocked(root: Path, *, dry_run: bool) -> UpgradeReport:
         try:
             raw = storage.load_yaml_strict(root / case_file)
             current = raw.get("schema_version")
+            changed = True
             if current == 2:
                 # v2 repair pass: preserve an imported snapshot's sole base
-                # candidate or prove an unmarked ready snapshot. A current v2
-                # case stays byte-unchanged and is not reported.
+                # candidate, prove an unmarked ready snapshot, or repair the
+                # one legacy producer state pairing. A current valid v2 case
+                # stays byte-unchanged and is not reported.
                 repaired = dict(raw)
                 changed = _backfill_requested_base_sha(repaired)
                 changed = _repair_ready_base_provenance(root, repaired) or changed
-                if not changed:
-                    continue
+                changed = _repair_legacy_unreplayable_curation(repaired) or changed
                 new_raw, recomputed = repaired, 0
             else:
                 if current != 1:
@@ -184,9 +208,12 @@ def _migrate_workspace_unlocked(root: Path, *, dry_run: bool) -> UpgradeReport:
                     )
                 new_raw, recomputed = _upgrade_case(raw, case_id)
                 _repair_ready_base_provenance(root, new_raw)
+                _repair_legacy_unreplayable_curation(new_raw)
             # strip the persisted audit field for validation (curation pattern),
             # but keep it in the written output — authored content is preserved.
             schema.CaseDocument.model_validate(schema._schema_ready(new_raw))
+            if not changed:
+                continue
             # Every staged case is written: the v1 schema_version bump is
             # unconditional, and a v2 repair is a real backfill.
             upgrades.append(CaseUpgrade(case_id=case_id, finding_ids_recomputed=recomputed,

--- a/daydream/benchmark/migrate.py
+++ b/daydream/benchmark/migrate.py
@@ -6,10 +6,10 @@ Issue #806 hardened the authoring schemas and made ``finding_id`` case-scoped
 ``CaseDocument.schema_version == 2`` so pre-change v1 workspaces stay loadable.
 This module deterministically re-derives ``finding_id`` for every v1 case and
 bumps its ``schema_version`` to 2, mutating only those two fields and never
-touching authored content. It also backfills ``requested_base_sha`` from
-``original_base_sha`` on ready/imported snapshots that predate the
-provenance split: on v1 cases during the upgrade, and on v2 cases as a repair
-pass that recomputes no finding ids and bumps no version.
+touching authored content. It also repairs legacy snapshot provenance:
+imported snapshots preserve their sole base candidate, while ready snapshots
+gain the merge-base marker only after local Git objects prove their requested
+tip, merge base, and trees.
 
 Invalid data is **never** silently rewritten: a case that fails to load or
 validate is surfaced in ``UpgradeReport.errors`` and left byte-unchanged.
@@ -23,7 +23,8 @@ from typing import Any
 
 import yaml
 
-from daydream.benchmark import schema, storage
+from daydream import git_ops
+from daydream.benchmark import schema, snapshot, storage
 
 
 @dataclass
@@ -44,18 +45,16 @@ class UpgradeReport:
 
 
 def _backfill_requested_base_sha(doc: dict[str, Any]) -> bool:
-    """Backfill ``requested_base_sha`` on a ready/imported snapshot that lacks it.
+    """Preserve the sole base candidate on an imported snapshot that lacks it.
 
-    Pre-provenance-split workspaces recorded only ``original_base_sha``; the
-    schema now requires ``requested_base_sha`` on ready/imported snapshots.
-    Repair copies the recorded merge base so the doc validates. Returns True
-    when the doc was repaired. Unreplayable snapshots keep the field nullable
-    and are never touched.
+    Imported snapshots have no frozen trees with which to prove a merge base,
+    so the legacy value remains the requested tip until materialization.
+    Ready snapshots use :func:`_repair_ready_base_provenance` instead.
     """
     snapshot = doc.get("snapshot")
     if not isinstance(snapshot, dict):
         return False
-    if snapshot.get("status") not in ("ready", "imported"):
+    if snapshot.get("status") != "imported":
         return False
     original = snapshot.get("original_base_sha")
     if snapshot.get("requested_base_sha") is not None or not original:
@@ -64,12 +63,57 @@ def _backfill_requested_base_sha(doc: dict[str, Any]) -> bool:
     return True
 
 
+def _repair_ready_base_provenance(root: Path, doc: dict[str, Any]) -> bool:
+    """Verify and atomically repair one unmarked ready snapshot.
+
+    ``False`` means only that the snapshot is not ready or is already marked.
+    Once an unmarked ready snapshot is found, every inability to prove the
+    recorded source trees raises and is surfaced as a per-case migration error.
+    """
+    raw_snapshot = doc.get("snapshot")
+    if not isinstance(raw_snapshot, dict) or raw_snapshot.get("status") != "ready":
+        return False
+    marker = raw_snapshot.get("base_resolution")
+    if marker == "merge_base_v1":
+        return False
+    if marker is not None:
+        raise ValueError("ready snapshot has an unsupported base-resolution marker")
+    requested_tip = raw_snapshot.get("requested_base_sha") or raw_snapshot.get(
+        "original_base_sha"
+    )
+    head_sha = raw_snapshot.get("original_head_sha")
+    if not isinstance(requested_tip, str) or not isinstance(head_sha, str):
+        raise ValueError("ready snapshot lacks source commit provenance")
+    mirror = snapshot.mirror(root)
+    if not mirror.exists():
+        raise ValueError("ready snapshot provenance requires cache/repository.git")
+    try:
+        resolved_base = snapshot.resolve_original_base(mirror, requested_tip, head_sha)
+        if resolved_base is None:
+            raise ValueError("ready snapshot source commits have no merge base")
+        trees = snapshot.resolve_trees(mirror, resolved_base, head_sha)
+    except git_ops.GitError as exc:
+        raise ValueError("ready snapshot provenance could not be verified") from exc
+    if not isinstance(trees, tuple):
+        raise ValueError("ready snapshot provenance references a missing Git object")
+    base_tree, head_tree = trees
+    if (
+        base_tree != raw_snapshot.get("base_tree_sha")
+        or head_tree != raw_snapshot.get("head_tree_sha")
+    ):
+        raise ValueError("ready snapshot source trees do not match recorded trees")
+    raw_snapshot["requested_base_sha"] = requested_tip
+    raw_snapshot["original_base_sha"] = resolved_base
+    raw_snapshot["base_resolution"] = "merge_base_v1"
+    return True
+
+
 def _upgrade_case(raw: dict[str, Any], case_id: str) -> tuple[dict[str, Any], int]:
     """Return a copy of *raw* with case-scoped finding ids and schema_version 2.
 
-    Only ``finding_id`` values, ``schema_version`` and a missing
-    ``requested_base_sha`` backfill are mutated; every authored field is
-    preserved verbatim.
+    Only ``finding_id`` values, ``schema_version`` and imported-snapshot base
+    backfill are mutated here; ready provenance is repaired separately after
+    the v1 projection and before validation.
     """
     doc = dict(raw)
     _backfill_requested_base_sha(doc)
@@ -124,11 +168,13 @@ def _migrate_workspace_unlocked(root: Path, *, dry_run: bool) -> UpgradeReport:
             raw = storage.load_yaml_strict(root / case_file)
             current = raw.get("schema_version")
             if current == 2:
-                # v2 repair pass: backfill a missing requested_base_sha without
-                # recomputing finding ids or bumping the version. A valid v2
+                # v2 repair pass: preserve an imported snapshot's sole base
+                # candidate or prove an unmarked ready snapshot. A current v2
                 # case stays byte-unchanged and is not reported.
                 repaired = dict(raw)
-                if not _backfill_requested_base_sha(repaired):
+                changed = _backfill_requested_base_sha(repaired)
+                changed = _repair_ready_base_provenance(root, repaired) or changed
+                if not changed:
                     continue
                 new_raw, recomputed = repaired, 0
             else:
@@ -137,6 +183,7 @@ def _migrate_workspace_unlocked(root: Path, *, dry_run: bool) -> UpgradeReport:
                         f"case {case_id} has unsupported schema_version {current!r}"
                     )
                 new_raw, recomputed = _upgrade_case(raw, case_id)
+                _repair_ready_base_provenance(root, new_raw)
             # strip the persisted audit field for validation (curation pattern),
             # but keep it in the written output — authored content is preserved.
             schema.CaseDocument.model_validate(schema._schema_ready(new_raw))

--- a/daydream/benchmark/schema.py
+++ b/daydream/benchmark/schema.py
@@ -339,6 +339,7 @@ class _SnapshotBase(BaseModel):
 
 class SnapshotReady(_SnapshotBase):
     status: Literal["ready"]
+    base_resolution: Literal["merge_base_v1"]
     # original_base_sha is the true merge base of base-tip and head (the
     # bundle's synthetic base commit); requested_base_sha is the selected
     # base-branch tip the merge base was resolved against.
@@ -381,6 +382,7 @@ _SNAPSHOT_ERROR_REASON = Literal[
     "equal_trees",
     "empty_diff",
     "bundle_failure",
+    "base_drift",
 ]
 
 
@@ -442,6 +444,21 @@ Snapshot = Annotated[
 # ---------------------------------------------------------------------------
 # location / finding / provenance / exclusions
 # ---------------------------------------------------------------------------
+
+
+def exact_git_tree_path(value: Any) -> str:
+    """Validate a Git-tree path without normalizing legal filename bytes."""
+    if not isinstance(value, str):
+        raise ValueError("Git tree path must be a string")
+    if not value:
+        raise ValueError("Git tree path must not be blank")
+    if value.startswith("/"):
+        raise ValueError(f"Git tree path must be relative, got {value!r}")
+    if "\x00" in value:
+        raise ValueError("Git tree path must not contain NUL")
+    if any(part in ("", ".", "..") for part in value.split("/")):
+        raise ValueError(f"Git tree path contains an invalid component: {value!r}")
+    return value
 
 
 def _relative_path(v: str, *, what: str = "location") -> str:
@@ -721,6 +738,7 @@ class PullRequestMeta(BaseModel):
     body_sha256: str = ""
     merged_at: datetime | None = None
     closed_at: datetime | None = None
+    changed_files: list[str] | None = None
 
     @field_validator("created_at", "updated_at", "merged_at", "closed_at", mode="before")
     @classmethod
@@ -735,6 +753,18 @@ class PullRequestMeta(BaseModel):
         if v != "":
             return _hex64(v)
         return v
+
+    @field_validator("changed_files", mode="before")
+    @classmethod
+    def _canonical_changed_files(cls, value: Any) -> list[str] | None:
+        if value is None:
+            return None
+        if not isinstance(value, list):
+            raise ValueError("changed_files must be a list or null")
+        paths = [exact_git_tree_path(path) for path in value]
+        if paths != sorted(set(paths)):
+            raise ValueError("changed_files must be sorted and duplicate-free")
+        return paths
 
     @model_validator(mode="after")
     def _body_hash_consistency(self) -> "PullRequestMeta":
@@ -1048,14 +1078,23 @@ class CaseDocument(BaseModel):
 
     @model_validator(mode="after")
     def _unreplayable_coupling(self) -> "CaseDocument":
-        if (
-            self.curation.state == "unreplayable"
-            and self.snapshot.status != "unreplayable"
-            and self.curation.case_exclusion is None
+        explicitly_excluded = (
+            self.curation.state == "excluded" and self.curation.case_exclusion is not None
+        )
+        if not explicitly_excluded and (
+            (self.curation.state == "unreplayable")
+            != (self.snapshot.status == "unreplayable")
         ):
             raise ValueError(
-                "unreplayable curation requires an unreplayable snapshot unless case_exclusion is set"
+                "unreplayable snapshot and curation states must match unless explicitly excluded"
             )
+        return self
+
+    @model_validator(mode="after")
+    def _requested_base_matches_pr(self) -> "CaseDocument":
+        requested = self.snapshot.requested_base_sha
+        if requested is not None and requested != self.pull_request.base.sha:
+            raise ValueError("snapshot requested_base_sha must match pull_request.base.sha")
         return self
 
 

--- a/daydream/benchmark/snapshot.py
+++ b/daydream/benchmark/snapshot.py
@@ -857,7 +857,12 @@ def freeze_one(
         return unreplayable(degen, f"no real code change between base and head ({degen})")
 
     if policy == "explicit_head":
-        extra_paths = sorted(changed_paths(m, base, head_sha) - pr_changed_files)
+        try:
+            extra_paths = sorted(changed_paths(m, base, head_sha) - pr_changed_files)
+        except git_ops.GitError as exc:
+            return unreplayable(
+                "bundle_failure", f"snapshot path-inventory probe failed: {exc}"
+            )
         if extra_paths:
             preview = ", ".join(repr(path) for path in extra_paths[:20])
             suffix = "" if len(extra_paths) <= 20 else f", and {len(extra_paths) - 20} more"

--- a/daydream/benchmark/snapshot.py
+++ b/daydream/benchmark/snapshot.py
@@ -14,7 +14,7 @@ import os
 import shutil
 import subprocess
 from pathlib import Path
-from typing import Any, Literal, NamedTuple, overload
+from typing import AbstractSet, Any, Literal, NamedTuple, overload
 
 from daydream import git_ops
 from daydream.benchmark import schema, storage
@@ -221,6 +221,56 @@ def _nul_fields(stdout: str | bytes) -> list[str]:
     """
     stdout = stdout if isinstance(stdout, bytes) else stdout.encode()
     return [f.decode("utf-8", errors="surrogateescape") for f in stdout.split(b"\0") if f]
+
+
+def changed_paths(mirror_repo: Path, base_sha: str, head_sha: str) -> frozenset[str]:
+    """Return every old/new path in a strict NUL-framed Git tree diff."""
+    proc = git_ops._run_git(
+        mirror_repo,
+        ["diff", "--name-status", "-z", "-M", base_sha, head_sha],
+        retries=0,
+        capture_bytes=True,
+        timeout=30,
+    )
+    if proc.returncode != 0:
+        stderr = (
+            proc.stderr.decode("utf-8", errors="replace")
+            if isinstance(proc.stderr, bytes)
+            else proc.stderr
+        )
+        raise git_ops.GitError(f"git diff --name-status failed: {stderr.strip()}")
+    raw = proc.stdout if isinstance(proc.stdout, bytes) else proc.stdout.encode()
+    if not raw:
+        return frozenset()
+    if not raw.endswith(b"\0"):
+        raise git_ops.GitError("git diff --name-status returned a truncated NUL record")
+    fields = raw[:-1].split(b"\0")
+    if any(field == b"" for field in fields):
+        raise git_ops.GitError("git diff --name-status returned an empty field")
+
+    paths: set[str] = set()
+    index = 0
+    while index < len(fields):
+        status = fields[index]
+        if status[:1] in (b"R", b"C"):
+            if (
+                len(status) < 2
+                or not status[1:].isdigit()
+                or int(status[1:]) > 100
+                or index + 2 >= len(fields)
+            ):
+                raise git_ops.GitError("git diff --name-status returned a malformed rename/copy record")
+            record_paths = fields[index + 1:index + 3]
+            index += 3
+        elif status in (b"A", b"D", b"M", b"T", b"U", b"X", b"B"):
+            if index + 1 >= len(fields):
+                raise git_ops.GitError("git diff --name-status returned a malformed one-path record")
+            record_paths = fields[index + 1:index + 2]
+            index += 2
+        else:
+            raise git_ops.GitError("git diff --name-status returned an unsupported status record")
+        paths.update(path.decode("utf-8", errors="surrogateescape") for path in record_paths)
+    return frozenset(paths)
 
 
 def _classify_diff(name_status: str | bytes, numstat: str | bytes) -> AnchorDiff:
@@ -710,6 +760,7 @@ def freeze_one(
     head_sha: str,
     policy: str,
     requested_head: str,
+    pr_changed_files: AbstractSet[str],
     origin_url: str | None = None,
 ) -> tuple[dict[str, Any], bytes | None]:
     """Freeze one requested head into a ``(ready|unreplayable, bundle_bytes)`` pair.
@@ -805,6 +856,16 @@ def freeze_one(
     if degen is not None:
         return unreplayable(degen, f"no real code change between base and head ({degen})")
 
+    if policy == "explicit_head":
+        extra_paths = sorted(changed_paths(m, base, head_sha) - pr_changed_files)
+        if extra_paths:
+            preview = ", ".join(repr(path) for path in extra_paths[:20])
+            suffix = "" if len(extra_paths) <= 20 else f", and {len(extra_paths) - 20} more"
+            return unreplayable(
+                "base_drift",
+                f"snapshot contains {len(extra_paths)} path(s) outside PR inventory: {preview}{suffix}",
+            )
+
     # 7) canonical diff + deterministic bundle + offline validation.
     #    The bundle is built under the private scratch area (never ``snapshots/<case>``)
     #    and cleaned up after its bytes are captured, so the final ``snapshots/`` path is
@@ -825,6 +886,7 @@ def freeze_one(
 
     ready = {
         "status": "ready",
+        "base_resolution": "merge_base_v1",
         "policy": policy,
         "requested_head": requested_head,
         # original_base_sha is the true merge base of the selected base tip and

--- a/daydream/benchmark/storage.py
+++ b/daydream/benchmark/storage.py
@@ -241,11 +241,12 @@ class WorkspaceLock:
 @dataclass
 class _TargetState:
     rel: str
-    stage_path: Path
+    operation: Literal["replace", "retire"]
+    stage_path: Path | None
     backup_path: Path | None
     original_existed: bool
     before_digest: str | None
-    after_digest: str
+    after_digest: str | None
     applied: bool = False
 
 
@@ -284,7 +285,8 @@ class Transaction:
             targets.append(
                 {
                     "rel": rel,
-                    "stage": st.stage_path.name,
+                    "operation": st.operation,
+                    "stage": st.stage_path.name if st.stage_path else None,
                     "backup": st.backup_path.name if st.backup_path else None,
                     "original_existed": st.original_existed,
                     "before_digest": st.before_digest,
@@ -351,6 +353,7 @@ class Transaction:
             before_digest = None
         self._states[rel] = _TargetState(
             rel=rel,
+            operation="replace",
             stage_path=stage_path,
             backup_path=backup_path,
             original_existed=original_existed,
@@ -363,6 +366,46 @@ class Transaction:
             self._replacement_order = self._order.copy()
         else:
             self._replacement_order = [r for r in self._replacement_order if r != "benchmark.yaml"] + [rel]
+
+    def retire(self, target_rel: str | Path, *, expected_sha256: str) -> None:
+        """Stage a digest-matched existing file for atomic deletion.
+
+        The target is backed up inside the same transaction before the journal
+        is prepared. A committing-state recovery restores that backup; a
+        complete transaction verifies that the target is absent. The digest
+        binds retirement to the exact file the caller inspected.
+        """
+        rel = _resolve_target(self._root, target_rel)
+        if rel in self._states:
+            raise WorkspaceCorrupt(f"{self._root}: duplicate staged target {rel!r}")
+        if not re.fullmatch(r"[0-9a-f]{64}", expected_sha256):
+            raise WorkspaceCorrupt(f"{self._root}: retirement digest is not lowercase sha256")
+        target = self._root / rel
+        if not target.is_file():
+            raise WorkspaceCorrupt(f"{self._root}: retirement target {rel!r} is missing")
+        actual = sha256_file(target)
+        if actual != expected_sha256:
+            raise WorkspaceCorrupt(
+                f"{self._root}: retirement target {rel!r} digest mismatch "
+                f"(expected {expected_sha256}, got {actual})"
+            )
+        index = len(self._order)
+        backup_path = self._dir / f"backup-{index:04d}.bin"
+        shutil.copyfile(target, backup_path)
+        _fsync_file(backup_path)
+        self._states[rel] = _TargetState(
+            rel=rel,
+            operation="retire",
+            stage_path=None,
+            backup_path=backup_path,
+            original_existed=True,
+            before_digest=actual,
+            after_digest=None,
+        )
+        self._order.append(rel)
+        self._replacement_order = [
+            r for r in self._replacement_order if r != "benchmark.yaml"
+        ] + [rel]
 
     def prepare(self) -> None:
         """Persist the ``prepared`` journal (fsync'd) for startup recovery."""
@@ -421,9 +464,16 @@ class Transaction:
             self._applied_count += 1
             self._write_journal()
             _fsync_file(self._journal_path())
-            os.replace(st.stage_path, target)
-            _fsync_file(target)
-            os.chmod(target, 0o600)
+            if st.operation == "retire":
+                target.unlink()
+            else:
+                if st.stage_path is None:
+                    raise WorkspaceCorrupt(
+                        f"{self._root}: replacement target {rel!r} has no staged file"
+                    )
+                os.replace(st.stage_path, target)
+                _fsync_file(target)
+                os.chmod(target, 0o600)
             _fsync_dir(target.parent)
 
     def commit(self) -> None:
@@ -434,6 +484,16 @@ class Transaction:
         self._write_journal()
         _fsync_file(self._journal_path())
         for st in self._states.values():
+            if st.operation == "retire":
+                if (self._root / st.rel).exists():
+                    raise WorkspaceCorrupt(
+                        f"{self._root}: commit verify retired target {st.rel} still exists"
+                    )
+                continue
+            if st.after_digest is None:
+                raise WorkspaceCorrupt(
+                    f"{self._root}: commit verify replacement {st.rel} lacks after digest"
+                )
             actual = sha256_file(self._root / st.rel)
             if actual != st.after_digest:
                 raise WorkspaceCorrupt(
@@ -767,15 +827,43 @@ def _validate_journal(root: Path, op_dir: Path, doc: dict[str, Any]) -> None:
         if rel in rels:
             raise WorkspaceCorrupt(f"{root}: duplicate target rel in journal: {rel!r}")
         rels.add(rel)
+        operation = t.get("operation", "replace")
+        if operation not in ("replace", "retire"):
+            raise WorkspaceCorrupt(
+                f"{root}: journal target {rel!r} has invalid operation {operation!r}"
+            )
         for field in ("stage", "backup"):
             val = t.get(field)
-            if val is None and field == "backup":
+            if val is None and (
+                field == "backup" or (field == "stage" and operation == "retire")
+            ):
                 continue
             # Reject empty strings too: os.path.basename("") == "", so the bare
             # name check alone would accept "", letting ``op_dir / "" == op_dir``
             # make _rollback_committing rename the whole op dir as the target.
             if not isinstance(val, str) or not val or os.path.basename(val) != val:
                 raise WorkspaceCorrupt(f"{root}: journal target {rel!r} {field} is not a bare filename")
+        if operation == "retire":
+            if t.get("stage") is not None or t.get("backup") is None:
+                raise WorkspaceCorrupt(
+                    f"{root}: retired journal target {rel!r} has invalid stage/backup"
+                )
+            before_digest = t.get("before_digest")
+            if (
+                t.get("original_existed") is not True
+                or not isinstance(before_digest, str)
+                or not re.fullmatch(r"[0-9a-f]{64}", before_digest)
+                or t.get("after_digest") is not None
+            ):
+                raise WorkspaceCorrupt(
+                    f"{root}: retired journal target {rel!r} has invalid digest state"
+                )
+            if state in ("prepared", "committing"):
+                backup_path = op_dir / t["backup"]
+                if not backup_path.is_file() or sha256_file(backup_path) != before_digest:
+                    raise WorkspaceCorrupt(
+                        f"{root}: retired journal target {rel!r} backup digest mismatch"
+                    )
     order = doc.get("replacement_order")
     if not isinstance(order, list):
         raise WorkspaceCorrupt(f"{root}: journal replacement_order is not a list")
@@ -809,9 +897,10 @@ def _targets_from_doc(doc: dict[str, Any]) -> list[dict[str, Any]]:
 def _rollback_prepared(root: Path, op_dir: Path, doc: dict[str, Any]) -> None:
     # Staged files only — no real target was replaced, so nothing to restore.
     for t in _targets_from_doc(doc):
-        stage = op_dir / t["stage"]
-        with suppress(OSError):
-            stage.unlink()
+        stage = t.get("stage")
+        if stage:
+            with suppress(OSError):
+                (op_dir / stage).unlink()
         backup = t.get("backup")
         if backup:
             with suppress(OSError):
@@ -867,6 +956,12 @@ def _verify_complete(root: Path, op_dir: Path, doc: dict[str, Any]) -> None:
     for t in _targets_from_doc(doc):
         rel = _resolve_target(root, t["rel"])
         target = root / rel
+        if t.get("operation", "replace") == "retire":
+            if target.exists():
+                raise WorkspaceCorrupt(
+                    f"{root}: complete journal retired target {rel} still exists"
+                )
+            continue
         if not target.exists():
             raise WorkspaceCorrupt(f"{root}: complete journal {rel} missing on disk")
         actual = sha256_file(target)

--- a/daydream/benchmark/workspace.py
+++ b/daydream/benchmark/workspace.py
@@ -291,6 +291,13 @@ def validate_workspace(root: Path) -> tuple[int, str]:
         except WorkspaceCorrupt as exc:
             return (classify_validation(corrupt=True, ready=False, incomplete=False), f"corrupt: {exc}")
 
+    reasons = sorted(
+        {
+            doc.snapshot.error.reason
+            for doc in docs.values()
+            if isinstance(doc.snapshot, schema.SnapshotUnreplayable)
+        }
+    )
     ready = resolved and state == "ready"
     if ready:
         label = "ready"
@@ -298,6 +305,8 @@ def validate_workspace(root: Path) -> tuple[int, str]:
         label = "incomplete: repository identity unresolved"
     else:
         label = f"incomplete: workspace state {state}"
+    if reasons:
+        label += f"; unreplayable snapshot reasons: {', '.join(reasons)}"
     return (classify_validation(ready=ready, incomplete=not ready, corrupt=False), label)
 
 
@@ -308,10 +317,11 @@ def _derived_state(
 
     Loading each indexed case document with the shared model-gated loader,
     resolving every indexed authoring file exactly once, and verifying each
-    fetched import's on-disk sha256 plus each ``ready`` snapshot's bundle
-    sha256 keeps the two read-only call paths on one rule, so a
-    state/resolution rule can't diverge between them. An unreadable/invalid
-    case or a checksum mismatch surfaces as :class:`WorkspaceCorrupt`.
+    fetched import's on-disk sha256, each ``ready`` snapshot's bundle fidelity,
+    and (when retained) local source-mirror provenance keeps the two read-only
+    call paths on one rule, so a state/resolution rule can't diverge between
+    them. An unreadable/invalid case or failed proof surfaces as
+    :class:`WorkspaceCorrupt`.
     """
     if docs is None:
         docs = load_case_documents(root, manifest)
@@ -330,6 +340,7 @@ def _derived_state(
     paths = _resolved_authoring_paths(root, manifest, docs)
     _verify_import_checksums(root, manifest, paths)
     _verify_snapshot_checksums(root, manifest, docs, paths)
+    _verify_snapshot_source_provenance(root, manifest, docs)
     _verify_cross_document(root, manifest, docs, imports=imports)
     _verify_duplicate_inodes(root, paths)
     resolved = manifest.source.repository_id is not None and manifest.source.visibility != "unresolved"
@@ -420,7 +431,10 @@ def _verify_snapshot_checksums(
     synthetic reachable commits, root base, head-parented-on-base, tree IDs
     and the canonical diff digest. A fidelity failure is corruption (exit 1),
     never curatable staleness; only a checksum-restamped tampered bundle
-    passes the sha256 gate yet still fails here.
+    passes the sha256 gate yet still fails here. Source-commit provenance is
+    the separate, local-only check in
+    :func:`_verify_snapshot_source_provenance`; this helper owns the portable
+    self-contained bundle contract.
     """
     for case in manifest.cases:
         snapshot = docs[case.case_file].snapshot
@@ -467,6 +481,55 @@ def _verify_snapshot_checksums(
                 f"{root}: case {case.case_id} snapshot bundle fails offline-clone "
                 f"fidelity: {exc}"
             ) from exc
+
+
+def _verify_snapshot_source_provenance(
+    root: Path,
+    manifest: BenchmarkManifest,
+    docs: dict[str, CaseDocument],
+) -> None:
+    """Re-attest ready snapshot commit linkage from the local mirror when present.
+
+    The ready marker records that the merge-base algorithm was already proven.
+    A retained authoring mirror lets status/validate repeat that proof without
+    network access.  Once disposable cache is cleaned, the required marker and
+    offline bundle-fidelity check remain the portable contract.
+    """
+    mirror = snapshot_mod.mirror(root)
+    if not mirror.exists():
+        return
+    for case in manifest.cases:
+        snapshot = docs[case.case_file].snapshot
+        if not isinstance(snapshot, schema.SnapshotReady):
+            continue
+        try:
+            resolved_base = snapshot_mod.resolve_original_base(
+                mirror,
+                snapshot.requested_base_sha,
+                snapshot.original_head_sha,
+            )
+            trees = snapshot_mod.resolve_trees(
+                mirror,
+                snapshot.original_base_sha,
+                snapshot.original_head_sha,
+            )
+        except git_ops.GitError as exc:
+            raise WorkspaceCorrupt(
+                f"{root}: case {case.case_id} snapshot source provenance cannot be resolved"
+            ) from exc
+        if resolved_base != snapshot.original_base_sha:
+            raise WorkspaceCorrupt(
+                f"{root}: case {case.case_id} snapshot source provenance merge-base mismatch"
+            )
+        if not isinstance(trees, tuple):
+            raise WorkspaceCorrupt(
+                f"{root}: case {case.case_id} snapshot source provenance object missing"
+            )
+        base_tree, head_tree = trees
+        if base_tree != snapshot.base_tree_sha or head_tree != snapshot.head_tree_sha:
+            raise WorkspaceCorrupt(
+                f"{root}: case {case.case_id} snapshot source provenance tree mismatch"
+            )
 
 
 def _load_import_document(root: Path, import_file: str) -> ImportDocument:
@@ -695,9 +758,10 @@ def _case_snapshot_summaries(
     """Per-case snapshot summary for ``status``: snapshot state + frozen head.
 
     For each indexed case, loads the case through the shared model-gated
-    loader and reports its snapshot ``status`` and the frozen head prefix
-    (``original_head_sha[:12]``) when present. An unreadable/invalid case
-    surfaces as :class:`WorkspaceCorrupt` (shared with the validate path).
+    loader and reports its snapshot ``status``, the frozen head prefix
+    (``original_head_sha[:12]``) when present, and the typed failure reason for
+    unreplayable snapshots. An unreadable/invalid case surfaces as
+    :class:`WorkspaceCorrupt` (shared with the validate path).
     """
     if docs is None:
         docs = load_case_documents(root, manifest)
@@ -706,11 +770,17 @@ def _case_snapshot_summaries(
         doc = docs[case.case_file]
         status = doc.snapshot.status or "imported"
         head = doc.snapshot.original_head_sha or ""
+        error_reason = (
+            doc.snapshot.error.reason
+            if isinstance(doc.snapshot, schema.SnapshotUnreplayable)
+            else ""
+        )
         summaries.append(
             {
                 "case_id": case.case_id,
                 "snapshot_status": status,
                 "head_prefix": head[:12],
+                "error_reason": error_reason,
             }
         )
     return summaries

--- a/daydream/benchmark/workspace.py
+++ b/daydream/benchmark/workspace.py
@@ -604,7 +604,8 @@ def _verify_cross_document(
 
     Each ``cases[]`` row must reference exactly ``cases/<case_id>.yaml`` and
     agree with its case document's ``pull_request.number``, and its PR must be
-    present in the ``pull_requests[]`` ledger. Every case_id a ledger entry
+    a fetched ledger entry whose import path/digest and immutable PR metadata
+    exactly match the case's source block and copied PR block. Every case_id a ledger entry
     claims must be backed by an indexed ``cases[]`` row naming the same PR —
     the reverse (every indexed case covered by ``case_ids``) is not required,
     because a fetched->fetched narrower re-import (shrink) rewrites the
@@ -632,6 +633,26 @@ def _verify_cross_document(
             raise WorkspaceCorrupt(
                 f"{root}: case {case.case_id} PR {case.pr_number} is absent from "
                 f"the pull_requests ledger"
+            )
+        entry = ledger[case.pr_number]
+        if (
+            entry.import_state != "fetched"
+            or entry.import_file is None
+            or entry.import_sha256 is None
+            or doc.source.import_file != entry.import_file
+            or doc.source.import_sha256 != entry.import_sha256
+        ):
+            raise WorkspaceCorrupt(
+                f"{root}: case {case.case_id} import provenance mismatches its ledger entry"
+            )
+        imp = (
+            imports[entry.import_file]
+            if imports is not None and entry.import_file in imports
+            else _load_import_document(root, entry.import_file)
+        )
+        if doc.pull_request != imp.pull_request:
+            raise WorkspaceCorrupt(
+                f"{root}: case {case.case_id} import provenance PR metadata mismatch"
             )
     indexed_cases = {case.case_id: case for case in manifest.cases}
     for pr in manifest.pull_requests:

--- a/daydream/benchmark/workspace.py
+++ b/daydream/benchmark/workspace.py
@@ -515,7 +515,8 @@ def _verify_snapshot_source_provenance(
             )
         except git_ops.GitError as exc:
             raise WorkspaceCorrupt(
-                f"{root}: case {case.case_id} snapshot source provenance cannot be resolved"
+                f"{root}: case {case.case_id} snapshot source provenance cannot be resolved "
+                "from cache/repository.git; restore that mirror before retrying"
             ) from exc
         if resolved_base != snapshot.original_base_sha:
             raise WorkspaceCorrupt(
@@ -523,7 +524,8 @@ def _verify_snapshot_source_provenance(
             )
         if not isinstance(trees, tuple):
             raise WorkspaceCorrupt(
-                f"{root}: case {case.case_id} snapshot source provenance object missing"
+                f"{root}: case {case.case_id} snapshot source provenance object is missing "
+                "from cache/repository.git; restore that mirror before retrying"
             )
         base_tree, head_tree = trees
         if base_tree != snapshot.base_tree_sha or head_tree != snapshot.head_tree_sha:

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -106,8 +106,9 @@ daydream benchmark status ~/bench-owner-repo
 Reports the derived workspace state (`empty` / `collecting` / `ready` / …),
 whether the repository identity is **unresolved**, the PR ledger, and per-indexed
 case snapshot state (`ready` / `unreplayable` / `imported`) with the frozen head
-prefix each case was caught at. Safe to run concurrently with other read-only
-commands.
+prefix each case was caught at. Unreplayable rows include their typed reason,
+such as `base_drift`, without exposing the private path detail. Safe to run
+concurrently with other read-only commands.
 
 ### `validate` — 0/2/1 exit codes
 
@@ -116,7 +117,8 @@ daydream benchmark validate ~/bench-owner-repo
 ```
 
 Returns a numeric **exit** code: `0` ready, `2` structurally valid but
-incomplete (for example an unresolved repository identity on a fresh workspace),
+incomplete (for example an unresolved repository identity on a fresh workspace;
+typed unreplayable reasons are appended to this label),
 `1` corrupt (invalid/missing `benchmark.yaml`, an orphan or missing indexed file,
 or a checksum-mismatched ready-snapshot bundle).
 
@@ -147,6 +149,12 @@ print) runs before any fetch; the first successful repository resolution fills
 import file and marks the PR `fetch_failed` in the resumable ledger. The command
 never selects gold and never filters bot authors — bot classification is retained
 as metadata only.
+
+Explicit historical heads are also checked against GitHub's complete final PR
+file inventory. If their merge-base snapshot touches an extra path, the case is
+refused as `base_drift`; the default final head keeps its existing behavior.
+Every ready snapshot carries `base_resolution: merge_base_v1`, recording that
+its persisted base was resolved and proven as the merge base.
 
 ### `curate` — golden review
 
@@ -526,8 +534,13 @@ commitment to content — it does **not** reveal the content it fingerprints.
 Pre-provenance-split workspaces need a one-time repair before they can build and
 run. `daydream benchmark upgrade <dir>` (and `--dry-run`) is that repair path:
 
-- It backfills `requested_base_sha` from the recorded `original_base_sha` on
-  every `ready`/`imported` snapshot — **v1 and already-v2 alike**.
+- For a legacy `ready` snapshot, it uses the private
+  `cache/repository.git` mirror to recompute the merge base and verify the
+  recorded base/head trees before writing `base_resolution: merge_base_v1`.
+  An old blind backfill (`original_base_sha == requested_base_sha`) is repaired
+  to the real merge base by the same proof.
+- For an `imported` snapshot, which has no frozen trees, it only preserves the
+  sole legacy base candidate as `requested_base_sha`.
 - It re-derives the v1→v2 **case-scoped `finding_id`** for the same snapshots.
 - **Authored content is left untouched** — curation, gold, and any author edits
   are preserved byte-for-byte.
@@ -537,6 +550,11 @@ run. `daydream benchmark upgrade <dir>` (and `--dry-run`) is that repair path:
   *would* be written without writing.
 - An **un-upgraded** such workspace fails `CaseDocument` validation and reports
   as **corrupt**.
+
+If provenance verification cannot run, restore the workspace's private
+`cache/repository.git` mirror (with the recorded commits), or refresh/re-import
+the PR before retrying `upgrade`. The command never stamps a ready snapshot from
+unverified metadata.
 
 ## 7. Failure and cleanup states
 

--- a/tests/harness/fake_gh.py
+++ b/tests/harness/fake_gh.py
@@ -25,6 +25,8 @@ response map (``responses.json``) plus built-in behaviors:
   success (the Task 0 spike's chosen stale-finding mechanism);
 - ``GET repos/<o>/<r>/pulls/<n>/reviews`` returns the configured review list
   (``[]`` by default);
+- ``GET repos/<o>/<r>/pulls/<n>/files`` returns the configured changed-file
+  inventory (``[]`` by default);
 - ``POST repos/<o>/<r>/pulls/<n>/reviews`` returns a fake ``html_url``.
 - ``gh pr view [<number>] --json ...`` emits the configured ``pr-view`` JSON
   and records the invocation; ``gh pr list`` projects that same response into
@@ -275,6 +277,8 @@ def _handle_api(argv: list[str], state: Path) -> tuple[int, str, str]:
             return 1, "", f"fake gh: 404 {endpoint} (no such resource)\n"
         return 0, _emit(responses[bare_key], jq), ""
     if method == "GET" and re.fullmatch(r"repos/[^/]+/[^/]+/pulls/\d+/reviews", endpoint):
+        return 0, _emit([], jq), ""
+    if method == "GET" and re.fullmatch(r"repos/[^/]+/[^/]+/pulls/\d+/files", endpoint):
         return 0, _emit([], jq), ""
     if method == "GET" and re.fullmatch(r"repos/[^/]+/[^/]+/pulls/\d+/comments", endpoint):
         return 0, _emit([], jq), ""

--- a/tests/test_benchmark_import_prs.py
+++ b/tests/test_benchmark_import_prs.py
@@ -19,6 +19,7 @@ from typing import Any, Literal
 
 import pytest
 
+from daydream import git_ops
 from tests.harness import github_schema as gs
 from tests.harness.fake_gh import FakeGh
 
@@ -47,6 +48,7 @@ _PR_HEADER = {
     "created_at": "2026-01-01T00:00:00Z",
     "updated_at": "2026-01-01T00:00:00Z",
     "user": {"login": "alice", "type": "User"},
+    "changed_files": 0,
 }
 
 _REPO_ID = "R_kgDOABC123"
@@ -99,6 +101,93 @@ def test_fetch_persists_complete_pr_header(tmp_path: Path, fake_gh: FakeGh) -> N
     assert pr.head.ref == "feature/cache"          # head.ref parity with base.ref
     assert pr.merged_at is not None and pr.closed_at is not None
     assert pr.number == 101 and pr.author.login == "alice"
+
+
+def test_fetch_changed_files_persists_complete_rename_union(
+    tmp_path: Path, fake_gh: FakeGh
+) -> None:
+    from daydream.benchmark import github_import as gi
+
+    ws = tmp_path / "ws"
+    (ws / "imports").mkdir(parents=True)
+    header = {**_PR_HEADER, "changed_files": 2}
+    fake_gh.set_response("GET", "repos/o/r/pulls/101", header)
+    fake_gh.set_response(
+        "GET",
+        "repos/o/r/pulls/101/files",
+        [
+            {"status": "modified", "filename": "src/a:b.py"},
+            {
+                "status": "renamed",
+                "filename": "src/new name.py",
+                "previous_filename": r"src\old.py",
+            },
+        ],
+    )
+    for ep in (
+        "repos/o/r/pulls/101/reviews",
+        "repos/o/r/pulls/101/comments",
+        "repos/o/r/issues/101/comments",
+    ):
+        fake_gh.set_response("GET", ep, [])
+
+    doc = gi.fetch_and_normalize(ws, "o/r", 101, include_changed_files=True)
+
+    assert doc.pull_request.changed_files == ["src/a:b.py", "src/new name.py", r"src\old.py"]
+    calls = fake_gh.calls("GET", "repos/o/r/pulls/101/files")
+    assert len(calls) == 1 and "--paginate" in (calls[0].argv or [])
+
+
+@pytest.mark.parametrize(
+    ("count", "rows"),
+    [
+        (2, [{"status": "modified", "filename": "a.py"}]),
+        (3001, []),
+        (1, [{"status": "renamed", "filename": "new.py"}]),
+        (1, [{"status": "modified", "filename": "new.py", "previous_filename": "old.py"}]),
+        (2, [
+            {"status": "modified", "filename": "a.py"},
+            {"status": "modified", "filename": "a.py"},
+        ]),
+        (1, [{"status": "modified", "filename": "../escape.py"}]),
+    ],
+)
+def test_fetch_changed_files_fails_closed_on_incomplete_or_malformed_inventory(
+    tmp_path: Path, fake_gh: FakeGh, count: int, rows: list[Any]
+) -> None:
+    from daydream.benchmark import github_import as gi
+
+    ws = tmp_path / "ws"
+    (ws / "imports").mkdir(parents=True)
+    fake_gh.set_response("GET", "repos/o/r/pulls/101", {**_PR_HEADER, "changed_files": count})
+    fake_gh.set_response("GET", "repos/o/r/pulls/101/files", rows)
+    for ep in (
+        "repos/o/r/pulls/101/reviews",
+        "repos/o/r/pulls/101/comments",
+        "repos/o/r/issues/101/comments",
+    ):
+        fake_gh.set_response("GET", ep, [])
+    with pytest.raises(git_ops.GitError, match="changed.files|inventory|3000"):
+        gi.fetch_and_normalize(ws, "o/r", 101, include_changed_files=True)
+
+
+def test_final_only_fetch_does_not_request_changed_files(
+    tmp_path: Path, fake_gh: FakeGh
+) -> None:
+    from daydream.benchmark import github_import as gi
+
+    ws = tmp_path / "ws"
+    (ws / "imports").mkdir(parents=True)
+    fake_gh.set_response("GET", "repos/o/r/pulls/101", _PR_HEADER)
+    for ep in (
+        "repos/o/r/pulls/101/reviews",
+        "repos/o/r/pulls/101/comments",
+        "repos/o/r/issues/101/comments",
+    ):
+        fake_gh.set_response("GET", ep, [])
+    doc = gi.fetch_and_normalize(ws, "o/r", 101)
+    assert doc.pull_request.changed_files is None
+    assert fake_gh.calls("GET", "repos/o/r/pulls/101/files") == []
 
 
 def test_materialized_case_carries_full_pr_header(tmp_path: Path, fake_gh: FakeGh) -> None:
@@ -1048,6 +1137,51 @@ def _seed_local_origin(tmp_path: Path, fake_gh: FakeGh) -> tuple[str, str, str]:
     return str(bare), base_sha, head_sha
 
 
+def _seed_stacked_origin(
+    tmp_path: Path, fake_gh: FakeGh
+) -> tuple[str, str, str, str]:
+    """Build an advanced-base PR with one reverted historical path.
+
+    The explicit head adds ``legacy.py`` and ``feature.py``; the final head
+    removes ``legacy.py`` again.  GitHub's final PR inventory therefore names
+    only ``feature.py``, while the historical snapshot includes both paths.
+    """
+    repo = tmp_path / "stacked_wt"
+    repo.mkdir()
+    _seed_git(repo, "init", "-b", "main")
+    _seed_write(repo, "readme.txt", "base\n")
+    base_sha = _seed_commit(repo, "base")
+    _seed_write(repo, "upstream.py", "UPSTREAM = 1\n")
+    base_tip = _seed_commit(repo, "advanced base")
+    _seed_git(repo, "checkout", "--detach", base_sha)
+    _seed_write(repo, "legacy.py", "LEGACY = 1\n")
+    _seed_write(repo, "feature.py", "FEATURE = 1\n")
+    explicit_sha = _seed_commit(repo, "historical feature")
+    _seed_git(repo, "rm", "legacy.py")
+    final_sha = _seed_commit(repo, "revert historical path")
+
+    bare = tmp_path / "stacked_origin.git"
+    bare.mkdir()
+    _seed_git(bare, "init", "--bare")
+    _seed_git(repo, "remote", "add", "origin", str(bare))
+    _seed_git(repo, "push", "origin", "main:main")
+    _seed_git(repo, "push", "origin", f"{final_sha}:refs/pull/101/head", check=False)
+    header = dict(_PR_HEADER)
+    header["base"] = {"ref": "main", "sha": base_tip}
+    header["head"] = {"ref": "feature", "sha": final_sha}
+    header["changed_files"] = 2
+    fake_gh.set_response("GET", "repos/o/r/pulls/101", header)
+    fake_gh.set_response(
+        "GET",
+        "repos/o/r/pulls/101/files",
+        [
+            {"status": "added", "filename": "feature.py"},
+            {"status": "added", "filename": "legacy.py"},
+        ],
+    )
+    return str(bare), base_tip, explicit_sha, final_sha
+
+
 def _seed_anchor_origin(tmp_path: Path, fake_gh: FakeGh) -> tuple[str, str, str, str]:
     """Bare origin with authored-rename history + re-seeded PR header.
 
@@ -1257,6 +1391,155 @@ def test_e2e_import_distinct_idempotent_explicit_head_and_shared_mirror(tmp_path
     # one shared mirror, no ref collision: the PR-head ref still resolves to head
     assert (ws / "cache" / "repository.git").exists()
     assert sn.rev_parse(ws / "cache/repository.git", "refs/pull/101/head") == head_sha
+
+
+def test_refresh_demotes_clean_draft_when_historical_head_leaves_pr_scope(
+    tmp_path: Path, fake_gh: FakeGh
+) -> None:
+    """The real import boundary applies final-inventory scope to retained heads."""
+    import yaml
+
+    from daydream.benchmark import github_import as gi
+    from daydream.benchmark.storage import load_yaml_strict
+    from daydream.benchmark.workspace import init_workspace
+
+    ws = tmp_path / "ws"
+    init_workspace(ws, "o/r", ["api.anthropic.com"], ["api.anthropic.com"])
+    _seed_preflight(ws, fake_gh)
+    origin_url, _base_tip, explicit_sha, final_sha = _seed_stacked_origin(tmp_path, fake_gh)
+
+    assert gi.run_import_prs(
+        ws, pr_numbers=[101], heads=[explicit_sha], origin_url=origin_url
+    ) == 0
+    explicit_path = ws / f"cases/pr-000101-{explicit_sha[:12]}.yaml"
+    explicit = load_yaml_strict(explicit_path)
+    assert explicit["snapshot"]["status"] == "ready"
+    explicit["curation"].update(
+        state="draft",
+        snapshot_attested=True,
+        clean_attested=True,
+        gold_status="clean",
+        task_spec_sha256="d" * 64,
+    )
+    explicit_path.write_text(yaml.safe_dump(explicit, sort_keys=False))
+
+    header = dict(_PR_HEADER)
+    header["base"] = {"ref": "main", "sha": _base_tip}
+    header["head"] = {"ref": "feature", "sha": final_sha}
+    header["changed_files"] = 1
+    fake_gh.set_response("GET", "repos/o/r/pulls/101", header)
+    fake_gh.set_response(
+        "GET", "repos/o/r/pulls/101/files", [{"status": "added", "filename": "feature.py"}]
+    )
+
+    assert gi.run_import_prs(
+        ws,
+        pr_numbers=[101],
+        heads=["final"],
+        refresh=True,
+        origin_url=origin_url,
+    ) == 0
+    explicit = load_yaml_strict(explicit_path)
+    assert explicit["snapshot"]["status"] == "unreplayable"
+    assert explicit["snapshot"]["error"]["reason"] == "base_drift"
+    assert explicit["curation"]["state"] == "unreplayable"
+    assert explicit["curation"]["snapshot_attested"] is False
+    assert explicit["curation"]["clean_attested"] is False
+    assert explicit["curation"]["gold_status"] is None
+    assert "task_spec_sha256" not in explicit["curation"]
+
+    final = load_yaml_strict(ws / f"cases/pr-000101-{final_sha[:12]}.yaml")
+    assert final["snapshot"]["status"] == "ready"
+
+
+def test_inventory_only_refresh_preserves_gold_when_snapshot_remains_in_scope(
+    tmp_path: Path, fake_gh: FakeGh
+) -> None:
+    """Changed-file scope evidence is persisted but is not reviewer task input."""
+    import yaml
+
+    from daydream.benchmark import github_import as gi
+    from daydream.benchmark.storage import load_yaml_strict
+    from daydream.benchmark.workspace import init_workspace
+
+    ws = tmp_path / "ws"
+    init_workspace(ws, "o/r", ["api.anthropic.com"], ["api.anthropic.com"])
+    _seed_preflight(ws, fake_gh)
+    origin_url, base_tip, explicit_sha, final_sha = _seed_stacked_origin(tmp_path, fake_gh)
+    assert gi.run_import_prs(
+        ws, pr_numbers=[101], heads=[explicit_sha], origin_url=origin_url
+    ) == 0
+    explicit_path = ws / f"cases/pr-000101-{explicit_sha[:12]}.yaml"
+    explicit = load_yaml_strict(explicit_path)
+    explicit["curation"].update(
+        state="draft",
+        snapshot_attested=False,
+        clean_attested=True,
+        gold_status="clean",
+    )
+    explicit_path.write_text(yaml.safe_dump(explicit, sort_keys=False))
+    before_curation = load_yaml_strict(explicit_path)["curation"]
+
+    header = dict(_PR_HEADER)
+    header["base"] = {"ref": "main", "sha": base_tip}
+    header["head"] = {"ref": "feature", "sha": final_sha}
+    header["changed_files"] = 3
+    fake_gh.set_response("GET", "repos/o/r/pulls/101", header)
+    fake_gh.set_response(
+        "GET",
+        "repos/o/r/pulls/101/files",
+        [
+            {"status": "added", "filename": "feature.py"},
+            {"status": "added", "filename": "legacy.py"},
+            {"status": "modified", "filename": "unrelated.py"},
+        ],
+    )
+    assert gi.run_import_prs(
+        ws,
+        pr_numbers=[101],
+        heads=["final"],
+        refresh=True,
+        origin_url=origin_url,
+    ) == 0
+
+    refreshed = load_yaml_strict(explicit_path)
+    assert refreshed["snapshot"]["status"] == "ready"
+    assert refreshed["pull_request"]["changed_files"] == [
+        "feature.py",
+        "legacy.py",
+        "unrelated.py",
+    ]
+    assert refreshed["curation"] == before_curation
+
+
+def test_in_scope_explicit_and_final_heads_validate_and_compile(
+    tmp_path: Path, fake_gh: FakeGh
+) -> None:
+    """The real import/curation/compile path keeps a covered explicit head."""
+    from daydream.benchmark import curation as cu
+    from daydream.benchmark import github_import as gi
+    from daydream.benchmark.harbor import build
+    from daydream.benchmark.storage import load_yaml_strict
+    from daydream.benchmark.workspace import init_workspace, validate_workspace
+
+    ws = tmp_path / "ws"
+    init_workspace(ws, "o/r", ["api.anthropic.com"], ["api.anthropic.com"])
+    _seed_preflight(ws, fake_gh)
+    origin_url, _base_tip, explicit_sha, _final_sha = _seed_stacked_origin(tmp_path, fake_gh)
+    assert gi.run_import_prs(
+        ws, pr_numbers=[101], heads=[explicit_sha], origin_url=origin_url
+    ) == 0
+
+    manifest = load_yaml_strict(ws / "benchmark.yaml")
+    for row in manifest["cases"]:
+        case_id = row["case_id"]
+        case = load_yaml_strict(ws / row["case_file"])
+        cu.attest_clean(ws, case_id)
+        cu.mark_ready(ws, case_id, head_sha=case["snapshot"]["original_head_sha"])
+
+    assert validate_workspace(ws) == (0, "ready")
+    lock = build.compile_workspace(ws)
+    assert len(lock["cases"]) == 2
 
 
 def test_import_writes_atomic_unit_and_no_file_on_failure(tmp_path: Path, fake_gh: FakeGh) -> None:

--- a/tests/test_benchmark_import_prs.py
+++ b/tests/test_benchmark_import_prs.py
@@ -12,6 +12,7 @@ origin (no network).
 import hashlib
 import json
 import os
+import shutil
 import subprocess
 from datetime import datetime, timezone
 from pathlib import Path
@@ -1518,6 +1519,96 @@ def test_refresh_demotes_clean_draft_when_historical_head_leaves_pr_scope(
         top_cli.main(["benchmark", "validate", str(ws)])
     assert validate_exit.value.code == 2
     assert "unreplayable snapshot reasons: base_drift" in capsys.readouterr().out
+
+
+def test_explicit_head_path_probe_git_failure_isolated_to_that_case(
+    tmp_path: Path, fake_gh: FakeGh, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A real git diff failure is a typed case result, not a whole-PR abort."""
+    from daydream.benchmark import github_import as gi
+    from daydream.benchmark.storage import load_yaml_strict
+    from daydream.benchmark.workspace import init_workspace
+
+    ws = tmp_path / "ws"
+    init_workspace(ws, "o/r", ["api.anthropic.com"], ["api.anthropic.com"])
+    _seed_preflight(ws, fake_gh)
+    origin_url, _base_tip, explicit_sha, final_sha = _seed_stacked_origin(tmp_path, fake_gh)
+
+    real_git = shutil.which("git")
+    assert real_git is not None
+    shim_dir = tmp_path / "git shim"
+    shim_dir.mkdir()
+    shim = shim_dir / "git"
+    shim.write_text(
+        "#!/bin/sh\n"
+        "if [ \"$1\" = diff ] && [ \"$2\" = --name-status ]; then\n"
+        "  echo 'injected path inventory failure' >&2\n"
+        "  exit 88\n"
+        "fi\n"
+        "exec \"$DAYDREAM_TEST_REAL_GIT\" \"$@\"\n"
+    )
+    shim.chmod(0o755)
+    monkeypatch.setenv("DAYDREAM_TEST_REAL_GIT", real_git)
+    monkeypatch.setenv("PATH", f"{shim_dir}{os.pathsep}{os.environ['PATH']}")
+
+    assert gi.run_import_prs(
+        ws, pr_numbers=[101], heads=[explicit_sha], origin_url=origin_url
+    ) == 0
+    manifest = load_yaml_strict(ws / "benchmark.yaml")
+    assert manifest["pull_requests"][0]["import_state"] == "fetched"
+    explicit = load_yaml_strict(ws / f"cases/pr-000101-{explicit_sha[:12]}.yaml")
+    final = load_yaml_strict(ws / f"cases/pr-000101-{final_sha[:12]}.yaml")
+    assert explicit["snapshot"]["status"] == "unreplayable"
+    assert explicit["snapshot"]["error"]["reason"] == "bundle_failure"
+    assert "injected path inventory failure" in explicit["snapshot"]["error"]["detail"]
+    assert final["snapshot"]["status"] == "ready"
+
+
+def test_refresh_legacy_ready_snapshot_requires_upgrade_before_retirement(
+    tmp_path: Path, fake_gh: FakeGh
+) -> None:
+    """Retirement names the upgrade needed for a pre-marker ready case."""
+    import yaml
+
+    from daydream.benchmark import github_import as gi
+    from daydream.benchmark.storage import load_yaml_strict
+    from daydream.benchmark.workspace import init_workspace
+
+    ws = tmp_path / "workspace with spaces"
+    init_workspace(ws, "o/r", ["api.anthropic.com"], ["api.anthropic.com"])
+    _seed_preflight(ws, fake_gh)
+    origin_url, base_tip, explicit_sha, final_sha = _seed_stacked_origin(tmp_path, fake_gh)
+    assert gi.run_import_prs(
+        ws, pr_numbers=[101], heads=[explicit_sha], origin_url=origin_url
+    ) == 0
+
+    explicit_path = ws / f"cases/pr-000101-{explicit_sha[:12]}.yaml"
+    prior = load_yaml_strict(explicit_path)
+    prior["snapshot"].pop("base_resolution")
+    explicit_path.write_text(yaml.safe_dump(prior, sort_keys=False))
+    prior_bytes = explicit_path.read_bytes()
+    prior_bundle = ws / prior["snapshot"]["bundle_file"]
+
+    header = dict(_PR_HEADER)
+    header["base"] = {"ref": "main", "sha": base_tip}
+    header["head"] = {"ref": "feature", "sha": final_sha}
+    header["changed_files"] = 1
+    fake_gh.set_response("GET", "repos/o/r/pulls/101", header)
+    fake_gh.set_response(
+        "GET", "repos/o/r/pulls/101/files", [{"status": "added", "filename": "feature.py"}]
+    )
+
+    assert gi.run_import_prs(
+        ws, pr_numbers=[101], heads=["final"], refresh=True, origin_url=origin_url
+    ) == 1
+    entry = load_yaml_strict(ws / "benchmark.yaml")["pull_requests"][0]
+    assert entry["import_state"] == "fetched"
+    message = entry["latest_error"]["message"]
+    assert "daydream benchmark upgrade <workspace>" in message
+    assert str(ws) in message
+    assert "base_resolution" in message
+    assert explicit_path.read_bytes() == prior_bytes
+    assert prior_bundle.exists()
 
 
 def test_bundle_retirement_preserves_a_ready_shared_reference(

--- a/tests/test_benchmark_import_prs.py
+++ b/tests/test_benchmark_import_prs.py
@@ -145,6 +145,9 @@ def test_fetch_changed_files_persists_complete_rename_union(
         (3001, []),
         (1, [{"status": "renamed", "filename": "new.py"}]),
         (1, [{"status": "modified", "filename": "new.py", "previous_filename": "old.py"}]),
+        (1, [{"filename": "a.py"}]),
+        (1, [{"status": "invented", "filename": "a.py"}]),
+        (1, [{"status": 17, "filename": "a.py"}]),
         (2, [
             {"status": "modified", "filename": "a.py"},
             {"status": "modified", "filename": "a.py"},
@@ -1439,7 +1442,7 @@ def test_e2e_import_distinct_idempotent_explicit_head_and_shared_mirror(tmp_path
 
 
 def test_refresh_demotes_clean_draft_when_historical_head_leaves_pr_scope(
-    tmp_path: Path, fake_gh: FakeGh
+    tmp_path: Path, fake_gh: FakeGh, capsys: pytest.CaptureFixture[str]
 ) -> None:
     """The real import boundary applies final-inventory scope to retained heads."""
     import yaml
@@ -1459,6 +1462,8 @@ def test_refresh_demotes_clean_draft_when_historical_head_leaves_pr_scope(
     explicit_path = ws / f"cases/pr-000101-{explicit_sha[:12]}.yaml"
     explicit = load_yaml_strict(explicit_path)
     assert explicit["snapshot"]["status"] == "ready"
+    prior_bundle = ws / explicit["snapshot"]["bundle_file"]
+    assert prior_bundle.exists()
     explicit["curation"].update(
         state="draft",
         snapshot_attested=True,
@@ -1495,6 +1500,71 @@ def test_refresh_demotes_clean_draft_when_historical_head_leaves_pr_scope(
 
     final = load_yaml_strict(ws / f"cases/pr-000101-{final_sha[:12]}.yaml")
     assert final["snapshot"]["status"] == "ready"
+    assert not prior_bundle.exists()
+
+    from daydream import cli as top_cli
+    from daydream.benchmark.workspace import validate_workspace
+
+    assert validate_workspace(ws) == (
+        2,
+        "incomplete: workspace state curating; unreplayable snapshot reasons: base_drift",
+    )
+    capsys.readouterr()
+    with pytest.raises(SystemExit) as status_exit:
+        top_cli.main(["benchmark", "status", str(ws)])
+    assert status_exit.value.code == 0
+    assert "snapshot unreplayable (base_drift)" in capsys.readouterr().out
+    with pytest.raises(SystemExit) as validate_exit:
+        top_cli.main(["benchmark", "validate", str(ws)])
+    assert validate_exit.value.code == 2
+    assert "unreplayable snapshot reasons: base_drift" in capsys.readouterr().out
+
+
+def test_bundle_retirement_preserves_a_ready_shared_reference(
+    tmp_path: Path, fake_gh: FakeGh
+) -> None:
+    """A transitioned case cannot retire a bundle another ready case retains."""
+    import copy
+
+    import yaml
+
+    from daydream.benchmark import github_import as gi
+    from daydream.benchmark.schema import case_id_for
+    from daydream.benchmark.storage import load_yaml_strict
+    from daydream.benchmark.workspace import init_workspace
+
+    ws = tmp_path / "ws"
+    init_workspace(ws, "o/r", ["api.anthropic.com"], ["api.anthropic.com"])
+    _seed_preflight(ws, fake_gh)
+    origin_url, _base_tip, explicit_sha, _final_sha = _seed_stacked_origin(tmp_path, fake_gh)
+    assert gi.run_import_prs(
+        ws, pr_numbers=[101], heads=[explicit_sha], origin_url=origin_url
+    ) == 0
+    manifest = load_yaml_strict(ws / "benchmark.yaml")
+    explicit_id = case_id_for(101, explicit_sha)
+    explicit_path = ws / f"cases/{explicit_id}.yaml"
+    explicit = load_yaml_strict(explicit_path)
+
+    alias_head = "e" * 40
+    alias_id = case_id_for(101, alias_head)
+    alias = copy.deepcopy(explicit)
+    alias["case_id"] = alias_id
+    alias["snapshot"]["original_head_sha"] = alias_head
+    alias["snapshot"]["requested_head"] = alias_head
+    alias_path = ws / f"cases/{alias_id}.yaml"
+    alias_path.write_text(yaml.safe_dump(alias, sort_keys=False))
+    manifest["cases"].append(
+        {"case_id": alias_id, "pr_number": 101, "case_file": f"cases/{alias_id}.yaml"}
+    )
+
+    transitioned = copy.deepcopy(explicit)
+    transitioned["snapshot"]["status"] = "unreplayable"
+    assert gi._retired_snapshot_bundles(
+        ws,
+        manifest,
+        101,
+        [(explicit_id, f"cases/{explicit_id}.yaml", transitioned)],
+    ) == []
 
 
 def test_inventory_only_refresh_preserves_gold_when_snapshot_remains_in_scope(

--- a/tests/test_benchmark_migrate.py
+++ b/tests/test_benchmark_migrate.py
@@ -2,6 +2,7 @@ import hashlib
 import os
 import subprocess
 import uuid
+from copy import deepcopy
 from pathlib import Path
 from typing import Any
 
@@ -156,6 +157,56 @@ def _seed_v1_workspace(tmp_path: Path) -> tuple[Any, ...]:
     return ws, case_id, _TITLE
 
 
+def _write_legacy_unreplayable_case(
+    ws: Path,
+    case_id: str,
+    *,
+    schema_version: int,
+    curation_state: str = "draft",
+) -> Path:
+    case_path = ws / "cases" / f"{case_id}.yaml"
+    raw = storage.load_yaml_strict(case_path)
+    raw["schema_version"] = schema_version
+    if schema_version == 2:
+        finding = raw["curation"]["findings"][0]
+        finding["finding_id"] = schema.derive_finding_id(finding, case_id=case_id)
+    raw["snapshot"] = {
+        "status": "unreplayable",
+        "policy": "final_pr_head",
+        "requested_head": "final",
+        "original_base_sha": None,
+        "requested_base_sha": raw["pull_request"]["base"]["sha"],
+        "original_head_sha": raw["pull_request"]["head"]["sha"],
+        "base_tree_sha": None,
+        "head_tree_sha": None,
+        "diff_sha256": None,
+        "bundle_file": None,
+        "bundle_sha256": None,
+        "error": {
+            "reason": "head_not_on_pr",
+            "detail": "legacy producer detail must be preserved",
+        },
+    }
+    curation = raw["curation"]
+    curation["state"] = curation_state
+    curation["snapshot_attested"] = curation_state == "ready"
+    curation["clean_attested"] = False
+    curation["gold_status"] = None if curation_state == "draft" else "findings"
+    curation["exclusions"] = [
+        {
+            "source_id": "github:review:7",
+            "reason": "other",
+            "note": "authored exclusion note must be preserved",
+        }
+    ]
+    curation["case_exclusion"] = None
+    if curation_state == "ready":
+        curation["task_spec_sha256"] = "d" * 64
+        curation["task_spec_approved_at"] = "2026-08-20T12:00:00Z"
+    storage.atomic_write_yaml(case_path, raw)
+    return case_path
+
+
 def test_migrate_recomputes_finding_ids_and_bumps_version(tmp_path: Path) -> None:
     ws, case_id, title = _seed_v1_workspace(tmp_path)
     report = migrate.migrate_workspace(ws)
@@ -235,19 +286,133 @@ def test_migrate_leaves_unreplayable_snapshot_without_backfill(tmp_path: Path) -
     raw["snapshot"] = {
         "status": "unreplayable", "policy": "final_pr_head", "requested_head": "final",
         "original_base_sha": None,
-        "original_head_sha": "0123456789abcdef0123456789abcdef01234567",
+        "original_head_sha": raw["pull_request"]["head"]["sha"],
         "base_tree_sha": None, "head_tree_sha": None, "diff_sha256": None,
         "bundle_file": None, "bundle_sha256": None,
         "error": {"reason": "head_not_on_pr", "detail": "head sha not on PR"},
     }
     raw["curation"]["state"] = "unreplayable"
     storage.atomic_write_yaml(ws / "cases" / f"{case_id}.yaml", raw)
-    before = storage.load_yaml_strict(ws / "cases" / f"{case_id}.yaml")
+    case_path = ws / "cases" / f"{case_id}.yaml"
+    before = case_path.read_bytes()
 
-    migrate.migrate_workspace(ws)
-    after = storage.load_yaml_strict(ws / "cases" / f"{case_id}.yaml")
-    assert after == before                            # nothing rewritten
+    report = migrate.migrate_workspace(ws)
+    after = storage.load_yaml_strict(case_path)
+    assert report.cases == [] and report.errors == []
+    assert case_path.read_bytes() == before
     assert "requested_base_sha" not in after["snapshot"]
+
+
+@pytest.mark.parametrize("legacy_version", [1, 2])
+def test_migrate_repairs_legacy_draft_unreplayable_curation(
+    tmp_path: Path, legacy_version: int
+) -> None:
+    ws, case_id, _ = _seed_v1_workspace(tmp_path)
+    case_path = _write_legacy_unreplayable_case(
+        ws, case_id, schema_version=legacy_version
+    )
+    before = storage.load_yaml_strict(case_path)
+    immutable_before = {
+        key: deepcopy(before[key])
+        for key in ("pull_request", "snapshot", "source", "candidates", "prioritization")
+        if key in before
+    }
+    findings_before = deepcopy(before["curation"]["findings"])
+    exclusions_before = deepcopy(before["curation"]["exclusions"])
+
+    report = migrate.migrate_workspace(ws)
+
+    assert report.errors == []
+    assert [case.case_id for case in report.cases] == [case_id]
+    migrated = storage.load_yaml_strict(case_path)
+    assert migrated["schema_version"] == 2
+    assert migrated["curation"]["state"] == "unreplayable"
+    assert migrated["curation"]["snapshot_attested"] is False
+    assert migrated["curation"]["clean_attested"] is False
+    assert migrated["curation"]["gold_status"] == "findings"
+    assert migrated["curation"]["exclusions"] == exclusions_before
+    if legacy_version == 1:
+        expected_findings = deepcopy(findings_before)
+        expected_findings[0]["finding_id"] = schema.derive_finding_id(
+            expected_findings[0], case_id=case_id
+        )
+        assert migrated["curation"]["findings"] == expected_findings
+    else:
+        assert migrated["curation"]["findings"] == findings_before
+    for key, expected in immutable_before.items():
+        assert migrated[key] == expected
+    schema.CaseDocument.model_validate(schema._schema_ready(migrated))
+
+
+@pytest.mark.parametrize("curation_state", ["ready", "stale", "excluded"])
+def test_migrate_rejects_other_v2_unreplayable_curation_mismatches(
+    tmp_path: Path, curation_state: str
+) -> None:
+    ws, case_id, _ = _seed_v1_workspace(tmp_path)
+    case_path = _write_legacy_unreplayable_case(
+        ws, case_id, schema_version=2, curation_state=curation_state
+    )
+    before = case_path.read_bytes()
+
+    report = migrate.migrate_workspace(ws)
+
+    assert report.cases == []
+    assert len(report.errors) == 1
+    assert "unreplayable snapshot and curation states must match" in report.errors[0]
+    assert case_path.read_bytes() == before
+
+
+def test_upgrade_cli_repairs_legacy_unreplayable_draft_atomically(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    from daydream import cli as top_cli
+
+    parent = tmp_path / "workspace parent with spaces"
+    parent.mkdir()
+    ws, case_id, _ = _seed_v1_workspace(parent)
+    case_path = _write_legacy_unreplayable_case(ws, case_id, schema_version=2)
+    before = case_path.read_bytes()
+
+    with pytest.raises(SystemExit) as dry_exit:
+        top_cli.main(["benchmark", "upgrade", str(ws), "--dry-run"])
+    assert dry_exit.value.code == 0
+    assert "changed=True" in capsys.readouterr().out
+    assert case_path.read_bytes() == before
+
+    with pytest.raises(SystemExit) as write_exit:
+        top_cli.main(["benchmark", "upgrade", str(ws)])
+    assert write_exit.value.code == 0
+    assert "changed=True" in capsys.readouterr().out
+    migrated = storage.load_yaml_strict(case_path)
+    assert migrated["curation"]["state"] == "unreplayable"
+    assert migrated["curation"]["exclusions"][0]["note"] == (
+        "authored exclusion note must be preserved"
+    )
+    after = case_path.read_bytes()
+
+    with pytest.raises(SystemExit) as second_exit:
+        top_cli.main(["benchmark", "upgrade", str(ws)])
+    assert second_exit.value.code == 0
+    assert case_path.read_bytes() == after
+
+
+def test_upgrade_cli_reports_invalid_unchanged_v2_without_rewriting(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    from daydream import cli as top_cli
+
+    ws, case_id, _ = _seed_v1_workspace(tmp_path)
+    case_path = _write_legacy_unreplayable_case(
+        ws, case_id, schema_version=2, curation_state="stale"
+    )
+    before = case_path.read_bytes()
+
+    with pytest.raises(SystemExit) as exc_info:
+        top_cli.main(["benchmark", "upgrade", str(ws)])
+
+    assert exc_info.value.code == 1
+    assert "unreplayable snapshot and curation states must match" in capsys.readouterr().err
+    assert case_path.read_bytes() == before
 
 
 def test_migrate_dry_run_writes_nothing_and_is_idempotent(tmp_path: Path) -> None:

--- a/tests/test_benchmark_migrate.py
+++ b/tests/test_benchmark_migrate.py
@@ -1,4 +1,6 @@
 import hashlib
+import os
+import subprocess
 import uuid
 from pathlib import Path
 from typing import Any
@@ -86,11 +88,72 @@ def _seed_v1_case() -> dict[str, Any]:
 def _seed_v1_workspace(tmp_path: Path) -> tuple[Any, ...]:
     ws = tmp_path / "ws"
     storage.ensure_private_dir(ws)
-    storage.atomic_write_yaml(ws / "benchmark.yaml", _seed_manifest())
+    repo = tmp_path / "source"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-b", "main"], cwd=repo, check=True, capture_output=True)
+    env = {
+        **os.environ,
+        "GIT_AUTHOR_NAME": "Tester",
+        "GIT_AUTHOR_EMAIL": "test@example.com",
+        "GIT_COMMITTER_NAME": "Tester",
+        "GIT_COMMITTER_EMAIL": "test@example.com",
+    }
+
+    def commit(name: str, content: str, message: str) -> str:
+        (repo / name).write_text(content)
+        subprocess.run(["git", "add", name], cwd=repo, env=env, check=True, capture_output=True)
+        subprocess.run(["git", "commit", "-m", message], cwd=repo, env=env, check=True, capture_output=True)
+        return subprocess.run(
+            ["git", "rev-parse", "HEAD"], cwd=repo, check=True, capture_output=True, text=True
+        ).stdout.strip()
+
+    merge_base = commit("base.py", "BASE = 1\n", "base")
+    subprocess.run(["git", "checkout", "-b", "feature"], cwd=repo, check=True, capture_output=True)
+    head_sha = commit("feature.py", "FEATURE = 1\n", "feature")
+    subprocess.run(["git", "checkout", "main"], cwd=repo, check=True, capture_output=True)
+    requested_tip = commit("upstream.py", "UPSTREAM = 1\n", "advanced base")
+    cache = ws / "cache"
+    storage.ensure_private_dir(cache)
+    subprocess.run(
+        ["git", "clone", "--mirror", str(repo), str(cache / "repository.git")],
+        check=True,
+        capture_output=True,
+    )
+    base_tree = subprocess.run(
+        ["git", "rev-parse", f"{merge_base}^{{tree}}"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    head_tree = subprocess.run(
+        ["git", "rev-parse", f"{head_sha}^{{tree}}"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    case_id = f"pr-000101-{head_sha[:12]}"
+    manifest = _seed_manifest()
+    manifest["cases"] = [
+        {"case_id": case_id, "pr_number": 101, "case_file": f"cases/{case_id}.yaml"}
+    ]
+    storage.atomic_write_yaml(ws / "benchmark.yaml", manifest)
     case_dir = ws / "cases"
     storage.ensure_private_dir(case_dir)
-    storage.atomic_write_yaml(case_dir / f"{_CASE_ID}.yaml", _seed_v1_case())
-    return ws, _CASE_ID, _TITLE
+    case = _seed_v1_case()
+    case["case_id"] = case_id
+    case["pull_request"]["base"]["sha"] = requested_tip
+    case["pull_request"]["head"]["sha"] = head_sha
+    case["snapshot"].update(
+        original_base_sha=merge_base,
+        requested_base_sha=requested_tip,
+        original_head_sha=head_sha,
+        base_tree_sha=base_tree,
+        head_tree_sha=head_tree,
+    )
+    storage.atomic_write_yaml(case_dir / f"{case_id}.yaml", case)
+    return ws, case_id, _TITLE
 
 
 def test_migrate_recomputes_finding_ids_and_bumps_version(tmp_path: Path) -> None:
@@ -110,11 +173,12 @@ def test_migrate_recomputes_finding_ids_and_bumps_version(tmp_path: Path) -> Non
 
 
 def test_migrate_backfills_requested_base_sha_on_v1_ready_snapshot(tmp_path: Path) -> None:
-    """A pre-provenance-split v1 workspace (ready snapshot without
-    requested_base_sha) is repaired: the backfill copies the recorded
-    original_base_sha so the migrated doc validates."""
+    """The sole legacy base candidate is verified before splitting provenance."""
     ws, case_id, _ = _seed_v1_workspace(tmp_path)
     raw = storage.load_yaml_strict(ws / "cases" / f"{case_id}.yaml")
+    requested_tip = raw["snapshot"]["requested_base_sha"]
+    merge_base = raw["snapshot"]["original_base_sha"]
+    raw["snapshot"]["original_base_sha"] = requested_tip
     del raw["snapshot"]["requested_base_sha"]
     storage.atomic_write_yaml(ws / "cases" / f"{case_id}.yaml", raw)
 
@@ -124,21 +188,25 @@ def test_migrate_backfills_requested_base_sha_on_v1_ready_snapshot(tmp_path: Pat
     assert report.cases[0].changed is True
     raw = storage.load_yaml_strict(ws / "cases" / f"{case_id}.yaml")
     assert raw["schema_version"] == 2
-    assert raw["snapshot"]["requested_base_sha"] == raw["snapshot"]["original_base_sha"]
+    assert raw["snapshot"]["requested_base_sha"] == requested_tip
+    assert raw["snapshot"]["original_base_sha"] == merge_base
+    assert raw["snapshot"]["base_resolution"] == "merge_base_v1"
     from daydream.benchmark.schema import _schema_ready
     schema.CaseDocument.model_validate(_schema_ready(raw))  # no longer corrupt
 
 
 def test_migrate_backfills_requested_base_sha_on_v2_ready_snapshot(tmp_path: Path) -> None:
-    """A v2 workspace persisted before requested_base_sha became required is
-    backfilled without touching finding ids (no recompute, no version bump),
-    and a second run is a no-op."""
+    """An old v2 blind backfill is verified and repaired without touching ids."""
     ws, case_id, _ = _seed_v1_workspace(tmp_path)
     migrate.migrate_workspace(ws)                       # v1 -> v2 (field present)
     raw = storage.load_yaml_strict(ws / "cases" / f"{case_id}.yaml")
     assert raw["schema_version"] == 2
     finding_ids = [f["finding_id"] for f in raw["curation"]["findings"]]
+    requested_tip = raw["snapshot"]["requested_base_sha"]
+    merge_base = raw["snapshot"]["original_base_sha"]
+    raw["snapshot"]["original_base_sha"] = requested_tip
     del raw["snapshot"]["requested_base_sha"]          # simulate pre-break v2
+    del raw["snapshot"]["base_resolution"]
     storage.atomic_write_yaml(ws / "cases" / f"{case_id}.yaml", raw)
 
     report = migrate.migrate_workspace(ws)
@@ -147,7 +215,9 @@ def test_migrate_backfills_requested_base_sha_on_v2_ready_snapshot(tmp_path: Pat
     assert report.cases[0].changed is True
     raw = storage.load_yaml_strict(ws / "cases" / f"{case_id}.yaml")
     assert raw["schema_version"] == 2                  # no bump
-    assert raw["snapshot"]["requested_base_sha"] == raw["snapshot"]["original_base_sha"]
+    assert raw["snapshot"]["requested_base_sha"] == requested_tip
+    assert raw["snapshot"]["original_base_sha"] == merge_base
+    assert raw["snapshot"]["base_resolution"] == "merge_base_v1"
     assert [f["finding_id"] for f in raw["curation"]["findings"]] == finding_ids
     from daydream.benchmark.schema import _schema_ready
     schema.CaseDocument.model_validate(_schema_ready(raw))
@@ -199,6 +269,59 @@ def test_migrate_surfaces_invalid_case_without_rewriting(tmp_path: Path) -> None
     assert report.cases == []                        # no case rewritten
     assert any("duplicate" in e for e in report.errors)
     assert storage.load_yaml_strict(ws / "cases" / f"{case_id}.yaml")["schema_version"] == 1  # untouched
+
+
+@pytest.mark.parametrize("failure", ["missing_mirror", "tree_mismatch"])
+def test_migrate_ready_provenance_failure_is_atomic(
+    tmp_path: Path, failure: str
+) -> None:
+    """A failed proof reports the case and leaves its v1 bytes unchanged."""
+    import shutil
+
+    ws, case_id, _ = _seed_v1_workspace(tmp_path)
+    case_path = ws / "cases" / f"{case_id}.yaml"
+    if failure == "missing_mirror":
+        shutil.rmtree(ws / "cache" / "repository.git")
+    else:
+        raw = storage.load_yaml_strict(case_path)
+        raw["snapshot"]["base_tree_sha"] = "f" * 40
+        storage.atomic_write_yaml(case_path, raw)
+    before = case_path.read_bytes()
+
+    report = migrate.migrate_workspace(ws)
+
+    assert report.cases == []
+    assert len(report.errors) == 1
+    assert "provenance" in report.errors[0] or "source trees" in report.errors[0]
+    assert case_path.read_bytes() == before
+
+
+def test_migrate_imported_snapshot_preserves_sole_base_without_mirror(tmp_path: Path) -> None:
+    """Imported legacy snapshots have no trees to verify and keep their candidate."""
+    import shutil
+
+    ws, case_id, _ = _seed_v1_workspace(tmp_path)
+    case_path = ws / "cases" / f"{case_id}.yaml"
+    raw = storage.load_yaml_strict(case_path)
+    base_tip = raw["pull_request"]["base"]["sha"]
+    head_sha = raw["snapshot"]["original_head_sha"]
+    raw["snapshot"] = {
+        "status": "imported",
+        "policy": "final_pr_head",
+        "requested_head": "final",
+        "original_base_sha": base_tip,
+        "original_head_sha": head_sha,
+        "error": None,
+    }
+    storage.atomic_write_yaml(case_path, raw)
+    shutil.rmtree(ws / "cache" / "repository.git")
+
+    report = migrate.migrate_workspace(ws)
+
+    assert report.errors == []
+    migrated = storage.load_yaml_strict(case_path)
+    assert migrated["snapshot"]["requested_base_sha"] == base_tip
+    assert "base_resolution" not in migrated["snapshot"]
 
 def test_upgrade_cli_wiring_dry_run_and_real_run(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
     """The ``upgrade`` verb drives migrate_workspace through the CLI seam (exit 0)."""

--- a/tests/test_benchmark_snapshot.py
+++ b/tests/test_benchmark_snapshot.py
@@ -600,6 +600,85 @@ def test_offline_clone_fidelity_rejects_tampering(tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
+def test_changed_paths_returns_both_names_for_rename(tmp_path: Path) -> None:
+    from daydream.benchmark import snapshot as sn
+
+    origin, authoring_sha, head_sha = _seed_rename_origin(tmp_path)
+    sn.ensure_mirror(tmp_path, "o/r", origin_url=origin)
+    sn.fetch_head_refs(tmp_path, "o/r", 1, explicit_shas=[head_sha], origin_url=origin)
+    assert sn.changed_paths(sn.mirror(tmp_path), authoring_sha, head_sha) == {
+        "old.py",
+        "new.py",
+    }
+
+
+@pytest.mark.parametrize(
+    "stdout",
+    [
+        b"M\x00a.py",
+        b"M\x00\x00",
+        b"R100\x00old.py\x00",
+        b"R101\x00old.py\x00new.py\x00",
+        b"R100\x00old.py\x00new.py\x00junk\x00",
+        b"Z\x00a.py\x00",
+    ],
+)
+def test_changed_paths_rejects_malformed_nul_records(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, stdout: bytes
+) -> None:
+    from daydream.benchmark import snapshot as sn
+
+    monkeypatch.setattr(
+        git_ops,
+        "_run_git",
+        lambda *args, **kwargs: subprocess.CompletedProcess(args, 0, stdout, b""),
+    )
+    with pytest.raises(GitError, match="name-status"):
+        sn.changed_paths(tmp_path, "a" * 40, "b" * 40)
+
+
+def test_freeze_explicit_head_rejects_paths_outside_pr_inventory(tmp_path: Path) -> None:
+    from daydream.benchmark import snapshot as sn
+
+    origin = _seed_origin(tmp_path)
+    drifted, bundle = sn.freeze_one(
+        tmp_path,
+        "o/r",
+        1,
+        base_tip=_SHA_BASE3,
+        head_sha=_SHA_HEAD,
+        policy="explicit_head",
+        requested_head=_SHA_HEAD,
+        pr_changed_files={"feature.py"},
+        origin_url=origin,
+    )
+    assert drifted["status"] == "unreplayable"
+    assert drifted["error"]["reason"] == "base_drift"
+    assert "base.py" in drifted["error"]["detail"]
+    assert drifted["original_base_sha"] == _SHA_BASE2
+    assert drifted["requested_base_sha"] == _SHA_BASE3
+    assert bundle is None
+
+
+def test_freeze_final_head_skips_pr_inventory_guard(tmp_path: Path) -> None:
+    from daydream.benchmark import snapshot as sn
+
+    origin = _seed_origin(tmp_path)
+    ready, bundle = sn.freeze_one(
+        tmp_path,
+        "o/r",
+        1,
+        base_tip=_SHA_BASE3,
+        head_sha=_SHA_HEAD,
+        policy="final_pr_head",
+        requested_head="final",
+        pr_changed_files=set(),
+        origin_url=origin,
+    )
+    assert ready["status"] == "ready"
+    assert isinstance(bundle, bytes)
+
+
 def test_freeze_one_ready_and_reasons(tmp_path: Path) -> None:
     from daydream.benchmark import snapshot as sn
     from daydream.benchmark.schema import case_id_for
@@ -609,7 +688,8 @@ def test_freeze_one_ready_and_reasons(tmp_path: Path) -> None:
     sn.fetch_pr_refs(tmp_path, "o/r", 1, base_tip=_SHA_BASE2,
                      explicit_shas=[_SHA_HEAD], origin_url=origin)
     ready, bundle = sn.freeze_one(tmp_path, "o/r", 1, base_tip=_SHA_BASE2, head_sha=_SHA_HEAD,
-                           policy="final_pr_head", requested_head="final", origin_url=origin)
+                           policy="final_pr_head", requested_head="final",
+                           pr_changed_files=set(), origin_url=origin)
     assert ready["status"] == "ready"
     assert ready["original_base_sha"] == _SHA_BASE2 and ready["original_head_sha"] == _SHA_HEAD
     assert ready["requested_base_sha"] == _SHA_BASE2
@@ -624,13 +704,15 @@ def test_freeze_one_ready_and_reasons(tmp_path: Path) -> None:
     assert not (tmp_path / expect_rel).exists()
     # head_not_on_pr: a base3 head reachable elsewhere is rejected
     ur, bundle = sn.freeze_one(tmp_path, "o/r", 1, base_tip=_SHA_BASE3, head_sha=_SHA_BASE3,
-                               policy="explicit_head", requested_head=_SHA_BASE3, origin_url=origin)
+                               policy="explicit_head", requested_head=_SHA_BASE3,
+                               pr_changed_files=set(), origin_url=origin)
     assert ur["status"] == "unreplayable" and ur["error"]["reason"] == "head_not_on_pr"
     assert bundle is None
     assert ur["bundle_file"] is None and ur["base_tree_sha"] is None
     # head_unreachable: a sha absent from the mirror
     ur2, bundle2 = sn.freeze_one(tmp_path, "o/r", 1, base_tip=_SHA_BASE2, head_sha="0" * 40,
-                                 policy="explicit_head", requested_head="0" * 40, origin_url=origin)
+                                 policy="explicit_head", requested_head="0" * 40,
+                                 pr_changed_files=set(), origin_url=origin)
     assert ur2["status"] == "unreplayable" and ur2["error"]["reason"] == "head_unreachable"
     assert bundle2 is None
     assert ur2["bundle_file"] is None
@@ -645,9 +727,11 @@ def test_freeze_two_prs_unrelated_base_tips_both_ready(tmp_path: Path) -> None:
     sn.ensure_mirror(tmp_path, "o/r", origin_url=origin)
     m = sn.mirror(tmp_path)
     ready1, b1 = sn.freeze_one(tmp_path, "o/r", 1, base_tip=_SHA_BASE2, head_sha=_SHA_HEAD,
-                               policy="final_pr_head", requested_head="final", origin_url=origin)
+                               policy="final_pr_head", requested_head="final",
+                               pr_changed_files=set(), origin_url=origin)
     ready2, b2 = sn.freeze_one(tmp_path, "o/r", 2, base_tip=dev_tip, head_sha=pr2_head,
-                               policy="final_pr_head", requested_head="final", origin_url=origin)
+                               policy="final_pr_head", requested_head="final",
+                               pr_changed_files=set(), origin_url=origin)
     assert ready1["status"] == "ready" and isinstance(b1, bytes)
     assert ready2["status"] == "ready" and isinstance(b2, bytes)
     # the shared base_tip ref was force-re-pointed from base2 to the unrelated dev tip
@@ -666,7 +750,8 @@ def test_freeze_one_base_advanced_two_sha(tmp_path: Path) -> None:
                      explicit_shas=[_SHA_HEAD], origin_url=origin)
     # PR head is forked from base2; main has advanced to base3.
     ready, bundle = sn.freeze_one(tmp_path, "o/r", 1, base_tip=_SHA_BASE3, head_sha=_SHA_HEAD,
-                           policy="final_pr_head", requested_head="final", origin_url=origin)
+                           policy="final_pr_head", requested_head="final",
+                           pr_changed_files=set(), origin_url=origin)
     assert ready["status"] == "ready"
     assert ready["original_base_sha"] == _SHA_BASE2      # the true merge base
     assert ready["requested_base_sha"] == _SHA_BASE3      # the selected base-branch tip
@@ -682,13 +767,15 @@ def test_freeze_distinct_base_vs_head_unreachable(tmp_path: Path) -> None:
     origin = _seed_origin(tmp_path)
     # base-tip ref absent on the origin (only base1..3 + refs/pull/1/head exist)
     ur, b = sn.freeze_one(tmp_path, "o/r", 1, base_tip="0" * 40, head_sha=_SHA_HEAD,
-                          policy="final_pr_head", requested_head="final", origin_url=origin)
+                          policy="final_pr_head", requested_head="final",
+                          pr_changed_files=set(), origin_url=origin)
     assert ur["status"] == "unreplayable" and ur["error"]["reason"] == "base_unreachable"
     assert b is None
     assert ur["requested_base_sha"] == "0" * 40
     # PR-head ref absent (origin has only refs/pull/1/head, not 999)
     ur2, b2 = sn.freeze_one(tmp_path, "o/r", 999, base_tip=_SHA_BASE2, head_sha="0" * 40,
-                            policy="final_pr_head", requested_head="final", origin_url=origin)
+                            policy="final_pr_head", requested_head="final",
+                            pr_changed_files=set(), origin_url=origin)
     assert ur2["error"]["reason"] == "head_unreachable" and b2 is None
     assert ur2["requested_base_sha"] == _SHA_BASE2
 

--- a/tests/test_benchmark_workspace.py
+++ b/tests/test_benchmark_workspace.py
@@ -224,27 +224,23 @@ def _write_case_docs(root: Path, curation_state: str) -> Any:
     raw["source"]["visibility"] = "private"
     repo_slug = raw["source"]["repository"]
 
-    # The PR-meta SHAs recorded on the doc stay the fixture's fixed
-    # schema-valid values (provenance metadata, never cross-checked by
-    # validate); the bundle bytes + tree IDs + digests come from the real
-    # origin so the authoritative offline-clone fidelity check passes.
-    head_sha = "0123456789ab" + "0" * 28
-    base_sha = "b" * 40
+    # The PR and snapshot metadata name the real source commits so the local
+    # mirror provenance check and the portable bundle fidelity check agree.
+    origin_url, base_sha, head_sha = _seed_local_origin(root)
     case_id = f"pr-000101-{head_sha[:12]}"
     case_file = f"cases/{case_id}.yaml"
     import_file = "imports/pr-000101.json"
     bundle_rel = f"snapshots/{case_id}.bundle"
 
-    origin_url, real_base_sha, real_head_sha = _seed_local_origin(root)
     sn.ensure_mirror(root, repo_slug, origin_url)
-    sn.fetch_pr_refs(root, repo_slug, 101, base_tip=real_base_sha,
-                     explicit_shas=[real_head_sha], origin_url=origin_url)
+    sn.fetch_pr_refs(root, repo_slug, 101, base_tip=base_sha,
+                     explicit_shas=[head_sha], origin_url=origin_url)
     m = sn.mirror(root)
     bundle_path = root / bundle_rel
-    sn.build_bundle(m, real_base_sha, real_head_sha, bundle_path)
-    base_tree_sha = sn.rev_parse(m, f"{real_base_sha}^{{tree}}")
-    head_tree_sha = sn.rev_parse(m, f"{real_head_sha}^{{tree}}")
-    diff_sha256 = sn.canonical_diff_sha256(m, real_base_sha, real_head_sha)
+    sn.build_bundle(m, base_sha, head_sha, bundle_path)
+    base_tree_sha = sn.rev_parse(m, f"{base_sha}^{{tree}}")
+    head_tree_sha = sn.rev_parse(m, f"{head_sha}^{{tree}}")
+    diff_sha256 = sn.canonical_diff_sha256(m, base_sha, head_sha)
     bundle_sha256 = hashlib.sha256(bundle_path.read_bytes()).hexdigest()
 
     pr_meta = PullRequestMeta(
@@ -326,6 +322,7 @@ def _write_case_docs(root: Path, curation_state: str) -> Any:
         pull_request=pr_meta,
         snapshot=SnapshotReady(
             status="ready",
+            base_resolution="merge_base_v1",
             policy="final_pr_head",
             requested_head="final",
             original_base_sha=base_sha,
@@ -533,7 +530,128 @@ def test_status_reports_snapshot_state_per_case(tmp_path: Path, capsys: pytest.C
     rc = _handle_benchmark_command(["status", str(ws)])
     assert rc == 0
     out = capsys.readouterr().out
-    assert "ready" in out and "pr-000101-0123456789ab" in out and "0123456789ab" in out
+    case_id = next((ws / "cases").glob("*.yaml")).stem
+    assert "ready" in out and case_id in out and case_id.rsplit("-", 1)[-1] in out
+
+
+def _make_case_base_drift(root: Path) -> str:
+    """Convert the fixture's ready case into a valid typed drift refusal."""
+    import yaml
+
+    case_path = next((root / "cases").glob("*.yaml"))
+    raw = load_yaml_strict(case_path)
+    snapshot = raw["snapshot"]
+    (root / snapshot["bundle_file"]).unlink()
+    raw["snapshot"] = {
+        "status": "unreplayable",
+        "policy": "explicit_head",
+        "requested_head": snapshot["original_head_sha"],
+        "original_base_sha": snapshot["original_base_sha"],
+        "requested_base_sha": snapshot["requested_base_sha"],
+        "original_head_sha": snapshot["original_head_sha"],
+        "base_tree_sha": None,
+        "head_tree_sha": None,
+        "diff_sha256": None,
+        "bundle_file": None,
+        "bundle_sha256": None,
+        "error": {"reason": "base_drift", "detail": "private path omitted"},
+    }
+    raw["curation"].update(
+        state="unreplayable",
+        snapshot_attested=False,
+        clean_attested=False,
+        gold_status="findings",
+    )
+    raw["curation"].pop("task_spec_sha256", None)
+    case_path.write_text(yaml.safe_dump(raw, sort_keys=False))
+    return str(raw["case_id"])
+
+
+def test_status_and_validate_surface_typed_unreplayable_reason(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Public status/validate expose the reason code, never private detail."""
+    from daydream import cli as top_cli
+    from daydream.benchmark.workspace import validate_workspace, workspace_status
+
+    root = _write_curated_workspace(tmp_path, "ready")
+    case_id = _make_case_base_drift(root)
+    status = workspace_status(root)
+    assert status.case_snapshots == [
+        {
+            "case_id": case_id,
+            "snapshot_status": "unreplayable",
+            "head_prefix": case_id.rsplit("-", 1)[-1],
+            "error_reason": "base_drift",
+        }
+    ]
+    assert validate_workspace(root) == (
+        2,
+        "incomplete: workspace state curating; unreplayable snapshot reasons: base_drift",
+    )
+
+    with pytest.raises(SystemExit) as status_exit:
+        top_cli.main(["benchmark", "status", str(root)])
+    assert status_exit.value.code == 0
+    status_out = capsys.readouterr().out
+    assert "snapshot unreplayable (base_drift)" in status_out
+    assert "private path omitted" not in status_out
+
+    with pytest.raises(SystemExit) as validate_exit:
+        top_cli.main(["benchmark", "validate", str(root)])
+    assert validate_exit.value.code == 2
+    validate_out = capsys.readouterr().out
+    assert "unreplayable snapshot reasons: base_drift" in validate_out
+    assert "private path omitted" not in validate_out
+
+
+def test_validate_rechecks_marked_snapshot_source_when_mirror_is_present(tmp_path: Path) -> None:
+    """A marker cannot hide commit-linkage tampering in a live authoring mirror."""
+    import yaml
+
+    from daydream.benchmark.workspace import validate_workspace
+
+    root = _write_curated_workspace(tmp_path, "ready")
+    assert validate_workspace(root) == (0, "ready")
+    case_path = next((root / "cases").glob("*.yaml"))
+    raw = load_yaml_strict(case_path)
+    raw["snapshot"]["original_base_sha"] = "a" * 40
+    case_path.write_text(yaml.safe_dump(raw, sort_keys=False))
+
+    code, label = validate_workspace(root)
+    assert code == 1
+    assert "source provenance" in label
+    assert "feature.py" not in label
+
+
+def test_validate_keeps_verified_snapshot_portable_after_mirror_cleanup(tmp_path: Path) -> None:
+    """The marker plus offline bundle remains sufficient after cache cleanup."""
+    import shutil
+
+    from daydream.benchmark.workspace import validate_workspace
+
+    root = _write_curated_workspace(tmp_path, "ready")
+    assert validate_workspace(root) == (0, "ready")
+    shutil.rmtree(root / "cache" / "repository.git")
+    assert validate_workspace(root) == (0, "ready")
+
+
+def test_base_drift_case_is_rejected_before_compile_stage_mutation(tmp_path: Path) -> None:
+    """The existing curation gate rejects typed drift before Harbor staging."""
+    from daydream.benchmark.harbor import build
+
+    root = _write_curated_workspace(tmp_path, "ready")
+    case_id = _make_case_base_drift(root)
+    harbor = root / "harbor"
+    harbor.mkdir()
+    sentinel = harbor / "sentinel.txt"
+    sentinel.write_text("prior build\n")
+
+    with pytest.raises(build.CompileError, match=rf"{case_id}.*unreplayable"):
+        build.compile_workspace(root)
+
+    assert sentinel.read_text() == "prior build\n"
+    assert not (root / "cache" / "harbor-build-stage").exists()
 
 
 def test_curated_fixture_writes_schema_valid_case(tmp_path: Path) -> None:

--- a/tests/test_benchmark_workspace.py
+++ b/tests/test_benchmark_workspace.py
@@ -636,6 +636,37 @@ def test_validate_keeps_verified_snapshot_portable_after_mirror_cleanup(tmp_path
     assert validate_workspace(root) == (0, "ready")
 
 
+@pytest.mark.parametrize("tamper", ["base", "source", "source_file", "inventory"])
+def test_portable_validation_binds_case_to_checksummed_import(
+    tmp_path: Path, tamper: str
+) -> None:
+    """A cleaned workspace still binds copied case metadata to its import."""
+    import shutil
+
+    import yaml
+
+    from daydream.benchmark.workspace import validate_workspace
+
+    root = _write_curated_workspace(tmp_path, "ready")
+    shutil.rmtree(root / "cache" / "repository.git")
+    case_path = next((root / "cases").glob("*.yaml"))
+    raw = load_yaml_strict(case_path)
+    if tamper == "base":
+        raw["pull_request"]["base"]["sha"] = "f" * 40
+        raw["snapshot"]["requested_base_sha"] = "f" * 40
+    elif tamper == "source":
+        raw["source"]["import_sha256"] = "f" * 64
+    elif tamper == "source_file":
+        raw["source"]["import_file"] = "imports/other.json"
+    else:
+        raw["pull_request"]["changed_files"] = []
+    case_path.write_text(yaml.safe_dump(raw, sort_keys=False))
+
+    code, label = validate_workspace(root)
+    assert code == 1
+    assert "import provenance" in label
+
+
 def test_base_drift_case_is_rejected_before_compile_stage_mutation(tmp_path: Path) -> None:
     """The existing curation gate rejects typed drift before Harbor staging."""
     from daydream.benchmark.harbor import build

--- a/tests/test_benchmark_workspace.py
+++ b/tests/test_benchmark_workspace.py
@@ -624,6 +624,33 @@ def test_validate_rechecks_marked_snapshot_source_when_mirror_is_present(tmp_pat
     assert "feature.py" not in label
 
 
+def test_validate_partial_mirror_reports_restore_guidance_without_mutation(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The real CLI names the retained mirror and leaves its repair to the user."""
+    import shutil
+
+    from daydream import cli as top_cli
+
+    parent = tmp_path / "parent with spaces"
+    parent.mkdir()
+    root = _write_curated_workspace(parent, "ready")
+    mirror = root / "cache" / "repository.git"
+    shutil.rmtree(mirror / "objects")
+    (mirror / "objects").mkdir()
+    sentinel = mirror / "restore-me"
+    sentinel.write_text("operator recovery marker\n")
+
+    with pytest.raises(SystemExit) as exc:
+        top_cli.main(["benchmark", "validate", str(root)])
+    assert exc.value.code == 1
+    output = capsys.readouterr().out
+    assert str(root) in output
+    assert "cache/repository.git" in output
+    assert "restore" in output.lower()
+    assert sentinel.read_text() == "operator recovery marker\n"
+
+
 def test_validate_keeps_verified_snapshot_portable_after_mirror_cleanup(tmp_path: Path) -> None:
     """The marker plus offline bundle remains sufficient after cache cleanup."""
     import shutil

--- a/tests/test_benchmark_workspace_cli.py
+++ b/tests/test_benchmark_workspace_cli.py
@@ -164,3 +164,6 @@ def test_private_benchmark_docs_document_the_new_verb() -> None:
     assert "--reviewer-host" in text and "--judge-host" in text
     assert "daydream benchmark validate" in text
     assert "exit" in text.lower()  # 0/2/1 codes surfaced
+    assert "merge_base_v1" in text
+    assert "restore" in text.lower() and "cache/repository.git" in text
+    assert "base_drift" in text

--- a/tests/test_benchmark_workspace_schema.py
+++ b/tests/test_benchmark_workspace_schema.py
@@ -228,7 +228,7 @@ def _valid_import_document() -> dict[str, Any]:
             "state": "open",
             "title_sha256": hashlib.sha256(b"Fix cache").hexdigest(),
             "body_sha256": hashlib.sha256("fixes the cache".encode()).hexdigest(),
-            "base": {"ref": "main", "sha": "b" * 40},
+            "base": {"ref": "main", "sha": "0123456789abcdef0123456789abcdef01234567"},
             "head": {"ref": "feature/cache", "sha": "h" * 40},
             "created_at": "2026-01-01T00:00:00Z",
             "updated_at": "2026-01-01T00:00:00Z",
@@ -316,6 +316,44 @@ def test_pull_request_meta_predate_reads_empty_and_validates() -> None:
     assert m.body == "" and m.title_sha256 == "" and m.body_sha256 == ""
     assert m.merged_at is None and m.closed_at is None and m.html_url == ""
     assert m.head.ref is None
+
+
+def test_pull_request_changed_files_is_optional_but_canonical_when_present() -> None:
+    raw = {
+        "number": 101, "url": "u", "title": "t", "state": "open",
+        "base": {"sha": "b" * 40}, "head": {"sha": "a" * 40},
+        "created_at": "2026-01-01T00:00:00Z", "updated_at": "2026-01-01T00:00:00Z",
+        "author": {"login": "a", "type": "User"},
+    }
+    assert PullRequestMeta.model_validate(raw).changed_files is None
+    assert PullRequestMeta.model_validate({**raw, "changed_files": []}).changed_files == []
+    paths = ["a:b.py", r"dir\literal.py", "src/file with spaces.py"]
+    assert PullRequestMeta.model_validate({**raw, "changed_files": paths}).changed_files == paths
+
+
+@pytest.mark.parametrize(
+    "paths",
+    [
+        ["b.py", "a.py"],
+        ["a.py", "a.py"],
+        [""],
+        ["/absolute.py"],
+        ["../escape.py"],
+        ["src/../escape.py"],
+        ["src//empty.py"],
+        ["nul\x00.py"],
+        [1],
+    ],
+)
+def test_pull_request_changed_files_rejects_noncanonical_paths(paths: list[Any]) -> None:
+    raw = {
+        "number": 101, "url": "u", "title": "t", "state": "open",
+        "base": {"sha": "b" * 40}, "head": {"sha": "a" * 40},
+        "created_at": "2026-01-01T00:00:00Z", "updated_at": "2026-01-01T00:00:00Z",
+        "author": {"login": "a", "type": "User"}, "changed_files": paths,
+    }
+    with pytest.raises(ValidationError):
+        PullRequestMeta.model_validate(raw)
 
 
 def test_pull_request_meta_fails_closed_on_malformed_required() -> None:
@@ -418,7 +456,7 @@ def _valid_case_dict() -> dict[str, Any]:
             "state": "open",
             "title_sha256": hashlib.sha256(b"Fix cache").hexdigest(),
             "body_sha256": hashlib.sha256("fix".encode()).hexdigest(),
-            "base": {"ref": "main", "sha": "b" * 40},
+            "base": {"ref": "main", "sha": "0123456789abcdef0123456789abcdef01234567"},
             "head": {"ref": "feature/cache", "sha": "h" * 40},
             "created_at": "2026-01-01T00:00:00Z",
             "updated_at": "2026-01-01T00:00:00Z",
@@ -428,6 +466,7 @@ def _valid_case_dict() -> dict[str, Any]:
         },
         "snapshot": {
             "status": "ready",
+            "base_resolution": "merge_base_v1",
             "policy": "final_pr_head",
             "requested_head": "final",
             "original_base_sha": "0123456789abcdef0123456789abcdef01234567",
@@ -503,6 +542,42 @@ def test_ready_snapshot_valid() -> None:
     assert doc.curation.state == "ready"
 
 
+def test_ready_snapshot_requires_merge_base_resolution_marker() -> None:
+    marked = _valid_case_dict()
+    assert CaseDocument.model_validate(marked).snapshot.status == "ready"
+
+    missing = _valid_case_dict()
+    missing["snapshot"].pop("base_resolution")
+    with pytest.raises(ValidationError):
+        CaseDocument.model_validate(missing)
+
+    marked["snapshot"]["base_resolution"] = "invented"
+    with pytest.raises(ValidationError):
+        CaseDocument.model_validate(marked)
+
+
+def test_base_drift_is_the_only_new_snapshot_reason() -> None:
+    raw = _valid_case_dict()
+    raw["snapshot"] = {
+        "status": "unreplayable", "policy": "explicit_head", "requested_head": "a" * 40,
+        "original_base_sha": "b" * 40,
+        "requested_base_sha": "0123456789abcdef0123456789abcdef01234567",
+        "original_head_sha": "0123456789abcdef0123456789abcdef01234567",
+        "base_tree_sha": None, "head_tree_sha": None, "diff_sha256": None,
+        "bundle_file": None, "bundle_sha256": None,
+        "error": {"reason": "base_drift", "detail": "one extra path"},
+    }
+    raw["curation"].update({
+        "state": "unreplayable", "snapshot_attested": False,
+        "clean_attested": False, "gold_status": None, "findings": [],
+        "task_spec_sha256": None,
+    })
+    assert CaseDocument.model_validate(raw).snapshot.status == "unreplayable"
+    raw["snapshot"]["error"]["reason"] = "invented_reason"
+    with pytest.raises(ValidationError):
+        CaseDocument.model_validate(raw)
+
+
 def test_ready_snapshot_rejects_missing_bundle_fields() -> None:
     # Re-validate from a raw dict so a missing required field is caught.
     raw = _valid_case_dict()
@@ -556,6 +631,36 @@ def test_unreplayable_curation_requires_unreplayable_snapshot() -> None:
     assert doc.curation.state == "unreplayable"
 
 
+def test_unreplayable_snapshot_requires_matching_curation_unless_excluded() -> None:
+    raw = _valid_case_dict()
+    raw["snapshot"] = {
+        "status": "unreplayable", "policy": "explicit_head", "requested_head": "a" * 40,
+        "original_base_sha": "b" * 40,
+        "requested_base_sha": "0123456789abcdef0123456789abcdef01234567",
+        "original_head_sha": "0123456789abcdef0123456789abcdef01234567",
+        "base_tree_sha": None, "head_tree_sha": None, "diff_sha256": None,
+        "bundle_file": None, "bundle_sha256": None,
+        "error": {"reason": "head_not_on_pr", "detail": "not on PR"},
+    }
+    with pytest.raises(ValidationError):
+        CaseDocument.model_validate(raw)
+
+    raw["curation"].update({
+        "state": "excluded", "snapshot_attested": False, "clean_attested": False,
+        "gold_status": None, "findings": [], "task_spec_sha256": None,
+        "case_exclusion": {"reason": "unreplayable", "note": None},
+    })
+    assert CaseDocument.model_validate(raw).curation.state == "excluded"
+
+
+def test_snapshot_requested_base_must_match_pull_request_base() -> None:
+    raw = _valid_case_dict()
+    raw["snapshot"]["base_resolution"] = "merge_base_v1"
+    raw["snapshot"]["requested_base_sha"] = "c" * 40
+    with pytest.raises(ValidationError):
+        CaseDocument.model_validate(raw)
+
+
 def test_unreplayable_snapshot_requires_error_and_null_bundle() -> None:
     raw = _valid_case_dict()
     raw["snapshot"] = {
@@ -572,6 +677,11 @@ def test_unreplayable_snapshot_requires_error_and_null_bundle() -> None:
         "bundle_sha256": None,
         "error": {"reason": "head_not_on_pr", "detail": "head sha not on PR"},
     }
+    raw["curation"].update({
+        "state": "unreplayable", "snapshot_attested": False,
+        "clean_attested": False, "gold_status": None, "findings": [],
+        "task_spec_sha256": None,
+    })
     doc = CaseDocument.model_validate(raw)
     assert doc.snapshot.status == "unreplayable"
 

--- a/tests/test_benchmark_workspace_storage.py
+++ b/tests/test_benchmark_workspace_storage.py
@@ -119,6 +119,53 @@ def test_transaction_commit_replaces_all_and_manifest_last(tmp_path: Path) -> No
     assert not (tmp_path / "transactions").exists() or not list((tmp_path / "transactions").iterdir())
 
 
+def test_transaction_retires_digest_matched_file_atomically(tmp_path: Path) -> None:
+    bundle = tmp_path / "snapshots" / "old.bundle"
+    bundle.parent.mkdir(parents=True)
+    bundle.write_bytes(b"old bundle")
+    digest = sha256_file(bundle)
+    with Transaction(tmp_path, op_id="retire", kind="import") as tx:
+        tx.retire("snapshots/old.bundle", expected_sha256=digest)
+        tx.stage("benchmark.yaml", b"after")
+        tx.commit()
+    assert not bundle.exists()
+    assert (tmp_path / "benchmark.yaml").read_bytes() == b"after"
+
+
+@pytest.mark.parametrize("applied", [0, 1, 2])
+def test_transaction_retirement_rolls_back_with_other_targets(
+    tmp_path: Path, applied: int
+) -> None:
+    root = tmp_path / f"ws-{applied}"
+    bundle = root / "snapshots" / "old.bundle"
+    case = root / "cases" / "case.yaml"
+    manifest = root / "benchmark.yaml"
+    bundle.parent.mkdir(parents=True)
+    case.parent.mkdir(parents=True)
+    bundle.write_bytes(b"old bundle")
+    case.write_bytes(b"old case")
+    manifest.write_bytes(b"old manifest")
+    with Transaction(root, op_id="retire-crash", kind="import") as tx:
+        tx.retire("snapshots/old.bundle", expected_sha256=sha256_file(bundle))
+        tx.stage("cases/case.yaml", b"new case")
+        tx.stage("benchmark.yaml", b"new manifest")
+        tx.inject_crash(f"target-{applied}")
+    recover_startup(root)
+    assert bundle.read_bytes() == b"old bundle"
+    assert case.read_bytes() == b"old case"
+    assert manifest.read_bytes() == b"old manifest"
+
+
+def test_transaction_retirement_refuses_digest_mismatch(tmp_path: Path) -> None:
+    bundle = tmp_path / "snapshots" / "old.bundle"
+    bundle.parent.mkdir(parents=True)
+    bundle.write_bytes(b"old bundle")
+    with Transaction(tmp_path, op_id="retire-wrong", kind="import") as tx:
+        with pytest.raises(WorkspaceCorrupt, match="digest mismatch"):
+            tx.retire("snapshots/old.bundle", expected_sha256="f" * 64)
+    assert bundle.read_bytes() == b"old bundle"
+
+
 def test_prepared_journal_rolls_back_on_startup(tmp_path: Path) -> None:
     data = tmp_path / "cases" / "b.yaml"
     data.parent.mkdir(parents=True)


### PR DESCRIPTION
## Summary

Reject explicit-head benchmark snapshots when their replayed merge-base diff includes files outside the complete GitHub PR inventory. Keep requested base tips distinct from the merge base actually frozen, validate that provenance, and migrate legacy metadata only when local Git evidence proves the correction.

Closes #835. Closes #897.

## Behavior

- Fetch and validate a complete changed-file inventory only for explicit-head snapshots, including both sides of renames/copies. Missing, truncated, duplicated, or malformed inventory fails closed; final-only imports avoid the extra endpoint.
- Mark unreplayable explicit snapshots `base_drift` without producing an invalid bundle. Refresh demotes affected drafts and transactionally retires an exact old bundle only when no ready case still references it. Last-good curated snapshot semantics remain protected.
- New ready snapshots explicitly record `merge_base_v1` provenance. Requested base, actual merge base, frozen trees, bundle bytes, and checksummed import/case identity are verified consistently.
- Portable snapshots remain valid without a source mirror, but copied case PR metadata and source paths/digests must match their validated import. Legacy migration is atomic and evidence-based; missing or unprovable Git history remains an actionable case error.
- Repair the legacy draft/unreplayable pairing without discarding authored evidence, and validate unchanged v2 cases before reporting an upgrade no-op. Classify drift-probe Git failures per case; identify upgrade-required cases and unusable source mirrors with actionable recovery messages.

## Testing

- Real Git/production CLI tests cover stacked/squash drift, ordinary direct-branch controls, refresh/status/validate, portable tampering, migration idempotence, and retained gold behavior.
- Transaction tests cover exact digest refusal, shared-bundle preservation, and recovery before and after individual retirement/replacement operations.
- All 451 affected tests passed; Ruff and mypy passed across 17 affected files. Independent review's three findings were fixed with RED/GREEN evidence; correction re-review approved and repeated 28 focused/compatibility tests.
- The final ordinary signed commit and hook-enabled push at b0ff4e0f083597551c81e4b6fe4ab38b028c39a7 passed full `make check`: 6,586 root tests and 202 standalone tests, 89.03% coverage, plus lint, types, dead-code, locks, and workflow checks. Existing skips: 9 root and 2 standalone.
- Required `daydream . --precision --backend pi --trace-to honeyhive --trace-to langsmith` completed with exit 0 (session 3d9f97c5-948f-4318-b31b-ef898ef802d6). Substantiated migration/classification/recovery-message findings were fixed with real CLI/Git RED/GREEN regressions. The alleged header-count clamp lacked primary evidence and its claimed fail-open effect contradicted the set-difference guard; the complete-inventory boundary remains strict.
- Final-SHA GitHub CI is running; this PR will not merge before it is green.
