### PR TITLE
refactor(benchmark): isolate transaction fault injection

### DIFF
--- a/daydream/benchmark/storage.py
+++ b/daydream/benchmark/storage.py
@@ -244,9 +244,9 @@ class Transaction:
 
     The context manager *stores* a transaction; it does not auto-*commit*.
     Callers drive ``stage``/``prepare``/``begin_commit``/``commit`` explicitly
-    so a simulated crash (``inject_crash``) leaves the journal in the exact
-    mid-state ``recover_startup`` is meant to heal. ``__exit__`` is therefore a
-    no-op — partial state is deliberately left for recovery to adjudicate.
+    so an interrupted operation leaves the exact mid-state
+    ``recover_startup`` is meant to heal. ``__exit__`` is therefore a no-op —
+    partial state is deliberately left for recovery to adjudicate.
     """
 
     def __init__(self, root: Path, *, op_id: str, kind: str) -> None:
@@ -408,10 +408,7 @@ class Transaction:
 
         A transaction enters ``committing`` by rewriting the journal with
         ``state == committing`` and ``applied_count == 0`` before any target
-        is replaced. Both ``begin_commit`` and the per-target crash-injection
-        branch collapse to this single sequence, so the ``target-<n>``
-        mid-loop crash state stays byte-identical to a real halt reached via
-        ``begin_commit``.
+        is replaced.
         """
         self._state = "committing"
         self._applied_count = 0
@@ -432,43 +429,41 @@ class Transaction:
         self._apply_replacements()
         _fsync_dir(self._root)
 
-    def _apply_replacements(self, *, stop_after: int | None = None) -> None:
+    def _apply_replacements(self) -> None:
         """Apply targets in ``replacement_order``, fsyncing each rename.
 
         Each target's rename is made durable (file + *parent directory* fsync)
         before the next target is applied, so a crash at any per-target
         boundary still restores the whole before- or after-state, never a
-        checksum-drifted mix. ``stop_after`` (a test-only hook) applies only
-        the first ``N`` targets and leaves the journal ``committing`` with
-        ``applied_count == N``, byte-identical to a real mid-loop crash.
+        checksum-drifted mix.
         """
-        for i, rel in enumerate(self._replacement_order):
-            if stop_after is not None and i >= stop_after:
-                break
-            st = self._states[rel]
-            rel = _resolve_target(self._root, rel)
-            target = self._root / rel
-            ensure_private_dir(target.parent)
-            st.applied = True
-            self._applied_count += 1
-            self._write_journal()
-            _fsync_file(self._journal_path())
-            if st.operation == "retire":
-                target.unlink()
-            else:
-                if st.stage_path is None:
-                    raise WorkspaceCorrupt(
-                        f"{self._root}: replacement target {rel!r} has no staged file"
-                    )
-                os.replace(st.stage_path, target)
-                _fsync_file(target)
-                os.chmod(target, 0o600)
-            _fsync_dir(target.parent)
+        for rel in self._replacement_order:
+            self._apply_replacement(rel)
 
-    def commit(self) -> None:
-        """Run the full pipeline to ``complete`` and remove the journal."""
-        self.prepare()
-        self.begin_commit()
+    def _apply_replacement(self, rel: str) -> None:
+        """Durably apply one already-journaled target in replacement order."""
+        st = self._states[rel]
+        rel = _resolve_target(self._root, rel)
+        target = self._root / rel
+        ensure_private_dir(target.parent)
+        st.applied = True
+        self._applied_count += 1
+        self._write_journal()
+        _fsync_file(self._journal_path())
+        if st.operation == "retire":
+            target.unlink()
+        else:
+            if st.stage_path is None:
+                raise WorkspaceCorrupt(
+                    f"{self._root}: replacement target {rel!r} has no staged file"
+                )
+            os.replace(st.stage_path, target)
+            _fsync_file(target)
+            os.chmod(target, 0o600)
+        _fsync_dir(target.parent)
+
+    def _complete_commit(self) -> None:
+        """Publish and verify the durable complete state before cleanup."""
         self._state = "complete"
         self._write_journal()
         _fsync_file(self._journal_path())
@@ -488,71 +483,13 @@ class Transaction:
                 raise WorkspaceCorrupt(
                     f"{self._root}: commit verify {st.rel} expected {st.after_digest} got {actual}"
                 )
+
+    def commit(self) -> None:
+        """Run the full pipeline to ``complete`` and remove the journal."""
+        self.prepare()
+        self.begin_commit()
+        self._complete_commit()
         self._cleanup()
-
-    def inject_crash(self, boundary: str | None = None) -> None:
-        """Simulate a crash at a named pipeline boundary (test-only).
-
-        With ``boundary is None`` this simply halts at the transaction's
-        current state — recovery must adjudicate whatever phase is already
-        persisted. With a named ``boundary``
-        (``staged|backup|journal|data|manifest``) it first advances to that
-        boundary (so a caller may drive an arbitrary mid-state) and then
-        halts. A ``target-<n>`` boundary applies exactly the first ``n``
-        targets of ``replacement_order`` under ``committing`` and halts,
-        leaving a crash state byte-identical to a real mid-loop halt.
-        """
-        if boundary is None or boundary in ("staged", "backup"):
-            # Staging (and any backup file) is written but no journal is
-            # persisted yet — recovery finds nothing and leaves the target
-            # perfectly ``before``.
-            return
-        if boundary == "journal":
-            # Persist the ``prepared`` journal; recovery rolls the staged set
-            # back (no target was ever replaced).
-            self.prepare()
-            return
-        if boundary == "data":
-            # Begin the commit: targets are applied under ``committing`` and
-            # recovery rolls them back from backups.
-            self.prepare()
-            self.begin_commit()
-            return
-        if boundary == "manifest":
-            # Run the full commit to ``complete`` so recovery verifies the
-            # whole after-state.
-            self.prepare()
-            self.begin_commit()
-            self.force_state("complete")
-            return
-        if boundary is not None and boundary.startswith("target-"):
-            # Per-target boundary ``target-<n>``: prepare, then apply exactly
-            # the first ``n`` targets and halt before the parent-dir fsync of
-            # the next rename / the final root fsync. Recovery rolls all of
-            # them back, restoring the all-old state. ``target-0`` is exactly
-            # the ``journal`` boundary (prepared, nothing applied).
-            suffix = boundary[len("target-"):]
-            try:
-                n = int(suffix)
-            except ValueError:
-                raise ValueError(f"invalid target boundary {boundary!r}") from None
-            if not (0 <= n <= len(self._replacement_order)):
-                raise ValueError(f"target boundary {n!r} out of range")
-            self.prepare()
-            if n == 0:
-                return
-            self._begin_committing()
-            self._apply_replacements(stop_after=n)
-            return
-        raise ValueError(f"unknown crash boundary {boundary!r}")
-
-    def force_state(self, state: str) -> None:
-        """Force the journal into ``state`` (test-only hook)."""
-        if state not in ("prepared", "committing", "complete"):
-            raise ValueError(f"invalid journal state {state!r}")
-        self._state = state
-        self._write_journal()
-        _fsync_file(self._journal_path())
 
     def _cleanup(self) -> None:
         """Remove the journal + staging dir, leaving an empty ``transactions/`` root."""
@@ -563,7 +500,7 @@ class Transaction:
         return self
 
     # The journal state machine is driven explicitly above; leaving the with
-    # block after prepare()/begin_commit()/inject_crash() must NOT clean up so
+    # block after prepare()/begin_commit() must NOT clean up so
     # the persisted crash-state remains for recover_startup to heal.
     def __exit__(self, *_exc: object) -> Literal[False]:
         return False

--- a/tests/harness/transaction_faults.py
+++ b/tests/harness/transaction_faults.py
@@ -1,0 +1,53 @@
+"""Durable-boundary fault driver for transaction recovery tests."""
+
+from pathlib import Path
+
+from daydream.benchmark.storage import Transaction
+
+
+class TransactionFaultDriver:
+    """Drive a real transaction to one documented interruption boundary.
+
+    Tests stage targets through :attr:`transaction`, then call
+    :meth:`halt_at`. ``staged`` and ``backup`` mean immediately after that
+    caller-owned staging work; ``manifest`` means complete-before-cleanup.
+    The driver shares the transaction's actual durable transitions; it never
+    manufactures a journal document or changes state directly.
+    """
+
+    def __init__(self, root: Path, *, op_id: str, kind: str) -> None:
+        self.transaction = Transaction(root, op_id=op_id, kind=kind)
+
+    def halt_at(self, boundary: str) -> None:
+        """Leave the transaction at a documented durable crash boundary."""
+        tx = self.transaction
+        if boundary in ("staged", "backup"):
+            return
+        if boundary in ("journal", "target-0"):
+            tx.prepare()
+            return
+        if boundary == "data":
+            tx.prepare()
+            tx.begin_commit()
+            return
+        if boundary == "manifest":
+            tx.prepare()
+            tx.begin_commit()
+            tx._complete_commit()
+            return
+        if boundary.startswith("target-"):
+            suffix = boundary[len("target-"):]
+            try:
+                count = int(suffix)
+            except ValueError:
+                raise ValueError(f"invalid target boundary {boundary!r}") from None
+            if not (0 <= count <= len(tx._replacement_order)):
+                raise ValueError(f"target boundary {count!r} out of range")
+            tx.prepare()
+            if count == 0:
+                return
+            tx._begin_committing()
+            for rel in tx._replacement_order[:count]:
+                tx._apply_replacement(rel)
+            return
+        raise ValueError(f"unknown crash boundary {boundary!r}")

--- a/tests/test_benchmark_curation.py
+++ b/tests/test_benchmark_curation.py
@@ -1047,16 +1047,19 @@ def test_read_only_paths_run_concurrent_with_a_writer(tmp_path: Path, fake_gh: F
 
 def test_locked_mutation_heals_interrupted_journal_before_new_write(tmp_path: Path, fake_gh: FakeGh) -> None:
     from daydream.benchmark import curation as cu
-    from daydream.benchmark.storage import Transaction
+    from tests.harness.transaction_faults import TransactionFaultDriver
     ws, case_id, _ = _seed_ready_case(tmp_path, fake_gh, lines=3)
     path = ws / "cases" / f"{case_id}.yaml"
     raw = load_yaml_strict(path)
     mutated = dict(raw)
     mutated["curation"] = dict(raw["curation"])
     mutated["curation"]["state"] = "excluded"          # an interrupted mutation left in flight
-    with Transaction(ws, op_id=f"curate-{case_id}", kind="curation:exclude-case") as tx:
+    faults = TransactionFaultDriver(
+        ws, op_id=f"curate-{case_id}", kind="curation:exclude-case"
+    )
+    with faults.transaction as tx:
         tx.stage(f"cases/{case_id}.yaml", yaml.safe_dump(mutated, sort_keys=False).encode("utf-8"))
-        tx.inject_crash("target-1")                    # target applied under 'committing', then halt
+        faults.halt_at("target-1")                     # target applied under 'committing', then halt
     assert load_yaml_strict(path)["curation"]["state"] == "excluded"
     cu.add_finding(ws, case_id, title="recovered", body="b", severity="low",
                    location={"path": "feature.py", "start_line": 1, "end_line": 1}, source_ids=[])

--- a/tests/test_benchmark_migrate.py
+++ b/tests/test_benchmark_migrate.py
@@ -529,15 +529,18 @@ def test_migrate_heals_interrupted_journal_under_lock(tmp_path: Path) -> None:
     other locked writer) so a crashed curator journal is healed before it reads;
     and its transaction op_id must be flat so no residue is left that bricks a
     later recover_startup with WorkspaceCorrupt."""
+    from tests.harness.transaction_faults import TransactionFaultDriver
+
     ws, case_id, _ = _seed_v1_workspace(tmp_path)
     path = ws / "cases" / f"{case_id}.yaml"
     raw = storage.load_yaml_strict(path)
     mutated = dict(raw)
     mutated["curation"] = dict(raw["curation"])
     mutated["curation"]["state"] = "excluded"    # an interrupted mutation left in flight
-    with storage.Transaction(ws, op_id=f"migrate-{case_id}", kind="migrate") as tx:
+    faults = TransactionFaultDriver(ws, op_id=f"migrate-{case_id}", kind="migrate")
+    with faults.transaction as tx:
         tx.stage(f"cases/{case_id}.yaml", yaml.safe_dump(mutated, sort_keys=False).encode("utf-8"))
-        tx.inject_crash("target-1")              # target applied under 'committing', then halt
+        faults.halt_at("target-1")               # target applied under 'committing', then halt
     assert storage.load_yaml_strict(path)["curation"]["state"] == "excluded"
 
     migrate.migrate_workspace(ws)               # recover_startup under lock rolls the crash back

--- a/tests/test_benchmark_snapshot.py
+++ b/tests/test_benchmark_snapshot.py
@@ -793,8 +793,8 @@ def test_freeze_crash_recovers_whole_before_or_after(tmp_path: Path) -> None:
     ``manifest`` keeps the complete after-state, and ``transactions/`` is left
     empty after recovery.
     """
-    from daydream.benchmark import storage
     from daydream.benchmark.storage import recover_startup
+    from tests.harness.transaction_faults import TransactionFaultDriver
 
     for boundary in ("journal", "data", "manifest"):
         case_dir = tmp_path / "cases"
@@ -804,11 +804,12 @@ def test_freeze_crash_recovers_whole_before_or_after(tmp_path: Path) -> None:
         (case_dir / "pr-000001-aaaaaaaaaaaa.yaml").write_text("case-before")
         (snap_dir / "pr-000001-aaaaaaaaaaaa.bundle").write_bytes(b"bundle-before")
         (tmp_path / "benchmark.yaml").write_text("ledger-before")
-        with storage.Transaction(tmp_path, op_id=f"freeze-{boundary}", kind="freeze") as tx:
+        faults = TransactionFaultDriver(tmp_path, op_id=f"freeze-{boundary}", kind="freeze")
+        with faults.transaction as tx:
             tx.stage("snapshots/pr-000001-aaaaaaaaaaaa.bundle", b"bundle-after")
             tx.stage("cases/pr-000001-aaaaaaaaaaaa.yaml", b"case-after")
             tx.stage("benchmark.yaml", b"ledger-after")
-            tx.inject_crash(boundary)
+            faults.halt_at(boundary)
         recover_startup(tmp_path)
         if boundary in ("journal", "data"):
             assert (snap_dir / "pr-000001-aaaaaaaaaaaa.bundle").read_bytes() == b"bundle-before"

--- a/tests/test_benchmark_workspace_storage.py
+++ b/tests/test_benchmark_workspace_storage.py
@@ -1,8 +1,9 @@
 import fcntl
+import inspect
 import os
 import stat
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 import pytest
 
@@ -20,6 +21,7 @@ from daydream.benchmark.storage import (
     resolve_authoring_path,
     sha256_file,
 )
+from tests.harness.transaction_faults import TransactionFaultDriver
 
 
 def test_load_yaml_rejects_duplicate_keys(tmp_path: Path) -> None:
@@ -119,6 +121,17 @@ def test_transaction_commit_replaces_all_and_manifest_last(tmp_path: Path) -> No
     assert not (tmp_path / "transactions").exists() or not list((tmp_path / "transactions").iterdir())
 
 
+def test_transaction_has_no_fault_or_state_forging_surface(tmp_path: Path) -> None:
+    tx = Transaction(tmp_path, op_id="surface", kind="write")
+    assert not hasattr(tx, "inject_crash")
+    assert not hasattr(tx, "force_state")
+    assert "stop_after" not in inspect.signature(tx._apply_replacements).parameters
+    faults = TransactionFaultDriver(tmp_path, op_id="faults", kind="write")
+    assert isinstance(faults.transaction, Transaction)
+    assert not hasattr(faults, "stage")
+    assert not hasattr(faults, "force_state")
+
+
 def test_transaction_retires_digest_matched_file_atomically(tmp_path: Path) -> None:
     bundle = tmp_path / "snapshots" / "old.bundle"
     bundle.parent.mkdir(parents=True)
@@ -132,11 +145,11 @@ def test_transaction_retires_digest_matched_file_atomically(tmp_path: Path) -> N
     assert (tmp_path / "benchmark.yaml").read_bytes() == b"after"
 
 
-@pytest.mark.parametrize("applied", [0, 1, 2])
-def test_transaction_retirement_rolls_back_with_other_targets(
-    tmp_path: Path, applied: int
+@pytest.mark.parametrize("boundary", [0, 1, 2, 3, "manifest"])
+def test_transaction_retirement_recovers_with_other_targets(
+    tmp_path: Path, boundary: int | Literal["manifest"]
 ) -> None:
-    root = tmp_path / f"ws-{applied}"
+    root = tmp_path / f"ws-{boundary}"
     bundle = root / "snapshots" / "old.bundle"
     case = root / "cases" / "case.yaml"
     manifest = root / "benchmark.yaml"
@@ -145,15 +158,34 @@ def test_transaction_retirement_rolls_back_with_other_targets(
     bundle.write_bytes(b"old bundle")
     case.write_bytes(b"old case")
     manifest.write_bytes(b"old manifest")
-    with Transaction(root, op_id="retire-crash", kind="import") as tx:
+    faults = TransactionFaultDriver(root, op_id="retire-crash", kind="import")
+    with faults.transaction as tx:
         tx.retire("snapshots/old.bundle", expected_sha256=sha256_file(bundle))
         tx.stage("cases/case.yaml", b"new case")
         tx.stage("benchmark.yaml", b"new manifest")
-        tx.inject_crash(f"target-{applied}")
+        faults.halt_at("manifest" if boundary == "manifest" else f"target-{boundary}")
+    doc = load_json_strict(root / "transactions" / "retire-crash" / "journal.json")
+    applied = 3 if boundary == "manifest" else boundary
+    assert doc["state"] == (
+        "complete" if boundary == "manifest" else "prepared" if applied == 0 else "committing"
+    )
+    assert doc["applied_count"] == applied
+    if applied:
+        assert not bundle.exists()  # retirement was genuinely performed before recovery
+    if applied >= 2:
+        assert case.read_bytes() == b"new case"
+    if applied >= 3:
+        assert manifest.read_bytes() == b"new manifest"
     recover_startup(root)
-    assert bundle.read_bytes() == b"old bundle"
-    assert case.read_bytes() == b"old case"
-    assert manifest.read_bytes() == b"old manifest"
+    if boundary == "manifest":
+        assert not bundle.exists()
+        assert case.read_bytes() == b"new case"
+        assert manifest.read_bytes() == b"new manifest"
+    else:
+        assert bundle.read_bytes() == b"old bundle"
+        assert case.read_bytes() == b"old case"
+        assert manifest.read_bytes() == b"old manifest"
+    recover_startup(root)  # retirement recovery is idempotent after cleanup
 
 
 def test_transaction_retirement_refuses_digest_mismatch(tmp_path: Path) -> None:
@@ -176,28 +208,73 @@ def test_prepared_journal_rolls_back_on_startup(tmp_path: Path) -> None:
     assert not data.exists()
 
 
-def test_committing_journal_rolls_back_in_reverse(tmp_path: Path) -> None:
-    target = tmp_path / "target.yaml"
-    target.write_text("old")
-    with Transaction(tmp_path, op_id="op-3", kind="write") as tx:
-        _stage(tx, target, "new")
-        tx.prepare()
-        tx.begin_commit()  # set state=committing, apply target with new
-        tx.inject_crash()  # leave committing incomplete, applied=1
-    assert target.read_text() == "new"
+def test_committing_journal_rolls_back_in_reverse(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    rels = ["cases/a.yaml", "cases/b.yaml", "benchmark.yaml"]
+    for rel in rels:
+        target = tmp_path / rel
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(f"before-{rel}")
+    faults = TransactionFaultDriver(tmp_path, op_id="op-3", kind="write")
+    with faults.transaction as tx:
+        for rel in rels:
+            _stage(tx, rel, f"after-{rel}")
+        faults.halt_at("target-3")
+    doc = load_json_strict(tmp_path / "transactions" / "op-3" / "journal.json")
+    assert doc["state"] == "committing" and doc["applied_count"] == 3
+    assert [(tmp_path / rel).read_text() for rel in rels] == [f"after-{rel}" for rel in rels]
+
+    observed: list[str] = []
+    real_replace = os.replace
+
+    def observe_replace(source: str | Path, destination: str | Path) -> None:
+        observed.append(Path(source).name)
+        real_replace(source, destination)
+
+    monkeypatch.setattr(os, "replace", observe_replace)
     recover_startup(tmp_path)
-    assert target.read_text() == "old"  # restored from backup
+    assert observed == ["backup-0002.bin", "backup-0001.bin", "backup-0000.bin"]
+    assert [(tmp_path / rel).read_text() for rel in rels] == [f"before-{rel}" for rel in rels]
 
 
 def test_complete_journal_is_verified_and_cleaned(tmp_path: Path) -> None:
     target = tmp_path / "target.yaml"
     target.write_text("old")
-    with Transaction(tmp_path, op_id="op-4", kind="write") as tx:
+    faults = TransactionFaultDriver(tmp_path, op_id="op-4", kind="write")
+    with faults.transaction as tx:
         _stage(tx, target, "new")
-        tx.commit()
-        tx.force_state("complete")  # simulate crash right after mark-complete, before journal removal
+        faults.halt_at("manifest")
     recover_startup(tmp_path)
     assert target.read_text() == "new"  # after state verified, journal cleaned
+
+
+def test_complete_journal_rejects_altered_replacement_at_startup(tmp_path: Path) -> None:
+    target = tmp_path / "target.yaml"
+    target.write_text("old")
+    faults = TransactionFaultDriver(tmp_path, op_id="complete-altered", kind="write")
+    with faults.transaction as tx:
+        _stage(tx, target, "new")
+        faults.halt_at("manifest")
+    target.write_text("altered")
+    with pytest.raises(WorkspaceCorrupt, match="digest mismatch"):
+        recover_startup(tmp_path)
+    assert (tmp_path / "transactions" / "complete-altered" / "journal.json").exists()
+
+
+def test_complete_journal_rejects_reappearing_retired_target_at_startup(tmp_path: Path) -> None:
+    retired = tmp_path / "snapshots" / "old.bundle"
+    retired.parent.mkdir(parents=True)
+    retired.write_bytes(b"old")
+    faults = TransactionFaultDriver(tmp_path, op_id="complete-retired", kind="write")
+    with faults.transaction as tx:
+        tx.retire("snapshots/old.bundle", expected_sha256=sha256_file(retired))
+        tx.stage("benchmark.yaml", b"new manifest")
+        faults.halt_at("manifest")
+    retired.write_bytes(b"returned")
+    with pytest.raises(WorkspaceCorrupt, match="retired target"):
+        recover_startup(tmp_path)
+    assert (tmp_path / "transactions" / "complete-retired" / "journal.json").exists()
 
 
 def test_no_journal_orphan_is_corruption(tmp_path: Path) -> None:
@@ -225,9 +302,27 @@ def test_crash_injection_at_every_boundary_restores_before_or_after(tmp_path: Pa
     for boundary in ("staged", "backup", "journal", "data", "manifest"):
         target = tmp_path / f"t-{boundary}.yaml"
         target.write_text("before")
-        with Transaction(tmp_path, op_id=f"op-{boundary}", kind="write") as tx:
+        faults = TransactionFaultDriver(tmp_path, op_id=f"op-{boundary}", kind="write")
+        with faults.transaction as tx:
             tx.stage(target.relative_to(tmp_path), b"after")
-            tx.inject_crash(boundary)
+            faults.halt_at(boundary)
+        op_dir = tmp_path / "transactions" / f"op-{boundary}"
+        journal = op_dir / "journal.json"
+        if boundary in ("staged", "backup"):
+            assert not journal.exists()
+            assert target.read_text() == "before"
+        else:
+            doc = load_json_strict(journal)
+            expected_state = {
+                "journal": "prepared",
+                "data": "committing",
+                "manifest": "complete",
+            }[boundary]
+            assert doc["state"] == expected_state
+            assert doc["applied_count"] == (0 if boundary == "journal" else 1)
+            assert target.read_text() == ("before" if boundary == "journal" else "after")
+            if boundary == "manifest":
+                assert (op_dir / "backup-0000.bin").exists()
         recover_startup(tmp_path)
         if boundary in ("staged", "backup"):
             # Crash before the journal is written: recovery has nothing to do
@@ -247,9 +342,10 @@ def test_crash_injection_at_every_boundary_restores_before_or_after(tmp_path: Pa
 def test_prejournal_stage_residue_is_removed(tmp_path: Path) -> None:
     target = tmp_path / "t.yaml"
     target.write_text("before")
-    with Transaction(tmp_path, op_id="op-pre", kind="write") as tx:
+    faults = TransactionFaultDriver(tmp_path, op_id="op-pre", kind="write")
+    with faults.transaction as tx:
         _stage(tx, target, "after")
-        tx.inject_crash("staged")  # stage-*.bin written, NO journal.json
+        faults.halt_at("staged")  # stage-*.bin written, NO journal.json
     recover_startup(tmp_path)
     assert target.read_text() == "before"  # untouched
     txn = tmp_path / "transactions"
@@ -259,12 +355,31 @@ def test_prejournal_stage_residue_is_removed(tmp_path: Path) -> None:
 def test_prejournal_backup_residue_is_removed(tmp_path: Path) -> None:
     target = tmp_path / "t.yaml"
     target.write_text("before")
-    with Transaction(tmp_path, op_id="op-pre2", kind="write") as tx:
+    faults = TransactionFaultDriver(tmp_path, op_id="op-pre2", kind="write")
+    with faults.transaction as tx:
         _stage(tx, target, "after")
-        tx.inject_crash("backup")  # stage + backup written, NO journal.json
+        faults.halt_at("backup")  # stage + backup written, NO journal.json
     recover_startup(tmp_path)
     txn = tmp_path / "transactions"
     assert not txn.exists() or not list(txn.iterdir())
+
+
+@pytest.mark.parametrize(
+    "boundary",
+    ["prepared", "committing", "complete", "unknown", "target-nope", "target--1", "target-2"],
+)
+def test_invalid_fault_boundaries_do_not_publish_a_journal_or_change_targets(
+    tmp_path: Path, boundary: str
+) -> None:
+    target = tmp_path / "target.yaml"
+    target.write_text("before")
+    faults = TransactionFaultDriver(tmp_path, op_id="invalid-boundary", kind="write")
+    with faults.transaction as tx:
+        _stage(tx, target, "after")
+        with pytest.raises(ValueError):
+            faults.halt_at(boundary)
+    assert target.read_text() == "before"
+    assert not (tmp_path / "transactions" / "invalid-boundary" / "journal.json").exists()
 
 
 def test_unidentifiable_residue_is_corruption_and_left_untouched(tmp_path: Path) -> None:
@@ -288,11 +403,12 @@ def test_import_crash_transaction_restores_before_or_after(tmp_path: Path) -> No
             f.parent.mkdir(parents=True, exist_ok=True)
             f.write_text("before")
         manifest.write_text("ledger-before")
-        with Transaction(tmp_path, op_id=f"imp-{boundary}", kind="import") as tx:
+        faults = TransactionFaultDriver(tmp_path, op_id=f"imp-{boundary}", kind="import")
+        with faults.transaction as tx:
             tx.stage("imports/pr-000101.json", b"import-after")
             tx.stage("cases/pr-000101-aaaaaaaaaaaa.yaml", b"case-after")
             tx.stage("benchmark.yaml", b"ledger-after")
-            tx.inject_crash(boundary)
+            faults.halt_at(boundary)
         recover_startup(tmp_path)
         if boundary in ("journal", "data"):
             assert imp.read_text() == "before"
@@ -468,7 +584,7 @@ def test_empty_transactions_removes_only_positive_residue(tmp_path: Path) -> Non
 
 
 def test_multi_target_each_per_target_boundary_restores_all_old(tmp_path: Path) -> None:
-    # 3 targets; inject a crash after each individual rename/fsync boundary.
+    # 3 targets; halt after each individual durable rename/fsync boundary.
     for n in range(0, 4):  # after applying 0, 1, 2, 3 of the 3 targets
         root = tmp_path / f"ws-{n}"
         root.mkdir()
@@ -479,10 +595,17 @@ def test_multi_target_each_per_target_boundary_restores_all_old(tmp_path: Path) 
             p = root / rel
             p.parent.mkdir(parents=True, exist_ok=True)
             p.write_text(before[rel])
-        with Transaction(root, op_id=f"op-{n}", kind="import") as tx:
+        faults = TransactionFaultDriver(root, op_id=f"op-{n}", kind="import")
+        with faults.transaction as tx:
             for i in range(3):
                 _stage(tx, root / f"cases/t{i}.yaml", f"after-{i}")
-            tx.inject_crash(boundary=f"target-{n}")  # new per-target boundary
+            faults.halt_at(f"target-{n}")
+        doc = load_json_strict(root / "transactions" / f"op-{n}" / "journal.json")
+        assert doc["state"] == ("prepared" if n == 0 else "committing")
+        assert doc["applied_count"] == n
+        for i in range(3):
+            expected = f"after-{i}" if i < n else before[f"cases/t{i}.yaml"]
+            assert (root / f"cases/t{i}.yaml").read_text() == expected
         recover_startup(root)
         for rel, content in before.items():
             assert (root / rel).read_text() == content  # every target back to all-old
@@ -494,9 +617,10 @@ def test_single_target_target_boundary(tmp_path: Path) -> None:
     root.mkdir()
     t = root / "t.yaml"
     t.write_text("before")
-    with Transaction(root, op_id="op-1t", kind="write") as tx:
+    faults = TransactionFaultDriver(root, op_id="op-1t", kind="write")
+    with faults.transaction as tx:
         _stage(tx, t, "after")
-        tx.inject_crash(boundary="target-0")
+        faults.halt_at("target-0")
     recover_startup(root)
     assert t.read_text() == "before"
     assert not (root / "transactions").exists() or not list((root / "transactions").iterdir())
@@ -506,10 +630,10 @@ def test_verify_complete_preserves_0600_target(tmp_path: Path) -> None:
     t = tmp_path / "target.yaml"
     t.write_text("old")
     os.chmod(t, 0o600)
-    with Transaction(tmp_path, op_id="op-c", kind="write") as tx:
+    faults = TransactionFaultDriver(tmp_path, op_id="op-c", kind="write")
+    with faults.transaction as tx:
         _stage(tx, t, "new")
-        tx.commit()
-        tx.force_state("complete")
+        faults.halt_at("manifest")
     recover_startup(tmp_path)
     assert stat.S_IMODE(t.stat().st_mode) == 0o600
 
@@ -532,7 +656,6 @@ def test_rollback_committing_restored_target_is_0600(tmp_path: Path) -> None:
     with Transaction(tmp_path, op_id="op-r", kind="write") as tx:
         _stage(tx, t, "new")
         tx.begin_commit()
-        tx.inject_crash()
     recover_startup(tmp_path)
     assert t.read_text() == "old"
     assert stat.S_IMODE(t.stat().st_mode) == 0o600
@@ -544,7 +667,6 @@ def test_restart_recovery_is_idempotent(tmp_path: Path) -> None:
     with Transaction(tmp_path, op_id="op-idem", kind="write") as tx:
         _stage(tx, t, "new")
         tx.begin_commit()
-        tx.inject_crash()
     recover_startup(tmp_path)   # first pass: roll back committing journal
     first_txn = list((tmp_path / "transactions").iterdir()) if (tmp_path / "transactions").exists() else []
     recover_startup(tmp_path)   # second pass: must be a clean no-op
@@ -556,10 +678,10 @@ def test_restart_recovery_is_idempotent(tmp_path: Path) -> None:
 def test_complete_restart_recovery_is_idempotent(tmp_path: Path) -> None:
     t = tmp_path / "target.yaml"
     t.write_text("old")
-    with Transaction(tmp_path, op_id="op-idem2", kind="write") as tx:
+    faults = TransactionFaultDriver(tmp_path, op_id="op-idem2", kind="write")
+    with faults.transaction as tx:
         _stage(tx, t, "new")
-        tx.commit()
-        tx.force_state("complete")
+        faults.halt_at("manifest")
     recover_startup(tmp_path)
     recover_startup(tmp_path)   # second pass: complete journal already verified+cleaned
     assert t.read_text() == "new"
@@ -575,7 +697,6 @@ def test_recovery_trusts_canonical_rel_not_raw_doc_rel(tmp_path: Path) -> None:
         _stage(tx, target, "new")
         tx.prepare()
         tx.begin_commit()   # state=committing, applied_count=1, target -> "new"
-        tx.inject_crash()
     # Corrupt the journal target rel to a non-canonical form that still
     # resolves inside root; keep replacement_order canonical (as the
     # validator's rels set is built from _resolve_target).


### PR DESCRIPTION
## Summary

Transaction recovery tests now interrupt real durable transitions through a test-only driver. Production `Transaction` no longer exposes crash injection, arbitrary journal-state controls, or a partial-replacement switch.

## Motivation

Closes #1023. The previous complete-state tests could recreate a journal after cleanup; they now stop at the actual complete-before-cleanup boundary with backups still present.

## Changes

- Share the existing per-target replacement and completion/verification operations between normal commits and the test driver, preserving journal schema, ordering, fsync, and recovery behavior.
- Migrate storage, curation, snapshot, and migration tests. Assert actual intermediate states, reverse rollback, completed retirement verification, permissions, and repeated recovery.

## Test Plan

- Focused storage, curation, snapshot, and migration suites: 174 passed.
- `make check`: 7,989 passed, 15 skipped; 88.74% coverage. Ruff, root/RL dead-code scans, mypy, and Docker workflow lint passed.
- `daydream . --precision --non-interactive --backend codex` before this PR: exit 0, no actionable findings, six of six files reviewed. Final reviewed SHA: `2ffe1bc33c369ded915c1dacf37e9ca2ff3b0ba5`; session: `5caed90f-d74c-4d7c-8f09-5de551cd4317`.
- Review report and trajectories retained locally in `.beagle/plans/refactor-backlog/evidence/1023/`. Normal signed commit and push use all repository hooks.
