### PR TITLE
fix(benchmark): share strict manifest validation and approval state

### DIFF
--- a/daydream/benchmark/cli.py
+++ b/daydream/benchmark/cli.py
@@ -258,7 +258,8 @@ def _handle_benchmark_status(dir_path: Path) -> int:
             snapshot_status += f" ({reason})"
         print(
             f"  case {summary.get('case_id', '')}: "
-            f"snapshot {snapshot_status} @ {head}"
+            f"snapshot {snapshot_status} @ {head}; "
+            f"task-spec approval {summary.get('task_spec_approval', 'not-required')}"
         )
     return 0
 

--- a/daydream/benchmark/harbor/build.py
+++ b/daydream/benchmark/harbor/build.py
@@ -17,14 +17,14 @@ import json
 import os
 import re
 import shutil
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
-
-from pydantic import ValidationError
+from typing import Any, Literal
 
 from daydream import severity
 from daydream.benchmark import schema, snapshot, storage, workspace
 from daydream.benchmark.harbor import verifier_core as vc
+from daydream.benchmark.manifest import load_benchmark_manifest
 
 TEMPLATE_VERSION = "4"
 
@@ -324,6 +324,29 @@ def task_spec_digest(case_doc: dict[str, Any]) -> str:
     return hashlib.sha256(
         render_task_spec(case_doc, instruction=ASSIGNMENT_TEXT)
     ).hexdigest()
+
+
+TaskSpecApprovalState = Literal["not-required", "current", "stale"]
+
+
+@dataclass(frozen=True)
+class TaskSpecApproval:
+    state: TaskSpecApprovalState
+    current_sha256: str
+    approved_sha256: str | None
+
+
+def task_spec_approval(case_doc: dict[str, Any]) -> TaskSpecApproval:
+    current = task_spec_digest(case_doc)
+    curation = case_doc.get("curation") or {}
+    approved = curation.get("task_spec_sha256")
+    if curation.get("state") != "ready":
+        return TaskSpecApproval("not-required", current, approved if isinstance(approved, str) else None)
+    return TaskSpecApproval(
+        "current" if approved == current else "stale",
+        current,
+        approved if isinstance(approved, str) else None,
+    )
 
 
 def _flatten_finding(finding: dict[str, Any]) -> dict[str, Any]:
@@ -646,15 +669,14 @@ def _write_task_spec(stage: Path, case_doc: dict[str, Any]) -> str:
     row.
     """
     task_spec_bytes = render_task_spec(case_doc, instruction=ASSIGNMENT_TEXT)
-    task_spec_sha256 = task_spec_digest(case_doc)
-    approved = (case_doc.get("curation") or {}).get("task_spec_sha256")
-    if task_spec_sha256 != approved:
+    approval = task_spec_approval(case_doc)
+    if approval.state != "current":
         raise CompileError(
             f"case {case_doc.get('case_id')} task spec digest "
-            f"{task_spec_sha256} != approved {approved}"
+            f"{approval.current_sha256} != approved {approval.approved_sha256}"
         )
     (stage / "Task.md").write_bytes(task_spec_bytes)
-    return task_spec_sha256
+    return approval.current_sha256
 
 
 def _compile_case(
@@ -863,21 +885,12 @@ def compile_workspace(root: Path, *, wheel: Path | None = None) -> dict[str, Any
     runtime_lock_fields = pkg.runtime_lock_header_fields(runtime_lock.decode("utf-8"))
     with storage.WorkspaceLock(root):
         storage.recover_startup(root)
-        manifest = storage.load_yaml_strict(root / "benchmark.yaml")
+        try:
+            loaded_manifest = load_benchmark_manifest(root, canonicalize_case_order=True)
+        except storage.WorkspaceCorrupt as exc:
+            raise CompileError(str(exc)) from exc
+        manifest = loaded_manifest.raw
         repo_slug = manifest.get("source", {}).get("repository") or ""
-
-        # Compile canonicalizes the manifest's ``cases[]`` row order to the
-        # schema's canonical (pr_number, head-sha, case_id) order before model
-        # validation, so compile output stays row-order-insensitive (the model
-        # requires the canonical order; reversed rows are not corruption here).
-        manifest["cases"] = sorted(
-            manifest.get("cases") or [],
-            key=lambda c: (
-                int(c.get("pr_number", 0) or 0),
-                schema.head_sha_from_case_id(c.get("case_id", "")),
-                c.get("case_id", ""),
-            ),
-        )
         # Every indexed case is loaded through the shared model-gated loader
         # (same ``_schema_ready`` + ``CaseDocument`` validation as the
         # validate/status read path); a present-but-corrupt case raises
@@ -885,10 +898,7 @@ def compile_workspace(root: Path, *, wheel: Path | None = None) -> dict[str, Any
         # validation (which rejects malformed/empty privacy host lists) is
         # surfaced as ``CompileError`` so a disallowed-host policy fails the
         # compile closed through the documented rejection type.
-        try:
-            manifest_model = schema.BenchmarkManifest.model_validate(manifest)
-        except ValidationError as exc:
-            raise CompileError(f"{root}: invalid benchmark.yaml: {exc}") from exc
+        manifest_model = loaded_manifest.model
         # The compiled network policy is sourced from the workspace's persisted
         # privacy allowlists -- never a hardcoded default. The Privacy field
         # validators (_normalize_host_list) already reject empty/malformed

--- a/daydream/benchmark/harbor/calibrate.py
+++ b/daydream/benchmark/harbor/calibrate.py
@@ -29,7 +29,7 @@ from pathlib import Path
 from typing import Any, Callable
 
 from daydream.benchmark import storage
-from daydream.benchmark.schema import BenchmarkManifest
+from daydream.benchmark.manifest import load_benchmark_manifest
 
 _HARBOR = Path(__file__).parent
 _TEMPLATES = _HARBOR / "templates"
@@ -192,16 +192,7 @@ def _load_workspace_allowlist(workspace: Path) -> list[str]:
     a malformed or missing manifest raises the project's existing workspace
     error (``WorkspaceCorrupt``) — never a silent default.
     """
-    try:
-        raw = storage.load_yaml_strict(workspace / "benchmark.yaml")
-    except storage.WorkspaceCorrupt:
-        raise
-    try:
-        manifest = BenchmarkManifest.model_validate(raw)
-    except Exception as exc:
-        raise storage.WorkspaceCorrupt(
-            f"{workspace}: invalid benchmark.yaml: {exc}"
-        ) from exc
+    manifest = load_benchmark_manifest(workspace).model
     return list(manifest.privacy.judge_allowed_hosts)
 
 

--- a/daydream/benchmark/manifest.py
+++ b/daydream/benchmark/manifest.py
@@ -1,0 +1,47 @@
+"""One strict, bounded-error reader for benchmark manifests."""
+
+from __future__ import annotations
+
+import copy
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from daydream.benchmark import schema, storage
+
+
+@dataclass(frozen=True)
+class LoadedBenchmarkManifest:
+    raw: dict[str, Any]
+    model: schema.BenchmarkManifest
+
+
+def load_benchmark_manifest(
+    root: Path, *, canonicalize_case_order: bool = False
+) -> LoadedBenchmarkManifest:
+    """Read once, optionally canonicalize case rows, and model-validate."""
+    root = Path(root)
+    try:
+        loaded = storage.load_yaml_strict(root / "benchmark.yaml")
+        raw = copy.deepcopy(loaded)
+        if canonicalize_case_order and "cases" in raw:
+            rows = raw["cases"]
+            if not isinstance(rows, list):
+                raise TypeError("cases must be a list")
+            validated = [schema.CaseIndexEntry.model_validate(row) for row in rows]
+            paired = sorted(
+                zip(validated, rows, strict=True),
+                key=lambda pair: (
+                    pair[0].pr_number,
+                    schema.head_sha_from_case_id(pair[0].case_id),
+                    pair[0].case_id,
+                ),
+            )
+            raw["cases"] = [row for _model, row in paired]
+        model = schema.BenchmarkManifest.model_validate(raw)
+        raw_ids = [row["case_id"] for row in raw.get("cases", [])]
+        if raw_ids != [row.case_id for row in model.cases]:
+            raise ValueError("raw/model case order mismatch")
+        return LoadedBenchmarkManifest(raw=raw, model=model)
+    except (storage.WorkspaceCorrupt, OSError, ValueError, TypeError) as exc:
+        raise storage.WorkspaceCorrupt(f"{root}: invalid benchmark.yaml") from exc

--- a/daydream/benchmark/schema.py
+++ b/daydream/benchmark/schema.py
@@ -1017,7 +1017,7 @@ def _schema_ready(raw: dict[str, Any]) -> dict[str, Any]:
     curation = dict(raw.get("curation") or {})
     curation.pop("gold_mode", None)
     curation.pop("task_spec_approved_at", None)
-    if curation.get("state") == "ready" and curation.get("task_spec_sha256") is None:
+    if curation.get("state") == "ready" and "task_spec_sha256" not in curation:
         from daydream.benchmark.harbor.build import (
             task_spec_digest,
         )

--- a/daydream/benchmark/schema.py
+++ b/daydream/benchmark/schema.py
@@ -979,6 +979,11 @@ class Curation(BaseModel):
     case_exclusion: CaseExclusion | None = None
     task_spec_sha256: str | None = None
 
+    @field_validator("task_spec_sha256")
+    @classmethod
+    def _approved_spec_digest(cls, value: str | None) -> str | None:
+        return _hex64(value) if value is not None else None
+
     @model_validator(mode="after")
     def _consistent(self) -> "Curation":
         if self.case_exclusion is not None and self.state != "excluded":

--- a/daydream/benchmark/workspace.py
+++ b/daydream/benchmark/workspace.py
@@ -265,6 +265,13 @@ def validate_workspace(root: Path) -> tuple[int, str]:
     with WorkspaceLock(root):
         try:
             recover_startup(root)
+        except Exception:  # recovery diagnostics must not disclose journal contents
+            return (
+                classify_validation(corrupt=True, ready=False, incomplete=False),
+                f"corrupt: {root}: workspace recovery failed",
+            )
+
+        try:
             manifest = load_benchmark_manifest(root).model
         except Exception:  # schema/checksum/unreadable all map to corruption
             return (

--- a/daydream/benchmark/workspace.py
+++ b/daydream/benchmark/workspace.py
@@ -25,6 +25,7 @@ from pydantic import BaseModel
 from daydream import git_ops
 from daydream.benchmark import schema
 from daydream.benchmark import snapshot as snapshot_mod
+from daydream.benchmark.manifest import load_benchmark_manifest
 from daydream.benchmark.schema import (
     BenchmarkManifest,
     CaseDocument,
@@ -175,8 +176,12 @@ def init_workspace(
                 if sub != "transactions":
                     tx.create_dir(sub)
             tx.commit()
+        try:
+            manifest = load_benchmark_manifest(root).model
+        except WorkspaceCorrupt as exc:
+            raise InitError(f"{root}: invalid benchmark.yaml") from exc
 
-    return BenchmarkManifest.model_validate(load_yaml_strict(root / "benchmark.yaml"))
+    return manifest
 
 
 @dataclass
@@ -210,11 +215,7 @@ def workspace_status(root: Path) -> WorkspaceStatus:
     root = Path(root)
     with WorkspaceLock(root):
         recover_startup(root)
-        raw = load_yaml_strict(root / "benchmark.yaml")
-        try:
-            manifest = BenchmarkManifest.model_validate(raw)
-        except Exception as exc:
-            raise WorkspaceCorrupt(f"{root}: invalid benchmark.yaml: {exc}") from exc
+        manifest = load_benchmark_manifest(root).model
         docs = load_case_documents(root, manifest)
         state, resolved = _derived_state(root, manifest, docs)
         case_snapshots = _case_snapshot_summaries(root, manifest, docs)
@@ -264,12 +265,11 @@ def validate_workspace(root: Path) -> tuple[int, str]:
     with WorkspaceLock(root):
         try:
             recover_startup(root)
-            raw = load_yaml_strict(root / "benchmark.yaml")
-            manifest = BenchmarkManifest.model_validate(raw)
-        except Exception as exc:  # schema/checksum/unreadable all map to corruption
+            manifest = load_benchmark_manifest(root).model
+        except Exception:  # schema/checksum/unreadable all map to corruption
             return (
                 classify_validation(corrupt=True, ready=False, incomplete=False),
-                f"corrupt: invalid benchmark.yaml ({exc})",
+                f"corrupt: {root}: invalid benchmark.yaml",
             )
 
         # Orphan + missing-indexed-file rule over the case/import/bundle set.
@@ -771,7 +771,14 @@ def _case_curation_states(
         docs = load_case_documents(root, manifest)
     states: list[dict[str, str]] = []
     for case in manifest.cases:
-        states.append({"curation_state": docs[case.case_file].curation.state})
+        doc = docs[case.case_file]
+        state = doc.curation.state
+        if state == "ready":
+            from daydream.benchmark.harbor.build import task_spec_approval
+
+            if task_spec_approval(doc.model_dump(mode="json")).state == "stale":
+                state = "stale"
+        states.append({"curation_state": state})
     return states
 
 
@@ -804,9 +811,16 @@ def _case_snapshot_summaries(
                 "snapshot_status": status,
                 "head_prefix": head[:12],
                 "error_reason": error_reason,
+                "task_spec_approval": _task_spec_approval_state(doc),
             }
         )
     return summaries
+
+
+def _task_spec_approval_state(doc: CaseDocument) -> str:
+    from daydream.benchmark.harbor.build import task_spec_approval
+
+    return task_spec_approval(doc.model_dump(mode="json")).state
 
 
 def _scan_authoring_files(root: Path) -> set[Path]:

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -127,8 +127,8 @@ typed unreplayable reasons are appended to this label),
 `1` corrupt (invalid/missing `benchmark.yaml`, an orphan or missing indexed file,
 or a checksum-mismatched ready-snapshot bundle).
 
-A valid-shaped task-spec digest that no longer matches the canonical `Task.md`
-is structurally valid but incomplete (`2`). A present null or invalid digest is
+A valid-shaped task specification digest that no longer matches the canonical
+`Task.md` is structurally valid but incomplete (`2`). A present null or invalid digest is
 corrupt (`1`). For compatibility, legacy ready cases where the approval key is
 entirely absent receive the canonical derived approval in memory and remain
 ready; status and validate leave the persisted key absent.
@@ -301,8 +301,8 @@ daydream benchmark calibrate-judge ~/bench-owner-repo --yes
 `calibrate-judge` is an optional, **diagnostic**-only pass that measures the
 configured judge's agreement with an **unverified** fixture. It is not an
 authorization, correctness, or validation check, and it carries no operational
-authority. Current and stale task-spec approvals follow the same calibration
-path; calibration is neither a task-approval gate nor a training gate.
+authority. Current and stale task specification approvals follow the same
+calibration path; calibration is neither a task approval gate nor a training gate.
 
 ### `clean` — disposable artifacts
 

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -103,12 +103,17 @@ harbor/` and a self-ignoring `.gitignore`.
 daydream benchmark status ~/bench-owner-repo
 ```
 
-Reports the derived workspace state (`empty` / `collecting` / `ready` / …),
+Reports the derived workspace state (`empty` / `collecting` / `curating` /
+`stale` / `ready`),
 whether the repository identity is **unresolved**, the PR ledger, and per-indexed
 case snapshot state (`ready` / `unreplayable` / `imported`) with the frozen head
-prefix each case was caught at. Unreplayable rows include their typed reason,
-such as `base_drift`, without exposing the private path detail. Safe to run
-concurrently with other read-only commands.
+prefix each case was caught at. Each case also reports whether its approved
+task specification is `current`, `stale`, or `not-required`. A stale approval
+cannot produce global `ready`, though an outstanding import or draft case keeps
+the existing higher-priority global `collecting` or `curating` label.
+Unreplayable rows include their typed reason, such as `base_drift`, without
+exposing the private path detail. Safe to run concurrently with other read-only
+commands.
 
 ### `validate` — 0/2/1 exit codes
 
@@ -121,6 +126,12 @@ incomplete (for example an unresolved repository identity on a fresh workspace;
 typed unreplayable reasons are appended to this label),
 `1` corrupt (invalid/missing `benchmark.yaml`, an orphan or missing indexed file,
 or a checksum-mismatched ready-snapshot bundle).
+
+A valid-shaped task-spec digest that no longer matches the canonical `Task.md`
+is structurally valid but incomplete (`2`). A present null or invalid digest is
+corrupt (`1`). For compatibility, legacy ready cases where the approval key is
+entirely absent receive the canonical derived approval in memory and remain
+ready; status and validate leave the persisted key absent.
 
 ### `import-prs` — explicit private evidence
 
@@ -253,6 +264,8 @@ daydream benchmark build-harbor ~/bench-owner-repo --daydream-wheel dist/daydrea
 Packages a validated workspace for Harbor `0.22`. `--daydream-wheel` names the
 wheel for this Daydream version; the emitted `harbor/benchmark.lock.json`
 `daydream` block records its version and SHA-256.
+Compilation re-renders every ready case's canonical task specification and
+rejects a stale approval before replacing an existing `harbor/` tree.
 
 ### `upgrade` — repair legacy case documents
 
@@ -288,7 +301,8 @@ daydream benchmark calibrate-judge ~/bench-owner-repo --yes
 `calibrate-judge` is an optional, **diagnostic**-only pass that measures the
 configured judge's agreement with an **unverified** fixture. It is not an
 authorization, correctness, or validation check, and it carries no operational
-authority.
+authority. Current and stale task-spec approvals follow the same calibration
+path; calibration is neither a task-approval gate nor a training gate.
 
 ### `clean` — disposable artifacts
 

--- a/tests/test_benchmark_curation.py
+++ b/tests/test_benchmark_curation.py
@@ -461,7 +461,7 @@ def test_mark_ready_clean_attested_empty_yields_ready(tmp_path: Path, fake_gh: F
     from daydream.benchmark.workspace import validate_workspace
     ws, case_id, head_sha = _seed_ready_case(tmp_path, fake_gh, lines=2)  # empty gold
     cu.attest_clean(ws, case_id)
-    cu.mark_ready(ws, case_id, task_spec_sha256="d" * 64, head_sha=head_sha)
+    cu.mark_ready(ws, case_id, head_sha=head_sha)  # canonical Task.md digest derived in-lock
     cur = load_yaml_strict(ws / "cases" / f"{case_id}.yaml")["curation"]
     assert cur["state"] == "ready" and cur["snapshot_attested"] is True
     assert cur["clean_attested"] is True
@@ -726,7 +726,7 @@ def test_curate_and_validate_after_mirror_removal(tmp_path: Path, fake_gh: FakeG
     assert rows[0]["changed_files"] == 2 and rows[0]["changed_lines"] == 6
     # attest ready (re-exercises location-vs-head from the bundle), so the
     # workspace reaches the ``ready`` exit-0 state on validation
-    cu.mark_ready(ws, case_id, task_spec_sha256="d" * 64, head_sha=head_sha)
+    cu.mark_ready(ws, case_id, head_sha=head_sha)  # canonical Task.md digest derived in-lock
     # validate_workspace still passes (fidelity is bundle-based)
     code, label = validate_workspace(ws)
     assert code == 0 and label == "ready"

--- a/tests/test_benchmark_import_prs.py
+++ b/tests/test_benchmark_import_prs.py
@@ -1815,6 +1815,7 @@ def _curate_case(ws: Path, case_file: Any) -> None:
     """Mark a materialized case ready + attested with one historical finding."""
     import yaml
 
+    from daydream.benchmark.harbor.build import task_spec_digest
     from daydream.benchmark.schema import derive_finding_id
     from daydream.benchmark.storage import load_yaml_strict
 
@@ -1836,8 +1837,8 @@ def _curate_case(ws: Path, case_file: Any) -> None:
         "findings": [finding],
         "exclusions": [],
         "case_exclusion": None,
-        "task_spec_sha256": "d" * 64,
     }
+    raw["curation"]["task_spec_sha256"] = task_spec_digest(raw)
     path.write_text(yaml.safe_dump(raw, sort_keys=False))
 
 

--- a/tests/test_benchmark_manifest.py
+++ b/tests/test_benchmark_manifest.py
@@ -1,0 +1,84 @@
+from pathlib import Path
+
+import pytest
+import yaml
+
+from daydream.benchmark.manifest import load_benchmark_manifest
+from daydream.benchmark.storage import WorkspaceCorrupt
+from daydream.benchmark.workspace import init_workspace
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        "cases: null\n",
+        "cases: {}\n",
+        "cases: 7\n",
+        "cases:\n  - nope\n",
+        "cases:\n  - case_id: broken\n",
+        "x: 1\nx: 2\n",
+        "x: !!python/object/apply:os.system ['false']\n",
+        "",
+        "- not\n- a\n- mapping\n",
+    ],
+)
+def test_manifest_loader_bounds_every_invalid_shape(tmp_path: Path, payload: str) -> None:
+    (tmp_path / "benchmark.yaml").write_text(payload)
+    with pytest.raises(WorkspaceCorrupt) as excinfo:
+        load_benchmark_manifest(tmp_path, canonicalize_case_order=True)
+    assert str(excinfo.value) == f"{tmp_path}: invalid benchmark.yaml"
+
+
+def test_manifest_loader_preserves_absent_cases_default(tmp_path: Path) -> None:
+    root = tmp_path / "ws"
+    init_workspace(root, "O/R", ["review.example"], ["judge.example"])
+    raw = yaml.safe_load((root / "benchmark.yaml").read_text())
+    raw.pop("cases")
+    (root / "benchmark.yaml").write_text(yaml.safe_dump(raw, sort_keys=False))
+
+    loaded = load_benchmark_manifest(root, canonicalize_case_order=True)
+
+    assert "cases" not in loaded.raw
+    assert loaded.model.cases == []
+
+
+def test_manifest_loader_canonicalizes_copy_without_mutating_manifest(tmp_path: Path) -> None:
+    root = tmp_path / "ws"
+    init_workspace(root, "O/R", ["review.example"], ["judge.example"])
+    raw = yaml.safe_load((root / "benchmark.yaml").read_text())
+    first = {"case_id": "pr-000002-" + "b" * 12, "case_file": "cases/b.yaml", "pr_number": 2}
+    second = {"case_id": "pr-000001-" + "a" * 12, "case_file": "cases/a.yaml", "pr_number": 1}
+    raw["cases"] = [first, second]
+    manifest_path = root / "benchmark.yaml"
+    manifest_path.write_text(yaml.safe_dump(raw, sort_keys=False))
+    original_bytes = manifest_path.read_bytes()
+
+    with pytest.raises(WorkspaceCorrupt, match="invalid benchmark.yaml"):
+        load_benchmark_manifest(root)
+
+    loaded = load_benchmark_manifest(root, canonicalize_case_order=True)
+
+    assert manifest_path.read_bytes() == original_bytes
+    assert yaml.safe_load(manifest_path.read_text())["cases"] == [first, second]
+    assert [row["case_id"] for row in loaded.raw["cases"]] == [second["case_id"], first["case_id"]]
+    assert [row.case_id for row in loaded.model.cases] == [second["case_id"], first["case_id"]]
+    loaded.raw["cases"][0]["case_id"] = "changed-in-memory"
+    assert manifest_path.read_bytes() == original_bytes
+    assert loaded.model.cases[0].case_id == second["case_id"]
+
+
+@pytest.mark.parametrize("kind", ["missing", "directory", "invalid-encoding", "unhashable-key"])
+def test_manifest_loader_bounds_real_read_and_decode_errors(tmp_path: Path, kind: str) -> None:
+    path = tmp_path / "benchmark.yaml"
+    if kind == "directory":
+        path.mkdir()
+    elif kind == "invalid-encoding":
+        path.write_bytes(b"\xff\xff\x00")
+    elif kind == "unhashable-key":
+        path.write_text("? [one, two]\n: value\n")
+
+    with pytest.raises(WorkspaceCorrupt) as excinfo:
+        load_benchmark_manifest(tmp_path)
+
+    assert str(excinfo.value) == f"{tmp_path}: invalid benchmark.yaml"
+    assert excinfo.value.__cause__ is not None

--- a/tests/test_benchmark_workspace.py
+++ b/tests/test_benchmark_workspace.py
@@ -358,9 +358,12 @@ def _write_case_docs(root: Path, curation_state: str) -> Any:
     (root / import_file).write_bytes(import_bytes)
     (root / "snapshots").mkdir(parents=True, exist_ok=True)
     (root / "cases").mkdir(parents=True, exist_ok=True)
-    (root / case_file).write_text(
-        yaml.safe_dump(case_doc.model_dump(mode="json"), sort_keys=False)
-    )
+    case_raw = case_doc.model_dump(mode="json")
+    if case_raw["curation"]["state"] == "ready":
+        from daydream.benchmark.harbor.build import task_spec_digest
+
+        case_raw["curation"]["task_spec_sha256"] = task_spec_digest(case_raw)
+    (root / case_file).write_text(yaml.safe_dump(case_raw, sort_keys=False))
     return root
 
 
@@ -485,6 +488,53 @@ def test_status_derives_ready_from_curated_cases(tmp_path: Path) -> None:
     assert st.repository_identity_resolved is True
 
 
+def test_status_and_validate_project_changed_ready_task_spec_as_stale_without_writing(
+    tmp_path: Path,
+) -> None:
+    import yaml
+
+    from daydream.benchmark.schema import derive_finding_id
+    from daydream.benchmark.workspace import validate_workspace, workspace_status
+
+    root = _write_curated_workspace(tmp_path, "ready")
+    case_path = next((root / "cases").glob("*.yaml"))
+    raw = load_yaml_strict(case_path)
+    raw["curation"]["findings"][0]["title"] = "Changed after approval"
+    raw["curation"]["findings"][0]["severity"] = "medium"
+    raw["curation"]["findings"][0]["finding_id"] = derive_finding_id(
+        raw["curation"]["findings"][0], case_id=raw["case_id"]
+    )
+    case_path.write_text(yaml.safe_dump(raw, sort_keys=False))
+    before = case_path.read_bytes()
+
+    status = workspace_status(root)
+
+    assert status.workspace_state == "stale"
+    assert status.case_snapshots[0]["task_spec_approval"] == "stale"
+    assert validate_workspace(root) == (2, "incomplete: workspace state stale")
+    assert case_path.read_bytes() == before
+
+
+def test_legacy_ready_approval_is_derived_in_memory_without_writing(tmp_path: Path) -> None:
+    import yaml
+
+    from daydream.benchmark.workspace import validate_workspace, workspace_status
+
+    root = _write_curated_workspace(tmp_path, "ready")
+    case_path = next((root / "cases").glob("*.yaml"))
+    raw = load_yaml_strict(case_path)
+    raw["curation"].pop("task_spec_sha256")
+    case_path.write_text(yaml.safe_dump(raw, sort_keys=False))
+    before = case_path.read_bytes()
+
+    status = workspace_status(root)
+
+    assert status.workspace_state == "ready"
+    assert status.case_snapshots[0]["task_spec_approval"] == "current"
+    assert validate_workspace(root) == (0, "ready")
+    assert case_path.read_bytes() == before
+
+
 def _seed_frozen_case(ws: Any) -> Any:
     """Seed one ``ready`` snapshot case + its bundle + the indexed ledger.
 
@@ -583,6 +633,7 @@ def test_status_and_validate_surface_typed_unreplayable_reason(
             "snapshot_status": "unreplayable",
             "head_prefix": case_id.rsplit("-", 1)[-1],
             "error_reason": "base_drift",
+            "task_spec_approval": "not-required",
         }
     ]
     assert validate_workspace(root) == (

--- a/tests/test_benchmark_workspace_cli.py
+++ b/tests/test_benchmark_workspace_cli.py
@@ -77,6 +77,32 @@ def _tree_sha(root: Path) -> str:
     return digest.hexdigest()
 
 
+def _tree_bytes(root: Path) -> dict[str, bytes]:
+    return {
+        path.relative_to(root).as_posix(): path.read_bytes()
+        for path in sorted(root.rglob("*"))
+        if path.is_file()
+    }
+
+
+def _git_states(root: Path) -> dict[str, tuple[str, bytes | None]]:
+    states: dict[str, tuple[str, bytes | None]] = {}
+    for git_dir in sorted(root.rglob(".git")):
+        if not git_dir.is_dir():
+            continue
+        repo = git_dir.parent
+        head_result = subprocess.run(
+            ["git", "rev-parse", "--verify", "HEAD"], cwd=repo, check=False, capture_output=True, text=True
+        )
+        if head_result.returncode != 0:
+            continue
+        head = head_result.stdout
+        index_path = git_dir / "index"
+        index = index_path.read_bytes() if index_path.is_file() else None
+        states[repo.relative_to(root).as_posix()] = (head, index)
+    return states
+
+
 def test_benchmark_help_lists_subcommands() -> None:
     r = subprocess.run(  # noqa: S603 - args are not user-controlled
         [sys.executable, "-m", "daydream", "benchmark", "--help"], capture_output=True, text=True
@@ -153,6 +179,227 @@ def test_validate_exit_code_contract_preserved(tmp_path: Path) -> None:
     assert validate_workspace(_write_curated_workspace(tmp_path / "r2", "draft"))[0] == 2
     assert validate_workspace(_write_minimal_invalid_workspace(tmp_path / "r3"))[0] == 1
     assert validate_workspace(_write_curated_workspace(tmp_path / "r4", "ready", resolved=False))[0] == 2
+
+
+def test_real_cli_reports_and_rejects_stale_task_spec_without_mutation(
+    tmp_path: Path,
+    fake_gh: Any,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    import importlib.metadata
+
+    import yaml
+
+    from daydream import cli as top_cli
+    from daydream.benchmark import cli as benchmark_cli
+    from daydream.benchmark.harbor.build import task_spec_digest
+    from daydream.benchmark.schema import derive_finding_id
+    from daydream.benchmark.storage import load_yaml_strict
+    from tests.test_benchmark_curate_tui import _scripted
+    from tests.test_benchmark_curation import _seed_ready_case
+
+    parent = tmp_path / "workspace parent with spaces"
+    parent.mkdir()
+    ws, case_id, _head_sha = _seed_ready_case(parent, fake_gh, candidate=True)
+    monkeypatch.setattr(benchmark_cli, "_is_interactive_tty", lambda: True)
+    monkeypatch.setattr("builtins.input", _scripted("a", "1", "r", "y", "q"))
+    with pytest.raises(SystemExit) as curated:
+        top_cli.main(["benchmark", "curate", str(ws), "--case", case_id])
+    assert curated.value.code == 0
+    approved = load_yaml_strict(ws / "cases" / f"{case_id}.yaml")
+    assert approved["curation"]["state"] == "ready"
+    assert approved["curation"]["task_spec_sha256"] == task_spec_digest(approved)
+    wheel = tmp_path / f"daydream-{importlib.metadata.version('daydream')}-py3-none-any.whl"
+    wheel.write_bytes(b"PK\x05\x06" + b"\x00" * 18)
+    with pytest.raises(SystemExit) as built:
+        top_cli.main(["benchmark", "build-harbor", str(ws), "--daydream-wheel", str(wheel)])
+    assert built.value.code == 0
+    harbor_before = _tree_bytes(ws / "harbor")
+    assert harbor_before
+    git_before = _git_states(parent)
+    assert git_before
+    manifest = (ws / "benchmark.yaml").read_bytes()
+    case_path = next((ws / "cases").glob("*.yaml"))
+    import_path = next((ws / "imports").glob("*.json"))
+    bundle_path = next((ws / "snapshots").glob("*.bundle"))
+
+    raw = load_yaml_strict(case_path)
+    approved_digest = raw["curation"]["task_spec_sha256"]
+    raw["curation"]["findings"][0]["title"] = "Approval is now stale"
+    raw["curation"]["findings"][0]["severity"] = "medium"
+    raw["curation"]["findings"][0]["finding_id"] = derive_finding_id(
+        raw["curation"]["findings"][0], case_id=raw["case_id"]
+    )
+    case_path.write_text(yaml.safe_dump(raw, sort_keys=False))
+    authored = {
+        "manifest": manifest,
+        "case": case_path.read_bytes(),
+        "import": import_path.read_bytes(),
+        "bundle": bundle_path.read_bytes(),
+    }
+
+    with pytest.raises(SystemExit) as status:
+        top_cli.main(["benchmark", "status", str(ws)])
+    assert status.value.code == 0
+    assert "task-spec approval stale" in capsys.readouterr().out
+    with pytest.raises(SystemExit) as validated:
+        top_cli.main(["benchmark", "validate", str(ws)])
+    assert validated.value.code == 2
+    with pytest.raises(SystemExit) as rejected:
+        top_cli.main(["benchmark", "build-harbor", str(ws), "--daydream-wheel", str(wheel)])
+    assert rejected.value.code == 1
+
+    assert (ws / "benchmark.yaml").read_bytes() == authored["manifest"]
+    assert case_path.read_bytes() == authored["case"]
+    assert import_path.read_bytes() == authored["import"]
+    assert bundle_path.read_bytes() == authored["bundle"]
+    retained = load_yaml_strict(case_path)
+    assert retained["curation"]["state"] == "ready"
+    assert retained["curation"]["task_spec_sha256"] == approved_digest
+    assert _tree_bytes(ws / "harbor") == harbor_before
+    assert _git_states(parent) == git_before
+    assert not (ws / "cache" / "harbor-build-stage").exists()
+
+
+def test_real_cli_calibration_treats_current_and_stale_approval_identically(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import yaml
+
+    from daydream import cli as top_cli
+    from daydream.benchmark.harbor import calibrate
+    from daydream.benchmark.schema import derive_finding_id
+    from daydream.benchmark.storage import load_yaml_strict
+    from tests.test_benchmark_calibrate import _env, _scripted_http, _scripted_responses
+    from tests.test_benchmark_workspace import _write_curated_workspace
+
+    workspaces = [
+        _write_curated_workspace(tmp_path / "current", "ready"),
+        _write_curated_workspace(tmp_path / "stale", "ready"),
+    ]
+    for ws in workspaces:
+        manifest = load_yaml_strict(ws / "benchmark.yaml")
+        manifest["privacy"]["judge_allowed_hosts"] = ["127.0.0.1"]
+        (ws / "benchmark.yaml").write_text(yaml.safe_dump(manifest, sort_keys=False))
+    stale_case = next((workspaces[1] / "cases").glob("*.yaml"))
+    stale = load_yaml_strict(stale_case)
+    stale["curation"]["findings"][0]["title"] = "Changed after approval"
+    stale["curation"]["findings"][0]["finding_id"] = derive_finding_id(
+        stale["curation"]["findings"][0], case_id=stale["case_id"]
+    )
+    stale_case.write_text(yaml.safe_dump(stale, sort_keys=False))
+
+    import httpx
+
+    responses = _scripted_responses(calibrate._load_fixture())
+    fake_http, request_counter = _scripted_http(responses)
+    construction_counter = 0
+
+    class FakeAsyncClient:
+        async def __aenter__(self) -> "FakeAsyncClient":
+            return self
+
+        async def __aexit__(self, *_args: Any) -> None:
+            return None
+
+        async def post(self, *args: Any, **kwargs: Any) -> Any:
+            return await fake_http.post(*args, **kwargs)
+
+    def external_http_client() -> FakeAsyncClient:
+        nonlocal construction_counter
+        construction_counter += 1
+        return FakeAsyncClient()
+
+    monkeypatch.setattr(httpx, "AsyncClient", external_http_client)
+    for name, value in _env().items():
+        monkeypatch.setenv(name, value)
+
+    from daydream.benchmark.harbor.build import task_spec_approval
+
+    assert task_spec_approval(load_yaml_strict(next((workspaces[0] / "cases").glob("*.yaml")))).state == "current"
+    assert task_spec_approval(load_yaml_strict(stale_case)).state == "stale"
+    request_totals = []
+    construction_totals = []
+    for ws in workspaces:
+        with pytest.raises(SystemExit) as result:
+            top_cli.main(["benchmark", "calibrate-judge", str(ws), "--yes"])
+        assert result.value.code == 0
+        assert (ws / "runtime" / "calibration-receipt.json").is_file()
+        request_totals.append(request_counter[0])
+        construction_totals.append(construction_counter)
+    assert request_totals == [72, 144]
+    assert construction_totals == [72, 144]
+
+
+def test_real_cli_malformed_manifest_matrix_is_bounded_and_preserves_outputs(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    import importlib.metadata
+
+    import httpx
+    import yaml
+
+    from daydream import cli as top_cli
+    from tests.test_benchmark_workspace import _write_curated_workspace
+
+    ws = _write_curated_workspace(tmp_path / "malformed workspace", "ready")
+    wheel = tmp_path / f"daydream-{importlib.metadata.version('daydream')}-py3-none-any.whl"
+    wheel.write_bytes(b"PK\x05\x06" + b"\x00" * 18)
+    with pytest.raises(SystemExit) as built:
+        top_cli.main(["benchmark", "build-harbor", str(ws), "--daydream-wheel", str(wheel)])
+    assert built.value.code == 0
+    harbor_before = _tree_bytes(ws / "harbor")
+    assert harbor_before
+    manifest_path = ws / "benchmark.yaml"
+    malformed = yaml.safe_load(manifest_path.read_text())
+    malformed["schema_version"] = "PRIVATE_SENTINEL"
+    manifest_path.write_text(yaml.safe_dump(malformed, sort_keys=False))
+    receipt = ws / "runtime" / "calibration-receipt.json"
+    receipt.write_bytes(b"prior-receipt\n")
+    receipt_before = receipt.read_bytes()
+    http_constructions = 0
+
+    def forbidden_http_client(*_args: Any, **_kwargs: Any) -> Any:
+        nonlocal http_constructions
+        http_constructions += 1
+        raise AssertionError("malformed manifest reached external HTTP client")
+
+    monkeypatch.setattr(httpx, "AsyncClient", forbidden_http_client)
+
+    commands = [
+        ["benchmark", "status", str(ws)],
+        ["benchmark", "validate", str(ws)],
+        ["benchmark", "build-harbor", str(ws), "--daydream-wheel", str(wheel)],
+        ["benchmark", "calibrate-judge", str(ws), "--yes"],
+    ]
+    for command in commands:
+        with pytest.raises(SystemExit) as result:
+            top_cli.main(command)
+        assert result.value.code == 1
+        captured = capsys.readouterr()
+        output = captured.out + captured.err
+        assert "invalid benchmark.yaml" in output
+        assert "PRIVATE_SENTINEL" not in output
+    assert http_constructions == 0
+    assert receipt.read_bytes() == receipt_before
+    assert _tree_bytes(ws / "harbor") == harbor_before
+    assert not (ws / "cache" / "harbor-build-stage").exists()
+
+
+def test_stale_approval_keeps_collecting_and_curating_priority_contract() -> None:
+    from daydream.benchmark.schema import derive_workspace_state
+
+    assert derive_workspace_state(
+        pull_requests=[{"import_state": "pending"}],
+        cases=[{"curation_state": "stale"}],
+    ) == "collecting"
+    assert derive_workspace_state(
+        pull_requests=[{"import_state": "fetched"}],
+        cases=[{"curation_state": "stale"}, {"curation_state": "draft"}],
+    ) == "curating"
 
 
 def test_private_benchmark_docs_document_the_new_verb() -> None:

--- a/tests/test_benchmark_workspace_cli.py
+++ b/tests/test_benchmark_workspace_cli.py
@@ -262,6 +262,77 @@ def test_real_cli_reports_and_rejects_stale_task_spec_without_mutation(
     assert not (ws / "cache" / "harbor-build-stage").exists()
 
 
+@pytest.mark.parametrize("digest", [None, "PRIVATE_DIGEST_SENTINEL"])
+def test_real_cli_rejects_corrupt_approval_digest_without_disclosure_or_mutation(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    digest: str | None,
+) -> None:
+    import importlib.metadata
+
+    import yaml
+
+    from daydream import cli as top_cli
+    from daydream.benchmark.storage import load_yaml_strict
+    from tests.test_benchmark_workspace import _write_curated_workspace
+
+    ws = _write_curated_workspace(tmp_path / "malformed approval workspace", "ready")
+    wheel = tmp_path / f"daydream-{importlib.metadata.version('daydream')}-py3-none-any.whl"
+    wheel.write_bytes(b"PK\x05\x06" + b"\x00" * 18)
+    with pytest.raises(SystemExit) as built:
+        top_cli.main(["benchmark", "build-harbor", str(ws), "--daydream-wheel", str(wheel)])
+    assert built.value.code == 0
+    assert _tree_bytes(ws / "harbor")
+    capsys.readouterr()
+
+    case_path = next((ws / "cases").glob("*.yaml"))
+    raw = load_yaml_strict(case_path)
+    raw["curation"]["task_spec_sha256"] = digest
+    case_path.write_text(yaml.safe_dump(raw, sort_keys=False))
+    before = _tree_bytes(ws)
+    git_before = _git_states(tmp_path)
+
+    commands = [
+        ["benchmark", "status", str(ws)],
+        ["benchmark", "validate", str(ws)],
+        ["benchmark", "build-harbor", str(ws), "--daydream-wheel", str(wheel)],
+    ]
+    for command in commands:
+        with pytest.raises(SystemExit) as result:
+            top_cli.main(command)
+        assert result.value.code == 1
+        captured = capsys.readouterr()
+        output = captured.out + captured.err
+        assert "PRIVATE_DIGEST_SENTINEL" not in output
+        assert "Traceback" not in output
+        assert _tree_bytes(ws) == before
+        assert _git_states(tmp_path) == git_before
+
+
+def test_real_cli_validate_distinguishes_recovery_corruption_without_disclosure(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str],
+) -> None:
+    from daydream import cli as top_cli
+    from tests.test_benchmark_workspace import _write_curated_workspace
+
+    ws = _write_curated_workspace(tmp_path / "corrupt journal workspace", "ready")
+    residue = ws / "transactions" / "PRIVATE_JOURNAL_SENTINEL"
+    residue.write_bytes(b"private unknown transaction residue\n")
+    before = _tree_bytes(ws)
+
+    with pytest.raises(SystemExit) as result:
+        top_cli.main(["benchmark", "validate", str(ws)])
+
+    assert result.value.code == 1
+    captured = capsys.readouterr()
+    output = captured.out + captured.err
+    assert "workspace recovery failed" in output
+    assert "invalid benchmark.yaml" not in output
+    assert "PRIVATE_JOURNAL_SENTINEL" not in output
+    assert "private unknown transaction residue" not in output
+    assert _tree_bytes(ws) == before
+
+
 def test_real_cli_calibration_treats_current_and_stale_approval_identically(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_benchmark_workspace_schema.py
+++ b/tests/test_benchmark_workspace_schema.py
@@ -822,6 +822,37 @@ def test_legacy_ready_without_task_spec_digest_backfills_and_validates() -> None
     assert CaseDocument.model_validate(prepared).curation.task_spec_sha256 == digest
 
 
+def test_present_null_ready_task_spec_digest_is_not_legacy_backfilled() -> None:
+    import daydream.benchmark.schema as schema
+
+    raw = _valid_case_dict()
+    raw["curation"]["task_spec_sha256"] = None
+
+    prepared = schema._schema_ready(raw)
+
+    assert "task_spec_sha256" in prepared["curation"]
+    assert prepared["curation"]["task_spec_sha256"] is None
+    with pytest.raises(ValidationError):
+        CaseDocument.model_validate(prepared)
+
+
+def test_task_spec_approval_reports_nonready_current_and_stale() -> None:
+    from daydream.benchmark.harbor.build import task_spec_approval, task_spec_digest
+
+    raw = _valid_case_dict()
+    raw["curation"]["state"] = "draft"
+    assert task_spec_approval(raw).state == "not-required"
+    raw = _valid_case_dict()
+    digest = task_spec_digest(raw)
+    raw["curation"]["task_spec_sha256"] = digest
+    assert task_spec_approval(raw).state == "current"
+    raw["curation"]["task_spec_sha256"] = "0" * 64
+    approval = task_spec_approval(raw)
+    assert approval.state == "stale"
+    assert approval.current_sha256 == digest
+    assert approval.approved_sha256 == "0" * 64
+
+
 def test_gold_status_and_mode_derived() -> None:
     case = _valid_case()  # ready, 1 finding, clean_attested=False
     assert derive_gold_status(case.curation) == "findings"

--- a/tests/test_benchmark_workspace_schema.py
+++ b/tests/test_benchmark_workspace_schema.py
@@ -836,6 +836,19 @@ def test_present_null_ready_task_spec_digest_is_not_legacy_backfilled() -> None:
         CaseDocument.model_validate(prepared)
 
 
+@pytest.mark.parametrize("digest", ["", "zzz", "a" * 63, "a" * 65, "g" * 64, "A" * 64])
+def test_malformed_task_spec_digest_is_corruption_not_staleness(digest: str) -> None:
+    import daydream.benchmark.schema as schema
+
+    raw = _valid_case_dict()
+    raw["curation"]["task_spec_sha256"] = digest
+    prepared = schema._schema_ready(raw)
+
+    assert prepared["curation"]["task_spec_sha256"] == digest
+    with pytest.raises(ValidationError, match="lowercase 64-hex"):
+        CaseDocument.model_validate(prepared)
+
+
 def test_task_spec_approval_reports_nonready_current_and_stale() -> None:
     from daydream.benchmark.harbor.build import task_spec_approval, task_spec_digest
 


### PR DESCRIPTION
## Summary

Closes #870. Closes #861.

- Use one strict, model-validated benchmark manifest reader for init, status, validate, Harbor build, and judge calibration. Invalid input produces a bounded error without exposing field values.
- Keep canonical build ordering on a copy and preserve the missing-`cases` default. Existing workspace locking and recovery boundaries remain unchanged.
- Share the canonical task-spec approval comparison between build and workspace status. A valid digest mismatch is stale/incomplete; a present null or invalid digest is corruption. Legacy absent-key compatibility is derived in memory without writing approval.
- Keep diagnostic judge calibration independent of task approval, while malformed manifests stop before external client construction.

## Verification

- Independent final code review: approved with no actionable findings.
- 251 manifest/schema/workspace/build/calibration tests passed; 25 CLI/manifest tests passed after final acceptance strengthening. Ruff and eight-file mypy checks passed.
- Real CLI acceptance curates a candidate, marks it ready, builds successfully, edits a finding coherently while preserving its old approval, then verifies stale status, validation exit 2, and failed rebuild without changing authoring, snapshot, Git index/HEAD, or prior Harbor output.
- Malformed-manifest public CLI matrix preserves prior output and calibration receipts, redacts the invalid field value, and creates zero HTTP clients. Current and stale cases follow the same real calibration path with only external HTTP faked.
- The first normal push found stale approval placeholders in three existing test workflows and a documentation-secret-pattern collision. The fixtures now derive real canonical approvals and the prose was reworded; no gate or expected behavior was weakened. All 28 directly affected tests passed.
- The required review identified malformed approval digests being classified as stale and recovery failures being mislabeled as manifest corruption. Both are corrected with real CLI regressions preserving existing bytes and bounded private-value-free diagnostics. The corrections passed 182 affected tests; independent narrow review approved them with nine focused regressions and clean Ruff/mypy.
- Final ordinary hook-enabled push passed: 6,620 main tests (9 skipped), 202 standalone tests (2 skipped), 89.10% coverage, signatures, locks, lint, types, dead-code, and workflow checks. All six checks passed on `057603d8`.
- The exact required HoneyHive/LangSmith-traced Daydream command completed with exit 0 (session `6e453283-0471-447b-8d6b-234df0c71c64`). All stack reports and three final records were adjudicated: the two actionable defects are fixed; the remaining repeated pure-render suggestion has no correctness impact. A prior provider HTTP-524 failure was not counted as completion. No training or paid judge calibration requests were performed.
