### PR TITLE
fix(archive): tier the bundle secret scan, unwedge dump rollback

### DIFF
--- a/.github/workflows/daydream-review.yml
+++ b/.github/workflows/daydream-review.yml
@@ -207,6 +207,10 @@ jobs:
           path: findings/failure.json
 
       - name: Upload findings artifact
+        # always(): a findings.json already written before a late-stage failure
+        # (e.g. a refused egress scan) is exactly what the operator needs; the
+        # default success() gate would discard it.
+        if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: daydream-findings

--- a/daydream/archive/__init__.py
+++ b/daydream/archive/__init__.py
@@ -48,6 +48,17 @@ class ArchiveFinalizationError(RuntimeError):
     """Strict host archive finalization did not complete successfully."""
 
 
+def _warn(message: str) -> None:
+    """Print a one-line warning through the daydream console (never raises).
+
+    Lazily imported (mirroring ``hub._warn``) so the archive import graph does
+    not pull the UI package in for callers that never warn.
+    """
+    from daydream.ui import create_console, print_warning
+
+    print_warning(create_console(), message)
+
+
 def _flow_runs_merge(flow: DaydreamRunFlow, flow_name: str | None) -> bool:
     """Whether the executed flow runs the deep cross-stack/single-stack merge.
 
@@ -335,8 +346,17 @@ def finalize_archive_run(
                 raise ArchiveFinalizationError("dump finalization path is missing")
             from daydream.archive import scan
 
-            if not scan.scan_run_dir(assembly_dir).clean:
-                raise ArchiveFinalizationError("dump artifact secret scan refused publication")
+            scan_result = scan.scan_run_dir(assembly_dir)
+            if scan_result.blocking:
+                raise ArchiveFinalizationError(
+                    f"dump artifact secret scan refused publication ({scan_result.summary()})"
+                )
+            if scan_result.findings:
+                _warn(
+                    "Publishing the dump for "
+                    f"{recorder_provenance.session_id} with advisory secret-scan findings "
+                    f"({scan_result.summary()})"
+                )
             dump_started = True
             shutil.copytree(assembly_dir, dump_path, dirs_exist_ok=True)
         _validate_frozen_artifacts(artifacts)

--- a/daydream/archive/hub.py
+++ b/daydream/archive/hub.py
@@ -65,11 +65,19 @@ def upload_run_bundle(run_dir: Path, repo_id: str, session_id: str) -> bool:
     ``HF_TOKEN`` is absent. A pre-existing repo is reused with its current
     visibility (documented behavior), but a public one triggers a warning
     before the upload proceeds. Before anything reaches the Hub the bundle is
-    scanned for secrets (fail-closed): a dirty bundle — or a scanner error —
-    is refused with a safe-only warning and ``False``. Retries the upload
+    scanned for secrets (fail-closed): a *blocking* finding — or a scanner
+    error — refuses the upload with a safe-only warning and ``False``. An
+    advisory finding is by construction not a credential (issue #1170), and a
+    rule that cannot identify a secret must not gate irreversible egress
+    either, so it is reported and the upload proceeds. Retries the upload
     commit up to 3 total
     attempts on a commit-conflict shape (concurrent commits from parallel
     processes), backing off exponentially between attempts.
+
+    Note: this function's "never raises" contract is honored here, but its only
+    caller converts a ``False`` return into an ``ArchiveFinalizationError``.
+    That contract violation between a function and its caller is tracked
+    separately and deliberately not addressed here.
 
     Returns:
         True on success, False when skipped or failed.
@@ -91,12 +99,19 @@ def upload_run_bundle(run_dir: Path, repo_id: str, session_id: str) -> bool:
     from daydream.archive import scan
 
     scan_result = scan.scan_run_dir(run_dir)
-    if not scan_result.clean:
+    if scan_result.blocking:
         _warn(
             f"Refusing HF upload of {session_id}: bundle secret scan found "
             f"problems ({scan_result.summary()})"
         )
         return False
+    if scan_result.findings:
+        # Advisory-only: a name/template shape, not a credential. Reported
+        # value-free so the operator sees it, never silently swallowed.
+        _warn(
+            f"HF upload of {session_id} proceeding with advisory-only scan "
+            f"findings ({scan_result.summary()})"
+        )
 
     try:
         api = HfApi()

--- a/daydream/archive/hydrate.py
+++ b/daydream/archive/hydrate.py
@@ -92,6 +92,13 @@ class VerificationError(HydrationError):
     """The clean-room verification cycle failed — success is never reported (M20)."""
 
 
+def _warn(message: str) -> None:
+    """Print a one-line warning through the daydream console (never raises)."""
+    from daydream.ui import create_console, print_warning  # noqa: PLC0415 - lazy: avoid ui import at module load
+
+    print_warning(create_console(), message)
+
+
 def resolve_source_revision(client: HubClient, revision: str, *, exploratory: bool) -> str:
     """Resolve ``revision`` to a pinned, immutable commit SHA (issue #982 M2).
 
@@ -2512,7 +2519,8 @@ def verify_publication(
     Downloads exactly the pinned output commit into a fresh staging dir,
     validates SHA256SUMS against the uploaded content, validates the curation
     manifest against the frozen schema, rescan every published batch with
-    ``scan_run_dir`` (must be clean), rebuilds a scratch index from the
+    ``scan_run_dir`` (must carry no blocking finding; advisory findings are
+    reported value-free — #1170), rebuilds a scratch index from the
     portable artifacts alone, and recomputes the candidate count. Any mismatch
     raises :class:`VerificationError` — success is never reported on a failed
     verification. Returns the verified admitted count.
@@ -2577,8 +2585,20 @@ def verify_publication(
             target.parent.mkdir(parents=True, exist_ok=True)
             target.write_bytes(_download(relpath))
         scan = scan_run_dir(batch_dir)
-        if not scan.clean:
-            raise VerificationError(redact_text(f"verify: published batch {sid!r} fails the secrets scan"))
+        if scan.blocking:
+            raise VerificationError(
+                redact_text(
+                    f"verify: published batch {sid!r} fails the secrets scan ({scan.summary()})"
+                )
+            )
+        if scan.findings:
+            # Advisory-only: a name/template shape, not a credential (#1170).
+            # Reported value-free rather than failing an already-published
+            # commit that a rule which cannot identify a secret objected to.
+            _warn(
+                f"verify: published batch {sid!r} carries advisory-only scan "
+                f"findings ({scan.summary()})"
+            )
         if sanitize._derivative_digest(batch_dir) != batch["content_digest"]:
             raise VerificationError(redact_text(f"verify: batch {sid!r} digest mismatch"))
         data = _read_manifest_dict(batch_dir)

--- a/daydream/archive/importer.py
+++ b/daydream/archive/importer.py
@@ -212,11 +212,13 @@ def redact_imported_metadata(rows: list[dict[str, Any]], *, scan_dir: Path) -> d
     Returns:
         ``{"payload": [...], "blocked": bool, "scan_summary": str,
         "blocked_reasons": [...]}``. ``blocked`` is ``True`` only when the
-        post-redaction scan is dirty — the payload cannot be published; the
-        offending rows are kept in ``payload`` (never dropped silently) and
-        ``blocked_reasons`` carries the stable
-        ``import_unredactable_metadata`` reason code. Redaction runs before
-        ``publish_annotation_state`` (which re-scans and hard-fails on dirty).
+        post-redaction scan carries a *blocking* finding — the payload cannot
+        be published; the offending rows are kept in ``payload`` (never dropped
+        silently) and ``blocked_reasons`` carries the stable
+        ``import_unredactable_metadata`` reason code. An advisory-only scan
+        publishes, with the value-free ``scan_summary`` still reported (#1170).
+        Redaction runs before ``publish_annotation_state`` (which re-scans and
+        hard-fails on dirty).
 
     Raises:
         ValueError: When a ``rubric_json``/``reward_json`` blob is malformed
@@ -242,7 +244,12 @@ def redact_imported_metadata(rows: list[dict[str, Any]], *, scan_dir: Path) -> d
         json.dumps(payload, indent=2, sort_keys=True, default=str) + "\n", encoding="utf-8"
     )
     scan = scan_run_dir(scan_dir)
-    blocked = not scan.clean
+    # Only a blocking finding withholds publication. An advisory finding is a
+    # name/template shape, not a credential (#1170) — and this payload is built
+    # from free-text ``rubric_json``/``reward_json``/``notes``, exactly the
+    # content that carries the ``env_var`` name shape. The value-free summary
+    # is returned either way, so an advisory finding is visible, not silent.
+    blocked = scan.blocking
     return {
         "payload": payload,
         "blocked": blocked,

--- a/daydream/archive/sanitize.py
+++ b/daydream/archive/sanitize.py
@@ -8,15 +8,18 @@ Transformation pipeline per file:
 
 * ``manifest.json`` (and any JSON file): credential-bearing URL string leaves
   are rewritten through :func:`daydream.archive.git_safe.normalize_remote_url`
-  (the sole URL authority); the whole document is then passed through
+  (the sole URL authority); every string leaf then runs through the same text
+  pipeline the non-JSON branch uses, and the whole document through
   :func:`daydream.trajectory.redact_value`.
 * Text files: :func:`daydream.trajectory.redact_text` plus the scanner's
   extended userinfo/query-param substitutions.
 
 Release gate: every derivative is re-scanned with
-:func:`daydream.archive.scan.scan_run_dir`; a derivative that does not come
-back clean is moved to ``<archive_dir>/quarantine/<session_id>/`` and recorded
-with ``status="quarantined"`` — never released (fail-closed).
+:func:`daydream.archive.scan.scan_run_dir`; a derivative carrying a *blocking*
+finding is moved to ``<archive_dir>/quarantine/<session_id>/`` and recorded
+with ``status="quarantined"`` — never released (fail-closed). An advisory
+finding is a name/template shape, not a credential (issue #1170): it is
+reported value-free and the derivative is released.
 
 ``derivative_digest`` is a SHA-256 over a canonical manifest of
 ``(relative path, per-file SHA-256)`` pairs, stable across runs on identical
@@ -53,6 +56,13 @@ _DERIVATIVE_MARKER = ".daydream_derivative_marker"
 
 def _now_iso_utc() -> str:
     return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _warn(message: str) -> None:
+    """Print a one-line warning through the daydream console (never raises)."""
+    from daydream.ui import create_console, print_warning  # noqa: PLC0415 - lazy: avoid ui import at module load
+
+    print_warning(create_console(), message)
 
 
 @dataclass(frozen=True)
@@ -115,12 +125,34 @@ def _sanitize_json_value(value: Any) -> Any:
     return value
 
 
+def _sanitize_json_document(doc: Any) -> Any:
+    """Canonicalize URL leaves, then run every string leaf through the text pipeline.
+
+    ``_sanitize_json_value`` + :func:`redact_value` alone omit the three
+    scan-local substitutions that only :func:`_sanitize_text` carries, so a
+    JSON string leaf holding an SCP, token-only or query-credential shape — the
+    shape a trajectory tool observation routinely has — was quarantined instead
+    of sanitized, deterministically on every pass (issue #1170). Routing leaves
+    through :func:`_sanitize_text` is what makes that function's docstring claim
+    ("a rule added there applies here too") true for the JSON branch as well.
+    """
+    if isinstance(doc, dict):
+        return {key: _sanitize_json_document(child) for key, child in doc.items()}
+    if isinstance(doc, list):
+        return [_sanitize_json_document(child) for child in doc]
+    if isinstance(doc, str):
+        return _sanitize_text(_sanitize_url_string(doc))
+    return doc
+
+
 def _sanitize_text(text: str) -> str:
     """Redact one text file body, then re-check with the scanner's extra rules.
 
     The scanner's two local gaps (token-only userinfo, credential query params)
     are applied from scan.py's own patterns, so a rule added there applies here
-    too and the derivative passes the release scan (M16).
+    too and the derivative passes the release scan (M16). JSON string leaves
+    route through here as well (:func:`_sanitize_json_document`), so the claim
+    holds for both branches.
     """
     text = redact_text(text)
     text = scan._TOKEN_ONLY_USERINFO_PATTERN.sub(r"\1[REDACTED_USER]@", text)
@@ -141,7 +173,7 @@ def _sanitize_derivative(derivative_dir: Path) -> None:
             except ValueError:
                 doc = None
             if isinstance(doc, (dict, list)):
-                sanitized = redact_value(_sanitize_json_value(doc))
+                sanitized = redact_value(_sanitize_json_document(doc))
                 file_path.write_text(
                     json.dumps(sanitized, indent=2, sort_keys=True, default=str) + "\n",
                     encoding="utf-8",
@@ -278,10 +310,18 @@ def sanitize_bundle(run_dir: Path, archive_dir: Path) -> SanitizeResult:
                 shutil.copy2(item, target)
         _sanitize_derivative(derivative_dir)
 
-        # Fail-closed release gate: only a clean scan releases the derivative.
+        # Fail-closed release gate: a blocking finding (or a scanner error)
+        # withholds the derivative. An advisory finding is by construction not
+        # a credential (#1170) — a rule that cannot identify a secret must not
+        # gate egress either — so it is reported and the derivative released.
         scan_result = scan.scan_run_dir(derivative_dir)
-        if not scan_result.clean:
+        if scan_result.blocking:
             raise _DerivativeUncleanError(f"derivative scan found {scan_result.summary()}")
+        if scan_result.findings:
+            _warn(
+                f"Sanitized derivative for {session_id} carries advisory-only scan "
+                f"findings ({scan_result.summary()})"
+            )
 
         digest = _derivative_digest(derivative_dir)
     except _DerivativeUncleanError:
@@ -365,15 +405,22 @@ def sanitize_archive(archive_dir: Path) -> list[SanitizeResult]:
 def import_bundle(run_dir: Path, archive_dir: Path) -> ImportResult:
     """Fail-closed ingest gate for a downloaded Hub bundle (M18).
 
-    The incoming bundle is scanned before ingestion. A clean bundle is
-    imported in place; an affected bundle is moved to
-    ``<archive_dir>/quarantine/<session_id>/`` and skipped — never imported
-    raw, even when a released derivative exists. The move is never a deletion
-    of a source bundle; when the quarantine slot is already occupied the move
-    is skipped and the bundle is still reported quarantined.
+    The incoming bundle is scanned before ingestion. A bundle with no blocking
+    finding is imported in place (advisory findings are reported value-free and
+    do not gate ingest — #1170); a bundle carrying a blocking finding, or a
+    scanner error, is moved to ``<archive_dir>/quarantine/<session_id>/`` and
+    skipped — never imported raw, even when a released derivative exists. The
+    move is never a deletion of a source bundle; when the quarantine slot is
+    already occupied the move is skipped and the bundle is still reported
+    quarantined.
     """
     scan_result = scan.scan_run_dir(run_dir)
-    if scan_result.clean:
+    if not scan_result.blocking:
+        if scan_result.findings:
+            _warn(
+                f"Importing bundle {run_dir.name} with advisory-only scan "
+                f"findings ({scan_result.summary()})"
+            )
         return ImportResult(source=run_dir, imported=True, quarantined=False)
     quarantine_dir = archive_dir / "quarantine" / run_dir.name
     quarantine_dir.parent.mkdir(parents=True, exist_ok=True)

--- a/daydream/archive/scan.py
+++ b/daydream/archive/scan.py
@@ -10,12 +10,19 @@ value or its surrounding content. Any scanner error is absorbed into a
 Redaction rule shapes are imported from :mod:`daydream.trajectory` (reuse, not
 copy); the pattern gaps unique to serialized bundles (token-only userinfo,
 scheme-less SCP userinfo, credential-bearing query params) are local additions.
+
+Rules are tiered by severity (issue #1170). A redactor needs recall — over-
+matching ``SORT_KEY = "created_at"`` costs one value in a log. A publication
+gate needs precision — over-matching costs the whole run. So the name-shape
+heuristics that carry no value constraint report as ``advisory`` and only the
+high-confidence value shapes are ``blocking``. Every rule still reports; the
+severity decides whether egress is refused.
 """
 
 import hashlib
 import json
 import re
-from collections.abc import Iterator
+from collections.abc import Iterable, Iterator
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -28,7 +35,12 @@ from daydream.trajectory import (
     _URL_CREDENTIAL_PATTERN,
 )
 
-__all__ = ["Finding", "ScanResult", "scan_run_dir"]
+__all__ = ["SEVERITY_ADVISORY", "SEVERITY_BLOCKING", "Finding", "ScanResult", "scan_run_dir"]
+
+#: A rule whose match is a credential by value shape. Refuses egress.
+SEVERITY_BLOCKING = "blocking"
+#: A rule whose match is only a name/template shape. Reported, never refused.
+SEVERITY_ADVISORY = "advisory"
 
 # Token-only userinfo: ``https://x-access-token@github.com/...`` — the
 # trajectory URL-credential rule only matches ``user:pass@``, so this closes
@@ -53,16 +65,41 @@ _QUERY_CREDENTIAL_PATTERN = re.compile(
 # (pattern, category) pairs applied in order to every scanned text. The
 # trajectory rules are imported; the two local rules close the userinfo/query
 # gaps without touching the shared trajectory module.
-_RULES: tuple[tuple[re.Pattern[str], str], ...] = (
+#
+# Blocking tier: every rule here constrains the matched *value*, so a hit is a
+# credential (a known token prefix, key armor, a literal ``user:pass@``, a
+# credential-bearing query param) rather than a name that merely sounds like
+# one.
+_BLOCKING_RULES: tuple[tuple[re.Pattern[str], str], ...] = (
     (_URL_CREDENTIAL_PATTERN, "url_credential"),
     (_TOKEN_ONLY_USERINFO_PATTERN, "url_credential"),
     (_SCP_USERINFO_PATTERN, "url_credential"),
     (_QUERY_CREDENTIAL_PATTERN, "query_credential"),
     (_PEM_KEY_PATTERN, "pem_key"),
-    (_ENV_VAR_PATTERN, "env_var"),
     (_API_KEY_PATTERN, "api_key"),
     (_JWT_PATTERN, "jwt"),
 )
+# Advisory tier: pure name-shape heuristics. ``_ENV_VAR_PATTERN``'s value group
+# is ``[^\s\n\r;]+`` — any non-space token — so it matches ``SORT_KEY =
+# "created_at"``, ``AUTH=none`` and ``API_TOKEN=${API_TOKEN}``. Correct for
+# redaction, far too coarse to refuse a publication.
+_ADVISORY_RULES: tuple[tuple[re.Pattern[str], str], ...] = (
+    (_ENV_VAR_PATTERN, "env_var"),
+)
+_RULES: tuple[tuple[re.Pattern[str], str, str], ...] = tuple(
+    [(p, c, SEVERITY_BLOCKING) for p, c in _BLOCKING_RULES]
+    + [(p, c, SEVERITY_ADVISORY) for p, c in _ADVISORY_RULES]
+)
+
+# A userinfo part that is entirely an interpolation slot (``{cfg.DB_USER}``,
+# ``{password}``, ``${PGPASSWORD}``) is a template, not a value. The optional
+# opener/closer absorbs the string literal the slot is written inside: the
+# userinfo character classes are greedy over quotes, so the first captured part
+# of ``f"{cfg.DB_USER}:{cfg.DB_PASSWORD}@..."`` is ``f"{cfg.DB_USER}``, not
+# ``{cfg.DB_USER}``. A quote is never a credential character (RFC 3986 userinfo
+# excludes it), and the prefix letters are only accepted when a quote follows,
+# so ``pw{n}`` stays blocking.
+_PLACEHOLDER_PART_PATTERN = re.compile(r"""(?:[A-Za-z]{0,2}["'`])?\$?\{[^{}]*\}["'`]?""")
 
 
 @dataclass(frozen=True)
@@ -73,6 +110,10 @@ class Finding:
     location: str
     category: str
     digest: str
+    #: ``SEVERITY_BLOCKING`` or ``SEVERITY_ADVISORY``. Defaults to blocking so
+    #: every construction site that predates the tiering — and ``scan_error``
+    #: in particular — stays fail-closed without naming the field.
+    severity: str = SEVERITY_BLOCKING
 
 
 @dataclass
@@ -80,30 +121,105 @@ class ScanResult:
     clean: bool = True
     findings: list[Finding] = field(default_factory=list)
 
+    @property
+    def blocking(self) -> bool:
+        """Whether egress must be refused.
+
+        Fail-closed tie-break: a result that is not clean but carries no
+        findings blocks, so a caller that only knows ``clean=False`` (a
+        hand-built stub, a future producer) can never publish by omission.
+        """
+        if not self.clean and not self.findings:
+            return True
+        return any(f.severity == SEVERITY_BLOCKING for f in self.findings)
+
     def summary(self) -> str:
-        """Human-readable counts + paths only — never finding values."""
+        """Human-readable counts, paths and categories — never finding values."""
         if self.clean:
             return "clean"
-        by_path: dict[str, int] = {}
+        if not self.findings:
+            return "not clean (no findings recorded)"
+        blocking = sum(1 for f in self.findings if f.severity == SEVERITY_BLOCKING)
+        by_path: dict[str, list[str]] = {}
         for f in self.findings:
-            by_path[f.path] = by_path.get(f.path, 0) + 1
-        parts = ", ".join(f"{p}: {n}" for p, n in sorted(by_path.items()))
-        return f"{len(self.findings)} finding(s) — {parts}"
+            by_path.setdefault(f.path, []).append(f.category)
+        parts = ", ".join(
+            f"{p}: {len(cats)} ({'/'.join(sorted(set(cats)))})" for p, cats in sorted(by_path.items())
+        )
+        return (
+            f"{len(self.findings)} finding(s) "
+            f"({blocking} blocking, {len(self.findings) - blocking} advisory) — {parts}"
+        )
 
 
 def _digest(matched: str) -> str:
     return hashlib.sha256(matched.encode()).hexdigest()[:12]
 
 
-def _scan_text(text: str) -> Iterator[tuple[str, str, str]]:
-    """Yield (category, matched_value, digest) for every rule hit in *text*."""
-    for pattern, category in _RULES:
+def _userinfo_parts(pattern: re.Pattern[str], match: re.Match[str]) -> list[str] | None:
+    """Colon-separated userinfo parts a userinfo rule captured, else ``None``.
+
+    Each rule captures the userinfo differently: ``_URL_CREDENTIAL_PATTERN``
+    has separate user/password groups, ``_TOKEN_ONLY_USERINFO_PATTERN`` only
+    captures the scheme, and ``_SCP_USERINFO_PATTERN``'s group 1 is the
+    *combined* ``user:pass@`` with no separate groups at all — hence the split.
+    """
+    if pattern is _URL_CREDENTIAL_PATTERN:
+        return [match.group(2), match.group(3)]
+    if pattern is _TOKEN_ONLY_USERINFO_PATTERN:
+        return match.group(0)[len(match.group(1)) :].removesuffix("@").split(":")
+    if pattern is _SCP_USERINFO_PATTERN:
+        return match.group(1).removesuffix("@").split(":")
+    return None
+
+
+def _is_placeholder_userinfo(parts: list[str]) -> bool:
+    """Whether every userinfo part is wholly a ``{...}`` interpolation slot.
+
+    ``f"postgresql://{cfg.DB_USER}:{cfg.DB_PASSWORD}@{cfg.DB_HOST}:..."`` has
+    the credential shape but carries no credential. The guard covers all three
+    userinfo rules, not just the scheme-bearing one: ``_URL_CREDENTIAL_PATTERN``
+    is a strict *subset* of ``_TOKEN_ONLY_USERINFO_PATTERN`` (both match
+    ``https://{a}:{b}@``), so guarding one and not the other leaves every
+    ``https://``-scheme template blocking through the wider rule.
+    """
+    return bool(parts) and all(_PLACEHOLDER_PART_PATTERN.fullmatch(part) for part in parts)
+
+
+def _scan_text(text: str) -> Iterator[tuple[str, str, str, str]]:
+    """Yield (category, matched_value, digest, severity) per rule hit in *text*."""
+    for pattern, category, severity in _RULES:
         for match in pattern.finditer(text):
             # Redaction markers are already-safe output, not secrets; scanning
             # sanitized text must not flag its own markers.
             if "[REDACTED_" in match.group(0):
                 continue
-            yield category, match.group(0), _digest(match.group(0))
+            effective = severity
+            if severity == SEVERITY_BLOCKING:
+                parts = _userinfo_parts(pattern, match)
+                if parts is not None and _is_placeholder_userinfo(parts):
+                    effective = SEVERITY_ADVISORY
+            yield category, match.group(0), _digest(match.group(0)), effective
+
+
+def _dedupe(findings: Iterable[Finding]) -> list[Finding]:
+    """Collapse identical findings, resolving to the strictest severity.
+
+    Keyed on ``(path, location, category, digest)``. The URL-credential and
+    token-only rules both fire on every ``scheme://user:pass@`` with the same
+    matched string, so without an explicit blocking-wins tie-break a text's
+    severity would depend on rule iteration order. Insertion order is kept so
+    the finding list stays reproducible.
+    """
+    resolved: dict[tuple[str, str, str, str], Finding] = {}
+    for finding in findings:
+        key = (finding.path, finding.location, finding.category, finding.digest)
+        existing = resolved.get(key)
+        if existing is None or (
+            existing.severity != SEVERITY_BLOCKING and finding.severity == SEVERITY_BLOCKING
+        ):
+            resolved[key] = finding
+    return list(resolved.values())
 
 
 def _json_string_leaves(value: object) -> Iterator[tuple[str, str]]:
@@ -129,28 +245,54 @@ def _scan_file(rel_path: str, text: str) -> list[Finding]:
     if isinstance(parsed, (dict, list)):
         findings = []
         for key_path, leaf in _json_string_leaves(parsed):
-            for category, _matched, digest in _scan_text(leaf):
+            for category, _matched, digest, severity in _scan_text(leaf):
                 findings.append(
                     Finding(
                         path=rel_path,
                         location=f"{key_path} (json)" if key_path else "(json)",
                         category=category,
                         digest=digest,
+                        severity=severity,
                     )
                 )
-        return findings
+        return _dedupe(findings)
     findings = []
     for line_number, line in enumerate(text.splitlines(), start=1):
-        for category, _matched, digest in _scan_text(line):
+        for category, _matched, digest, severity in _scan_text(line):
             findings.append(
                 Finding(
                     path=rel_path,
                     location=f"line {line_number}",
                     category=category,
                     digest=digest,
+                    severity=severity,
                 )
             )
-    return findings
+    findings.extend(_scan_multiline_pem(rel_path, text))
+    return _dedupe(findings)
+
+
+def _scan_multiline_pem(rel_path: str, text: str) -> Iterator[Finding]:
+    """Yield PEM findings the per-line pass structurally cannot see (#1170 D4).
+
+    ``_PEM_KEY_PATTERN`` is ``re.DOTALL`` and spans BEGIN..END lines, but the
+    non-JSON pass above scans line by line, so real key armor in ``diff.patch``
+    was invisible while the same key inside a JSON string leaf was caught. The
+    location is the line the block starts on. A single-line block matches both
+    passes with the same span, and ``_dedupe`` collapses it.
+    """
+    for match in _PEM_KEY_PATTERN.finditer(text):
+        matched = match.group(0)
+        if "[REDACTED_" in matched:
+            continue
+        start_line = text.count("\n", 0, match.start()) + 1
+        yield Finding(
+            path=rel_path,
+            location=f"line {start_line}",
+            category="pem_key",
+            digest=_digest(matched),
+            severity=SEVERITY_BLOCKING,
+        )
 
 
 def scan_run_dir(run_dir: Path) -> ScanResult:

--- a/daydream/artifact_visibility.py
+++ b/daydream/artifact_visibility.py
@@ -2730,6 +2730,111 @@ def _retire_source_stage(source: Path, transaction_id: str, purpose: str, *, wor
     _remove_owned_tree(stage, source.parent)
 
 
+def _reset_source_stage(source: Path, transaction_id: str, purpose: str, *, workspace_key: str) -> None:
+    """Drop this exact identity's own leftover stage so a retry is not blocked.
+
+    A restore that raised before retiring its stage leaves the directory
+    behind, and ``_create_source_stage`` then refuses every later attempt with
+    "artifact source-stage collision" (#1172). A stage attesting exactly this
+    workspace, transaction and purpose holds nothing but regenerable copies of
+    durable state (``canonical`` and the transaction's own baselines), so it is
+    this identity's to reclaim. Anything else — a foreign directory, tampered
+    or absent attestation — is left alone and still collides.
+    """
+    stage = _source_stage_path(source, transaction_id, purpose)
+    if not stage.exists() and not stage.is_symlink():
+        return
+    if stage.is_symlink() or not stage.is_dir():
+        return
+    owner = stage / "stage-owner.json"
+    if not owner.is_file():
+        return
+    if _load_json(owner) != _source_stage_owner(source, transaction_id, purpose, workspace_key):
+        return
+    _remove_owned_tree(stage, source.parent)
+
+
+def _quarantine_transaction(state_root: Path, transaction: Path) -> Path:
+    """Move a transaction out of the replay path without destroying it.
+
+    Retiring a transaction deletes its ``destination-NNNN-baseline`` copies,
+    which are the only surviving record of an in-source destination's prior
+    bytes once detach has transferred them out of the source. Leaving the
+    journal under ``transactions/`` instead makes every later session open
+    replay a restore that already failed deterministically (#1172). Renaming
+    the transaction under ``unreconciled/`` does neither: recovery never looks
+    there, and the operator keeps every byte.
+    """
+    root = state_root / "unreconciled"
+    _create_private_directory(root)
+    preserved = root / transaction.name
+    if preserved.exists() or preserved.is_symlink():
+        raise ArtifactVisibilityError("artifact unreconciled transaction collision")
+    os.replace(transaction, preserved)
+    _fsync_directory(transaction.parent)
+    _fsync_directory(root)
+    return preserved
+
+
+class _NamedTransactionError(ArtifactVisibilityError):
+    """A storage error whose message already names its transaction and workspace."""
+
+
+def _transaction_context(error: Exception, state_root: Path, transaction: Path, *, detail: str = "") -> Exception:
+    """Re-raise ``error`` naming the transaction and workspace it belongs to.
+
+    A bare storage message ("dump destination projection is malformed") tells
+    an operator nothing about which transaction to act on or where its state
+    lives, which is the whole difficulty in #1172. The original text is kept
+    verbatim as the prefix so callers matching on it keep working.
+    """
+    if isinstance(error, _NamedTransactionError):
+        return error
+    suffix = f" (artifact transaction {transaction.name} in workspace {state_root}{detail})"
+    contextual = _NamedTransactionError(f"{error}{suffix}")
+    contextual.__cause__ = error
+    return contextual
+
+
+def _transaction_holds_conflict(transaction: Path) -> bool:
+    """Whether this transaction carries a durably recorded, unadjudicated conflict.
+
+    Either registry — ``conflicts.json`` or a ``conflict`` lifecycle in the
+    external-entry ledger — is the module's deliberate hard stop:
+    ``_retire_transaction`` refuses such a transaction and recovery refuses to
+    replay past it, because it is the only record of what diverged and only a
+    human can settle it.
+    """
+    registry = transaction / "conflicts.json"
+    if registry.exists() or registry.is_symlink():
+        return True
+    return any(
+        record["lifecycle"] == _ExternalEntryLifecycle.CONFLICT.value for record in _external_records(transaction)
+    )
+
+
+def _clear_failed_restore(state_root: Path, source: Path, transaction: Path, error: Exception) -> Exception:
+    """Take a transaction whose *destination* restore failed out of the replay path.
+
+    Recovery reruns the same records through the same code, so a destination
+    restore that fails once fails identically at every later session open and
+    wedges the workspace permanently. Both call sites have already reinstalled
+    the public tree by this point, which is why dropping the journal is safe
+    here and never for a public-restore failure — there the retained journal is
+    itself the mechanism that puts the public tree back.
+    """
+    if _transaction_holds_conflict(transaction):
+        return _transaction_context(error, state_root, transaction)
+    _reset_source_stage(source, transaction.name, "restore", workspace_key=state_root.name)
+    preserved = _quarantine_transaction(state_root, transaction)
+    return _transaction_context(
+        error,
+        state_root,
+        transaction,
+        detail=f"; it could not restore every explicit destination and is preserved at {preserved}",
+    )
+
+
 def _copy_regular_entry(
     source: Path,
     target: Path,
@@ -2849,6 +2954,41 @@ def _replace_destination_from_tree(
         raise ArtifactVisibilityError("explicit artifact destination verification failed")
 
 
+def _remove_directory_destination(
+    record: _DestinationRecord,
+    *,
+    transaction: Path,
+    workspace_key: str,
+) -> None:
+    """Project a directory destination back to "not present".
+
+    Whatever is live at the record was already validated against the record's
+    allowed manifests by the caller, so this removes that tree and gives back
+    every parent directory the record itself had to create.
+    """
+    root = Path(record.base)
+    actual = _manifest(root, (record.relative,))
+    if actual:
+        _remove_manifested(
+            root,
+            actual,
+            (record.relative,),
+            transaction=transaction,
+            workspace_key=workspace_key,
+            purpose="remove-dump-destination",
+            stage_parent=root,
+            record_id=record.record_id,
+            changed_message="dump destination changed during removal",
+        )
+    for parent_relative in reversed(record.missing_parents):
+        parent = root / parent_relative
+        with suppress(OSError):
+            parent.rmdir()
+            _fsync_directory(parent.parent)
+    if _manifest(root, (record.relative,)):
+        raise ArtifactVisibilityError("dump destination removal verification failed")
+
+
 def _merge_directory_from_tree(
     tree: Path,
     record: _DestinationRecord,
@@ -2862,6 +3002,16 @@ def _merge_directory_from_tree(
     target_root = root / record.relative
     baseline = {entry.path: entry for entry in record.baseline}
     desired_by_path = {entry.path: entry for entry in desired}
+    if not desired:
+        # ``_manifest`` omits names that do not exist, so an empty projection is
+        # the normal shape of a directory destination that was not there before
+        # the run. Its rollback target is "not present", not a malformed
+        # projection (#1171). An empty projection over a real baseline is still
+        # a genuine malformation and keeps failing closed.
+        if record.baseline:
+            raise ArtifactVisibilityError("dump destination projection dropped a baseline file")
+        _remove_directory_destination(record, transaction=transaction, workspace_key=workspace_key)
+        return
     desired_root = desired_by_path.get(record.relative)
     if desired_root is None or desired_root.kind != "directory":
         raise ArtifactVisibilityError("dump destination projection is malformed")
@@ -3109,132 +3259,154 @@ def _recover_transactions(state_root: Path, source: Path) -> None:
     completed_sessions: set[str] = set()
     records.sort(key=lambda item: (not item[1].is_publish, item[0].name))
     for transaction, state, session_id in records:
-        if (transaction / "conflicts.json").exists() or (transaction / "conflicts.json").is_symlink():
-            raise ArtifactVisibilityError("artifact recovery retained a closed conflict")
-        if session_id in completed_sessions and not state.is_publish:
-            _retire_transaction(state_root, transaction, terminal_state=_TerminalState.DETACHED_RECONCILED)
-            continue
-        canonical = state_root / "canonical"
-        canonical_manifest = state_root / "canonical-manifest.json"
-        transaction_manifest = transaction / "manifest.json"
-        published_entries: tuple[ArtifactManifestEntry, ...] | None = None
-        destination_records = _load_destination_records(transaction, include_published=state.is_publish)
-        _reconcile_external_entries(transaction, destination_records)
-        publication_stage = (_source_stage_path(source, transaction.name, "publish") if state.is_publish else None)
-        restore_stage: Path | None = None
-        if state.is_publish:
-            published_entries = _parse_manifest(transaction / "publish-manifest.json")
-        if state is _Transition.DETACH_STAGED:
-            entries = _parse_manifest(transaction_manifest)
-            stage = transaction / "detach-stage"
-            if not canonical.exists():
-                if _manifest(stage) != entries:
-                    raise ArtifactVisibilityError("staged detach is incomplete")
-                os.replace(stage, canonical)
-                _fsync_directory(state_root)
-            else:
-                if _manifest(canonical) != entries:
-                    raise ArtifactVisibilityError("staged detach ownership is ambiguous")
-                if stage.exists() and _manifest(stage) != entries:
-                    raise ArtifactVisibilityError("staged detach ownership is ambiguous")
-            if not canonical_manifest.exists():
-                _atomic_json(canonical_manifest, _manifest_payload(entries))
-        if state is _Transition.PUBLISH_INSTALLED and not canonical.exists():
-            replacement = transaction / "canonical-stage"
-            if published_entries is None or _manifest(replacement) != published_entries:
+        try:
+            _recover_transaction(
+                state_root, source, transaction, state, session_id, completed_sessions
+            )
+        except Exception as exc:
+            # A bare storage message names neither the transaction nor the
+            # workspace an operator has to act on (#1172).
+            raise _transaction_context(exc, state_root, transaction) from exc
+
+
+def _recover_transaction(
+    state_root: Path,
+    source: Path,
+    transaction: Path,
+    state: _Transition,
+    session_id: str,
+    completed_sessions: set[str],
+) -> None:
+    """Reconcile one journalled transaction, retiring it when it is settled."""
+    if (transaction / "conflicts.json").exists() or (transaction / "conflicts.json").is_symlink():
+        raise ArtifactVisibilityError("artifact recovery retained a closed conflict")
+    if session_id in completed_sessions and not state.is_publish:
+        _retire_transaction(state_root, transaction, terminal_state=_TerminalState.DETACHED_RECONCILED)
+        return
+    canonical = state_root / "canonical"
+    canonical_manifest = state_root / "canonical-manifest.json"
+    transaction_manifest = transaction / "manifest.json"
+    published_entries: tuple[ArtifactManifestEntry, ...] | None = None
+    destination_records = _load_destination_records(transaction, include_published=state.is_publish)
+    _reconcile_external_entries(transaction, destination_records)
+    publication_stage = (_source_stage_path(source, transaction.name, "publish") if state.is_publish else None)
+    restore_stage: Path | None = None
+    if state.is_publish:
+        published_entries = _parse_manifest(transaction / "publish-manifest.json")
+    if state is _Transition.DETACH_STAGED:
+        entries = _parse_manifest(transaction_manifest)
+        stage = transaction / "detach-stage"
+        if not canonical.exists():
+            if _manifest(stage) != entries:
+                raise ArtifactVisibilityError("staged detach is incomplete")
+            os.replace(stage, canonical)
+            _fsync_directory(state_root)
+        else:
+            if _manifest(canonical) != entries:
+                raise ArtifactVisibilityError("staged detach ownership is ambiguous")
+            if stage.exists() and _manifest(stage) != entries:
+                raise ArtifactVisibilityError("staged detach ownership is ambiguous")
+        if not canonical_manifest.exists():
+            _atomic_json(canonical_manifest, _manifest_payload(entries))
+    if state is _Transition.PUBLISH_INSTALLED and not canonical.exists():
+        replacement = transaction / "canonical-stage"
+        if published_entries is None or _manifest(replacement) != published_entries:
+            raise ArtifactVisibilityError("staged canonical publication copy is corrupt")
+        os.replace(replacement, canonical)
+        _fsync_directory(state_root)
+    if not canonical.exists() or not canonical_manifest.exists():
+        raise ArtifactVisibilityError("canonical artifact recovery copy is missing")
+    canonical_entries = _parse_manifest(canonical_manifest)
+    canonical_actual = _manifest(canonical)
+    if canonical_actual != canonical_entries and not (
+        state is _Transition.PUBLISH_INSTALLED and canonical_actual == published_entries
+    ):
+        raise ArtifactVisibilityError("canonical artifact recovery copy is corrupt")
+
+    if state is _Transition.PUBLISH_INSTALLED:
+        assert published_entries is not None
+        if _manifest(source, (_DAYDREAM, _REVIEW_OUTPUT)) != published_entries:
+            raise ArtifactVisibilityError("installed public artifact recovery copy is corrupt")
+        replacement = transaction / "canonical-stage"
+        if replacement.exists():
+            if _manifest(replacement) != published_entries:
                 raise ArtifactVisibilityError("staged canonical publication copy is corrupt")
+            backup = transaction / "old-canonical"
+            os.replace(canonical, backup)
             os.replace(replacement, canonical)
             _fsync_directory(state_root)
-        if not canonical.exists() or not canonical_manifest.exists():
-            raise ArtifactVisibilityError("canonical artifact recovery copy is missing")
-        canonical_entries = _parse_manifest(canonical_manifest)
-        canonical_actual = _manifest(canonical)
-        if canonical_actual != canonical_entries and not (
-            state is _Transition.PUBLISH_INSTALLED and canonical_actual == published_entries
-        ):
-            raise ArtifactVisibilityError("canonical artifact recovery copy is corrupt")
-
-        if state is _Transition.PUBLISH_INSTALLED:
-            assert published_entries is not None
-            if _manifest(source, (_DAYDREAM, _REVIEW_OUTPUT)) != published_entries:
-                raise ArtifactVisibilityError("installed public artifact recovery copy is corrupt")
-            replacement = transaction / "canonical-stage"
-            if replacement.exists():
-                if _manifest(replacement) != published_entries:
-                    raise ArtifactVisibilityError("staged canonical publication copy is corrupt")
-                backup = transaction / "old-canonical"
-                os.replace(canonical, backup)
-                os.replace(replacement, canonical)
-                _fsync_directory(state_root)
-            elif _manifest(canonical) != published_entries:
-                raise ArtifactVisibilityError("installed canonical publication copy is missing")
-            _atomic_json(canonical_manifest, _manifest_payload(published_entries))
-            canonical_entries = published_entries
-        elif state is _Transition.PUBLISH_VERIFIED:
-            assert published_entries is not None
-            if canonical_entries != published_entries:
-                raise ArtifactVisibilityError("verified canonical publication identity is corrupt")
-            if _manifest(source, (_DAYDREAM, _REVIEW_OUTPUT)) != canonical_entries:
-                raise ArtifactVisibilityError("verified public artifact recovery copy is corrupt")
-        else:
-            public_entries = _manifest(source, (_DAYDREAM, _REVIEW_OUTPUT))
-            allowed = [canonical_entries]
-            if published_entries is not None:
-                allowed.append(published_entries)
-            if not any(_manifest_is_subset(public_entries, candidate) for candidate in allowed):
-                _append_conflict(
-                    transaction,
-                    record_id="public",
-                    reason="unexpected_replacement",
-                    expected_sha256=None,
-                    observed_sha256=None,
-                    expected_kind="directory",
-                    observed_kind="unknown",
-                    stage_id=None,
-                )
-                raise ArtifactVisibilityError("public artifacts changed during recovery")
-            if public_entries:
-                _remove_manifested(
-                    source,
-                    public_entries,
-                    transaction=transaction,
-                    workspace_key=state_root.name,
-                    purpose="recover-public",
-                    stage_parent=source.parent,
-                )
-            restore_stage = _create_source_stage(source, transaction.name, "restore", workspace_key=state_root.name)
-            public_stage = restore_stage / "public"
-            _copy_tree(canonical, public_stage, canonical_entries)
-            _replace_public_from_tree(source, public_stage, canonical_entries)
-        if state in (_Transition.PUBLISH_INSTALLED, _Transition.PUBLISH_VERIFIED):
-            for record in destination_records:
-                if _manifest(Path(record.base), (record.relative,)) != record.published:
-                    raise ArtifactVisibilityError("installed explicit artifact recovery copy is corrupt")
-        else:
-            if destination_records:
-                assert restore_stage is not None
+        elif _manifest(canonical) != published_entries:
+            raise ArtifactVisibilityError("installed canonical publication copy is missing")
+        _atomic_json(canonical_manifest, _manifest_payload(published_entries))
+        canonical_entries = published_entries
+    elif state is _Transition.PUBLISH_VERIFIED:
+        assert published_entries is not None
+        if canonical_entries != published_entries:
+            raise ArtifactVisibilityError("verified canonical publication identity is corrupt")
+        if _manifest(source, (_DAYDREAM, _REVIEW_OUTPUT)) != canonical_entries:
+            raise ArtifactVisibilityError("verified public artifact recovery copy is corrupt")
+    else:
+        public_entries = _manifest(source, (_DAYDREAM, _REVIEW_OUTPUT))
+        allowed = [canonical_entries]
+        if published_entries is not None:
+            allowed.append(published_entries)
+        if not any(_manifest_is_subset(public_entries, candidate) for candidate in allowed):
+            _append_conflict(
+                transaction,
+                record_id="public",
+                reason="unexpected_replacement",
+                expected_sha256=None,
+                observed_sha256=None,
+                expected_kind="directory",
+                observed_kind="unknown",
+                stage_id=None,
+            )
+            raise ArtifactVisibilityError("public artifacts changed during recovery")
+        if public_entries:
+            _remove_manifested(
+                source,
+                public_entries,
+                transaction=transaction,
+                workspace_key=state_root.name,
+                purpose="recover-public",
+                stage_parent=source.parent,
+            )
+        _reset_source_stage(source, transaction.name, "restore", workspace_key=state_root.name)
+        restore_stage = _create_source_stage(source, transaction.name, "restore", workspace_key=state_root.name)
+        public_stage = restore_stage / "public"
+        _copy_tree(canonical, public_stage, canonical_entries)
+        _replace_public_from_tree(source, public_stage, canonical_entries)
+    if state in (_Transition.PUBLISH_INSTALLED, _Transition.PUBLISH_VERIFIED):
+        for record in destination_records:
+            if _manifest(Path(record.base), (record.relative,)) != record.published:
+                raise ArtifactVisibilityError("installed explicit artifact recovery copy is corrupt")
+    else:
+        assert restore_stage is not None
+        if destination_records:
+            try:
                 _restore_destination_records(source, transaction, destination_records, restore_stage)
-            assert restore_stage is not None
-            _retire_source_stage(source, transaction.name, "restore", workspace_key=state_root.name)
-        if state.is_publish:
-            completed_sessions.add(session_id)
-            if publication_stage is None:
-                raise ArtifactVisibilityError("artifact publication stage is missing")
-            if publication_stage.exists() or publication_stage.is_symlink():
-                _retire_source_stage(source, transaction.name, "publish", workspace_key=state_root.name)
-            elif state is not _Transition.PUBLISH_VERIFIED:
-                raise ArtifactVisibilityError("artifact publication stage is missing")
-        _retire_transaction(
-            state_root,
-            transaction,
-            terminal_state=(
-                _TerminalState.PUBLISH_VERIFIED
-                if state is _Transition.PUBLISH_VERIFIED
-                else _TerminalState.PUBLISH_RECONCILED
-                if state.is_publish
-                else _TerminalState.DETACHED_RECONCILED
-            ),
-        )
+            except Exception as exc:
+                raise _clear_failed_restore(state_root, source, transaction, exc) from exc
+        _retire_source_stage(source, transaction.name, "restore", workspace_key=state_root.name)
+    if state.is_publish:
+        completed_sessions.add(session_id)
+        if publication_stage is None:
+            raise ArtifactVisibilityError("artifact publication stage is missing")
+        if publication_stage.exists() or publication_stage.is_symlink():
+            _retire_source_stage(source, transaction.name, "publish", workspace_key=state_root.name)
+        elif state is not _Transition.PUBLISH_VERIFIED:
+            raise ArtifactVisibilityError("artifact publication stage is missing")
+    _retire_transaction(
+        state_root,
+        transaction,
+        terminal_state=(
+            _TerminalState.PUBLISH_VERIFIED
+            if state is _Transition.PUBLISH_VERIFIED
+            else _TerminalState.PUBLISH_RECONCILED
+            if state.is_publish
+            else _TerminalState.DETACHED_RECONCILED
+        ),
+    )
 
 
 class _SessionState(str, Enum):
@@ -4000,43 +4172,60 @@ class ArtifactSession:
         self._state = _SessionState.PUBLISHED
 
     def _restore_prior(self) -> None:
-        canonical = self.layout.state_root / "canonical"
+        state_root = self.layout.state_root
+        transaction = self._detach_transaction
+        if not transaction.exists():
+            # Already retired or already taken out of the replay path by an
+            # earlier attempt (``finalize_frozen`` and session close both call
+            # this). There is nothing left to restore from.
+            return
+        canonical = state_root / "canonical"
+        _reset_source_stage(
+            self.layout.source, transaction.name, "restore", workspace_key=self.layout.workspace_key
+        )
         source_stage = _create_source_stage(
             self.layout.source,
-            self._detach_transaction.name,
+            transaction.name,
             "restore",
             workspace_key=self.layout.workspace_key,
         )
-        errors: list[Exception] = []
+        # Destination failures and public failures need opposite treatment, so
+        # they are collected apart rather than into one list.
+        destination_errors: list[Exception] = []
+        public_errors: list[Exception] = []
         try:
-            _restore_destination_records(self.layout.source, self._detach_transaction, self._records(), source_stage)
+            _restore_destination_records(self.layout.source, transaction, self._records(), source_stage)
         except Exception as exc:
-            errors.append(exc)
+            destination_errors.append(exc)
         try:
             projection = source_stage / "public"
             _copy_tree(canonical, projection, self._canonical_entries)
             _replace_public_from_tree(self.layout.source, projection, self._canonical_entries)
         except Exception as exc:
-            errors.append(exc)
-        _retire_source_stage(
-            self.layout.source,
-            self._detach_transaction.name,
-            "restore",
-            workspace_key=self.layout.workspace_key,
-        )
+            public_errors.append(exc)
         try:
-            _cleanup_external_directories(self._detach_transaction, self._created_external_parents)
+            _retire_source_stage(
+                self.layout.source, transaction.name, "restore", workspace_key=self.layout.workspace_key
+            )
+        except Exception as exc:
+            destination_errors.append(exc)
+        try:
+            _cleanup_external_directories(transaction, self._created_external_parents)
             self._created_external_parents.clear()
         except Exception as exc:
-            errors.append(exc)
-        if errors:
-            raise errors[0]
-        self._retire_late_paths()
-        _retire_transaction(
-            self.layout.state_root,
-            self._detach_transaction,
-            terminal_state=_TerminalState.DETACHED_RECONCILED,
-        )
+            destination_errors.append(exc)
+        if public_errors:
+            # The journal has to stay: the next session open replays it and
+            # reinstalls the public tree from canonical before anything can
+            # adopt the missing tree as a new baseline. Name it instead.
+            raise _transaction_context(public_errors[0], state_root, transaction)
+        try:
+            self._retire_late_paths()
+        except Exception as exc:
+            destination_errors.append(exc)
+        if destination_errors:
+            raise _clear_failed_restore(state_root, self.layout.source, transaction, destination_errors[0])
+        _retire_transaction(state_root, transaction, terminal_state=_TerminalState.DETACHED_RECONCILED)
 
     def _close(self) -> None:
         self._state = _SessionState.CLOSED

--- a/daydream/runner.py
+++ b/daydream/runner.py
@@ -1157,6 +1157,11 @@ def _finalize_run_artifacts(
         run_artifacts.session.finalize_frozen(snapshot, disposition=disposition)
     except Exception as exc:
         if archive_error is not None:
+            # The rollback failure is what propagates and gets rendered, so the
+            # archive error the operator actually needs — which gate refused and
+            # which file tripped it — would otherwise be lost: ``add_note``
+            # carries only the type name and nothing renders notes (#1171).
+            print_error(console, "Artifact Finalization", str(archive_error))
             exc.add_note(f"strict archive finalization also failed ({type(archive_error).__name__})")
         raise
     return archive_error

--- a/daydream/templates/workflows/daydream-review.yml
+++ b/daydream/templates/workflows/daydream-review.yml
@@ -183,6 +183,10 @@ jobs:
           path: findings/failure.json
 
       - name: Upload findings artifact
+        # always(): a findings.json already written before a late-stage failure
+        # (e.g. a refused egress scan) is exactly what the operator needs; the
+        # default success() gate would discard it.
+        if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: daydream-findings

--- a/daydream/templates/workflows/single/daydream.yml
+++ b/daydream/templates/workflows/single/daydream.yml
@@ -288,6 +288,11 @@ jobs:
           path: findings/failure.json
 
       - name: Upload findings artifact
+        # always(): a findings.json already written before a late-stage failure
+        # (e.g. a refused egress scan) is exactly what the operator needs; the
+        # default success() gate would discard it. `post` still gates on
+        # needs.analyze.result == 'success', so this never widens posting.
+        if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: daydream-findings

--- a/docs/runbooks/credential-remediation.md
+++ b/docs/runbooks/credential-remediation.md
@@ -121,8 +121,8 @@ Choose exactly one option, in escalating order of destructiveness:
 |---|---|---|---|
 | `report_inventory()` scoping | No (read-only, value-free) | Agent or human | — |
 | Reading `sanitized/audit.jsonl` | No | Agent or human | Never print values |
-| `sanitize_archive()` / `sanitize_bundle()` | No (produces derivatives; bronze sources never modified) | Agent or human | Fail-closed scan; failures quarantine |
-| Quarantine **release** (moving a derivative out of `quarantine/` after review) | No | Agent or human | Must pass `scan_run_dir()` clean first |
+| `sanitize_archive()` / `sanitize_bundle()` | No (produces derivatives; bronze sources never modified) | Agent or human | Fail-closed scan; blocking findings quarantine, advisory findings are reported and released |
+| Quarantine **release** (moving a derivative out of `quarantine/` after review) | No | Agent or human | Must pass `scan_run_dir()` with no blocking finding first (see §6.2); advisory findings do not hold a release |
 | Credential revocation / rotation | **Destructive** | **Human only** | Human approval; never automated |
 | Hub revision deletion (4b) | **Destructive** | **Human only** | Approval + executed revocation + written deletion record |
 | Hub history rewrite (4c) | **Destructive** | **Human only** | Approval + executed revocation + written deletion record |
@@ -136,14 +136,35 @@ Post-remediation, confirm the incident is closed:
    `unparseable`, if pre-existing) remain.
 2. **Re-scan:** run the fail-closed scanner (`daydream.archive.scan.scan_run_dir`)
    over sanitized derivatives and any bundle that will egress. It must report
-   clean.
+   **no blocking findings** (`ScanResult.blocking` empty). The scanner reports
+   two tiers, and only the blocking tier is an acceptance criterion:
+   - **Blocking** — high-confidence credential formats: API-key prefixes
+     (`api_key`), PEM key material (`pem_key`), JWTs (`jwt`), literal
+     `user:pass@` userinfo and token-only userinfo (`url_credential`),
+     credential-bearing query parameters (`query_credential`), and any
+     `scan_error` (a scan that could not complete never reads clean). A
+     blocking finding refuses publication on every egress path.
+   - **Advisory** — shapes the scanner cannot attribute to a credential value:
+     a secret-*named* variable whose value is not secret-shaped (`env_var`,
+     e.g. `SORT_KEY = "created_at"`), and a userinfo template whose parts are
+     entirely `{placeholder}` interpolation. These are reported to the operator
+     but no longer refuse egress.
+
+   So a bundle carrying advisory findings will **not** report `clean` yet will
+   still egress. That is deliberate: a rule that cannot identify a credential
+   value must not gate irreversible publication. Read the advisory list anyway —
+   it names the path, location, and category (never a value), and it is where a
+   credential in an unrecognized format would show up. If an advisory finding
+   looks like a real credential, treat it as an incident and go back to step 1
+   rather than releasing.
 3. **Revocation holds:** attempt authentication with a revoked token from the
    operator's own terminal and confirm it fails.
 4. **Going forward:** the fail-closed scan (upload preflight in
-   `daydream/archive/hub.py`, the `--dump-artifacts` copy gate, and the
-   sanitizer release gate) blocks any bundle that is not provably clean from
-   every egress path. Future incidents should be caught at that gate, before
-   upload.
+   `daydream/archive/hub.py`, the `--dump-artifacts` copy gate, the sanitizer
+   release and metadata-import gates, and clean-room verification) blocks any
+   bundle carrying a blocking finding from every egress path, and reports the
+   advisory tier without blocking. Future incidents in a recognized credential
+   format should be caught at that gate, before upload.
 
 ## 7. How the harvest clone step authenticates
 

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -9,7 +9,6 @@ import subprocess
 from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
-from types import SimpleNamespace
 from typing import Any, cast
 
 import pytest
@@ -5204,9 +5203,22 @@ def test_strict_archive_dump_scan_refusal_leaves_late_stage_empty(
     )
     dump_stage = tmp_path / "late"
     dump_stage.mkdir()
+    from daydream.archive.scan import SEVERITY_BLOCKING, Finding, ScanResult
+
     monkeypatch.setattr(
         "daydream.archive.scan.scan_run_dir",
-        lambda _path: SimpleNamespace(clean=False),
+        lambda _path: ScanResult(
+            clean=False,
+            findings=[
+                Finding(
+                    path="trajectory.json",
+                    location="steps.[0].observation (json)",
+                    category="api_key",
+                    digest="0123456789ab",
+                    severity=SEVERITY_BLOCKING,
+                )
+            ],
+        ),
     )
 
     with pytest.raises(ArchiveFinalizationError, match="secret scan"):

--- a/tests/test_archive_data_capture.py
+++ b/tests/test_archive_data_capture.py
@@ -607,6 +607,233 @@ async def test_no_dump_artifacts_leaves_no_extra_copy(
     assert not dump_dir.exists()
 
 
+# --- #1170: the dump secret-scan gate is tiered (advisory reports, blocking refuses) ---
+
+
+def _commit_scanned_file(target: Path, name: str, body: str) -> None:
+    """Commit *body* on the feature branch so it lands verbatim in ``diff.patch``.
+
+    ``_copy_run_artifacts`` carries ``diff.patch`` into the bundle with no
+    redaction, so a committed file is the real route by which arbitrary source
+    text reaches the egress scanner (#1170).
+    """
+    (target / name).write_text(body, encoding="utf-8")
+    git(target, "add", name)
+    git(target, "commit", "-m", f"add {name}")
+
+
+async def test_dump_artifacts_publishes_bundle_with_advisory_scan_findings(
+    multi_stack_target: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    archive_dir: Path,
+    tmp_path: Path,
+    capfd: pytest.CaptureFixture[str],
+) -> None:
+    """#1170: name-shape scan hits report and publish; they never refuse the run.
+
+    A settings module holding a dict-key constant and an f-string DSN template
+    carries no credential, but trips ``_ENV_VAR_PATTERN`` and the userinfo rules.
+    Before the tiering that refused the whole run after every LLM call had been
+    paid for. Now the operator gets a value-free advisory and the complete
+    bundle: review published, archive installed, dump copied, exit 0 (#981's
+    "preserving the local run").
+    """
+    from daydream.archive.index import query_runs
+
+    _install_deep_capture_backend(multi_stack_target, monkeypatch)
+    _commit_scanned_file(
+        multi_stack_target,
+        "settings.py",
+        'FEATURE_FLAG_OVERRIDE_KEY = "override_flag"\n'
+        'DSN = f"postgresql://{cfg.DB_USER}:{cfg.DB_PASSWORD}@{cfg.DB_HOST}:{cfg.DB_PORT}/{cfg.DB_NAME}"\n',
+    )
+
+    dump_dir = tmp_path / "uploaded-artifacts"
+
+    exit_code = await run(
+        RunConfig(
+            target=str(multi_stack_target),
+            assume="yes",
+            output_mode="loop",
+            cleanup=False,
+            dump_artifacts=str(dump_dir),
+        )
+    )
+    assert exit_code == 0
+
+    # Everything publishes: the dump, the archive index row, and the report.
+    run_dir = _only_archived_run(archive_dir)
+    assert (dump_dir / "manifest.json").is_file()
+    assert query_runs(archive_dir)
+    assert (multi_stack_target / ".review-output.md").is_file()
+
+    # The advisory is reported and value-free (M11): path and category only.
+    out = "".join(capfd.readouterr())
+    assert "diff.patch" in out
+    assert "env_var" in out
+    assert "override_flag" not in out
+    assert "DB_PASSWORD" not in out
+
+    # An advisory bundle is still dumped byte-for-byte — never redact-then-dump.
+    dumped = (dump_dir / "diff.patch").read_bytes()
+    assert dumped == (run_dir / "diff.patch").read_bytes()
+    assert b"FEATURE_FLAG_OVERRIDE_KEY" in dumped
+
+
+async def _assert_target_is_reusable(target: Path) -> None:
+    """A blocking dump refusal must not wedge the checkout for the next run.
+
+    Without a rollback that can restore an absent dump destination, the refusal
+    left a ``DETACHED`` transaction behind and every later run at this path —
+    with or without ``--dump-artifacts`` — exited 1 during session open before
+    any review work started (#1172). ``exit_code == 1`` and a missing dump
+    directory hold either way, so this is what makes the refusal tests real
+    guards rather than assertions that pass through the wedge.
+    """
+    exit_code = await run(
+        RunConfig(target=str(target), assume="yes", output_mode="loop", cleanup=False)
+    )
+    assert exit_code == 0
+
+
+async def test_dump_artifacts_refuses_token_canary_in_diff(
+    multi_stack_target: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    archive_dir: Path,
+    tmp_path: Path,
+    capfd: pytest.CaptureFixture[str],
+) -> None:
+    """#1170: a real token prefix in the diff still refuses every egress path.
+
+    The blocking tier keeps PR #1161's disposition exactly: no dump, no archive
+    row, exit 1 — and the console now names the file and rule that refused,
+    without echoing the credential.
+    """
+    from daydream.archive.index import query_runs
+
+    canary = "ghp_canaryfake123"
+    _install_deep_capture_backend(multi_stack_target, monkeypatch)
+    _commit_scanned_file(multi_stack_target, "creds.py", f'GITHUB_TOKEN = "{canary}"\n')
+
+    dump_dir = tmp_path / "uploaded-artifacts"
+
+    exit_code = await run(
+        RunConfig(
+            target=str(multi_stack_target),
+            assume="yes",
+            output_mode="loop",
+            cleanup=False,
+            dump_artifacts=str(dump_dir),
+        )
+    )
+    assert exit_code == 1
+    assert not dump_dir.exists()
+    assert query_runs(archive_dir) == []
+
+    out = "".join(capfd.readouterr())
+    assert canary not in out
+    assert "diff.patch" in out
+    assert "api_key" in out
+    # #1171: the scan refusal is the message, not the rollback's own failure.
+    assert "dump destination projection is malformed" not in out
+
+    await _assert_target_is_reusable(multi_stack_target)
+
+
+async def test_dump_artifacts_refuses_multiline_pem_in_diff(
+    multi_stack_target: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    archive_dir: Path,
+    tmp_path: Path,
+    capfd: pytest.CaptureFixture[str],
+) -> None:
+    """#1170 D4: multi-line key armor in ``diff.patch`` blocks the dump.
+
+    ``diff.patch`` is scanned line by line, and ``_PEM_KEY_PATTERN`` spans
+    BEGIN..END, so real key material in a patch was invisible to the gate while
+    the same key inside a JSON string leaf was caught. Separate from the token
+    canary on purpose: a bundle carrying both blocks on the canary alone, so a
+    combined test passes with the multi-line pass unimplemented.
+    """
+    from daydream.archive.index import query_runs
+
+    canary = "MIIFAKEKEYMATERIALFORTESTSONLY"
+    _install_deep_capture_backend(multi_stack_target, monkeypatch)
+    _commit_scanned_file(
+        multi_stack_target,
+        "deploy_key.pem",
+        "-----BEGIN PRIVATE KEY-----\n" f"{canary}\n{canary}\n" "-----END PRIVATE KEY-----\n",
+    )
+
+    dump_dir = tmp_path / "uploaded-artifacts"
+
+    exit_code = await run(
+        RunConfig(
+            target=str(multi_stack_target),
+            assume="yes",
+            output_mode="loop",
+            cleanup=False,
+            dump_artifacts=str(dump_dir),
+        )
+    )
+    assert exit_code == 1
+    assert not dump_dir.exists()
+    assert query_runs(archive_dir) == []
+
+    out = "".join(capfd.readouterr())
+    assert canary not in out
+    assert "diff.patch" in out
+    assert "pem_key" in out
+    assert "dump destination projection is malformed" not in out
+
+    await _assert_target_is_reusable(multi_stack_target)
+
+
+async def test_dump_refusal_reports_the_archive_error_when_the_rollback_also_fails(
+    multi_stack_target: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capfd: pytest.CaptureFixture[str],
+) -> None:
+    """#1171: a failing rollback must not be the only thing the operator sees.
+
+    The pending ``ArchiveFinalizationError`` reaches the re-raised storage error
+    only through ``add_note``, which carries its type name and which nothing
+    renders — so the gate that refused and the file that tripped it were
+    invisible whenever the rollback itself failed. With an absent dump
+    destination now restorable this branch is no longer on the ordinary refusal
+    path, so the rollback is forced to fail to keep the report proven.
+    """
+    from daydream import artifact_visibility
+
+    canary = "ghp_canaryfake123"
+    _install_deep_capture_backend(multi_stack_target, monkeypatch)
+    _commit_scanned_file(multi_stack_target, "creds.py", f'GITHUB_TOKEN = "{canary}"\n')
+
+    def refuse_restore(_session: object) -> None:
+        raise artifact_visibility.ArtifactVisibilityError("synthetic rollback failure")
+
+    monkeypatch.setattr(artifact_visibility.ArtifactSession, "_restore_prior", refuse_restore)
+
+    exit_code = await run(
+        RunConfig(
+            target=str(multi_stack_target),
+            assume="yes",
+            output_mode="loop",
+            cleanup=False,
+            dump_artifacts=str(tmp_path / "uploaded-artifacts"),
+        )
+    )
+    assert exit_code == 1
+
+    out = "".join(capfd.readouterr())
+    assert "Artifact Finalization" in out
+    assert "api_key" in out
+    assert "diff.patch" in out
+    assert "synthetic rollback failure" in out
+    assert canary not in out
+
+
 async def test_no_eval_leaves_manifest_eval_fields_null(
     multi_stack_target: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_archive_hydrate.py
+++ b/tests/test_archive_hydrate.py
@@ -1107,6 +1107,121 @@ class TestFinalizeAndVerify:
         assert not any(p.endswith("_SUCCESS") for p in hub.uploaded_paths)
 
 
+def _publish_verifiable_curation(
+    tmp_path: Path, batch_files: dict[str, str]
+) -> tuple[FakeHub, Path, str, str]:
+    """Hand-build one self-consistent published curation for verify_publication.
+
+    Every digest the verify cycle checks (SHA256SUMS over the published bytes,
+    the batch ``content_digest``) is computed from the same local tree, so the
+    only thing the scan gate can trip on is *batch_files*' content. Building
+    the published state directly is what makes the gate reachable at all: the
+    real pipeline sanitizes every bundle before publication, so neither an
+    advisory nor a credential-bearing batch can be driven into
+    :func:`verify_publication` through ``run_hydrate_hub``.
+
+    Returns ``(hub, stage, curation_id, output_commit_sha)``.
+    """
+    from daydream.archive import sanitize
+
+    curation_id = "cur-" + "0" * 16
+    prefix = f"curated/{curation_id}/"
+    local = tmp_path / "published"
+    batch_dir = local / "batches" / "sess-a"
+    batch_dir.mkdir(parents=True)
+    for name, content in batch_files.items():
+        (batch_dir / name).write_text(content, encoding="utf-8")
+    doc = {
+        "schema_version": hydrate_rules.HYDRATION_INDEX_SCHEMA_VERSION,
+        "source_hub_commit": "a" * 40,
+        "curation_id": curation_id,
+        "sanitizer_version": hydrate_rules.SANITIZER_VERSION,
+        "hydration_index_schema_version": hydrate_rules.HYDRATION_INDEX_SCHEMA_VERSION,
+        "admission_policy_version": hydrate_rules.ADMISSION_POLICY_VERSION,
+        "publication_prefix": prefix,
+        "batches": [
+            {
+                "session_id": "sess-a",
+                "content_digest": sanitize._derivative_digest(batch_dir),
+                "status": "admitted",
+                "reason_code": None,
+                "artifact_relpath": "batches/sess-a",
+                "manifest_relpath": "batches/sess-a/manifest.json",
+            }
+        ],
+    }
+    (local / "curation-manifest.json").write_text(json.dumps(doc, indent=2) + "\n")
+    relpaths = sorted(
+        p.relative_to(local).as_posix() for p in local.rglob("*") if p.is_file()
+    )
+    files = {f"{prefix}{rel}": (local / rel).read_bytes() for rel in relpaths}
+    files[f"{prefix}SHA256SUMS"] = "".join(
+        f"{hashlib.sha256((local / rel).read_bytes()).hexdigest()}  {prefix}{rel}\n"
+        for rel in relpaths
+    ).encode()
+    hub = FakeHub(repo_id="org/private-ds", private=True, files=files)
+    hub.commit_revision("b" * 40)
+    return hub, tmp_path / "stage", curation_id, "b" * 40
+
+
+_BATCH_MANIFEST = json.dumps(
+    {"session_id": "sess-a", "git": {"remote_url": "https://github.com/owner/repo-a"}}
+)
+
+
+def test_verify_publication_admits_advisory_only_batch(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Issue #1170: an advisory-only published batch verifies instead of failing.
+
+    ``diff.patch`` carries the issue's ``env_var`` false positive — an
+    upper-case name ending in ``KEY`` assigned an ordinary flag string. A rule
+    that cannot identify a secret must not fail an already-published commit, so
+    the batch verifies and the finding is reported value-free.
+    """
+    hub, stage, curation_id, output_sha = _publish_verifiable_curation(
+        tmp_path,
+        {
+            "manifest.json": _BATCH_MANIFEST,
+            "diff.patch": '+FEATURE_FLAG_OVERRIDE_KEY = "override_flag"\n',
+        },
+    )
+    verified = hydrate.verify_publication(
+        hub, stage, output_commit_sha=output_sha, curation_id=curation_id,
+        dry_run_admitted=1, source_commit="a" * 40,
+    )
+    assert verified == 1
+    from daydream.archive.scan import scan_run_dir
+
+    rescan = scan_run_dir(stage / "_verify" / "batches" / "sess-a")
+    assert rescan.clean is False and rescan.blocking is False  # advisory-only
+    captured = capsys.readouterr()
+    out = captured.out + captured.err
+    assert "advisory" in out
+    assert "diff.patch" in out
+    assert "override_flag" not in out  # M11: never a matched value
+
+
+def test_verify_publication_rejects_credential_bearing_batch(tmp_path: Path) -> None:
+    """A literal credential in a published batch still fails the clean-room scan."""
+    hub, stage, curation_id, output_sha = _publish_verifiable_curation(
+        tmp_path,
+        {
+            "manifest.json": _BATCH_MANIFEST,
+            "diff.patch": "+clone from https://user:s3cr3tcanary@github.com/x/y.git\n",
+        },
+    )
+    with pytest.raises(hydrate.VerificationError) as excinfo:
+        hydrate.verify_publication(
+            hub, stage, output_commit_sha=output_sha, curation_id=curation_id,
+            dry_run_admitted=1, source_commit="a" * 40,
+        )
+    message = str(excinfo.value)
+    assert "secrets scan" in message
+    assert "url_credential" in message  # value-free category, not the match
+    assert "s3cr3tcanary" not in message
+
+
 class TestPrefixBindingGate:
     """Issue #1094 task 7: a curated prefix records its policy binding at
     finalize; any republication whose binding differs fails closed before a

--- a/tests/test_archive_importer.py
+++ b/tests/test_archive_importer.py
@@ -1155,6 +1155,27 @@ def test_dirty_metadata_blocks_publish(tmp_path: Path) -> None:
     assert result["blocked_reasons"] == [REASON_CODE_IMPORT_UNREDACTABLE_METADATA]
 
 
+def test_advisory_metadata_does_not_block_publish(tmp_path: Path) -> None:
+    """Issue #1170: an advisory-only finding reports but never blocks the payload.
+
+    ``payload.json`` is built from free-text ``rubric_json``/``reward_json``/
+    ``notes``, which is exactly the content that carries the ``env_var`` name
+    shape — an upper-case name ending in ``KEY`` assigned an ordinary flag
+    string. The value-free summary is still returned, so the finding is visible
+    rather than silent.
+    """
+    row = _metadata_row(notes='FEATURE_FLAG_OVERRIDE_KEY = "override_flag"')
+    result = redact_imported_metadata([row], scan_dir=tmp_path / "scan")
+    scanned = scan_run_dir(tmp_path / "scan")
+    assert scanned.clean is False and scanned.blocking is False  # advisory-only
+    assert result["blocked"] is False
+    assert result["blocked_reasons"] == []
+    assert "env_var" in result["scan_summary"]
+    assert "override_flag" not in result["scan_summary"]  # M11: never a value
+    # The row is published as-is: an advisory shape is not credential material.
+    assert result["payload"][0]["notes"] == 'FEATURE_FLAG_OVERRIDE_KEY = "override_flag"'
+
+
 def test_blocked_payload_carries_marker_skipping(tmp_path: Path) -> None:
     # Already-redacted markers are safe output, not secrets: a payload whose
     # only "suspicious" text is our own marker scans clean.

--- a/tests/test_archive_sanitize.py
+++ b/tests/test_archive_sanitize.py
@@ -1,5 +1,6 @@
 """Legacy bronze bundle sanitizer (issue #981 M14/M15/M19)."""
 import json
+import re
 from pathlib import Path
 
 import pytest
@@ -120,6 +121,90 @@ def test_derivative_stays_quarantined_until_scan_passes(
     assert result.released is False  # M16
     assert (archive_dir / "quarantine" / "s1").is_dir()
     assert not (archive_dir / "sanitized" / "s1" / "manifest.json").exists()
+
+
+def test_advisory_only_derivative_is_released(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Issue #1170: an advisory-only release scan releases instead of quarantining.
+
+    The rule *table* is the seam, not ``scan_run_dir``: the real scanner walks
+    the real derivative, mints real ``Finding`` objects and resolves severity
+    through the real ``ScanResult.blocking`` property — only the rule that fires
+    is swapped for an advisory one. A rule table is needed because the
+    sanitizer's own transform now scrubs every shape the tiering can demote
+    (``env_var`` is redacted, the three userinfo shapes are substituted), so a
+    derivative that legitimately carries an advisory-only finding is by
+    construction unreachable through real content.
+    """
+    advisory_rule = (
+        re.compile(r"\bFEATURE_FLAG_OVERRIDE_KEY\b"),
+        "env_var",
+        scan_module.SEVERITY_ADVISORY,
+    )
+    monkeypatch.setattr(scan_module, "_RULES", (advisory_rule,))
+    archive_dir = tmp_path / "archive"
+    run_dir = archive_dir / "runs" / "s1"
+    run_dir.mkdir(parents=True)
+    (run_dir / "manifest.json").write_text(
+        json.dumps({"session_id": "s1", "git": {"remote_url": "https://github.com/o/r"}})
+    )
+    (run_dir / "diff.patch").write_text('+FEATURE_FLAG_OVERRIDE_KEY = "override_flag"\n')
+
+    result = sanitize.sanitize_bundle(run_dir, archive_dir)
+
+    assert result.released is True
+    assert result.status == "sanitized"
+    assert not (archive_dir / "quarantine" / "s1").exists()
+    assert (archive_dir / "sanitized" / "s1" / "manifest.json").is_file()
+    captured = capsys.readouterr()
+    out = captured.out + captured.err
+    assert "advisory" in out
+    assert "diff.patch" in out
+    assert "override_flag" not in out  # M11: never a matched value
+
+
+def test_json_leaf_userinfo_shapes_are_sanitized_not_quarantined(tmp_path: Path) -> None:
+    """Issue #1170 F5: the JSON branch applies the scan-local substitutions.
+
+    A trajectory tool observation is a JSON string leaf, and JSON leaves used to
+    run only through ``_sanitize_json_value`` + ``redact_value`` — neither of
+    which carries the three scanner-local rewrites. A bundle whose
+    ``trajectory.json`` holds a token-only userinfo remote, the issue's f-string
+    DSN template, or a credential-bearing query param was therefore quarantined
+    on every pass, deterministically, because ``_mark_done`` was never reached.
+    """
+    archive_dir = tmp_path / "archive"
+    run_dir = archive_dir / "runs" / "s1"
+    run_dir.mkdir(parents=True)
+    (run_dir / "manifest.json").write_text(
+        json.dumps({"session_id": "s1", "git": {"remote_url": "https://github.com/o/r"}})
+    )
+    dsn = 'return f"postgresql://{cfg.DB_USER}:{cfg.DB_PASSWORD}@{cfg.DB_HOST}:{cfg.DB_PORT}/x"'
+    (run_dir / "trajectory.json").write_text(
+        json.dumps(
+            {
+                "steps": [
+                    {"observation": dsn},
+                    {"observation": "fetch https://example.com/repo?token=abc123"},
+                    {"observation": "clone https://x-access-token@github.com/o/r.git"},
+                ]
+            }
+        )
+    )
+
+    result = sanitize.sanitize_bundle(run_dir, archive_dir)
+
+    assert result.released is True
+    assert not (archive_dir / "quarantine" / "s1").exists()
+    derivative = archive_dir / "sanitized" / "s1"
+    assert scan_module.scan_run_dir(derivative).clean is True  # re-scans clean
+    text = (derivative / "trajectory.json").read_text()
+    assert "x-access-token" not in text  # the blocking shape is gone, not tolerated
+    assert "token=abc123" not in text
+    assert "{cfg.DB_PASSWORD}" not in text
+    # M14: the source bundle is never modified.
+    assert "x-access-token" in (run_dir / "trajectory.json").read_text()
 
 
 def test_corpus_projection_reads_only_sanitized_paths(tmp_path: Path) -> None:

--- a/tests/test_archive_scan.py
+++ b/tests/test_archive_scan.py
@@ -60,3 +60,117 @@ def test_scan_failure_fails_closed(tmp_path: Path, monkeypatch: pytest.MonkeyPat
     monkeypatch.setattr(scan, "_scan_text", lambda _t: (_ for _ in ()).throw(RuntimeError("boom")))
     result = scan.scan_run_dir(run_dir)
     assert not result.clean  # M-constraint: any scanner error blocks egress
+    assert result.blocking  # scan_error is always blocking
+
+
+# --- V3: the tiered rule table (issue #1170) -------------------------------
+#
+# The scanner reuses redaction rules as publication rules. A redactor needs
+# recall; a publication gate needs precision, because over-matching costs the
+# whole run. These two corpora pin the split: ordinary config/template code
+# may report, but must never refuse egress; real credential values must.
+
+# Mirrors #455's exemplar (test_env_var_pattern_does_not_match_substring_lookalikes).
+_FALSE_POSITIVES = (
+    'SORT_KEY = "created_at"',
+    "PRIMARY_KEY = 'id'",
+    "CACHE_KEY = 'v1'",
+    "AUTH=none",
+    "API_TOKEN=${API_TOKEN}",
+    "PARTITION_KEY = event.get('pk')",
+    # The line from the issue's reproduction.
+    'FEATURE_FLAG_OVERRIDE_KEY = "override_flag"',
+    'return f"{cfg.DB_USER}:{cfg.DB_PASSWORD}@{cfg.DB_HOST}:{cfg.DB_PORT}/{cfg.DB_NAME}"',
+    'DSN = f"postgresql://{cfg.DB_USER}:{cfg.DB_PASSWORD}@{cfg.DB_HOST}:{cfg.DB_PORT}/{cfg.DB_NAME}"',
+    # The two https-scheme templates. _URL_CREDENTIAL_PATTERN is a strict
+    # subset of _TOKEN_ONLY_USERINFO_PATTERN, so a guard applied to only some
+    # of the userinfo rules leaves these blocking through the wider rule.
+    'REMOTE = f"https://{cfg.GH_USER}:{cfg.GH_PASSWORD}@github.com/{o}/{r}.git"',
+    'url = "https://{user}:{password}@registry.example.com/simple"',
+)
+
+_TRUE_POSITIVES = (
+    ('token = "ghp_canaryfake123"', "api_key"),
+    ('aws_key = "AKIAIOSFODNN7EXAMPLE"', "api_key"),
+    ('openai = "sk-abcdef1234567890"', "api_key"),
+    (
+        'jwt = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIn0.dBjftJeZ4CVPmB92K27uhbUJU1p1r_wW1gFWFOEjXk"',
+        "jwt",
+    ),
+    (
+        "-----BEGIN RSA PRIVATE KEY-----\n"
+        "MIIBOgIBAAJBAKj34GkxFhD90vcNLYLInFEX6Ppy1tPf9Cnzk4OcQ+wgUjOtOOg=\n"
+        "-----END RSA PRIVATE KEY-----",
+        "pem_key",
+    ),
+    ('url = "https://api.example.com/v1/x?token=s3cr3tvalue"', "query_credential"),
+    # Only _TOKEN_ONLY_USERINFO_PATTERN matches the single-token form, which is
+    # why that rule is guarded rather than dropped.
+    ('remote = "https://x-access-token@github.com/o/r"', "url_credential"),
+    # SCP-only literals: the discrimination the subset shadowing would destroy.
+    ("deploy:s3cr3tvalue@host.example.com:/srv/app", "url_credential"),
+    ("postgresql://real:s3cr3tvalue@db.example.com:5432/app", "url_credential"),
+)
+
+
+@pytest.mark.parametrize("text", _FALSE_POSITIVES)
+def test_ordinary_code_never_blocks_egress(text: str) -> None:
+    """Config-code and DSN-template shapes are advisory-or-clean, never blocking."""
+    findings = scan._scan_file("sample.py", text)
+    blocking = [f for f in findings if f.severity == scan.SEVERITY_BLOCKING]
+    assert blocking == [], [(f.category, f.location) for f in blocking]
+
+
+@pytest.mark.parametrize(("text", "category"), _TRUE_POSITIVES)
+def test_real_credential_shapes_block_egress(text: str, category: str) -> None:
+    findings = scan._scan_file("sample.txt", text)
+    blocking = {f.category for f in findings if f.severity == scan.SEVERITY_BLOCKING}
+    assert category in blocking, [(f.category, f.severity) for f in findings]
+
+
+def test_overlapping_userinfo_rules_dedupe_to_strictest_severity() -> None:
+    """Rules 1 and 2 both fire on ``scheme://user:pass@`` with the same match.
+
+    Without dedupe the finding is double-counted in ``summary()``; without the
+    blocking-wins tie-break its severity would depend on rule iteration order.
+    """
+    literal = scan._scan_file("f.txt", "https://user:s3cr3tvalue@example.com/x")
+    assert len(literal) == 1
+    assert literal[0].category == "url_credential"
+    assert literal[0].severity == scan.SEVERITY_BLOCKING
+
+    templated = scan._scan_file("f.txt", 'u = "https://{user}:{password}@example.com/x"')
+    assert len(templated) == 1
+    assert templated[0].severity == scan.SEVERITY_ADVISORY
+
+
+def test_dirty_result_without_findings_is_blocking() -> None:
+    """Fail-closed tie-break: ``clean=False`` blocks even with no findings."""
+    assert scan.ScanResult(clean=False).blocking
+    assert not scan.ScanResult().blocking
+
+
+# --- V4: multi-line PEM armor in a non-JSON file (issue #1170 D4) ----------
+
+
+def test_multiline_pem_in_patch_file_blocks(tmp_path: Path) -> None:
+    """``_PEM_KEY_PATTERN`` is DOTALL but the non-JSON pass is line-by-line, so
+    real key armor in ``diff.patch`` was invisible while the same key inside a
+    JSON string leaf was caught."""
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    (run_dir / "diff.patch").write_text(
+        "--- a/id_rsa\n"
+        "+++ b/id_rsa\n"
+        "@@ -0,0 +1,3 @@\n"
+        "+-----BEGIN RSA PRIVATE KEY-----\n"
+        "+MIIBOgIBAAJBAKj34GkxFhD90vcNLYLInFEX6Ppy1tPf9Cnzk4OcQ+wgUjOtOOg=\n"
+        "+-----END RSA PRIVATE KEY-----\n"
+    )
+    result = scan.scan_run_dir(run_dir)
+    assert result.blocking
+    pem = [f for f in result.findings if f.category == "pem_key"]
+    assert [(f.path, f.location, f.severity) for f in pem] == [
+        ("diff.patch", "line 4", scan.SEVERITY_BLOCKING)
+    ]
+    assert "MIIBOgIBAAJBAKj34" not in result.summary()  # M11: value-free

--- a/tests/test_artifact_visibility.py
+++ b/tests/test_artifact_visibility.py
@@ -2289,6 +2289,213 @@ async def test_public_subtree_trajectory_uses_whole_daydream_transaction(
         assert (reopened.daydream_dir / custom_relative.parent / "unrelated.bin").read_bytes() == b"unrelated"
 
 
+def _restore_stage_leaks(source: Path) -> list[str]:
+    """Leftover ``.<source>.daydream-restore-*`` stage names beside ``source``."""
+    prefix = f".{source.name}.daydream-restore-"
+    return sorted(child.name for child in source.parent.iterdir() if child.name.startswith(prefix))
+
+
+def _open_rolled_back_dump(session: Any, session_id: str, dump: Path) -> Path:
+    """Register an absent dump destination on ``session`` and roll the run back.
+
+    Mirrors what a ``--dump-artifacts`` run does when strict archive
+    finalization refuses: the finalization-merge stage is created and left
+    empty, because ``finalize_archive_run`` raises before it copies anything
+    into it, and the disposition becomes ``ROLLBACK``.
+    """
+    session.register_destination(session.layout.source / ".daydream", label=OutputLabel.PUBLIC_DAYDREAM)
+    session.register_destination(
+        session.layout.source / ".review-output.md", label=OutputLabel.PUBLIC_REVIEW_OUTPUT
+    )
+    route = session.register_destination(dump, label=OutputLabel.DUMP_DIRECTORY)
+    frozen = _freeze_run(session, session_id)
+    late = cast(Path, session.finalization_merge_path(route, snapshot=frozen))
+    assert late.is_dir()
+    assert not any(late.iterdir())
+    _publish(session, frozen, artifact_visibility.ArtifactDisposition.ROLLBACK)
+    return late
+
+
+async def test_rollback_of_an_absent_dump_destination_reopens_the_workspace(source: Path) -> None:
+    """#1171/#1172: an empty directory baseline is a restore target, not a fault.
+
+    A ``--dump-artifacts`` directory that did not exist before the run records
+    an empty baseline, so "restore to nothing" is the correct rollback target.
+    Raising "dump destination projection is malformed" instead aborted
+    ``_restore_prior`` before it retired anything, leaving a ``DETACHED``
+    journal that every later session open replayed into the identical failure,
+    plus a leaked restore stage that made the third open fail even earlier with
+    "artifact source-stage collision".
+    """
+    baseline = _seed_public_artifacts(source)
+    owner = _owner(source)
+    transactions = owner.artifact_state_root / "transactions"
+    dump = source.parent / "never-existed" / "out"
+
+    async with open_artifact_session(_work(source), session_id="rollback-dump", owner=owner) as session:
+        late = _open_rolled_back_dump(session, "rollback-dump", dump)
+
+    assert not dump.exists()
+    assert not dump.parent.exists()
+    assert _manifest(source) == baseline
+    assert not any(transactions.iterdir())
+    assert not late.exists()
+    assert not late.parent.exists()
+    assert _restore_stage_leaks(source) == []
+
+    # Two further opens: the first proves the replay is gone, the second that
+    # no restore stage was left to collide with.
+    for session_id in ("after-rollback-one", "after-rollback-two"):
+        async with open_artifact_session(_work(source), session_id=session_id, owner=owner) as reopened:
+            assert (reopened.daydream_dir / "deep" / "prior.md").read_bytes() == b"prior reasoning\n"
+        assert _manifest(source) == baseline
+        assert not any(transactions.iterdir())
+        assert _restore_stage_leaks(source) == []
+
+
+async def test_publishing_an_unused_dump_destination_leaves_it_absent(source: Path) -> None:
+    """The publish direction of the same projection: nothing written, nothing created.
+
+    ``_merge_directory_from_tree`` is reached twice — once with the baseline as
+    the projection (rollback) and once with the published manifest (install).
+    A registered dump route whose finalization stage was never taken publishes
+    an empty manifest, which used to abort the whole publication with
+    "dump destination projection is malformed".
+    """
+    _seed_public_artifacts(source)
+    owner = _owner(source)
+    dump = source.parent / "never-existed" / "out"
+
+    async with open_artifact_session(_work(source), session_id="unused-dump", owner=owner) as session:
+        session.register_destination(source / ".daydream", label=OutputLabel.PUBLIC_DAYDREAM)
+        session.register_destination(source / ".review-output.md", label=OutputLabel.PUBLIC_REVIEW_OUTPUT)
+        session.register_destination(dump, label=OutputLabel.DUMP_DIRECTORY)
+        _publish(session, _freeze_run(session, "unused-dump"))
+
+    assert not dump.exists()
+    assert not dump.parent.exists()
+    assert (source / ".daydream" / "runs" / "unused-dump" / "trajectory.json").is_file()
+    assert (source / ".daydream" / "deep" / "prior.md").read_bytes() == b"prior reasoning\n"
+    assert not any((owner.artifact_state_root / "transactions").iterdir())
+
+
+async def test_session_open_heals_a_pre_fix_wedged_dump_transaction(
+    source: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#1172: a workspace already wedged by the old behaviour heals on next open.
+
+    The wedge is built with the pre-fix code paths restored — the directory
+    merge raising on an empty projection, and a failed restore that neither
+    preserved the transaction nor reclaimed its stage — so the on-disk state is
+    the one operators are stuck with today: a ``DETACHED`` journal plus a
+    leaked ``.<source>.daydream-restore-*`` stage. Nothing about the wedge is
+    repaired by hand; the next real session open has to do it.
+    """
+    baseline = _seed_public_artifacts(source)
+    owner = _owner(source)
+    transactions = owner.artifact_state_root / "transactions"
+    dump = source.parent / "never-existed" / "out"
+    merge = artifact_visibility._merge_directory_from_tree
+
+    def pre_fix_merge(tree: Path, record: Any, *, desired: Any, **kwargs: Any) -> None:
+        if not desired:
+            raise ArtifactVisibilityError("dump destination projection is malformed")
+        merge(tree, record, desired=desired, **kwargs)
+
+    with monkeypatch.context() as patched:
+        patched.setattr(artifact_visibility, "_merge_directory_from_tree", pre_fix_merge)
+        patched.setattr(
+            artifact_visibility, "_clear_failed_restore", lambda _root, _source, _txn, error: error
+        )
+        patched.setattr(artifact_visibility, "_reset_source_stage", lambda *_args, **_kwargs: None)
+
+        with pytest.raises(ArtifactVisibilityError, match="projection is malformed"):
+            async with open_artifact_session(_work(source), session_id="wedge", owner=owner) as session:
+                _open_rolled_back_dump(session, "wedge", dump)
+
+        wedged = [child.name for child in transactions.iterdir()]
+        assert len(wedged) == 1
+        assert _load_json(transactions / wedged[0] / "journal.json")["state"] == "DETACHED"
+
+        # The second open replays the journal, fails identically, and leaks the
+        # restore stage that makes every later open collide instead.
+        with pytest.raises(ArtifactVisibilityError, match="projection is malformed"):
+            async with open_artifact_session(_work(source), session_id="wedged-open", owner=owner):
+                pass
+        assert _restore_stage_leaks(source) == [f".{source.name}.daydream-restore-{wedged[0]}"]
+
+    async with open_artifact_session(_work(source), session_id="healed", owner=owner) as healed:
+        assert (healed.daydream_dir / "deep" / "prior.md").read_bytes() == b"prior reasoning\n"
+
+    assert _manifest(source) == baseline
+    assert not any(transactions.iterdir())
+    assert _restore_stage_leaks(source) == []
+    assert not dump.exists()
+    assert not (owner.artifact_state_root / "unreconciled").exists()
+
+
+async def test_failed_destination_restore_preserves_the_transaction_and_reopens(
+    source: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#1172: a restore that cannot finish is preserved, never replayed forever.
+
+    Recovery reruns the same records through the same code, so a destination
+    restore that fails once fails identically at every later open. The
+    transaction's baselines are the only surviving copy of an in-source
+    destination's prior bytes, so the transaction is moved under
+    ``unreconciled/`` rather than retired — the operator keeps every byte, the
+    error names where they are, and a fresh session still starts.
+    """
+    baseline = _seed_public_artifacts(source)
+    owner = _owner(source)
+    state_root = owner.artifact_state_root
+    transactions = state_root / "transactions"
+    findings = tmp_path / "external" / "findings.json"
+    findings.parent.mkdir()
+    findings.write_bytes(b"prior findings")
+
+    def refuse(*_args: Any, **_kwargs: Any) -> None:
+        raise ArtifactVisibilityError("synthetic destination restore failure")
+
+    with monkeypatch.context() as patched:
+        patched.setattr(artifact_visibility, "_restore_destination_records", refuse)
+        with pytest.raises(ArtifactVisibilityError, match="synthetic destination restore failure") as caught:
+            async with open_artifact_session(_work(source), session_id="unrestorable", owner=owner) as session:
+                session.register_destination(source / ".daydream", label=OutputLabel.PUBLIC_DAYDREAM)
+                session.register_destination(
+                    source / ".review-output.md", label=OutputLabel.PUBLIC_REVIEW_OUTPUT
+                )
+                session.register_destination(findings, label=OutputLabel.FINDINGS_OUTPUT)
+                frozen = _freeze_run(session, "unrestorable")
+                _publish(session, frozen, artifact_visibility.ArtifactDisposition.ROLLBACK)
+
+    # The operator is told which transaction failed, in which workspace, and
+    # where its baselines were kept.
+    preserved = state_root / "unreconciled"
+    message = str(caught.value)
+    retained = [child.name for child in preserved.iterdir()]
+    assert len(retained) == 1
+    assert retained[0] in message
+    assert str(state_root) in message
+    assert str(preserved / retained[0]) in message
+
+    # Nothing was discarded: the public tree is back and the baseline copy of
+    # the explicit destination survives under the preserved transaction.
+    assert _manifest(source) == baseline
+    assert (preserved / retained[0] / "destination-0000-baseline" / "findings.json").read_bytes() == (
+        b"prior findings"
+    )
+    assert not any(transactions.iterdir())
+    assert _restore_stage_leaks(source) == []
+
+    async with open_artifact_session(_work(source), session_id="after-unrestorable", owner=owner) as reopened:
+        assert (reopened.daydream_dir / "deep" / "prior.md").read_bytes() == b"prior reasoning\n"
+    assert not any(transactions.iterdir())
+
+
 async def test_public_subtree_trajectory_requires_exact_public_owner(source: Path) -> None:
     requested = source / ".daydream" / "custom.json"
 

--- a/tests/test_hub_upload.py
+++ b/tests/test_hub_upload.py
@@ -279,3 +279,40 @@ def test_upload_proceeds_for_clean_bundle(
     uploads = _install_fake_hfapi(monkeypatch)
     assert hub.upload_run_bundle(hf_run_dir, "org/ds", "s1") is True
     assert len(uploads) == 1
+
+
+def test_upload_proceeds_for_advisory_only_bundle(
+    hf_run_dir: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Issue #1170: an advisory-only finding reports but never gates the Hub.
+
+    The manifest carries the issue's ``env_var`` false positive — an upper-case
+    name ending in ``KEY`` assigned an ordinary flag string. A rule that cannot
+    identify a secret must not refuse irreversible egress, so the upload
+    proceeds and the operator gets the value-free summary instead of silence.
+    """
+    (hf_run_dir / "manifest.json").write_text(
+        json.dumps(
+            {
+                "git": {"remote_url": "https://github.com/o/r"},
+                "notes": 'FEATURE_FLAG_OVERRIDE_KEY = "override_flag"',
+            }
+        ),
+        encoding="utf-8",
+    )
+    from daydream.archive import scan
+
+    result = scan.scan_run_dir(hf_run_dir)
+    assert result.clean is False and result.blocking is False  # advisory-only bundle
+    uploads = _install_fake_hfapi(monkeypatch)
+    assert hub.upload_run_bundle(hf_run_dir, "org/ds", "s1") is True
+    assert len(uploads) == 1
+    captured = capsys.readouterr()
+    out = captured.out + captured.err
+    assert "advisory" in out
+    assert "manifest.json" in out
+    assert "env_var" in out
+    assert "override_flag" not in out  # M11: never a matched value
+    assert "FEATURE_FLAG_OVERRIDE_KEY" not in out

--- a/tests/test_training_harvest.py
+++ b/tests/test_training_harvest.py
@@ -1984,6 +1984,46 @@ def test_hub_import_accepts_clean_bundle_in_place(tmp_path: Path) -> None:
     assert incoming.exists()
 
 
+def test_hub_import_accepts_advisory_only_bundle(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Issue #1170: an advisory-only incoming bundle ingests instead of quarantining.
+
+    The manifest carries the issue's ``env_var`` false positive (an upper-case
+    name ending in ``KEY`` assigned an ordinary flag string). It is a name
+    shape, not a credential, so it is reported value-free and the bundle is
+    imported in place.
+    """
+    from daydream.archive import sanitize, scan
+
+    archive_dir = tmp_path / "archive"
+    incoming = archive_dir / "incoming" / "s3"
+    incoming.mkdir(parents=True)
+    (incoming / "manifest.json").write_text(
+        json.dumps(
+            {
+                "session_id": "s3",
+                "git": {"remote_url": "https://github.com/o/r"},
+                "notes": 'FEATURE_FLAG_OVERRIDE_KEY = "override_flag"',
+            }
+        )
+    )
+    pre = scan.scan_run_dir(incoming)
+    assert pre.clean is False and pre.blocking is False  # advisory-only bundle
+
+    result = sanitize.import_bundle(incoming, archive_dir)
+
+    assert result.imported is True
+    assert result.quarantined is False
+    assert incoming.exists()
+    assert not (archive_dir / "quarantine" / "s3").exists()
+    captured = capsys.readouterr()
+    out = captured.out + captured.err
+    assert "advisory" in out
+    assert "env_var" in out
+    assert "override_flag" not in out  # M11: never a matched value
+
+
 def test_per_finding_resolution_round_trips_through_canonical_dict() -> None:
     from daydream.training.labeler_signals import (
         PerFindingResolution,

--- a/tests/test_workflow_templates.py
+++ b/tests/test_workflow_templates.py
@@ -20,6 +20,9 @@ cannot verify and that a careless edit could silently break:
 - Every App-token action in the live and packaged posting workflows stays pinned to the approved v3.2.0 commit.
 - The privilege split holds: the job that checks out untrusted PR code never
   holds the App key, and the privileged jobs never check out PR code.
+- The ``daydream-findings`` upload stays ``if: always()`` and stays after the
+  step that writes ``findings.json``, so a late-stage failure (a refused egress
+  scan, say) cannot discard findings the run already produced.
 - The repo's own Codex dogfood workflow persists ``codex login`` before the
   review runs (``codex exec`` does not read ``OPENAI_API_KEY`` for auth), and
   the repository workflow README names ``OPENAI_API_KEY`` as the credential the
@@ -312,6 +315,44 @@ def test_review_workflow_persists_failure_context(wf_path: Path) -> None:
     assert upload["uses"].startswith("actions/upload-artifact@")
     assert upload["with"]["name"] == "daydream-findings-failure"
     assert upload["with"]["path"] == "findings/failure.json"
+
+
+@pytest.mark.parametrize(
+    "wf_path",
+    [
+        TEMPLATES_DIR / "daydream-review.yml",
+        REPO_WORKFLOWS_DIR / "daydream-review.yml",
+        TEMPLATES_DIR / "single" / "daydream.yml",
+    ],
+    ids=["template", "live", "single"],
+)
+def test_findings_upload_survives_late_stage_failure(wf_path: Path) -> None:
+    """``findings.json`` written before a late-stage failure must still upload.
+
+    The review step writes ``findings/findings.json`` and only then reaches the
+    egress/archive tail, which can refuse (e.g. a blocking secret scan) and fail
+    the job. Under GitHub's implicit ``success()`` gate the already-written
+    findings would be discarded exactly when the operator needs them, so the
+    ``daydream-findings`` upload carries ``if: always()`` in every copy. This is
+    the passive-artifact upload, distinct from the ``failure()``-gated
+    ``daydream-findings-failure`` step.
+    """
+    wf = load_workflow(wf_path)
+    steps = job_steps(wf, "analyze")
+
+    upload = next(step for step in steps if step.get("name") == "Upload findings artifact")
+    assert upload.get("if", "") == "always()", (
+        f"{wf_path.name}: the findings upload must be if: always() so a late-stage "
+        "failure does not discard an already-written findings.json"
+    )
+    assert upload["uses"].startswith("actions/upload-artifact@")
+    assert upload["with"]["name"] == "daydream-findings"
+    assert upload["with"]["path"] == "findings/"
+
+    # The findings upload must come after the review step that writes the file,
+    # or always() would upload an empty directory on every run.
+    review = next(step for step in steps if "--findings-out" in step.get("run", ""))
+    assert steps.index(review) < steps.index(upload)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Closes #1170, #1171, #1172.

`daydream --dump-artifacts` exited 1 on ordinary config code after the review had
completed, published nothing, told the operator the wrong thing, and then left the
workspace unable to start another run. Four independent defects composed into that
one symptom.

## 1. The gate reused redaction rules as publication rules

`_RULES` imported five patterns from `trajectory.py`, where they exist for
**redaction**. A redactor needs recall — over-matching `SORT_KEY = "created_at"`
costs a value in a log. A publication gate needs **precision** — over-matching costs
the whole run. Two rules had no value constraint at all.

Now two tiers: `_BLOCKING_RULES` (API-key prefixes, PEM key material, JWT, literal
userinfo, credential query params) refuse publication; `_ADVISORY_RULES`
(`_ENV_VAR_PATTERN`) report without blocking.

The placeholder guard covers **all three** userinfo rules, not the two the issue
names. `_URL_CREDENTIAL_PATTERN` is a strict subset of
`_TOKEN_ONLY_USERINFO_PATTERN`, so guarding only the narrower rules is inert on any
`https://`-scheme template — a git-remote or PyPI-index helper. The issue's two
quoted forms are `postgresql://` and scheme-less, which is why the naive guard looks
sufficient against the issue text alone.

## 2. The disposition contradicted the requirement it was built for

#981 required refusal "while preserving the local run". #988 implemented exactly
that — warn, name the paths, skip the copy, keep the run. #1161 replaced it with a
raise and stated no rationale in its body or commit message; #1163 then compressed
`scan_result` to a discarded temporary, which is why the operator got a fixed string.

Blocking findings keep #1161's behavior **exactly** — dump withheld, archive
refused, nothing published. Advisory findings publish everything and report
value-free (path, location, category, digest; never a matched value, per M11).
Applied uniformly across all six gates, including the Hub preflight, which fires
earlier in the same function on identical bytes.

## 3. A refusal wedged the workspace permanently (#1172)

An absent dump destination records an empty baseline, which
`_merge_directory_from_tree` treated as a malformed projection. That aborted
`_restore_prior` before retirement, so the journal stayed `DETACHED` and every later
run at that checkout exited 1 at session open — with or without `--dump-artifacts`,
before any LLM call. A third run failed earlier still, on a leaked restore stage.

An empty baseline is now a valid rollback target. A partially-failed restore is
**quarantined, not retired**: `_retire_transaction` deletes the transaction tree,
which holds the only surviving copy of an in-source destination's prior bytes, so
retiring an unfinished restore would destroy a user's file. A stale restore stage is
reclaimed only under its own attestation, so a foreign collision still raises.
Already-wedged workspaces heal on next open.

Recovery failure stays **fatal** on purpose. Non-fatal would let a fresh session's
detach reach `_rebaseline_canonical_from_public`, see an empty public tree, and adopt
that as the new canonical baseline — discarding the prior `.daydream/` and
`.review-output.md` with only a warning.

## 4. The operator saw the wrong error (#1171)

The archive error lived on `archive_error` and survived only in `__notes__`, which
nothing renders; `add_note` carried the exception *type name*, not its message. The
console showed `dump destination projection is malformed`. It now reports the archive
error, and with #3 fixed that panel no longer appears at all on an ordinary refusal.

## Also fixed, both found while proving the tiering sound

- **A multi-line private key in `diff.patch` used to publish.** `_scan_file` scans
  non-JSON text line by line, so the DOTALL PEM rule never matched armor spanning
  lines. The one key-material rule was blind on the highest-risk file in the bundle.
  A real-path test confirms this fails on `main`.
- **`_sanitize_derivative`'s JSON branch omitted three substitutions**, so a bundle
  whose JSON string leaves carried an SCP, token-only or query shape was quarantined
  instead of sanitized — deterministically, every pass, because `_mark_done` is never
  reached. Live corpus-pipeline bug, unrelated to #1170's symptom.
- **`Upload findings artifact` had no `if:`** in all three review workflows, so an
  already-written `findings.json` was discarded on any late-stage failure — exactly
  when the operator most needs it.
- `docs/runbooks/credential-remediation.md` §5/§6.2/§6.4 updated: the gate now blocks
  on the blocking tier and reports the rest, so "must report clean" is no longer the
  acceptance criterion.

## Validation

`make check` green: **7663 passed, 15 skipped**, coverage 88.67% (minimum 86%).

`test_archive_data_capture.py` is in a known flaky cluster whose symptom is
`assert 1 == 0` — character for character the new test's assertion — so a green
`-n auto` run is not acceptable proof on its own. Serial gate, same command before
and after:

| Run | Result |
|---|---|
| Pre-change baseline, 8 files | 474 passed |
| Post-change, 12 files (every file touched) | **943 passed, 1 skipped** |
| New tests individually, 3x serial each | 9/9, no flake |

Every fix hunk was proven red/green by reverting it in place. The issue reproduction
was additionally confirmed red in a detached worktree at `56d0d24`, and the
pre-fix wedge was reconstructed under `monkeypatch.context()` to prove existing
wedged workspaces heal.

Two assertions in the refusal tests turned out to be path-agnostic by accident — the
scan summary reaches the console under an `Artifact Finalization` panel from either
`runner.py:1164` or `:1244` — so they hold unchanged now that the rollback succeeds.
Verified before touching them.

## Not fixed here

`upload_run_bundle`'s docstring promises it never raises, but its only caller
converts `False` into `ArchiveFinalizationError`. A contract violation between a
function and its caller, orthogonal to rule precision. Left for a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
