### PR TITLE
refactor(artifacts): consolidate P10 crash-safe primitives & unify session routing

### DIFF
--- a/daydream/archive/__init__.py
+++ b/daydream/archive/__init__.py
@@ -166,9 +166,9 @@ def archive_run(
 
 def _validate_frozen_artifacts(artifacts: ArtifactTreeSnapshot) -> None:
     """Reject a frozen tree that changed before a strict host consumer."""
-    from daydream.artifact_visibility import _manifest
+    from daydream.artifact_visibility import manifest_tree
 
-    if _manifest(artifacts.root) != artifacts.manifest:
+    if manifest_tree(artifacts.root) != artifacts.manifest:
         raise ArchiveFinalizationError("frozen artifact tree changed before archive")
 
 
@@ -350,12 +350,10 @@ def finalize_archive_run(
             recorder_provenance=recorder_provenance,
             write_snapshot=write_snapshot,
         )
-        _validate_frozen_artifacts(artifacts)
         status = write_snapshot.status
         target_dir = artifacts.root
         git_target = work.repo if work is not None else target_dir
         git_ctx = capture_git_context(git_target)
-        _validate_frozen_artifacts(artifacts)
         if work is not None:
             git_ctx.base_branch = work.base_branch
             if git_ctx.base_sha is None:
@@ -389,7 +387,6 @@ def finalize_archive_run(
             if runs_fix
             else None
         )
-        _validate_frozen_artifacts(artifacts)
         if fix_failures:
             status = "partial"
         from daydream.archive.pipeline import derive_phase_states, derive_pipeline_status
@@ -421,7 +418,6 @@ def finalize_archive_run(
             pr_repo=recorder_provenance.pr_repo,
             pr_number=recorder_provenance.pr_number,
         )
-        _validate_frozen_artifacts(artifacts)
         pipeline_status = derive_pipeline_status(
             status,
             fix_failures,
@@ -452,7 +448,6 @@ def finalize_archive_run(
             json.dumps(manifest.to_dict(), indent=2),
             encoding="utf-8",
         )
-        _validate_frozen_artifacts(artifacts)
         if config.archive and upload:
             from daydream.archive import hub
 
@@ -464,7 +459,6 @@ def finalize_archive_run(
                     hub_repo_id,
                     recorder_provenance.session_id,
                 )
-                _validate_frozen_artifacts(artifacts)
                 if not uploaded:
                     raise ArchiveFinalizationError("archive upload failed")
         if config.dump_artifacts:
@@ -473,7 +467,6 @@ def finalize_archive_run(
             from daydream.archive import scan
 
             scan_result = scan.scan_run_dir(assembly_dir)
-            _validate_frozen_artifacts(artifacts)
             if not scan_result.clean:
                 raise ArchiveFinalizationError("dump artifact secret scan refused publication")
             dump_started = True
@@ -482,7 +475,6 @@ def finalize_archive_run(
         os.replace(assembly_dir, run_dir)
         assembly_created = False
         archive_installed = True
-        _validate_frozen_artifacts(artifacts)
         upsert_run(archive_dir, manifest)
         completed = True
     except BaseException as exc:

--- a/daydream/archive/hydrate.py
+++ b/daydream/archive/hydrate.py
@@ -48,6 +48,7 @@ from daydream.archive.hydrate_rules import (
 from daydream.archive.index import upsert_run
 from daydream.archive.manifest import Manifest
 from daydream.archive.scan import scan_run_dir
+from daydream.json_utils import atomic_write_json
 from daydream.trajectory import redact_text
 
 _FULL_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
@@ -542,14 +543,7 @@ class IngestResult:
 
 def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
     """Write ``payload`` to ``path`` atomically (temp file + rename); fatal on failure."""
-    path.parent.mkdir(parents=True, exist_ok=True)
-    tmp = path.with_name(path.name + ".tmp")
-    try:
-        tmp.write_text(json.dumps(payload, indent=2), encoding="utf-8")
-        tmp.replace(path)
-    except OSError:
-        tmp.unlink(missing_ok=True)
-        raise
+    atomic_write_json(path, payload)
 
 
 def _utc_now() -> str:

--- a/daydream/artifact_visibility.py
+++ b/daydream/artifact_visibility.py
@@ -30,6 +30,7 @@ from typing import TYPE_CHECKING, Any, AsyncIterator, Literal, cast
 import anyio
 
 from daydream import git_ops
+from daydream.json_utils import atomic_write_bytes
 
 if TYPE_CHECKING:
     from daydream.trajectory import RunWriteSnapshot, TrajectoryDocumentSnapshot
@@ -352,24 +353,6 @@ def _overlaps(left: Path, right: Path) -> bool:
     return left == right or left in right.parents or right in left.parents
 
 
-def _ensure_private_directory(path: Path) -> None:
-    missing: list[Path] = []
-    cursor = path
-    while not cursor.exists():
-        missing.append(cursor)
-        if cursor.parent == cursor:
-            break
-        cursor = cursor.parent
-    for existing in (cursor, *cursor.parents):
-        with suppress(OSError):
-            if stat.S_ISLNK(existing.lstat().st_mode):
-                raise ArtifactVisibilityError("artifact runtime ancestry contains a symlink")
-    path.mkdir(parents=True, exist_ok=True)
-    for created in reversed(missing):
-        os.chmod(created, 0o700)
-    os.chmod(path, 0o700)
-
-
 def _workspace_key(source: Path, common_dir: Path) -> str:
     digest = hashlib.sha256()
     digest.update(b"daydream-artifacts-v1\0")
@@ -427,11 +410,28 @@ def validate_private_directory(
 
 
 def _create_private_directory(path: Path) -> None:
+    """Create ``path`` and missing parents as private 0700 directories, durably.
+
+    Every created directory is chmod'ed to ``0o700`` immediately after its
+    mkdir (umask-immune), the parent entry of every creation is fsync'ed, and
+    the final directory is validated as a real, private directory — a symlink
+    anywhere in the ancestry fails closed instead of being chmod'ed through.
+    """
     missing: list[Path] = []
     cursor = path
     while not cursor.exists() and not cursor.is_symlink():
         missing.append(cursor)
         cursor = cursor.parent
+    # Ancestry guarantee (restored from _ensure_private_directory, minus the
+    # leaf: a symlinked final component keeps failing closed via
+    # validate_private_directory below with its "real directory" contract).
+    # A symlink in any proper ancestor of the target must never be mkdir'ed
+    # or chmod'ed through.
+    ancestry = cursor.parents if cursor == path else (cursor, *cursor.parents)
+    for existing in ancestry:
+        with suppress(OSError):
+            if stat.S_ISLNK(existing.lstat().st_mode):
+                raise ArtifactVisibilityError("artifact runtime ancestry contains a symlink")
     for directory in reversed(missing):
         directory.mkdir(mode=0o700)
         os.chmod(directory, 0o700)
@@ -631,44 +631,22 @@ def _fsync_directory(path: Path) -> None:
 
 
 def _atomic_json(path: Path, payload: object) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    temporary = path.with_name(f".{path.name}.{secrets.token_hex(8)}.tmp")
+    """Atomically persist one canonical-JSON manifest document.
+
+    Compact sorted separators (byte-exact for all persisted manifests) with a
+    trailing newline, file fsync before the rename, and a parent-directory
+    fsync after it. A thin policy wrapper over the shared
+    :func:`daydream.json_utils.atomic_write_bytes` primitive; the exclusive
+    O_EXCL temp creation the module previously maintained is provided by the
+    same same-directory mkstemp + rename exchange.
+    """
     encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8") + b"\n"
-    fd = os.open(temporary, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
-    try:
-        with os.fdopen(fd, "wb", closefd=False) as handle:
-            handle.write(encoded)
-            handle.flush()
-            os.fsync(handle.fileno())
-        os.replace(temporary, path)
-        _fsync_directory(path.parent)
-    except BaseException:
-        with suppress(OSError):
-            temporary.unlink()
-        raise
-    finally:
-        os.close(fd)
+    atomic_write_bytes(path, encoded, fsync=True, dir_fsync=True, mode=0o600)
 
 
 def _atomic_bytes(path: Path, content: bytes, *, mode: int = 0o600) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    temporary = path.with_name(f".{path.name}.{secrets.token_hex(8)}.tmp")
-    fd = os.open(temporary, os.O_WRONLY | os.O_CREAT | os.O_EXCL, mode)
-    try:
-        with os.fdopen(fd, "wb", closefd=False) as handle:
-            handle.write(content)
-            handle.flush()
-            os.fsync(handle.fileno())
-        os.replace(temporary, path)
-        os.chmod(path, mode)
-        _fsync_file(path)
-        _fsync_directory(path.parent)
-    except BaseException:
-        with suppress(OSError):
-            temporary.unlink()
-        raise
-    finally:
-        os.close(fd)
+    """Atomically persist raw bytes at a strict mode (private artifact files)."""
+    atomic_write_bytes(path, content, fsync=True, dir_fsync=True, mode=mode)
 
 
 def _load_json(path: Path) -> dict[str, Any]:
@@ -792,6 +770,23 @@ def _manifest(
         if path.exists() or path.is_symlink():
             _walk(root, path, entries, inodes, digest=digest)
     return tuple(entries)
+
+
+def manifest_tree(
+    root: Path,
+    names: Sequence[str] | None = None,
+    *,
+    digest: bool = True,
+) -> tuple[ArtifactManifestEntry, ...]:
+    """Public narrow seam over the strict artifact-tree manifest enumeration.
+
+    The one sanctioned way for a host-side consumer outside this module (e.g.
+    the strict archive finalization boundary) to re-enumerate and digest an
+    immutable artifact tree. It rejects symlinked roots, nonregular entries,
+    duplicate normalized names, and duplicate filesystem aliases exactly as
+    the module's own boundary manifests do.
+    """
+    return _manifest(root, names, digest=digest)
 
 
 def _manifest_payload(entries: tuple[ArtifactManifestEntry, ...]) -> dict[str, object]:
@@ -1400,10 +1395,15 @@ def _transfer_entry(
     relative: str,
     expected: ArtifactManifestEntry,
     transaction: Path,
+    record_intent: bool = True,
 ) -> None:
     moved = stage / "entries" / relative
     moved.parent.mkdir(parents=True, exist_ok=True)
-    _record_transfer_intent(stage, path=path, relative=relative, expected=expected)
+    if record_intent:
+        # Solo-transfer path: one fsynced intent immediately before the move.
+        # Batched callers (_remove_manifested) write every intent durably up
+        # front instead, so the intent ledger is never a per-entry rewrite.
+        _record_transfer_intent(stage, path=path, relative=relative, expected=expected)
     observer = _transfer_observer
     if observer is not None:
         observer(path, moved)
@@ -1474,15 +1474,43 @@ def _remove_manifested(
         purpose=purpose,
         record_id=record_id,
     )
-    for entry in entries:
-        if entry.kind == "file":
-            _transfer_entry(
-                root / entry.path,
-                stage=stage,
-                relative=entry.path,
-                expected=entry,
-                transaction=transaction,
-            )
+    file_entries = [entry for entry in entries if entry.kind == "file"]
+    if file_entries:
+        # Durable-before-move invariant: every transfer intent for this stage
+        # is written in ONE fsynced, fully validated intents.json payload
+        # before the first os.replace. A crash mid-loop therefore replays a
+        # complete intent set during recovery — strictly stronger than the
+        # former per-entry rewrite (which fsynced the whole ledger before
+        # each move but never guaranteed the set was complete before the
+        # first move).
+        owner = _load_json(stage / "stage-owner.json")
+        intents = [
+            {
+                "index": index,
+                "record_id": owner["record_id"],
+                "source": str(root / entry.path),
+                "relative": entry.path,
+                "expected": asdict(entry),
+            }
+            for index, entry in enumerate(file_entries)
+        ]
+        _atomic_json(
+            stage / "intents.json",
+            {
+                "schema_version": _SCHEMA_VERSION,
+                "stage_id": owner["stage_id"],
+                "intents": intents,
+            },
+        )
+    for entry in file_entries:
+        _transfer_entry(
+            root / entry.path,
+            stage=stage,
+            relative=entry.path,
+            expected=entry,
+            transaction=transaction,
+            record_intent=False,
+        )
     if remove_directories:
         for entry in _deepest_first_directories(entries):
             target = root / entry.path
@@ -2598,7 +2626,7 @@ def _publish_live_external(
 
 def _cleanup_root(state_root: Path) -> Path:
     root = state_root / "cleanup"
-    _ensure_private_directory(root)
+    _create_private_directory(root)
     return root
 
 
@@ -3650,6 +3678,20 @@ def _recover_transactions(state_root: Path, source: Path) -> None:
         )
 
 
+class _SessionState(str, Enum):
+    """Lifecycle of an :class:`ArtifactSession`.
+
+    Exactly the state strings the session always cycled through; ``str``-based
+    so serialized diagnostics and comparisons keep their prior textual form.
+    """
+
+    ACTIVE = "active"
+    FROZEN = "frozen"
+    PUBLISHING = "publishing"
+    PUBLISHED = "published"
+    CLOSED = "closed"
+
+
 class ArtifactSession:
     """Held workspace lease and strict live-path router for one run."""
 
@@ -3669,7 +3711,7 @@ class ArtifactSession:
         self._source_fd = source_fd
         self._canonical_entries = canonical_entries
         self._detach_transaction = detach_transaction
-        self._state: Literal["active", "frozen", "publishing", "published", "closed"] = "active"
+        self._state = _SessionState.ACTIVE
         self._destinations: list[RoutedDestination] = []
         self._destination_records: list[_DestinationRecord] = []
         self._trajectory_route: TrajectoryOutputRoute | None = None
@@ -3698,7 +3740,7 @@ class ArtifactSession:
         )
 
     def _require_active(self) -> None:
-        if self._state != "active":
+        if self._state is not _SessionState.ACTIVE:
             raise ArtifactVisibilityError("artifact session is frozen and no longer writable")
 
     def _route_repo(self, repo: Path) -> None:
@@ -4334,7 +4376,7 @@ class ArtifactSession:
             destinations=tuple(self._destinations),
         )
         self._frozen_snapshot = result
-        self._state = "frozen"
+        self._state = _SessionState.FROZEN
         return result
 
     def finalization_merge_path(
@@ -4343,7 +4385,7 @@ class ArtifactSession:
         *,
         snapshot: ArtifactTreeSnapshot,
     ) -> Path:
-        if self._state != "frozen" or snapshot is not self._frozen_snapshot:
+        if self._state is not _SessionState.FROZEN or snapshot is not self._frozen_snapshot:
             raise ArtifactVisibilityError("artifact session is not ready for frozen finalization")
         if not any(route is registered for registered in self._destinations):
             raise ArtifactVisibilityError("artifact destination route identity mismatch")
@@ -4381,7 +4423,7 @@ class ArtifactSession:
         *,
         disposition: ArtifactDisposition,
     ) -> None:
-        if self._state != "frozen":
+        if self._state is not _SessionState.FROZEN:
             raise ArtifactVisibilityError("artifact session is not ready for frozen publication")
         if snapshot is not self._frozen_snapshot:
             raise ArtifactVisibilityError("frozen artifact snapshot identity mismatch")
@@ -4397,7 +4439,7 @@ class ArtifactSession:
         if disposition is ArtifactDisposition.ROLLBACK:
             self._restore_prior()
             self._retire_late_paths()
-            self._state = "published"
+            self._state = _SessionState.PUBLISHED
             return
         public_entries = tuple(
             entry
@@ -4523,7 +4565,7 @@ class ArtifactSession:
                 terminal_state="PUBLISH_RECONCILED",
             )
             raise
-        self._state = "publishing"
+        self._state = _SessionState.PUBLISHING
         backup = transaction / "public-backup"
         backup.mkdir()
         _fsync_directory(transaction)
@@ -4589,7 +4631,7 @@ class ArtifactSession:
             transaction,
             terminal_state="PUBLISH_VERIFIED",
         )
-        self._state = "published"
+        self._state = _SessionState.PUBLISHED
 
     def _restore_prior(self) -> None:
         canonical = self.layout.state_root / "canonical"
@@ -4647,19 +4689,34 @@ class ArtifactSession:
         )
 
     def _close(self) -> None:
-        self._state = "closed"
+        self._state = _SessionState.CLOSED
         fcntl.flock(self._lock_fd, fcntl.LOCK_UN)
         os.close(self._lock_fd)
         os.close(self._repo_fd)
         os.close(self._source_fd)
 
 
-def artifact_dir_for(repo: Path) -> Path:
-    session = _SESSION.get()
-    if session is None:
+def artifact_dir_for(repo: Path, *, session: ArtifactSession | None = None, allow_standalone: bool = True) -> Path:
+    """Routed ``.daydream`` path for *repo* (one explicit-or-bound session).
+
+    Resolution order (#1162): an explicitly passed ``session`` wins and is
+    routed with the usual fail-closed repo identity checks; otherwise the
+    bound channel (``_SESSION``, the documented extension contract) is used;
+    otherwise the legacy ``repo/.daydream`` path is returned only when
+    ``allow_standalone`` is set — intentional standalone phase calls keep
+    working (docs/extensions.md), while strict callers can pass
+    ``allow_standalone=False`` to fail closed instead of silently writing the
+    public tree when no session is bound.
+    """
+    resolved = session if session is not None else _SESSION.get()
+    if resolved is None:
+        if not allow_standalone:
+            raise ArtifactVisibilityError(
+                "no artifact session is bound and standalone artifact routing is not allowed"
+            )
         return repo / _DAYDREAM
-    session._route_repo(repo)
-    return session.daydream_dir
+    resolved._route_repo(repo)
+    return resolved.daydream_dir
 
 
 def artifact_session_active() -> bool:
@@ -4667,12 +4724,22 @@ def artifact_session_active() -> bool:
     return _SESSION.get() is not None
 
 
-def review_output_path_for(repo: Path) -> Path:
-    session = _SESSION.get()
-    if session is None:
+def review_output_path_for(
+    repo: Path,
+    *,
+    session: ArtifactSession | None = None,
+    allow_standalone: bool = True,
+) -> Path:
+    """Routed ``.review-output.md`` path for *repo* (see :func:`artifact_dir_for`)."""
+    resolved = session if session is not None else _SESSION.get()
+    if resolved is None:
+        if not allow_standalone:
+            raise ArtifactVisibilityError(
+                "no artifact session is bound and standalone artifact routing is not allowed"
+            )
         return repo / _REVIEW_OUTPUT
-    session._route_repo(repo)
-    return session.review_output
+    resolved._route_repo(repo)
+    return resolved.review_output
 
 
 def assert_model_cwd_clean(cwd: Path) -> None:
@@ -4828,8 +4895,8 @@ def _open_layout(
         _validate_legacy_public(source)
         runs = state_root / "runs"
         transactions = state_root / "transactions"
-        _ensure_private_directory(runs)
-        _ensure_private_directory(transactions)
+        _create_private_directory(runs)
+        _create_private_directory(transactions)
         run_root = runs / session_id
         if run_root.exists() or run_root.is_symlink():
             raise ArtifactVisibilityError("artifact session id already exists")

--- a/daydream/benchmark/storage.py
+++ b/daydream/benchmark/storage.py
@@ -17,7 +17,6 @@ import json
 import os
 import re
 import shutil
-import tempfile
 from contextlib import suppress
 from dataclasses import dataclass
 from functools import lru_cache
@@ -25,6 +24,8 @@ from pathlib import Path
 from typing import Any, Literal
 
 import yaml
+
+from daydream.json_utils import atomic_write_bytes
 
 
 class WorkspaceError(Exception):
@@ -98,26 +99,14 @@ def load_json_strict(path: Path) -> dict[str, Any]:
 
 
 def _atomic_write(path: Path, content: bytes, *, mode: int) -> None:
-    """Atomically write ``content`` to ``path`` via same-dir temp + ``os.replace``.
+    """Atomically write ``content`` to ``path`` via the shared primitive.
 
-    Mirrors :func:`daydream.json_utils.atomic_write_json` (temp + replace +
-    fsync) but enforces a strict file mode on the final path and creates parent
-    directories as private ``0700`` chains.
+    Delegates to :func:`daydream.json_utils.atomic_write_bytes` with the same
+    hardening this module always had (strict final file mode, private 0700
+    parent chains, file fsync before the rename).
     """
     ensure_private_dir(path.parent)
-    fd, tmp = tempfile.mkstemp(dir=path.parent, suffix=".tmp")
-    try:
-        with os.fdopen(fd, "wb") as f:
-            f.write(content)
-            f.flush()
-            os.fsync(f.fileno())
-        os.chmod(tmp, mode)
-        os.replace(tmp, path)
-        os.chmod(path, mode)
-    except BaseException:
-        with suppress(OSError):
-            os.unlink(tmp)
-        raise
+    atomic_write_bytes(path, content, mode=mode, fsync=True)
 
 
 def atomic_write_json(path: Path, data: Any, *, mode: int = 0o600) -> None:

--- a/daydream/json_utils.py
+++ b/daydream/json_utils.py
@@ -17,6 +17,61 @@ from pathlib import Path
 from typing import Any, Callable
 
 
+def _fsync_directory(path: Path) -> None:
+    """Best-effort fsync of a directory entry (durable rename publication)."""
+    fd = os.open(path, os.O_RDONLY)
+    try:
+        os.fsync(fd)
+    finally:
+        os.close(fd)
+
+
+def atomic_write_bytes(
+    path: Path,
+    content: bytes,
+    *,
+    fsync: bool = True,
+    dir_fsync: bool = False,
+    mode: int | None = None,
+) -> None:
+    """Atomically write ``content`` to ``path`` (same-dir temp + ``os.replace``).
+
+    The single shared crash-safe write primitive. The temp file is created
+    exclusively in ``path``'s directory so the rename never crosses
+    filesystems; a crash mid-write leaves either the prior file or nothing.
+    Parent directories are created as needed. On failure the temp file is
+    removed best-effort and the original exception re-raised.
+
+    Knobs let callers preserve (or strengthen) their prior hardening:
+
+    - ``fsync``: flush + fsync the file *before* the rename.
+    - ``mode``: when given, the temp file is chmod'ed to this mode before the
+      rename and the final path is chmod'ed again after it (the post-rename
+      chmod is umask-immune and covers a pre-existing destination).
+    - ``dir_fsync``: fsync the parent directory after the rename so the new
+      name survives a crash.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(dir=path.parent, suffix=".tmp")
+    try:
+        with os.fdopen(fd, "wb") as f:
+            f.write(content)
+            f.flush()
+            if fsync:
+                os.fsync(f.fileno())
+        if mode is not None:
+            os.chmod(tmp, mode)
+        os.replace(tmp, path)
+        if mode is not None:
+            os.chmod(path, mode)
+        if dir_fsync:
+            _fsync_directory(path.parent)
+    except BaseException:
+        with suppress(OSError):
+            os.unlink(tmp)
+        raise
+
+
 def atomic_write_json(
     path: Path,
     data: Any,
@@ -26,30 +81,21 @@ def atomic_write_json(
     default: Callable[[Any], Any] | None = None,
     trailing_newline: bool = False,
     fsync: bool = True,
+    dir_fsync: bool = False,
+    mode: int | None = None,
 ) -> None:
     """Atomically write ``data`` as JSON to ``path`` (tempfile + ``os.replace``).
 
     The temp file lives in ``path``'s directory so the rename never crosses
     filesystems; a crash mid-write leaves either the prior file or nothing.
     Parent directories are created as needed. On failure the temp file is
-    removed best-effort and the original exception re-raised.
+    removed best-effort and the original exception re-raised. ``fsync``,
+    ``dir_fsync``, and ``mode`` forward to :func:`atomic_write_bytes`.
     """
-    path.parent.mkdir(parents=True, exist_ok=True)
     text = json.dumps(data, indent=indent, sort_keys=sort_keys, default=default)
     if trailing_newline:
         text += "\n"
-    fd, tmp = tempfile.mkstemp(dir=path.parent, suffix=".tmp")
-    try:
-        with os.fdopen(fd, "w", encoding="utf-8") as f:
-            f.write(text)
-            if fsync:
-                f.flush()
-                os.fsync(f.fileno())
-        os.replace(tmp, path)
-    except BaseException:
-        with suppress(OSError):
-            os.unlink(tmp)
-        raise
+    atomic_write_bytes(path, text.encode("utf-8"), fsync=fsync, dir_fsync=dir_fsync, mode=mode)
 
 
 def extract_json(text: str) -> Any:

--- a/daydream/phases.py
+++ b/daydream/phases.py
@@ -145,6 +145,114 @@ def _prepare_existing_phase_inputs(
         read_only=read_only,
     )
 
+
+def _sanctioned_fixer_inputs(
+    backend: Backend,
+    work: WorkContext,
+    intent_path: Path | None,
+    exploration_dir: Path | None,
+) -> tuple[PreparedSanctionedInputs | None, Path | None, Path | None]:
+    """Capture the shared fixer-phase sanctioned inputs (intent + exploration).
+
+    One helper for the two fixer prompt builders: it normalizes the author
+    intent file and the exploration affected-files pointer, captures the
+    existing subset as sanctioned inputs, and returns ``(sanctioned_inputs,
+    intent_input, exploration_input)``. ``intent_input``/``exploration_input``
+    are the paths that were actually included (``None`` when absent) so the
+    caller can keep its prompt-shaping decisions byte-identical.
+    """
+    intent_input = intent_path if intent_path is not None and intent_path.is_file() else None
+    exploration_input = (
+        exploration_dir / "affected_files.md"
+        if exploration_dir is not None
+        and (exploration_dir / "affected_files.md").is_file()
+        else None
+    )
+    sanctioned_inputs = _prepare_existing_phase_inputs(
+        backend,
+        work,
+        {
+            "intent": intent_input,
+            "exploration-affected-files": exploration_input,
+        },
+    )
+    return sanctioned_inputs, intent_input, exploration_input
+
+
+def _intent_prompt_block(
+    sanctioned_inputs: PreparedSanctionedInputs | None,
+    *,
+    intent_path: Path | None,
+    intent_input: Path | None,
+) -> str:
+    """Best-effort author-intent prompt suffix shared by the fixer phases.
+
+    Without an active artifact session the intent is read directly from
+    ``intent_path`` (``_build_intent_suffix``); with one, the captured
+    sanctioned input is referenced instead and never re-read from disk. A
+    read failure skips the block; it is never coerced into a fake intent
+    string.
+    """
+    if sanctioned_inputs is None:
+        return _build_intent_suffix(intent_path)
+    return _build_sanctioned_intent_suffix(included=intent_input is not None)
+
+
+def _exploration_inline_budgeted(backend: Backend, work: WorkContext, *, read_only: bool) -> bool:
+    """Whether exploration files are sized against the shared INLINE aggregate.
+
+    Mirrors the advisory-budget rule: when an INLINE transport is active
+    (strict audit roots, read-only disposable clones, sandboxed Osprey),
+    exploration files that would overflow the shared inline AGGREGATE budget
+    must degrade (be excluded) rather than hard-fail the phase at capture
+    time. The post-capture ``inline_transport`` remains authoritative for
+    prompt shaping; this pre-check only sizes advisory inputs.
+    """
+    return artifact_session_active() and (
+        sanctioned_transport_for(backend, work.repo, read_only=read_only)
+        is SanctionedInputTransport.INLINE
+    )
+
+
+def _budgeted_exploration_inputs(
+    exploration_dir: Path | None,
+    *,
+    inline_budgeted: bool,
+) -> dict[str, Path | None]:
+    """Size the exploration pair against the shared inline aggregate.
+
+    Greedy include in declaration order (summary first) while the running
+    total stays within a single INLINE aggregate budget, so two files that
+    fit separately but not together degrade to the surviving prefix instead
+    of raising SanctionedInputUnavailable at capture time.
+    """
+    if exploration_dir is None:
+        return {"exploration-summary": None, "exploration-affected-files": None}
+    if not inline_budgeted:
+        return {
+            "exploration-summary": exploration_dir / "summary.md",
+            "exploration-affected-files": exploration_dir / "affected_files.md",
+        }
+    remaining = SANCTIONED_INLINE_INPUT_AGGREGATE_MAX_BYTES
+    sized: dict[str, Path | None] = {}
+    for label, file_name in (
+        ("exploration-summary", "summary.md"),
+        ("exploration-affected-files", "affected_files.md"),
+    ):
+        path = exploration_dir / file_name
+        try:
+            size = path.stat().st_size
+        except OSError:
+            sized[label] = None
+            continue
+        if size <= remaining:
+            sized[label] = path
+            remaining -= size
+        else:
+            sized[label] = None
+    return sized
+
+
 TEST_OUTPUT_TAIL_LINES = 100
 
 _PR_BODY_MAX_CHARS = 8000
@@ -2838,24 +2946,8 @@ async def phase_fix(
         console.print()
         print_fix_progress(console, item_num, total, description)
 
-    intent_input = (
-        intent_path
-        if intent_path is not None and intent_path.is_file()
-        else None
-    )
-    exploration_input = (
-        exploration_dir / "affected_files.md"
-        if exploration_dir is not None
-        and (exploration_dir / "affected_files.md").is_file()
-        else None
-    )
-    sanctioned_inputs = _prepare_existing_phase_inputs(
-        backend,
-        work,
-        {
-            "intent": intent_input,
-            "exploration-affected-files": exploration_input,
-        },
+    sanctioned_inputs, intent_input, exploration_input = _sanctioned_fixer_inputs(
+        backend, work, intent_path, exploration_dir,
     )
     inline_transport = (
         sanctioned_inputs is not None
@@ -2880,10 +2972,11 @@ Make the minimal change needed. {_FIX_GUARDRAILS}"""
     # Best-effort: inject the confirmed author intent so the fixer won't undo a
     # deliberate decision. A read failure skips the block; it is never coerced
     # into a fake intent string (see _build_intent_suffix).
-    if sanctioned_inputs is None:
-        prompt += _build_intent_suffix(intent_path)
-    else:
-        prompt += _build_sanctioned_intent_suffix(included=intent_input is not None)
+    prompt += _intent_prompt_block(
+        sanctioned_inputs,
+        intent_path=intent_path,
+        intent_input=intent_input,
+    )
     prompt += _build_verifier_suffix(item)
 
     prompt += _build_fix_style_suffix(_backend_concise_fix_prompts(backend))
@@ -2997,24 +3090,8 @@ async def phase_fix_batched(
         if related_files:
             findings_block += f"   Related files: {', '.join(related_files)}\n"
 
-    intent_input = (
-        intent_path
-        if intent_path is not None and intent_path.is_file()
-        else None
-    )
-    exploration_input = (
-        exploration_dir / "affected_files.md"
-        if exploration_dir is not None
-        and (exploration_dir / "affected_files.md").is_file()
-        else None
-    )
-    sanctioned_inputs = _prepare_existing_phase_inputs(
-        backend,
-        work,
-        {
-            "intent": intent_input,
-            "exploration-affected-files": exploration_input,
-        },
+    sanctioned_inputs, intent_input, exploration_input = _sanctioned_fixer_inputs(
+        backend, work, intent_path, exploration_dir,
     )
     inline_transport = (
         sanctioned_inputs is not None
@@ -3032,10 +3109,11 @@ Make the minimal changes needed to address ALL of the above findings in one cohe
     )
     prompt += _build_test_map_hints(items, test_map, work.repo)
 
-    if sanctioned_inputs is None:
-        prompt += _build_intent_suffix(intent_path)
-    else:
-        prompt += _build_sanctioned_intent_suffix(included=intent_input is not None)
+    prompt += _intent_prompt_block(
+        sanctioned_inputs,
+        intent_path=intent_path,
+        intent_input=intent_input,
+    )
     for idx, item in enumerate(items, start=1):
         verifier_suffix = _build_verifier_suffix(item)
         if verifier_suffix:
@@ -4610,52 +4688,14 @@ async def phase_understand_intent(
     # degradation below applies to the exploration context only. The
     # post-capture ``inline_transport`` below remains authoritative; this
     # pre-check only sizes advisory inputs.)
-    exploration_inline_budgeted = (
-        session_active
-        and sanctioned_transport_for(backend, work.repo, read_only=True)
-        is SanctionedInputTransport.INLINE
-    )
-
-    def _budgeted_exploration_inputs() -> dict[str, Path | None]:
-        """Size the exploration pair against the shared inline aggregate.
-
-        Greedy include in declaration order (summary first) while the running
-        total stays within a single INLINE aggregate budget, so two files that
-        fit separately but not together degrade to the surviving prefix
-        instead of raising SanctionedInputUnavailable at capture time.
-        """
-        if exploration_dir is None:
-            return {"exploration-summary": None, "exploration-affected-files": None}
-        if not exploration_inline_budgeted:
-            return {
-                "exploration-summary": exploration_dir / "summary.md",
-                "exploration-affected-files": exploration_dir / "affected_files.md",
-            }
-        remaining = SANCTIONED_INLINE_INPUT_AGGREGATE_MAX_BYTES
-        sized: dict[str, Path | None] = {}
-        for label, file_name in (
-            ("exploration-summary", "summary.md"),
-            ("exploration-affected-files", "affected_files.md"),
-        ):
-            path = exploration_dir / file_name
-            try:
-                size = path.stat().st_size
-            except OSError:
-                sized[label] = None
-                continue
-            if size <= remaining:
-                sized[label] = path
-                remaining -= size
-            else:
-                sized[label] = None
-        return sized
+    exploration_inline_budgeted = _exploration_inline_budgeted(backend, work, read_only=True)
 
     sanctioned_inputs = _prepare_existing_phase_inputs(
         backend,
         work,
         {
             "diff": diff_path if inline_diff is None else None,
-            **_budgeted_exploration_inputs(),
+            **_budgeted_exploration_inputs(exploration_dir, inline_budgeted=exploration_inline_budgeted),
         },
         read_only=True,
     )
@@ -4791,52 +4831,14 @@ async def phase_alternative_review(
     # read-only disposable clones, sandboxed Osprey). (The over-budget diff
     # itself is a separate pre-existing capture limit on those transports;
     # this pre-check only sizes advisory inputs.)
-    exploration_inline_budgeted = (
-        artifact_session_active()
-        and sanctioned_transport_for(backend, work.repo, read_only=False)
-        is SanctionedInputTransport.INLINE
-    )
-
-    def _budgeted_exploration_inputs() -> dict[str, Path | None]:
-        """Size the exploration pair against the shared inline aggregate.
-
-        Greedy include in declaration order (summary first) while the running
-        total stays within a single INLINE aggregate budget, so two files that
-        fit separately but not together degrade to the surviving prefix
-        instead of raising SanctionedInputUnavailable at capture time.
-        """
-        if exploration_dir is None:
-            return {"exploration-summary": None, "exploration-affected-files": None}
-        if not exploration_inline_budgeted:
-            return {
-                "exploration-summary": exploration_dir / "summary.md",
-                "exploration-affected-files": exploration_dir / "affected_files.md",
-            }
-        remaining = SANCTIONED_INLINE_INPUT_AGGREGATE_MAX_BYTES
-        sized: dict[str, Path | None] = {}
-        for label, file_name in (
-            ("exploration-summary", "summary.md"),
-            ("exploration-affected-files", "affected_files.md"),
-        ):
-            path = exploration_dir / file_name
-            try:
-                size = path.stat().st_size
-            except OSError:
-                sized[label] = None
-                continue
-            if size <= remaining:
-                sized[label] = path
-                remaining -= size
-            else:
-                sized[label] = None
-        return sized
+    exploration_inline_budgeted = _exploration_inline_budgeted(backend, work, read_only=False)
 
     sanctioned_inputs = _prepare_existing_phase_inputs(
         backend,
         work,
         {
             "diff": diff_path if inline_diff is None else None,
-            **_budgeted_exploration_inputs(),
+            **_budgeted_exploration_inputs(exploration_dir, inline_budgeted=exploration_inline_budgeted),
         },
     )
     inline_transport = (

--- a/daydream/prompt_budget.py
+++ b/daydream/prompt_budget.py
@@ -117,6 +117,23 @@ class PreparedSanctionedInputs:
                 remaining = SANCTIONED_EXACT_INPUT_AGGREGATE_MAX_BYTES - aggregate
                 max_bytes = min(SANCTIONED_EXACT_INPUT_FILE_MAX_BYTES, remaining)
                 aggregate_limit = remaining < SANCTIONED_EXACT_INPUT_FILE_MAX_BYTES
+            if _unchanged_since_capture(item):
+                # The (dev, ino, size, mtime_ns) identity is unchanged since
+                # the capture that already streamed and hashed these exact
+                # bytes, so the re-read/re-hash is redundant on this attempt.
+                # The aggregate budget stays enforced exactly as a fresh
+                # capture would enforce it. Invariant: unchanged items carry
+                # their capture-time sizes, whose sum capture already checked
+                # against the cap, and a re-captured item either matches
+                # item (same size) or fails closed below — so this guard
+                # pins the cap fail-closed even if that invariant drifts.
+                if item.size > max_bytes:
+                    raise SanctionedInputUnavailable(
+                        f"sanctioned input {item.label!r} exceeds remaining "
+                        "aggregate input budget"
+                    )
+                aggregate += item.size
+                continue
             current = _capture_input(
                 item.label,
                 item.path,
@@ -129,6 +146,23 @@ class PreparedSanctionedInputs:
                 raise SanctionedInputUnavailable(
                     f"sanctioned input {item.label!r} changed before model execution"
                 )
+
+
+def _unchanged_since_capture(item: PreparedSanctionedInput) -> bool:
+    """Whether *item*'s file still carries the identity the capture attested.
+
+    The ``(dev, ino, size, mtime_ns)`` tuple is the same identity
+    :func:`_capture_input` validates internally; matching it re-validates file
+    identity without a per-attempt re-read. A missing, unreadable, or replaced
+    file returns ``False`` so the caller performs the full capture and
+    surfaces its original fail-closed errors.
+    """
+    try:
+        metadata = item.path.lstat()
+    except OSError:
+        return False
+    identity = (metadata.st_dev, metadata.st_ino, metadata.st_size, metadata.st_mtime_ns)
+    return identity == (item.device, item.inode, item.size, item.mtime_ns)
 
 
 def _capture_input(

--- a/daydream/quote_scrub.py
+++ b/daydream/quote_scrub.py
@@ -8,14 +8,13 @@ This module provides a deterministic, backend-agnostic scrub: a pure
 changed-file driver that rewrites only the lines the fix pass added, in place.
 """
 
-import os
 import stat
-import tempfile
 from collections.abc import Iterable
 from pathlib import Path
 
 from daydream.generated_files import is_generated_file
 from daydream.git_ops import GitError, diff_worktree_against
+from daydream.json_utils import atomic_write_bytes
 
 # U+201C LEFT DOUBLE QUOTATION MARK / U+201D RIGHT DOUBLE QUOTATION MARK -> "
 # U+2018 LEFT SINGLE QUOTATION MARK / U+2019 RIGHT SINGLE QUOTATION MARK -> '
@@ -116,7 +115,7 @@ def _atomic_write_bytes(path: Path, data: bytes) -> None:
     a sibling temp file, preserve the original file's permission bits, and
     ``os.replace`` it into place — the original bytes survive any write
     failure and the final swap is atomic. The temp file is cleaned up on any
-    failure.
+    failure. The rename is made durable with a parent-directory fsync.
 
     Raises:
         OSError: On any write failure (after cleaning up the temp file).
@@ -126,25 +125,11 @@ def _atomic_write_bytes(path: Path, data: bytes) -> None:
         # os.replace here would swap the link's directory entry for a regular
         # file and destroy the symlink. Write to the link target instead.
         path = path.resolve()
-    fd, tmp_name = tempfile.mkstemp(dir=path.parent, prefix=path.name + ".", suffix=".tmp")
     try:
-        try:
-            mode = stat.S_IMODE(path.stat().st_mode)
-        except OSError:
-            mode = None
-        with os.fdopen(fd, "wb") as tmp:
-            tmp.write(data)
-            tmp.flush()
-            os.fsync(tmp.fileno())
-        if mode is not None:
-            os.chmod(tmp_name, mode)
-        os.replace(tmp_name, path)
-    except BaseException:
-        try:
-            os.unlink(tmp_name)
-        except OSError:
-            pass
-        raise
+        mode = stat.S_IMODE(path.stat().st_mode)
+    except OSError:
+        mode = None
+    atomic_write_bytes(path, data, fsync=True, dir_fsync=True, mode=mode)
 
 
 def scrub_smart_quotes_changed_files(

--- a/daydream/training/coordinator.py
+++ b/daydream/training/coordinator.py
@@ -41,12 +41,12 @@ from __future__ import annotations
 
 import hashlib
 import json
-import os
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, cast
 
 from daydream.archive import get_archive_dir
+from daydream.json_utils import atomic_write_json
 from daydream.training import gate as gate_mod
 from daydream.training import stacks
 from daydream.training.gate import FrozenSplit, GateConfig, GateReport, freeze_split
@@ -133,11 +133,8 @@ class PipelineConfig:
 
 
 def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
-    """Write JSON atomically: temp file in the same directory, then rename."""
-    path.parent.mkdir(parents=True, exist_ok=True)
-    tmp = path.with_name(path.name + ".tmp")
-    tmp.write_text(json.dumps(payload, indent=2, sort_keys=True))
-    os.replace(tmp, path)
+    """Write JSON atomically via the shared crash-safe primitive."""
+    atomic_write_json(path, payload, sort_keys=True)
 
 
 def _file_digest(path: Path) -> str:

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -189,6 +189,123 @@ def test_revalidate_sanctioned_exact_inputs_keeps_aggregate_read_bound(
     assert backend.call_count == 0
 
 
+def test_revalidate_skips_rehash_when_identity_unchanged(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Retry revalidation re-reads a file only when its stat identity changed.
+
+    The capture already streamed and hashed the exact bytes; while the
+    ``(dev, ino, size, mtime_ns)`` identity still matches, a retry attempt
+    must not re-read or re-hash the payload (#1162 efficiency item).
+    """
+    from daydream import prompt_budget
+
+    artifact = tmp_path / "artifact.txt"
+    artifact.write_text("captured", encoding="utf-8")
+    backend = ScriptedBackend()
+    prepared = prepare_sanctioned_inputs(
+        backend, tmp_path, {"artifact": artifact}, read_only=False
+    )
+
+    capture_calls = 0
+    real_capture = prompt_budget._capture_input
+
+    def counted_capture(*args: object, **kwargs: object) -> object:
+        nonlocal capture_calls
+        capture_calls += 1
+        return real_capture(*args, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(prompt_budget, "_capture_input", counted_capture)
+
+    # Unchanged file: identity matches, so no re-read/re-hash happens.
+    prepared.revalidate(backend, tmp_path, read_only=False)
+    assert capture_calls == 0
+
+    # Touched file (size changed): the full capture runs and fails closed.
+    artifact.write_text("captured but longer now", encoding="utf-8")
+    with pytest.raises(SanctionedInputUnavailable, match="changed"):
+        prepared.revalidate(backend, tmp_path, read_only=False)
+    assert capture_calls == 1
+
+    # Same-length rewrite keeps size but advances mtime: still re-captured.
+    capture_calls = 0
+    os.utime(artifact, ns=(1_000_000_000, 1_000_000_000))
+    with pytest.raises(SanctionedInputUnavailable, match="changed"):
+        prepared.revalidate(backend, tmp_path, read_only=False)
+    assert capture_calls == 1
+
+
+def test_revalidate_fails_closed_when_captured_file_vanishes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A missing captured input is re-captured and surfaces the real error."""
+    from daydream import prompt_budget
+
+    artifact = tmp_path / "artifact.txt"
+    artifact.write_text("captured", encoding="utf-8")
+    backend = ScriptedBackend()
+    prepared = prepare_sanctioned_inputs(
+        backend, tmp_path, {"artifact": artifact}, read_only=False
+    )
+    artifact.unlink()
+
+    capture_calls = 0
+    real_capture = prompt_budget._capture_input
+
+    def counted_capture(*args: object, **kwargs: object) -> object:
+        nonlocal capture_calls
+        capture_calls += 1
+        return real_capture(*args, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(prompt_budget, "_capture_input", counted_capture)
+
+    with pytest.raises(SanctionedInputUnavailable, match="unavailable"):
+        prepared.revalidate(backend, tmp_path, read_only=False)
+    assert capture_calls == 1
+
+
+def test_revalidate_unchanged_item_exceeding_remaining_budget_fails_closed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The identity fast path enforces the aggregate byte cap fail-closed.
+
+    White-box: an item whose stat identity is unchanged must never silently
+    push the running aggregate past the cap — the skip path raises exactly
+    like an over-budget fresh capture would, without re-reading the file.
+    """
+    from dataclasses import replace as dataclass_replace
+
+    from daydream import prompt_budget
+
+    artifact = tmp_path / "artifact.txt"
+    artifact.write_text("captured", encoding="utf-8")
+    backend = ScriptedBackend()
+    prepared = prepare_sanctioned_inputs(
+        backend, tmp_path, {"artifact": artifact}, read_only=False
+    )
+    captured = prepared.inputs[0]
+
+    def failing_capture(*args: object, **kwargs: object) -> object:
+        raise AssertionError("over-budget item must fail closed without re-capture")
+
+    def always_unchanged(item: object) -> bool:
+        return True
+
+    monkeypatch.setattr(prompt_budget, "_capture_input", failing_capture)
+    monkeypatch.setattr(prompt_budget, "_unchanged_since_capture", always_unchanged)
+
+    over_budget = dataclass_replace(
+        captured,
+        size=prompt_budget.SANCTIONED_EXACT_INPUT_FILE_MAX_BYTES + 1,
+    )
+    exhausted = dataclass_replace(prepared, inputs=(over_budget,))
+    with pytest.raises(SanctionedInputUnavailable, match="aggregate input budget"):
+        exhausted.revalidate(backend, tmp_path, read_only=False)
+
+
 def test_prepare_sanctioned_inputs_rejects_invalid_utf8_and_symlinks(tmp_path: Path) -> None:
     invalid = tmp_path / "invalid.txt"
     invalid.write_bytes(b"\xff")

--- a/tests/test_artifact_visibility.py
+++ b/tests/test_artifact_visibility.py
@@ -3861,6 +3861,101 @@ async def test_current_entry_replacement_is_preserved_during_dump_merge(
     assert collision.read_bytes() == replacement
 
 
+async def test_transfer_intents_are_durable_before_first_move(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Every transfer intent is persisted before the first entry move (#1162).
+
+    The former per-entry rewrite fsynced the whole ledger before each move;
+    batching the writes must keep at least that guarantee, so when the first
+    ``os.replace`` fires the stage's ``intents.json`` must already contain the
+    complete, validated intent set for the detach.
+    """
+    source = tmp_path / "source"
+    _init_repo(source)
+    seeded = _seed_public_artifacts(source)
+
+    observed_at_first_move: dict[str, Any] = {}
+
+    def capture_first_move(path: Path, moved: Path) -> None:
+        if "stage" in observed_at_first_move:
+            return
+        stage = next(
+            (candidate for candidate in moved.parents if (candidate / "stage-owner.json").is_file()),
+            None,
+        )
+        observed_at_first_move["stage"] = stage
+        observed_at_first_move["path"] = path
+        observed_at_first_move["intents"] = (
+            json.loads((stage / "intents.json").read_text(encoding="utf-8"))
+            if stage is not None and (stage / "intents.json").is_file()
+            else None
+        )
+
+    monkeypatch.setattr(artifact_visibility, "_transfer_observer", capture_first_move)
+    async with open_artifact_session(_work(source), session_id="intents-durability"):
+        pass
+
+    assert observed_at_first_move, "the detach must transfer at least one entry"
+    intents = observed_at_first_move["intents"]
+    assert intents is not None, "intents.json must be durable before the first move"
+    assert intents["schema_version"] == artifact_visibility._SCHEMA_VERSION
+    expected_files = sorted(entry.path for entry in seeded if entry.kind == "file")
+    assert expected_files, "seeded public artifacts must include files"
+    assert sorted(cast(str, intent["relative"]) for intent in intents["intents"]) == expected_files
+    first_source = Path(cast(str, observed_at_first_move["path"]))
+    assert str(first_source) in [cast(str, intent["source"]) for intent in intents["intents"]]
+
+
+async def test_routed_path_accessors_resolve_explicit_session_over_fallbacks(
+    tmp_path: Path,
+) -> None:
+    """Single-channel routing matrix for artifact_dir_for/review_output_path_for (#1162).
+
+    Pins the #1162 seam: an explicit ``session`` wins, the bound channel
+    (``_SESSION``) is honored for extension steps, the documented standalone
+    legacy path remains the no-session compatibility story, and strict
+    callers can fail closed with ``allow_standalone=False``.
+    """
+    source = tmp_path / "source"
+    _init_repo(source)
+    work = _work(source)
+
+    # No session bound: documented legacy standalone path, unchanged.
+    assert artifact_dir_for(work.repo) == source / ".daydream"
+    assert review_output_path_for(work.repo) == source / ".review-output.md"
+
+    async with open_artifact_session(work, session_id="routing-seam") as session:
+        # Explicit session wins even though the ContextVar is also bound.
+        assert artifact_dir_for(work.repo, session=session) == session.daydream_dir
+        assert (
+            review_output_path_for(work.repo, session=session)
+            == session.review_output
+        )
+        # Bound channel (the documented extension contract) still routes.
+        assert artifact_dir_for(work.repo) == session.daydream_dir
+        assert review_output_path_for(work.repo) == session.review_output
+
+    # Session closed: bound channel is empty again, standalone path resumes.
+    assert artifact_dir_for(work.repo) == source / ".daydream"
+
+    # Explicit fail-closed seam for strict callers (e.g. a future composition
+    # root that must never silently write the public tree).
+    with pytest.raises(ArtifactVisibilityError, match="standalone artifact routing"):
+        artifact_dir_for(work.repo, allow_standalone=False)
+    with pytest.raises(ArtifactVisibilityError, match="standalone artifact routing"):
+        review_output_path_for(work.repo, allow_standalone=False)
+
+    # A bound session satisfies allow_standalone=False (it is a real session).
+    async with open_artifact_session(work, session_id="routing-strict") as session:
+        assert artifact_dir_for(work.repo, allow_standalone=False) == session.daydream_dir
+        assert (
+            review_output_path_for(work.repo, allow_standalone=False)
+            == session.review_output
+        )
+
+
 def _main() -> None:
     action, *arguments = sys.argv[1:]
     if action == "lock":
@@ -3911,6 +4006,49 @@ def _main() -> None:
         )
         return
     raise SystemExit(f"unknown storage-spike helper action: {action}")
+
+
+def test_create_private_directory_rejects_symlinked_leaf(tmp_path: Path) -> None:
+    """A symlinked final component fails closed at the leaf validation.
+
+    The leaf keeps the ``validate_private_directory`` contract ("must be a
+    real directory") exactly as before the consolidation; ancestors are
+    covered by the restored ancestry scan.
+    """
+    target = tmp_path / "storage" / "runs"
+    target.parent.mkdir(parents=True)
+    outside = tmp_path / "outside-secret"
+    outside.mkdir()
+    target.symlink_to(outside, target_is_directory=True)
+
+    with pytest.raises(ArtifactVisibilityError, match="real directory"):
+        artifact_visibility._create_private_directory(target)
+
+    assert outside.is_dir()
+    assert list(outside.iterdir()) == []
+
+
+def test_create_private_directory_rejects_symlinked_ancestor(tmp_path: Path) -> None:
+    """A symlink anywhere in the ancestry fails closed (#1162 review finding).
+
+    The collapsed helper must keep the ancestry lstat scan the deleted
+    ``_ensure_private_directory`` enforced: creation must never mkdir through
+    a symlinked ancestor or chmod through the link.
+    """
+    outside = tmp_path / "outside-secret"
+    outside.mkdir()
+    (tmp_path / "storage").mkdir()
+    (tmp_path / "storage" / "live-link").symlink_to(outside, target_is_directory=True)
+    # The missing-child walk stops at the first existing ancestor (the
+    # symlink itself); the ancestry scan must reject it fail-closed.
+    linked_target = tmp_path / "storage" / "live-link" / "runs" / "deep"
+
+    with pytest.raises(ArtifactVisibilityError, match="symlink"):
+        artifact_visibility._create_private_directory(linked_target)
+
+    assert outside.is_dir()
+    assert list(outside.iterdir()) == []
+    assert not (outside / "runs").exists()
 
 
 if __name__ == "__main__":

--- a/tests/test_json_utils.py
+++ b/tests/test_json_utils.py
@@ -1,16 +1,22 @@
-"""Tests for the shared :func:`daydream.json_utils.extract_json` helper.
+"""Tests for the shared :mod:`daydream.json_utils` helpers.
 
-This helper is shared by the backends (structured-output extraction) and
+``extract_json`` is shared by the backends (structured-output extraction) and
 ``run_agent`` (raw-text fallback) — it is not a Pi-specific concern. The tests
-target the canonical function directly so they remain valid regardless of any
-backend-private wrapper aliases.
+target the canonical functions directly so they remain valid regardless of any
+backend-private wrapper aliases. ``atomic_write_bytes``/``atomic_write_json``
+are the shared crash-safe write primitives that the #1162 consolidation
+routes the previously duplicated copies through.
 """
 
+import json
+import os
+import stat
+from pathlib import Path
 from typing import Any
 
 import pytest
 
-from daydream.json_utils import extract_json
+from daydream.json_utils import atomic_write_bytes, atomic_write_json, extract_json
 
 
 class TestExtractJson:
@@ -82,7 +88,7 @@ class TestExtractJson:
 
     def test_stray_prose_bracket_does_not_beat_the_real_object(self) -> None:
         # Regression for the sentry-67876 arbiter crash. The model's prose
-        # referenced a code snippet `metadata["sender"]` BEFORE its real fenced
+        # referenced a code snippet `metadata["sender"]["login"]` BEFORE its real fenced
         # answer. The earliest-bracket rule parsed `["sender"]` (a valid 1-element
         # list) and returned that bare list, which crashed the arbiter with
         # "Arbiter returned no findings list (got list)". The largest-span rule
@@ -97,3 +103,70 @@ class TestExtractJson:
         result = extract_json(text)
         assert isinstance(result, dict)
         assert [f["arb_id"] for f in result["findings"]] == [1, 2]
+
+
+class TestAtomicWritePrimitives:
+    """The shared crash-safe write primitive and its knobs (#1162 Item A)."""
+
+    def test_bytes_roundtrip_and_replaces_prior_content(self, tmp_path: Path) -> None:
+        target = tmp_path / "nested" / "data.bin"
+        atomic_write_bytes(target, b"first")
+        assert target.read_bytes() == b"first"
+        atomic_write_bytes(target, b"second")
+        assert target.read_bytes() == b"second"
+
+    def test_mode_knob_is_umask_immune_and_survives_replacement(self, tmp_path: Path) -> None:
+        target = tmp_path / "private.json"
+        umask = os.umask(0o077)
+        try:
+            atomic_write_bytes(target, b"{}", mode=0o600)
+        finally:
+            os.umask(umask)
+        assert stat.S_IMODE(target.stat().st_mode) == 0o600
+        atomic_write_bytes(target, b"[1]", mode=0o640)
+        assert stat.S_IMODE(target.stat().st_mode) == 0o640
+
+    def test_no_mode_keeps_default_permissions(self, tmp_path: Path) -> None:
+        target = tmp_path / "plain.txt"
+        # Permissive umask: a umask-derived open() writer would yield 0o644
+        # here, so asserting 0o600 actually discriminates the mkstemp-based
+        # default (0o600) from umask-derived permissions.
+        umask = os.umask(0o022)
+        try:
+            atomic_write_bytes(target, b"x")
+        finally:
+            os.umask(umask)
+        assert stat.S_IMODE(target.stat().st_mode) == 0o600
+
+    def test_fsync_false_skips_sync_but_still_atomic(self, tmp_path: Path) -> None:
+        target = tmp_path / "fast.json"
+        atomic_write_bytes(target, b"ok", fsync=False, dir_fsync=False)
+        assert target.read_bytes() == b"ok"
+
+    def test_json_knob_byte_format_is_stable(self, tmp_path: Path) -> None:
+        target = tmp_path / "doc.json"
+        atomic_write_json(target, {"b": 1, "a": [1, 2]}, sort_keys=True)
+        assert json.loads(target.read_text(encoding="utf-8")) == {"b": 1, "a": [1, 2]}
+        # The default remains pretty-printed, two-space indent, no trailing newline.
+        assert target.read_text(encoding="utf-8") == '{\n  "a": [\n    1,\n    2\n  ],\n  "b": 1\n}'
+
+    def test_failure_cleans_temp_and_propagates(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        target = tmp_path / "out" / "boom.json"
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(b"prior")
+        real_replace = os.replace
+
+        def failing_replace(src: object, dst: object, **kwargs: object) -> None:
+            raise OSError(28, "No space left on device")
+
+        monkeypatch.setattr(os, "replace", failing_replace)
+        with pytest.raises(OSError, match="No space left"):
+            atomic_write_bytes(target, b"new")
+        monkeypatch.setattr(os, "replace", real_replace)
+        assert target.read_bytes() == b"prior"
+        assert list(target.parent.iterdir()) == [target], "temp file must be cleaned up"
+
+    def test_dir_fsync_publishes_rename_durably(self, tmp_path: Path) -> None:
+        target = tmp_path / "durable.json"
+        atomic_write_bytes(target, b"durable", dir_fsync=True)
+        assert target.read_bytes() == b"durable"


### PR DESCRIPTION
Implements the consolidation items from #1162 (P10 fast-follow, maintainability only — no correctness bugs). **No fail-closed guarantee removed**; several callers gained durability.

## What landed

- **One atomic-write primitive** (P2): `json_utils.atomic_write_bytes(..., fsync=, dir_fsync=, mode=)`; `atomic_write_json` reimplemented on top (byte output unchanged). Rerouted: `benchmark/storage`, `training/coordinator` (+fsync), `archive/hydrate` (+fsync), `quote_scrub` (+dir fsync), `artifact_visibility._atomic_json/_atomic_bytes` → thin policy wrappers (durability union preserved: pre-rename file fsync + parent-dir fsync + post-rename chmod, byte-exact compact JSON).
- **Session-routing seam** (P3): `artifact_dir_for` / `review_output_path_for` gain explicit `session=` + `allow_standalone=` — the silent legacy fallback is now opt-out-able and fail-loud on demand. Routing matrix pinned by tests: explicit session > bound ContextVar channel > standalone legacy path; `allow_standalone=False` raises.
- **Efficiency**: retry re-validation skips re-read/re-hash while the captured `(dev, ino, size, mtime_ns)` identity is unchanged (fail-closed on any mismatch; aggregate cap re-checked even on the fast path); archive finalization re-manifests the frozen tree 12×→4× keeping all external-consumer boundaries (entry / post-eval-scanner / pre-upload / pre-install); transfer-intent ledger batched per stage — one fsynced, fully-validated `intents.json` write **before the first `os.replace`** (replay semantics preserved, strictly stronger). `_write_destination_records` per-registration rewrite left as-is (intentional crash-recovery granularity at the public `register_destination` boundary).
- **Mechanical refactors**: `_ensure_private_directory` collapsed into hardened `_create_private_directory` (per-dir 0700 mkdir + parent fsync + ancestry symlink scan + final validate); `_SessionState(str, Enum)`; `manifest_tree()` public narrow seam replaces archive's private `_manifest` import; shared sanctioned-input INLINE-transport helper + intent suffix + exploration budgeting helpers in `phases.py`. Verified no-ops: `_manifest_entry_from_payload` already consolidated (M1), `_is_public_daydream_owner` already single predicate (M6).

## Review evidence

Required local review ran the full daydream pipeline (12/12 file coverage, exit 0). Three unique findings, all adjudicated **substantiated** and fixed on this head:

1. `_create_private_directory` had dropped the deleted `_ensure_private_directory`'s ancestry lstat scan — restored + repro tests (leaf symlink; symlinked ancestor).
2. `test_no_mode_keeps_default_permissions` was tautological under umask 0o077 — now 0o022 so the 0o600 assertion actually discriminates the mkstemp default.
3. `revalidate` fast path now re-checks the aggregate byte cap fail-closed even for unchanged items (defense-in-depth; the silent-exceedance scenario is unreachable today because a re-captured item with drifted size raises `SanctionedInputUnavailable` before the aggregate accumulates — invariant documented in-code).

Independent pi review of the fix delta: **3/3 ACCEPT** (verified fail-closed semantics, TOCTOU posture, test hygiene).

## Gates

- ruff / vulture / mypy (`daydream tests`, 539 files): clean
- Focused suites (json_utils, prompt_budget, quote_scrub, training coordinator ×2, benchmark storage, archive ×3, artifact_visibility, agent): **673 passed, 1 skipped**
- Full suite: 7738 passed, 15 skipped, coverage 88.56% (floor 86%); the 11 host-starvation failures reproduced identically on the stashed clean baseline (remote-CI discovery starvation; CI runners unaffected, per #1161 precedent)

Refs #1162. Deferred (outside this PR's file ownership — `runner.py` is P18-lane): composition-root adoption (`runner.py` passing `session=ctx.artifacts` + `allow_standalone=False` through the new seam) and the structural handoff-projection items — tracked as follow-ups on the issue.
