### PR TITLE
refactor(training): use shared atomic writer for split sidecars

### DIFF
--- a/daydream/training/gate.py
+++ b/daydream/training/gate.py
@@ -27,12 +27,12 @@ from __future__ import annotations
 
 import hashlib
 import json
-import os
 import random
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
+from daydream.json_utils import atomic_write_json
 from daydream.training.reward_model import _read_admitted_rows, score_comment
 
 _LABELS = {"accepted": 1.0, "rejected": 0.0}
@@ -167,7 +167,7 @@ def write_split_sidecar(
     Shared by every producer of the M18 resume-guard / stage-manifest split
     contract (:func:`freeze_split` and the corpus-v2 frozen-boundary path in
     :mod:`daydream.training.coordinator`), so the sidecar shape cannot drift
-    between them. Writes are atomic (tmp + ``os.replace``).
+    between them. Writes use the shared crash-safe JSON writer.
 
     Args:
         labels_path: Path of the labels file the sidecar sits beside.
@@ -188,9 +188,7 @@ def write_split_sidecar(
         "held_out_ids": sorted(held_out_ids),
         "train_ids": sorted(train_ids),
     }
-    tmp = sidecar_path.with_name(sidecar_path.name + ".tmp")
-    tmp.write_text(json.dumps(sidecar, indent=2, sort_keys=True))
-    os.replace(tmp, sidecar_path)
+    atomic_write_json(sidecar_path, sidecar, sort_keys=True)
     return sidecar_path.name
 
 

--- a/tests/test_training_gate.py
+++ b/tests/test_training_gate.py
@@ -36,17 +36,31 @@ def test_split_frozen_before_training(tmp_path: Path) -> None:
     labels = _pairs(tmp_path)
     frozen = freeze_split(labels, held_out_fraction=0.2, seed=3)
     assert frozen.fingerprint != ""
-    assert (tmp_path / frozen.digest_path).exists()
+    assert frozen.digest_path == "labels.jsonl.gate-split.json"
+    sidecar_path = tmp_path / frozen.digest_path
+    assert sidecar_path.exists()
     # frozen split is content-addressed: same seed+labels -> same digest
+    first_bytes = sidecar_path.read_bytes()
     again = freeze_split(labels, held_out_fraction=0.2, seed=3)
     assert again.digest == frozen.digest
+    assert sidecar_path.read_bytes() == first_bytes
     # digest file records the split digest for the resume guard (M18)
-    payload = json.loads((tmp_path / frozen.digest_path).read_text())
-    assert payload["digest"] == frozen.digest
+    expected = {
+        "digest": frozen.digest,
+        "held_out_fraction": 0.2,
+        "held_out_ids": sorted(
+            str(row["comment_id"]) for row in frozen.held_out_rows
+        ),
+        "seed": 3,
+        "train_ids": sorted(str(row["comment_id"]) for row in frozen.train_rows),
+    }
+    assert first_bytes == json.dumps(expected, indent=2, sort_keys=True).encode()
+    assert not first_bytes.endswith(b"\n")
+    assert json.loads(first_bytes) == expected
     # a second freeze with a different seed rewrites the sidecar with its own digest
     other = freeze_split(labels, held_out_fraction=0.2, seed=4)
     assert other.digest != frozen.digest
-    assert json.loads((tmp_path / frozen.digest_path).read_text())["digest"] == other.digest
+    assert json.loads(sidecar_path.read_text())["digest"] == other.digest
 
 
 def test_gate_pass_separates_classes(frozen_split: FrozenSplit, trained_model: OutcomeModel) -> None:


### PR DESCRIPTION
## Summary

Route frozen split sidecars through the shared atomic JSON writer. Both split producers now use its temporary-file cleanup and file fsync while preserving the sidecar filename and serialized bytes.

## Motivation

Closes #1020. The sidecar was the remaining local deterministic `.tmp`/`os.replace` implementation; the coordinator already delegates to the same sidecar function.

## Test Plan

- [x] Strengthened `test_split_frozen_before_training` passed before replacing the writer; it pins all five fields, the filename, sorted two-space JSON without a trailing newline, repeated-write byte stability, and different-seed overwrite.
- [x] `uv run pytest tests/test_training_gate.py tests/test_json_utils.py`: 29 passed. Existing shared-writer coverage verifies destination preservation and temporary-file cleanup on failure.
- [x] `make check`: 7,973 passed, 15 skipped, 88.71% coverage; Ruff, both dead-code scans, mypy, and Docker actionlint passed.
- [x] `daydream . --precision --non-interactive --backend codex` ran before opening this PR against `4f9688dded63a157db6e0b22d3c8ebd046bbfd44` and base `4dc73fb3`. No findings; both changed files read; no worktree changes.
- [x] The reviewer's bare-mypy diagnostic was resolved by the same scoped check in the installed project environment: `uv run mypy daydream/training/gate.py tests/test_training_gate.py` passed. The full project mypy check also passed.

## Checklist

- [x] Signed commit and normal Git hooks retained.
- [x] Reviewed report and trajectories retained locally in `.beagle/plans/refactor-backlog/evidence/1020/`; report `review-report.md`, session `faad40be-1727-4dd3-8561-74891901ffa0`.

Standalone RL checks run in the separate `rl-check` CI job; this PR changes no RL files. Both `check` and `rl-check` must pass for this head before merge.
