### PR TITLE
refactor(benchmark): publish candidate validation contract

### DIFF
--- a/daydream/benchmark/harbor/build.py
+++ b/daydream/benchmark/harbor/build.py
@@ -354,8 +354,8 @@ def _flatten_finding(finding: dict[str, Any]) -> dict[str, Any]:
 
     Returns the content fields ``{title, body, severity, path, start_line,
     end_line}``; ``path/start_line/end_line`` come from ``finding["location"]``
-    and are normalized by the verifier's own :func:`verifier_core._validate_location`
-    so the all-or-none location rule lives in exactly one place. A missing or
+    and are normalized by :func:`verifier_core.parse_finding_content`, so the
+    all-or-none location rule lives in exactly one place. A missing or
     ``None`` location (a locationless review finding that names a defect without
     a file or line) collapses to explicit null location fields -- a valid,
     provably locationless gold entry. A partially populated location (at least
@@ -366,25 +366,25 @@ def _flatten_finding(finding: dict[str, Any]) -> dict[str, Any]:
     location = finding.get("location")
     if not location:
         path = start_line = end_line = None
+    elif not isinstance(location, dict):
+        raise CompileError(f"finding {finding.get('finding_id')} has an invalid location")
     else:
         path = location.get("path")
         start_line = location.get("start_line")
         end_line = location.get("end_line")
     try:
-        path, start_line, end_line = vc._validate_location(path, start_line, end_line)
+        return vc.parse_finding_content({
+            "title": finding.get("title"),
+            "body": finding.get("body"),
+            "severity": finding.get("severity"),
+            "path": path,
+            "start_line": start_line,
+            "end_line": end_line,
+        })
     except vc.VerifierError as exc:
         raise CompileError(
-            f"finding {finding.get('finding_id')} has a partially populated location; "
-            "location must be all-null or fully populated"
+            f"finding {finding.get('finding_id')} is invalid: {exc}"
         ) from exc
-    return {
-        "title": finding.get("title"),
-        "body": finding.get("body"),
-        "severity": finding.get("severity"),
-        "path": path,
-        "start_line": start_line,
-        "end_line": end_line,
-    }
 
 
 def _gold_finding_ids(key: str, finding: dict[str, Any]) -> str:
@@ -412,11 +412,14 @@ def build_gold_list(findings: list[dict[str, Any]], *, key: str) -> list[dict[st
     its location fields; a partially populated location raises
     :class:`CompileError` from :func:`_flatten_finding`.
     """
-    if not findings:
-        return []
     flat = [(_flatten_finding(f), _gold_finding_ids(key, f)) for f in findings]
     flat.sort(key=lambda item: item[1])
-    return [{"finding_id": fid, **flattened} for flattened, fid in flat]
+    result = [{"finding_id": fid, **flattened} for flattened, fid in flat]
+    try:
+        vc.validate_gold_set(result, case_id=key)
+    except vc.VerifierError as exc:
+        raise CompileError(f"compiled gold findings are invalid: {exc}") from exc
+    return result
 
 
 def build_oracle_artifact(opaque_key: str, findings: list[dict[str, Any]]) -> dict[str, Any]:
@@ -437,14 +440,6 @@ def build_oracle_artifact(opaque_key: str, findings: list[dict[str, Any]]) -> di
     components so a locationless compiled artifact groups field-for-field with
     the verifier's own canonical tuple (``_canonical_tuple``).
     """
-    if not findings:
-        return {
-            "schema_version": 1,
-            "case_id": opaque_key,
-            "base_ref": "base",
-            "head_ref": "head",
-            "findings": [],
-        }
     flat = [(_flatten_finding(f), f["finding_id"]) for f in findings]
     flat.sort(key=lambda item: item[1])
     # Candidate ids are derived from canonical content + an occurrence ordinal
@@ -466,13 +461,18 @@ def build_oracle_artifact(opaque_key: str, findings: list[dict[str, Any]]) -> di
         entry = dict(flattened)
         entry["candidate_id"] = vc.derive_candidate_id(opaque_key, entry, ordinal)
         entries.append(entry)
-    return {
+    result = {
         "schema_version": 1,
         "case_id": opaque_key,
         "base_ref": "base",
         "head_ref": "head",
         "findings": entries,
     }
+    try:
+        vc.validate_candidate_artifact(result)
+    except vc.VerifierError as exc:
+        raise CompileError(f"compiled Oracle artifact is invalid: {exc}") from exc
+    return result
 
 
 # Verifier/solution template assets copied byte-for-byte into each compiled case.

--- a/daydream/benchmark/harbor/build.py
+++ b/daydream/benchmark/harbor/build.py
@@ -364,10 +364,10 @@ def _flatten_finding(finding: dict[str, Any]) -> dict[str, Any]:
     silent drop and never a fabricated path or line.
     """
     location = finding.get("location")
+    if location is not None and not isinstance(location, dict):
+        raise CompileError(f"finding {finding.get('finding_id')} has an invalid location")
     if not location:
         path = start_line = end_line = None
-    elif not isinstance(location, dict):
-        raise CompileError(f"finding {finding.get('finding_id')} has an invalid location")
     else:
         path = location.get("path")
         start_line = location.get("start_line")

--- a/daydream/benchmark/harbor/candidate.py
+++ b/daydream/benchmark/harbor/candidate.py
@@ -100,7 +100,7 @@ def build_candidate_findings(items: list[dict[str, Any]], *, case_id: str) -> li
         body = _assemble_body(fields)
         if not title.strip() or not body.strip():
             continue
-        entry: dict[str, Any] = {
+        entry_input = {
             "title": title,
             "body": body,
             "severity": fields.severity,
@@ -108,19 +108,8 @@ def build_candidate_findings(items: list[dict[str, Any]], *, case_id: str) -> li
             "start_line": fields.line_int,
             "end_line": fields.line_int,
         }
-        # Enforce the verifier's per-finding bounds fail-closed, reusing the
-        # verifier's own validators so no drift surfaces as a verifier-rejected
-        # artifact after the builder already declared success: an over-long
-        # body (>8 KiB), a non-enum severity, a
-        # rooted/'..'-containing/NUL path, or a non-positive/non-ascending
-        # line range are each a typed failure, never an artifact the verifier
-        # would reject (``_validate_location`` re-checks path + lines on parse).
         try:
-            vc._validate_title(title)
-            vc._validate_body(body)
-            vc._validate_severity(entry["severity"])
-            vc._validate_path(entry["path"])
-            vc._validate_lines(entry["start_line"], entry["end_line"])
+            entry = vc.parse_finding_content(entry_input)
         except vc.VerifierError as exc:
             raise CandidateError(
                 f"cannot build candidate finding: {exc}", kind="invalid_finding"
@@ -175,6 +164,12 @@ def build_candidate_artifact(
             f"candidate artifact exceeds {vc.MAX_ARTIFACT_BYTES} bytes",
             kind="over_limit",
         )
+    try:
+        vc.validate_candidate_artifact(artifact)
+    except vc.VerifierError as exc:
+        raise CandidateError(
+            f"cannot build candidate artifact: {exc}", kind="invalid_finding"
+        ) from exc
     return artifact
 
 

--- a/daydream/benchmark/harbor/verifier_core.py
+++ b/daydream/benchmark/harbor/verifier_core.py
@@ -28,6 +28,7 @@ _HEX64 = re.compile(r"^[0-9a-f]{64}$")
 CANDIDATE_ARTIFACT_KEYS = {"schema_version", "case_id", "base_ref", "head_ref", "findings"}
 CANDIDATE_FINDING_KEYS = {"candidate_id", "title", "body", "severity", "path", "start_line", "end_line"}
 GOLD_FINDING_KEYS = {"finding_id", "title", "body", "severity", "path", "start_line", "end_line"}
+_FINDING_CONTENT_KEYS = {"title", "body", "severity", "path", "start_line", "end_line"}
 
 
 class VerifierError(Exception):
@@ -117,24 +118,6 @@ def _validate_location(
     return (_validate_path(path), *_validate_lines(start_line, end_line))
 
 
-def _content_fields(raw: dict[str, object]) -> dict[str, object]:
-    """Validate the content fields shared by gold and candidate findings."""
-    try:
-        path, start_line, end_line = _validate_location(
-            raw["path"], raw["start_line"], raw["end_line"]
-        )
-        return {
-            "title": _validate_title(raw["title"]),
-            "body": _validate_body(raw["body"]),
-            "severity": _validate_severity(raw.get("severity")),
-            "path": path,
-            "start_line": start_line,
-            "end_line": end_line,
-        }
-    except KeyError as exc:
-        raise VerifierError(f"missing required field {exc.args[0]}") from exc
-
-
 @dataclass(frozen=True)
 class _FindingContent:
     """Content fields shared by gold and candidate findings."""
@@ -192,6 +175,29 @@ def validate_exact_keys(raw: object, allowed: set[str], context: str) -> None:
         raise VerifierError(f"{context} contains unknown field(s): {', '.join(extra)}")
 
 
+def parse_finding_content(raw: object) -> dict[str, object]:
+    """Validate and return the exact six content fields of a finding.
+
+    This is the public, stdlib-only parsing contract shared by host artifact
+    builders and the verifier source copied into compiled Harbor tasks. The
+    nullable ``severity`` field is still required as a key. Raises
+    :class:`VerifierError` when the shape, content, or location is invalid.
+    """
+    validate_exact_keys(raw, _FINDING_CONTENT_KEYS, "finding content")
+    assert isinstance(raw, dict)  # established by validate_exact_keys
+    path, start_line, end_line = _validate_location(
+        raw["path"], raw["start_line"], raw["end_line"]
+    )
+    return {
+        "title": _validate_title(raw["title"]),
+        "body": _validate_body(raw["body"]),
+        "severity": _validate_severity(raw["severity"]),
+        "path": path,
+        "start_line": start_line,
+        "end_line": end_line,
+    }
+
+
 def _finding_kwargs(
     raw: dict[str, object], *, side: str, id_key: str
 ) -> dict[str, object]:
@@ -207,7 +213,9 @@ def _finding_kwargs(
         ident = _validate_hex64(raw[id_key], id_key)
     except KeyError as exc:
         raise VerifierError(f"missing required field {exc.args[0]}") from exc
-    fields = _content_fields(raw)
+    fields = parse_finding_content(
+        {field: raw[field] for field in _FINDING_CONTENT_KEYS}
+    )
     fields[id_key] = ident
     return fields
 

--- a/mypy_stubs/verifier_core.py
+++ b/mypy_stubs/verifier_core.py
@@ -30,6 +30,9 @@ from daydream.benchmark.harbor.verifier_core import (
     maximum_matching as maximum_matching,
 )
 from daydream.benchmark.harbor.verifier_core import (
+    parse_finding_content as parse_finding_content,
+)
+from daydream.benchmark.harbor.verifier_core import (
     retained_edges as retained_edges,
 )
 from daydream.benchmark.harbor.verifier_core import (

--- a/tests/test_benchmark_harbor_agent.py
+++ b/tests/test_benchmark_harbor_agent.py
@@ -140,6 +140,34 @@ def test_artifact_caps_fail_closed_and_write_is_atomic(tmp_path: Path) -> None:
     assert list(dest.parent.glob("review.json*")) == [dest]
 
 
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [("candidate_id", "not-a-digest"), ("title", ""), ("body", "bad\x00body"),
+     ("severity", "critical"), ("path", "../escape"), ("start_line", 0)],
+)
+def test_assembled_candidate_finding_rejects_verifier_invalid_content(
+    field: str, value: object
+) -> None:
+    from daydream.benchmark.harbor import candidate
+    from daydream.benchmark.harbor import verifier_core as vc
+
+    finding: dict[str, object] = {
+        "candidate_id": "", "title": "Title", "body": "Body", "severity": "low",
+        "path": "src/a.py", "start_line": 1, "end_line": 1,
+    }
+    finding["candidate_id"] = vc.derive_candidate_id("case-key", finding, 0)
+    assert vc.validate_candidate_artifact({
+        "schema_version": 1, "case_id": "case-key", "base_ref": "base",
+        "head_ref": "head", "findings": [finding],
+    })
+    finding[field] = value
+    if field != "candidate_id":
+        finding["candidate_id"] = vc.derive_candidate_id("case-key", finding, 0)
+    with pytest.raises(candidate.CandidateError) as rejected:
+        candidate.build_candidate_artifact("case-key", [finding])
+    assert rejected.value.kind == "invalid_finding"
+
+
 def test_artifact_write_failure_raises(tmp_path: Path) -> None:
     from daydream.benchmark.harbor import candidate
 
@@ -824,6 +852,7 @@ def test_local_harbor_task_with_fake_backend(
     documented, but the runnable gate is a genuine executed pass."""
     import asyncio
     import importlib
+    import importlib.util
     import os
 
     import pytest
@@ -949,6 +978,35 @@ def test_local_harbor_task_with_fake_backend(
     assert [f["title"] for f in artifact["findings"]] == _EXPECTED_TITLES
     assert artifact["case_id"] == key
     assert artifact["base_ref"] == "base" and artifact["head_ref"] == "head"
+
+    # Validate both host-produced artifacts with the verifier copied into the
+    # compiled task, exercising the actual deployment boundary.
+    spec = importlib.util.spec_from_file_location(
+        "compiled_verifier", ws / "harbor" / key / "tests" / "verifier_core.py"
+    )
+    assert spec is not None and spec.loader is not None
+    copied = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, spec.name, copied)
+    spec.loader.exec_module(copied)
+    case = ws / "harbor" / key
+    gold = json.loads((case / "tests" / "golden-review.json").read_text())
+    copied_candidates = copied.validate_candidate_artifact(artifact)
+    copied_gold = copied.validate_gold_set(gold, case_id=key)
+    assert [
+        (p.candidate_id, p.title, p.body, p.severity, p.path, p.start_line, p.end_line)
+        for p in copied_candidates
+    ] == [
+        (p.candidate_id, p.title, p.body, p.severity, p.path, p.start_line, p.end_line)
+        for p in parsed
+    ]
+    host_gold = vc.validate_gold_set(gold, case_id=key)
+    assert [
+        (f.finding_id, f.title, f.body, f.severity, f.path, f.start_line, f.end_line)
+        for f in copied_gold
+    ] == [
+        (f.finding_id, f.title, f.body, f.severity, f.path, f.start_line, f.end_line)
+        for f in host_gold
+    ]
 
 
 def test_agent_run_accepts_claude_and_invokes_entrypoint(

--- a/tests/test_benchmark_harbor_build.py
+++ b/tests/test_benchmark_harbor_build.py
@@ -499,6 +499,65 @@ def test_build_gold_list_rejects_partially_populated_location() -> None:
         }], key=build.derive_task_key("pr-000101-1a2b3c4d5e6f"))
 
 
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [("title", ""), ("body", "bad\x00body"), ("severity", "critical"),
+     ("location", {"path": "../escape", "start_line": 1, "end_line": 1})],
+)
+@pytest.mark.parametrize("oracle", [False, True])
+def test_build_gold_and_oracle_reject_invalid_finding_content(
+    field: str, value: object, oracle: bool
+) -> None:
+    from daydream.benchmark.harbor import build
+
+    finding: dict[str, Any] = {
+        "finding_id": "a" * 64, "title": "T", "body": "B", "severity": "low",
+        "location": {"path": "src/a.py", "start_line": 1, "end_line": 1},
+        "provenance": {"kind": "authored", "source_ids": []},
+    }
+    finding[field] = value
+    key = build.derive_task_key("pr-000101-1a2b3c4d5e6f")
+    with pytest.raises(build.CompileError):
+        if oracle:
+            build.build_oracle_artifact(key, [finding])
+        else:
+            build.build_gold_list([finding], key=key)
+
+
+@pytest.mark.parametrize(("oracle", "count"), [(False, 51), (True, 101)])
+def test_build_gold_and_oracle_reject_over_cap(oracle: bool, count: int) -> None:
+    from daydream.benchmark.harbor import build
+
+    findings = [{
+        "finding_id": f"{i:064x}", "title": f"T{i}", "body": "B", "severity": "low",
+        "location": {"path": "src/a.py", "start_line": 1, "end_line": 1},
+        "provenance": {"kind": "authored", "source_ids": []},
+    } for i in range(count)]
+    key = build.derive_task_key("pr-000101-1a2b3c4d5e6f")
+    with pytest.raises(build.CompileError):
+        if oracle:
+            build.build_oracle_artifact(key, findings)
+        else:
+            build.build_gold_list(findings, key=key)
+
+
+@pytest.mark.parametrize(("oracle", "count"), [(False, 50), (True, 100)])
+def test_build_gold_and_oracle_accept_at_cap(oracle: bool, count: int) -> None:
+    from daydream.benchmark.harbor import build
+
+    findings = [{
+        "finding_id": f"{i:064x}", "title": f"T{i}", "body": "B", "severity": "low",
+        "location": {"path": "src/a.py", "start_line": 1, "end_line": 1},
+        "provenance": {"kind": "authored", "source_ids": []},
+    } for i in range(count)]
+    key = build.derive_task_key("pr-000101-1a2b3c4d5e6f")
+    if oracle:
+        artifact = build.build_oracle_artifact(key, findings)
+        assert len(artifact["findings"]) == count
+    else:
+        assert len(build.build_gold_list(findings, key=key)) == count
+
+
 def test_build_oracle_artifact_locationless_passes_validation() -> None:
     from daydream.benchmark.harbor import build
     from daydream.benchmark.harbor import verifier_core as vc

--- a/tests/test_benchmark_harbor_build.py
+++ b/tests/test_benchmark_harbor_build.py
@@ -502,7 +502,8 @@ def test_build_gold_list_rejects_partially_populated_location() -> None:
 @pytest.mark.parametrize(
     ("field", "value"),
     [("title", ""), ("body", "bad\x00body"), ("severity", "critical"),
-     ("location", {"path": "../escape", "start_line": 1, "end_line": 1})],
+     ("location", {"path": "../escape", "start_line": 1, "end_line": 1}),
+     ("location", []), ("location", ""), ("location", 0), ("location", False)],
 )
 @pytest.mark.parametrize("oracle", [False, True])
 def test_build_gold_and_oracle_reject_invalid_finding_content(
@@ -522,6 +523,25 @@ def test_build_gold_and_oracle_reject_invalid_finding_content(
             build.build_oracle_artifact(key, [finding])
         else:
             build.build_gold_list([finding], key=key)
+
+
+@pytest.mark.parametrize(
+    ("present", "location"),
+    [(False, None), (True, None), (True, {}), (True, {"path": None}),
+     (True, {"start_line": None, "end_line": None})],
+)
+def test_gold_and_oracle_preserve_locationless_inputs(present: bool, location: object) -> None:
+    from daydream.benchmark.harbor import build
+
+    finding: dict[str, Any] = {
+        "finding_id": "a" * 64, "title": "T", "body": "B", "severity": None,
+    }
+    if present:
+        finding["location"] = location
+    [gold] = build.build_gold_list([finding], key="case-locationless")
+    [oracle] = build.build_oracle_artifact("case-locationless", [finding])["findings"]
+    for parsed in (gold, oracle):
+        assert (parsed["path"], parsed["start_line"], parsed["end_line"]) == (None, None, None)
 
 
 @pytest.mark.parametrize(("oracle", "count"), [(False, 51), (True, 101)])

--- a/tests/test_benchmark_verifier_assets.py
+++ b/tests/test_benchmark_verifier_assets.py
@@ -6,15 +6,166 @@ absent-axis handling) plus the compiled metric's subprocess behavior, so
 later canonicalization work must preserve behavior rather than source text.
 """
 import hashlib
+import importlib.util
 import json
 import shutil
 import subprocess
+import sys
+from copy import deepcopy
+from dataclasses import asdict
 from pathlib import Path
+from types import ModuleType
 from typing import Any
+
+import pytest
 
 from daydream.benchmark.harbor import verifier_core
 
 REPO = Path(__file__).resolve().parents[1]
+
+
+@pytest.fixture
+def copied_verifier(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> ModuleType:
+    from daydream.benchmark.harbor.build import _copy_assets
+
+    _copy_assets(tmp_path)
+    path = tmp_path / "tests" / "verifier_core.py"
+    spec = importlib.util.spec_from_file_location("copied_validation_verifier", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, spec.name, module)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _finding_content() -> dict[str, Any]:
+    return {
+        "title": "Cache key omits tenant",
+        "body": "Two tenants can receive the same cached response.",
+        "severity": "high",
+        "path": "src/cache.py",
+        "start_line": 3,
+        "end_line": 5,
+    }
+
+
+@pytest.mark.parametrize("locationless", [False, True])
+def test_public_content_parser_preserves_valid_values(
+    copied_verifier: ModuleType, locationless: bool,
+) -> None:
+    raw = _finding_content()
+    raw.update(title=" t " + "x" * 497, body="é" * 4096, severity=None)
+    if locationless:
+        raw.update(path=None, start_line=None, end_line=None)
+    original = dict(raw)
+    for module in (verifier_core, copied_verifier):
+        parsed = module.parse_finding_content(raw)
+        assert parsed == original and parsed is not raw
+        assert raw == original
+
+
+@pytest.mark.parametrize(
+    "changes",
+    [
+        {"title": " "}, {"title": "x" * 501}, {"title": "a\x00b"},
+        {"body": ""}, {"body": "é" * 4096 + "x"}, {"body": "a\x00b"},
+        {"severity": "critical"}, {"path": ""}, {"path": "/src/cache.py"},
+        {"path": "src/../cache.py"}, {"path": "src/ca\x00che.py"},
+        {"start_line": True}, {"end_line": False}, {"start_line": 0},
+        {"end_line": -1}, {"start_line": "3"}, {"end_line": 2},
+        {"path": None}, {"start_line": None}, {"end_line": None},
+        {"path": None, "start_line": None},
+        {"path": None, "end_line": None},
+        {"start_line": None, "end_line": None},
+    ],
+)
+def test_public_content_parser_rejection_matches_copied_verifier(
+    copied_verifier: ModuleType, changes: dict[str, Any],
+) -> None:
+    raw = _finding_content() | changes
+    messages = []
+    for module in (verifier_core, copied_verifier):
+        with pytest.raises(module.VerifierError) as rejected:
+            module.parse_finding_content(raw)
+        messages.append(str(rejected.value))
+    assert messages[0] == messages[1]
+
+
+@pytest.mark.parametrize("shape", ["non-object", "missing-severity", "unknown-key"])
+def test_public_content_parser_requires_exact_keys(
+    copied_verifier: ModuleType, shape: str,
+) -> None:
+    raw: Any = _finding_content()
+    if shape == "non-object":
+        raw = []
+    elif shape == "missing-severity":
+        del raw["severity"]
+    else:
+        raw["finding_id"] = "a" * 64
+    for module in (verifier_core, copied_verifier):
+        with pytest.raises(module.VerifierError):
+            module.parse_finding_content(raw)
+
+
+def test_host_built_artifacts_match_copied_verifier(copied_verifier: ModuleType) -> None:
+    from daydream.benchmark.harbor import build, candidate
+
+    key = "case-validation-parity"
+    merged = {"file": "src/cache.py", "line": 3, "description": "Tenant omitted",
+              "rationale": "Responses cross tenants", "severity": "high"}
+    candidate_artifact = candidate.build_candidate_artifact(
+        key, candidate.build_candidate_findings([merged, merged], case_id=key)
+    )
+    findings: list[dict[str, Any]] = [
+        {"finding_id": "a" * 64, "title": "Cache key omits tenant", "body": "Wrong tenant",
+         "severity": "high", "location": {"path": "src/cache.py", "start_line": 3, "end_line": 5}},
+        {"finding_id": "b" * 64, "title": "Missing access check", "body": "No authorization",
+         "severity": None, "location": None},
+    ]
+    gold = build.build_gold_list(findings, key=key)
+    oracle = build.build_oracle_artifact(key, findings)
+    for artifact in (candidate_artifact, oracle, candidate.build_candidate_artifact(key, [])):
+        expected = [asdict(f) for f in verifier_core.validate_candidate_artifact(artifact)]
+        assert [asdict(f) for f in copied_verifier.validate_candidate_artifact(artifact)] == expected
+        assert [f["candidate_id"] for f in artifact["findings"]] == [f["candidate_id"] for f in expected]
+    assert candidate_artifact["findings"][0]["candidate_id"] != candidate_artifact["findings"][1]["candidate_id"]
+    for entries in (gold, []):
+        expected = [asdict(f) for f in verifier_core.validate_gold_set(entries, case_id=key)]
+        assert [asdict(f) for f in copied_verifier.validate_gold_set(entries, case_id=key)] == expected
+
+    # Mutate host-built artifacts at the input boundary: both deployed and host
+    # validators must reject them with their own public exception category.
+    located_gold = next(i for i, finding in enumerate(gold) if finding["path"] is not None)
+    for changes in ({"body": "é" * 4096 + "x"}, {"path": None}, {"severity": "critical"}):
+        bad_candidate = deepcopy(candidate_artifact)
+        bad_candidate["findings"][0].update(changes)
+        bad_gold = deepcopy(gold)
+        bad_gold[located_gold].update(changes)
+        for module in (verifier_core, copied_verifier):
+            with pytest.raises(module.VerifierError):
+                module.validate_candidate_artifact(bad_candidate)
+            with pytest.raises(module.VerifierError):
+                module.validate_gold_set(bad_gold, case_id=key)
+
+    for module in (verifier_core, copied_verifier):
+        wrong_id = deepcopy(candidate_artifact)
+        wrong_id["findings"][0]["candidate_id"] = "0" * 64
+        with pytest.raises(module.VerifierError, match="derived id"):
+            module.validate_candidate_artifact(wrong_id)
+        wrong_gold_id = deepcopy(gold)
+        wrong_gold_id[0]["finding_id"] = "0" * 64
+        with pytest.raises(module.VerifierError, match="canonical digest"):
+            module.validate_gold_set(wrong_gold_id, case_id=key)
+        too_many = deepcopy(candidate_artifact)
+        too_many["findings"] = candidate_artifact["findings"] * 51
+        with pytest.raises(module.VerifierError, match="100 findings"):
+            module.validate_candidate_artifact(too_many)
+        with pytest.raises(module.VerifierError, match="50 findings"):
+            module.validate_gold_set(gold * 26, case_id=key)
+        too_large = deepcopy(candidate_artifact)
+        too_large["findings"][0]["body"] = "x" * module.MAX_ARTIFACT_BYTES
+        with pytest.raises(module.VerifierError, match="1 MiB"):
+            module.validate_candidate_artifact(too_large)
 
 
 _MISSING = object()  # sentinel: bare "verifier_core" absent from sys.modules
@@ -277,4 +428,3 @@ def test_deployed_canonical_copy_exposes_score_review_surface(tmp_path: Path) ->
         "derive_candidate_id",
     ):
         assert name in ns and ns[name] is not None, name
-


### PR DESCRIPTION
## Summary

Host candidate, gold, and oracle builders now share a public finding parser with the verifier copied into Harbor tasks. Producers reject malformed or oversized artifacts before returning them, using their existing outer error categories.

## Motivation

Closes #1016. The host producers previously called private verifier helpers, and direct builder calls could return artifacts the compiled verifier would reject.

## Changes

- Publish `parse_finding_content()` in the existing stdlib-only canonical verifier and route finding parsing and host builders through it.
- Reuse final artifact/gold validation for IDs and caps while preserving candidate preprocessing, skip behavior, cap-error precedence, output ordering, and empty reviews.
- Exercise accepted/rejected semantics against the copied verifier and extend the existing compiled Harbor entrypoint journey to validate its real candidate and gold artifacts.

## Test Plan

- Harbor agent/build/package, verifier assets, and verifier core: 263 passed.
- `make check`: 8,049 passed, 15 skipped; coverage 88.76%. Ruff, root/RL dead-code scans, mypy, and Docker workflow lint passed.
- Ran `daydream . --precision --non-interactive --backend codex` before this PR. Fixed its location-type finding and repeated full validation and review. Final review: exit 0, zero findings, all seven files read at `98f1e73a37d1e7d76ca5d1cbceab0be7bc6b344e` (session `3d79eb0e-a7e8-4f5a-ba86-47935923826b`). Optional diagrams exceeded the dependency-input size budget; code-review passes completed successfully.
- Review reports, trajectories, finding disposition, and regression evidence retained locally under `.beagle/plans/refactor-backlog/evidence/1016/`. Commits and push use normal signing and repository hooks.
