### PR TITLE
fix(tests): write the fake codex readiness marker atomically

### DIFF
--- a/tests/test_subprocess_lifecycle.py
+++ b/tests/test_subprocess_lifecycle.py
@@ -203,11 +203,18 @@ async def test_runner_run_aborted_improve_reaps_group_and_releases_fds(
     bin_dir.mkdir()
     marker = tmp_path / "codex-ready"
     cli = bin_dir / "codex"
+    # The marker is written to a temp path and renamed into place so it never
+    # exists empty: `open(marker, 'w')` creates the file before the pid write
+    # lands, and `_wait_for_file` polls bare existence, so a non-atomic write
+    # races the reader into `int('')` on a loaded host.
     cli.write_text(
         "#!/usr/bin/env python3\n"
         "import os, subprocess, time\n"
         "subprocess.Popen(['sleep', '300'])\n"
-        f"open({str(marker)!r}, 'w').write(str(os.getpid()))\n"
+        f"tmp = {str(marker)!r} + '.tmp'\n"
+        "with open(tmp, 'w') as f:\n"
+        "    f.write(str(os.getpid()))\n"
+        f"os.replace(tmp, {str(marker)!r})\n"
         "time.sleep(1000)\n"
     )
     cli.chmod(0o755)


### PR DESCRIPTION
## Problem

`tests/test_subprocess_lifecycle.py::test_runner_run_aborted_improve_reaps_group_and_releases_fds` fails intermittently on main under `pytest -n auto`:

```
ValueError: invalid literal for int() with base 10: ''
```

The fake `codex` CLI wrote its readiness marker with `open(marker, 'w').write(str(os.getpid()))`. `open(..., 'w')` creates the file empty before the pid write lands, and `_wait_for_file` polls bare existence — so on a loaded host the test can observe the marker in that window and read an empty string.

## Fix

The fake CLI writes the pid to a temp path and `os.replace`s it into place, so the marker never exists without its content. No production code change — the race was entirely in the test's fake CLI.

## Verification

- `pytest tests/test_subprocess_lifecycle.py -n auto` × 5 consecutive runs, all green
- Full `make check` gate passed via the pre-push hook

🤖 Generated with [Claude Code](https://claude.com/claude-code)