### PR TITLE
fix(archive): honor upload_run_bundle's never-raises contract

### DIFF
--- a/daydream/archive/__init__.py
+++ b/daydream/archive/__init__.py
@@ -339,8 +339,15 @@ def finalize_archive_run(
             hub_repo_id = hub.resolve_hub_repo(config)
             _validate_frozen_artifacts(artifacts)
             if hub_repo_id:
-                if not hub.upload_run_bundle(assembly_dir, hub_repo_id, session_id):
-                    raise ArchiveFinalizationError("archive upload failed")
+                # A False disposition is a skip (no HF_TOKEN, no huggingface_hub),
+                # a fail-closed secret refusal, or a transport failure — and
+                # upload_run_bundle has already warned with the reason in every
+                # case. None of them is a reason to discard a completed review:
+                # issue #981 requires refusing the upload "while preserving the
+                # local run", and the refusal itself happens inside the callee,
+                # before anything reaches the Hub. Raising here would only throw
+                # the local bundle away without containing anything extra.
+                hub.upload_run_bundle(assembly_dir, hub_repo_id, session_id)
         if config.dump_artifacts:
             if dump_path is None:
                 raise ArchiveFinalizationError("dump finalization path is missing")

--- a/daydream/archive/hub.py
+++ b/daydream/archive/hub.py
@@ -74,11 +74,6 @@ def upload_run_bundle(run_dir: Path, repo_id: str, session_id: str) -> bool:
     attempts on a commit-conflict shape (concurrent commits from parallel
     processes), backing off exponentially between attempts.
 
-    Note: this function's "never raises" contract is honored here, but its only
-    caller converts a ``False`` return into an ``ArchiveFinalizationError``.
-    That contract violation between a function and its caller is tracked
-    separately and deliberately not addressed here.
-
     Returns:
         True on success, False when skipped or failed.
     """

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -5047,8 +5047,15 @@ def test_strict_archive_upload_refusal_removes_incomplete_local_success(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """The external uploader's False disposition is a closed host failure."""
-    from daydream.archive import ArchiveFinalizationError, finalize_archive_run
+    """A refused upload withholds the Hub copy and keeps the local archive.
+
+    Issue #981 requires refusing the upload "while preserving the local run",
+    and ``upload_run_bundle`` documents that it never raises so the archive
+    callback cannot fail the run. The refusal already happened inside the
+    callee, before anything reached the Hub, so failing finalization here would
+    discard a completed review without containing anything extra.
+    """
+    from daydream.archive import finalize_archive_run
     from daydream.archive.manifest import ArchiveRecorderProvenance
     from daydream.artifact_visibility import (
         ArtifactEvidenceProvenance,
@@ -5076,30 +5083,34 @@ def test_strict_archive_upload_refusal_removes_incomplete_local_success(
         root_trajectory_id=session_id,
         documents=(TrajectoryDocumentSnapshot(session_id, source_run / "trajectory.json", encoded),),
     )
+    uploaded: list[tuple[Any, ...]] = []
+
+    def _refuse(*args: object, **_kwargs: object) -> bool:
+        uploaded.append(args)
+        return False
+
     monkeypatch.setattr("daydream.archive.hub.resolve_hub_repo", lambda _config: "private/repo")
-    monkeypatch.setattr(
-        "daydream.archive.hub.upload_run_bundle",
-        lambda *_args, **_kwargs: False,
+    monkeypatch.setattr("daydream.archive.hub.upload_run_bundle", _refuse)
+
+    finalize_archive_run(
+        recorder_provenance=ArchiveRecorderProvenance(
+            session_id, DaydreamRunFlow.NORMAL, None, None
+        ),
+        artifacts=ArtifactTreeSnapshot(session_id, "workspace", frozen, _manifest(frozen), ()),
+        artifact_provenance=ArtifactEvidenceProvenance(
+            "workspace", session_id, tmp_path / "source", tmp_path / "live"
+        ),
+        config=cast(Any, _MockConfig(run_eval=False, archive=True)),
+        write_snapshot=snapshot,
+        work=None,
+        upload=True,
     )
 
-    with pytest.raises(ArchiveFinalizationError, match="upload"):
-        finalize_archive_run(
-            recorder_provenance=ArchiveRecorderProvenance(
-                session_id, DaydreamRunFlow.NORMAL, None, None
-            ),
-            artifacts=ArtifactTreeSnapshot(
-                session_id, "workspace", frozen, _manifest(frozen), ()
-            ),
-            artifact_provenance=ArtifactEvidenceProvenance(
-                "workspace", session_id, tmp_path / "source", tmp_path / "live"
-            ),
-            config=cast(Any, _MockConfig(run_eval=False, archive=True)),
-            write_snapshot=snapshot,
-            work=None,
-            upload=True,
-        )
-
-    assert not (get_archive_dir() / "runs" / session_id).exists()
+    assert len(uploaded) == 1, "the upload must still be attempted and refused by the callee"
+    archive_dir = get_archive_dir()
+    assert (archive_dir / "runs" / session_id / "manifest.json").is_file()
+    assert len(query_runs(archive_dir, "session_id = ?", (session_id,))) == 1
+    assert not list(archive_dir.glob("runs/.*.finalizing"))
 
 
 def test_strict_archive_upload_refuses_frozen_tree_mutated_before_publication(


### PR DESCRIPTION
Follow-up to #1173, which documented this as deliberately out of scope.

`upload_run_bundle` documents:

> Never raises: all failures degrade to a one-line warning and `False` so the archive callback cannot fail the run.

Its only caller did the opposite:

```python
if not hub.upload_run_bundle(assembly_dir, hub_repo_id, session_id):
    raise ArchiveFinalizationError("archive upload failed")
```

That raise becomes exit 1 and an `ArtifactDisposition.ROLLBACK` that discards the completed review — report, findings and trajectory — after every LLM call has been paid for.

## Why none of the four outcomes justifies it

`False` conflates four cases, and the callee already warns with the reason in each:

| Case | What it means |
|---|---|
| `HF_TOKEN` unset | Incomplete configuration. Setting `DAYDREAM_TRAJECTORY_HUB_REPO` without a token made **every run exit 1**. |
| `huggingface_hub` not installed | Same — optional dependency absent. |
| Blocking secret finding | A genuine fail-closed refusal, which already happened **inside** the callee. |
| Transport failure | Warned verbatim as `non-fatal`, which the caller made untrue. |

The secret case is the one worth dwelling on: the refusal takes effect before anything reaches the Hub. Raising afterwards contains nothing extra — it only throws the local bundle away. Issue #981 asks for the opposite in the same sentence as the refusal:

> Refuse the upload when a credential-like value remains, **while preserving the local run** and reporting only safe counts, field names, and digests.

## What changed

Two lines deleted in `finalize_archive_run`, replaced by a comment recording why the disposition is deliberate. The stale "tracked separately" note removed from the docstring.

This reverses the disposition #1161 introduced. Its test asserted *"The external uploader's False disposition is a closed host failure."* That test now asserts the #981 behavior instead: the upload is still attempted and refused, the local archive is installed, the run row is written, and no `.finalizing` assembly directory is left behind. Amended deliberately, not incidentally.

## Validation

- `make lint`, `make typecheck` clean.
- `uv run pytest -p no:randomly tests/test_archive.py tests/test_hub_upload.py tests/test_archive_integration.py tests/test_archive_data_capture.py -q` → **338 passed**.
- Red/green proven by restoring the raise in place: the amended test fails with `ArchiveFinalizationError: archive upload failed`, then passes once reverted.

The Hub upload remains three-way opt-in (repo id via `--trajectory-hub-repo` or `DAYDREAM_TRAJECTORY_HUB_REPO`, plus `config.archive`, plus `HF_TOKEN`), and the fail-closed scan inside `upload_run_bundle` is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)