### PR TITLE
refactor(exploration): remove unsupported depth configuration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -255,8 +255,8 @@ exploration pre-scan (cached across runs)
   artifacts — so it writes no `diff-key` either. Its recorder/manifest label is `DaydreamRunFlow.DIAGRAM`,
   never `TTT`: that mapping would make `_flow_runs_merge` true and let the run inherit the surviving
   `merged-items.json` as its own pipeline state.
-- `.daydream/exploration/` survives the run, reused only on an **exact** key match (format version + head SHA + diff + tier +
-  depth, in a sibling `cache-key` file) — a near-match hit would misground every prompt. Uncommitted edits
+- `.daydream/exploration/` survives the run, reused only on an **exact** key match (format version + head SHA + diff + tier,
+  in a sibling `cache-key` file) — a near-match hit would misground every prompt. Uncommitted edits
   are not in the key, so an exact hit on a dirty tree can serve pre-edit exploration. `--shallow`/`--review`
   delete the directory, so alternating modes always miss.
 - `--start-at` refuses stale artifacts: a fresh run records its diff in `.daydream/deep/diff-key`; a resume

--- a/daydream/deep/orchestrator.py
+++ b/daydream/deep/orchestrator.py
@@ -1090,7 +1090,7 @@ async def _step_exploration(ctx: FlowContext) -> None:
         # The in-process context short-circuits first; the disk cache is only
         # consulted when there is no in-memory context to reuse.
         cache_key = exploration_cache_key(
-            ctx.work.head_sha or "", diff, tier, config.exploration_depth
+            ctx.work.head_sha or "", diff, tier
         )
         if (
             exploration_path.is_dir()
@@ -1120,7 +1120,6 @@ async def _step_exploration(ctx: FlowContext) -> None:
                     explore_backend,
                     target_dir,
                     diff,
-                    config.exploration_depth,
                     diff_ref=_compute_diff_ref(target_dir),
                     strategies={
                         "exploration.pattern_scan": ctx.strategy("exploration.pattern_scan"),
@@ -5891,7 +5890,7 @@ async def _run_review_spine(
 
         # Nothing is torn down after the flow. .daydream/exploration/ is a
         # content-keyed cache (see ``exploration_cache_key``) the next run reuses
-        # on an exact head+diff+tier+depth match and rewrites on a miss, and
+        # on an exact head+diff+tier match and rewrites on a miss, and
         # .daydream/deep/ is preserved per RESEARCH.md Open Question 1 so
         # subsequent --start-at resumes can find the artifacts they need.
         #

--- a/daydream/exploration.py
+++ b/daydream/exploration.py
@@ -364,10 +364,10 @@ CACHE_KEY_FILENAME = "cache-key"
 
 # Bump when the artifact generator changes (e.g. a new boundary rendering) so
 # upgrades force regeneration instead of serving pre-upgrade artifacts on a key match.
-_CACHE_VERSION = 3
+_CACHE_VERSION = 4
 
 
-def exploration_cache_key(head_sha: str, diff: str, tier: str, depth: int | str) -> str:
+def exploration_cache_key(head_sha: str, diff: str, tier: str) -> str:
     """Content key identifying one exploration pre-scan result.
 
     Exact-match only: a stale hit misgrounds every downstream review prompt, so
@@ -378,12 +378,12 @@ def exploration_cache_key(head_sha: str, diff: str, tier: str, depth: int | str)
 
     An exact key match is reused even with uncommitted worktree edits: the key
     intentionally excludes uncommitted edits because reuse is exact-match-only
-    on format version + head SHA + diff + tier + depth. The generating code is
+    on format version + head SHA + diff + tier. The generating code is
     versioned into the key too, so an upgrade that changes artifact rendering
     (``_CACHE_VERSION``) never serves stale pre-upgrade artifacts on an exact
     match.
     """
-    payload = f"{_CACHE_VERSION}\n{head_sha}\n{diff}\n{tier}\n{depth}"
+    payload = f"{_CACHE_VERSION}\n{head_sha}\n{diff}\n{tier}"
     return hashlib.sha256(payload.encode("utf-8")).hexdigest()
 
 

--- a/daydream/exploration_runner.py
+++ b/daydream/exploration_runner.py
@@ -194,7 +194,6 @@ async def pre_scan(
     backend: Backend,
     repo_root: Path,
     diff_text: str,
-    depth: int = 1,
     diff_ref: str = "HEAD",
     strategies: dict[str, str] | None = None,
 ) -> ExplorationContext:
@@ -212,7 +211,6 @@ async def pre_scan(
         repo_root: Repository root used by ``detect_affected_files``.
         diff_text: Raw git diff string (used locally for file detection only;
             never embedded in specialist prompts).
-        depth: Static-resolution depth (forwarded to ``detect_affected_files``).
         diff_ref: Git ref or range (e.g. ``"main...HEAD"``) passed to specialist
             prompts so they can run ``git diff <ref> -- <file>`` per file.
         strategies: Optional mapping of the four exploration strategy contents
@@ -235,7 +233,7 @@ async def pre_scan(
 
     static_files: list[FileInfo] = []
     try:
-        static_files = detect_affected_files(diff_text, repo_root, depth)
+        static_files = detect_affected_files(diff_text, repo_root)
     except Exception:  # noqa: BLE001 - best-effort path; exploration degrades silently per D-08
         pass
 

--- a/daydream/runner.py
+++ b/daydream/runner.py
@@ -323,7 +323,6 @@ class RunConfig:
     fix_model: str | None = None
     test_model: str | None = None
     exploration_context: ExplorationContext | None = None
-    exploration_depth: int = 1
     exploration_model: str | None = None
     ignore_paths: list[str] = field(default_factory=list)
     trajectory_path: Path | None = None

--- a/daydream/tree_sitter_index.py
+++ b/daydream/tree_sitter_index.py
@@ -1187,15 +1187,12 @@ def definitions_in_file(repo_root: Path, path: str) -> list[dict[str, object]]:
 def detect_affected_files(
     diff_text: str,
     repo_root: Path,
-    depth: int = 1,
 ) -> list[FileInfo]:
     """Return changed files plus their 1-hop import dependencies.
 
     Args:
         diff_text: Raw output of ``git diff`` (unified format).
         repo_root: Repository root used for resolving import paths on disk.
-        depth: Reserved for future multi-hop tracing. Only ``depth=1`` is
-            supported. Passing any other value raises ``NotImplementedError``.
 
     Returns:
         A list of ``FileInfo`` entries containing the modified files (always)
@@ -1203,7 +1200,6 @@ def detect_affected_files(
         (``role="imported_by"``). Deduplicated by ``(path, role)``.
 
     Raises:
-        NotImplementedError: If ``depth != 1``.
         TreeSitterBadVersionError: If the installed tree-sitter version is in
             the known-bad set (issue #1087): the index consumer refuses to
             construct a parser that could SIGSEGV the process.
@@ -1213,9 +1209,6 @@ def detect_affected_files(
     # construction, so no native parsing happens on a bad install. No-op on
     # good installs; errors propagate to the caller unwrapped.
     assert_tree_sitter_safe()
-
-    if depth != 1:
-        raise NotImplementedError("depth > 1 reserved for future use")
 
     results: list[FileInfo] = []
     seen: set[tuple[str, str]] = set()

--- a/tests/test_exploration_cache.py
+++ b/tests/test_exploration_cache.py
@@ -1,7 +1,7 @@
 """Cross-run reuse of the deep pipeline's exploration pre-scan.
 
 ``.daydream/exploration/`` now survives a run and is keyed by
-``head sha + diff + tier + depth + format version``
+``head sha + diff + tier + format version``
 (``daydream.exploration.exploration_cache_key``).
 A second run with an identical key reuses the directory verbatim and fires zero
 specialist agents; any key change re-runs the pre-scan and rewrites the files.
@@ -12,6 +12,7 @@ backend seam stubbed.
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import pytest
@@ -67,22 +68,64 @@ async def _run_deep(target: Path) -> int:
     return await run(RunConfig(target=str(target), start_at="review", cleanup=False))
 
 
+def _add_one_hop_graph_on_main(multi_stack_target: Path) -> None:
+    """Make a committed one-hop Python graph before the feature-only edit."""
+    _git(multi_stack_target, "checkout", "main")
+    (multi_stack_target / "changed.py").write_text(
+        "from dep import direct\n\n\ndef subject() -> str:\n    return direct()\n"
+    )
+    (multi_stack_target / "dep.py").write_text(
+        "from secondhop import indirect\n\n\ndef direct() -> str:\n    return indirect()\n"
+    )
+    (multi_stack_target / "secondhop.py").write_text(
+        "def indirect() -> str:\n    return 'base'\n"
+    )
+    (multi_stack_target / "consumer.py").write_text(
+        "from changed import subject\n\n\ndef consume() -> str:\n    return subject()\n"
+    )
+    (multi_stack_target / "outer_consumer.py").write_text(
+        "from consumer import consume\n\n\ndef outer() -> str:\n    return consume()\n"
+    )
+    _git(multi_stack_target, "add", "changed.py", "dep.py", "secondhop.py", "consumer.py", "outer_consumer.py")
+    _git(multi_stack_target, "commit", "-m", "add one-hop exploration graph")
+    _git(multi_stack_target, "checkout", "feature")
+    _git(multi_stack_target, "rebase", "main")
+    (multi_stack_target / "changed.py").write_text(
+        "from dep import direct\n\n\ndef subject() -> str:\n    return direct() + '-changed'\n"
+    )
+    _git(multi_stack_target, "add", "changed.py")
+    _git(multi_stack_target, "commit", "-m", "change one-hop graph root")
+
+
 async def test_second_run_reuses_exploration(
     multi_stack_target: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """An exact key match reuses the directory and fires zero specialists."""
     silence(monkeypatch)
+    _add_one_hop_graph_on_main(multi_stack_target)
     stub1 = _install(monkeypatch, multi_stack_target, "RUN1 SENTINEL")
     assert await _run_deep(multi_stack_target) == 0
     assert _count_specialist_calls(stub1) > 0
 
     exploration = multi_stack_target / ".daydream" / "exploration"
     assert exploration.is_dir(), "exploration must survive the run"
-    assert (exploration / "cache-key").read_text().strip()
+    first_key = (exploration / "cache-key").read_text().strip()
+    first_exploration = (exploration / "exploration.json").read_bytes()
+    assert first_key
+    affected = {
+        (row["path"], row["role"])
+        for row in json.loads(first_exploration)["affected_files"]
+    }
+    assert ("changed.py", "modified") in affected
+    assert ("dep.py", "imports") in affected
+    assert ("consumer.py", "imported_by") in affected
+    assert all(path not in {"secondhop.py", "outer_consumer.py"} for path, _ in affected)
 
     stub2 = _install(monkeypatch, multi_stack_target, "RUN2 SENTINEL")
     assert await _run_deep(multi_stack_target) == 0
     assert _count_specialist_calls(stub2) == 0, "cache hit must fire no specialists"
+    assert (exploration / "cache-key").read_text().strip() == first_key
+    assert (exploration / "exploration.json").read_bytes() == first_exploration
 
     # Reviewers are still grounded by the pointer.
     review_prompt = next(
@@ -171,29 +214,25 @@ async def test_daydream_artifacts_do_not_block_writing_a_rebuilt_cache_key(
     assert (exploration / "cache-key").read_text().strip() != "stale"
 
 
-async def test_depth_change_invalidates_cache(
+async def test_cache_version_change_invalidates_cache(
     multi_stack_target: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """exploration_depth is part of the key, so changing it re-runs the pre-scan."""
-    from daydream.runner import RunConfig, run
+    """A cache-format bump forces a real second-run pre-scan."""
+    from daydream import exploration as exploration_mod
 
     silence(monkeypatch)
     stub1 = _install(monkeypatch, multi_stack_target, "RUN1 SENTINEL")
-    assert await run(
-        RunConfig(target=str(multi_stack_target), start_at="review", cleanup=False)
-    ) == 0
+    assert await _run_deep(multi_stack_target) == 0
     assert _count_specialist_calls(stub1) > 0
+    exploration = multi_stack_target / ".daydream" / "exploration"
+    first_key = (exploration / "cache-key").read_text().strip()
 
+    monkeypatch.setattr(exploration_mod, "_CACHE_VERSION", exploration_mod._CACHE_VERSION + 1)
     stub2 = _install(monkeypatch, multi_stack_target, "RUN2 SENTINEL")
-    assert await run(
-        RunConfig(
-            target=str(multi_stack_target),
-            start_at="review",
-            cleanup=False,
-            exploration_depth=3,
-        )
-    ) == 0
-    assert _count_specialist_calls(stub2) > 0, "changed depth must re-fire specialists"
+    assert await _run_deep(multi_stack_target) == 0
+    assert _count_specialist_calls(stub2) > 0, "version change must re-fire specialists"
+    assert (exploration / "cache-key").read_text().strip() != first_key
+    assert "RUN2 SENTINEL" in (exploration / "dependencies.md").read_text()
 
 
 async def test_corrupt_key_file_is_a_miss_not_a_crash(
@@ -253,28 +292,27 @@ async def test_failed_exploration_is_not_durably_cached(
 def test_cache_key_is_sensitive_to_every_component(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Each of head, diff, tier, depth, and the format version changes the key."""
+    """Each of head, diff, tier, and the format version changes the key."""
     from daydream import exploration as exploration_mod
     from daydream.exploration import exploration_cache_key
 
-    base = exploration_cache_key("sha1", "diff", "standard", 2)
-    assert base == exploration_cache_key("sha1", "diff", "standard", 2)
-    assert base != exploration_cache_key("sha2", "diff", "standard", 2)
-    assert base != exploration_cache_key("sha1", "other", "standard", 2)
-    assert base != exploration_cache_key("sha1", "diff", "deep", 2)
-    assert base != exploration_cache_key("sha1", "diff", "standard", 3)
+    base = exploration_cache_key("sha1", "diff", "standard")
+    assert base == exploration_cache_key("sha1", "diff", "standard")
+    assert base != exploration_cache_key("sha2", "diff", "standard")
+    assert base != exploration_cache_key("sha1", "other", "standard")
+    assert base != exploration_cache_key("sha1", "diff", "deep")
 
     # The format version is part of the key: a bump must change it. The override
     # value is arbitrary (never assert the production value), so a legitimate
     # upgrade stays green while a removal from the payload goes red.
     monkeypatch.setattr(exploration_mod, "_CACHE_VERSION", 999)
-    assert base != exploration_cache_key("sha1", "diff", "standard", 2)
+    assert base != exploration_cache_key("sha1", "diff", "standard")
 
 
 def test_cache_key_components_cannot_be_confused_by_delimiters() -> None:
     """Shifting content across the newline boundary changes the key."""
     from daydream.exploration import exploration_cache_key
 
-    assert exploration_cache_key("a", "b", "standard", 2) != exploration_cache_key(
-        "a\nb", "", "standard", 2
+    assert exploration_cache_key("a", "b", "standard") != exploration_cache_key(
+        "a\nb", "", "standard"
     )

--- a/tests/test_exploration_runner.py
+++ b/tests/test_exploration_runner.py
@@ -591,7 +591,7 @@ def test_pre_scan_passes_cwd_absolute_static_files(tmp_path: Path, monkeypatch: 
     monkeypatch.setattr(
         er,
         "detect_affected_files",
-        lambda diff_text, repo_root, depth: [FileInfo("services/taste/dep.py", "imports", "helper")],
+        lambda diff_text, repo_root: [FileInfo("services/taste/dep.py", "imports", "helper")],
     )
     # 2 files => single tier => dependency_tracer gets static_files.
     diff_text = _multifile_diff(["services/taste/a.py", "services/taste/b.py"])
@@ -608,8 +608,11 @@ def test_pre_scan_fallback_uses_rename_new_path(tmp_path: Path, monkeypatch: pyt
     """Fallback seeding is rename-aware: a renamed file seeds its new path, not the old one."""
     import daydream.exploration_runner as er
 
-    # Force the fallback path: static resolution yields nothing.
-    monkeypatch.setattr(er, "detect_affected_files", lambda diff_text, repo_root, depth: [])
+    # Force the fallback path with a genuine static-analysis failure.
+    def analyzer_failure(diff_text: str, repo_root: Path) -> list[FileInfo]:
+        raise OSError("tree-sitter source unavailable")
+
+    monkeypatch.setattr(er, "detect_affected_files", analyzer_failure)
     # A rename plus a second file => 2 files => single tier => dependency_tracer runs.
     rename_diff = (
         "diff --git a/services/taste/old_name.py b/services/taste/new_name.py\n"
@@ -648,6 +651,12 @@ def test_pre_scan_threads_profile_strategy(tmp_path: Path) -> None:
 
     diff_text = (FIXTURES / "python_multifile.diff").read_text()
     ctx = anyio.run(
-        lambda: er.pre_scan(cast(Backend, _SpecialistMockBackend()), tmp_path, diff_text, 1, "HEAD", strategies)
+        lambda: er.pre_scan(
+            cast(Backend, _SpecialistMockBackend()),
+            tmp_path,
+            diff_text,
+            diff_ref="HEAD",
+            strategies=strategies,
+        )
     )
     assert ctx is not None

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -146,10 +146,9 @@ def _handoff_turn(body: str) -> Turn:
     return (ResultEvent(structured_output={"handoff_prompt": body}, continuation=None),)
 
 
-def test_run_config_exploration_depth() -> None:
-    assert RunConfig().exploration_depth == 1
-    cfg = RunConfig(exploration_depth=2)
-    assert cfg.exploration_depth == 2
+def test_run_config_rejects_unsupported_exploration_depth() -> None:
+    with pytest.raises(TypeError, match="exploration_depth"):
+        RunConfig(exploration_depth=2)  # type: ignore[call-arg]
 
 
 def test_run_config_diagram_defaults_to_unset_not_auto() -> None:

--- a/tests/test_tree_sitter_index.py
+++ b/tests/test_tree_sitter_index.py
@@ -1,6 +1,5 @@
 """Unit tests for daydream.tree_sitter_index.detect_affected_files()."""
 
-import inspect
 from pathlib import Path
 from typing import Any
 
@@ -62,7 +61,7 @@ def test_detect_affected_files_rows_are_static_provenance(tmp_path: Path) -> Non
     (tmp_path / "pkg").mkdir()
     (tmp_path / "pkg" / "widget.py").write_text("x = 1\n")
     (tmp_path / "app.py").write_text("import pkg.widget\n")
-    results = detect_affected_files(_modified_diff("app.py"), tmp_path, depth=1)
+    results = detect_affected_files(_modified_diff("app.py"), tmp_path)
     assert results, "static resolution must produce rows"
     assert all(f.provenance == "static" for f in results)
 
@@ -79,7 +78,7 @@ def test_python_impact_surface(tmp_path: Path) -> None:
             "daydream_demo/models.py": '"""Models module."""\n\nclass User:\n    pass\n',
         },
     )
-    results = detect_affected_files(diff_text, repo, depth=1)
+    results = detect_affected_files(diff_text, repo)
     paths_by_role = {(r.path, r.role) for r in results}
     assert ("daydream_demo/api.py", "modified") in paths_by_role
     assert ("daydream_demo/models.py", "modified") in paths_by_role
@@ -159,7 +158,7 @@ def test_python_multilevel_relative_imports(
     expected_import_path: str | set[str],
 ) -> None:
     repo = _materialize(tmp_path, files)
-    results = detect_affected_files(_modified_diff(api_rel), repo, depth=1)
+    results = detect_affected_files(_modified_diff(api_rel), repo)
     imports_pairs = {(r.path, r.role) for r in results if r.role == "imports"}
     if isinstance(expected_import_path, str):
         assert imports_pairs == {(expected_import_path, "imports")}
@@ -195,7 +194,7 @@ def test_python_parent_relative_imports(
     expected_import_paths: set[str],
 ) -> None:
     repo = _materialize(tmp_path, files)
-    results = detect_affected_files(_modified_diff(api_rel), repo, depth=1)
+    results = detect_affected_files(_modified_diff(api_rel), repo)
     imports_paths = {r.path for r in results if r.role == "imports"}
     assert imports_paths == expected_import_paths
 
@@ -212,7 +211,7 @@ def test_typescript_impact_surface(tmp_path: Path) -> None:
             "src/models.ts": "// Models module\n\nexport class User {}\n",
         },
     )
-    results = detect_affected_files(diff_text, repo, depth=1)
+    results = detect_affected_files(diff_text, repo)
     assert any(r.path == "src/api.ts" and r.role == "modified" for r in results)
     assert any(r.path == "src/models.ts" and r.role == "modified" for r in results)
     assert ("src/models.ts", "imports") in {
@@ -246,7 +245,7 @@ def test_go_imports_reuse_one_package_index(tmp_path: Path, monkeypatch: pytest.
     monkeypatch.setattr(Path, "rglob", one_go_traversal)
 
     results = detect_affected_files(
-        _modified_diff("cmd/alpha.go") + _modified_diff("cmd/beta.go"), repo, depth=1
+        _modified_diff("cmd/alpha.go") + _modified_diff("cmd/beta.go"), repo
     )
     imports_paths = {r.path for r in results if r.role == "imports"}
     assert imports_paths == {"models/user.go", "models/order.go", "helpers/format.go"}
@@ -262,17 +261,12 @@ def test_rust_impact_surface(tmp_path: Path) -> None:
             "src/models.rs": "// models module\n\npub struct User;\n",
         },
     )
-    results = detect_affected_files(diff_text, repo, depth=1)
+    results = detect_affected_files(diff_text, repo)
     assert any(r.path == "src/api.rs" and r.role == "modified" for r in results)
     assert any(r.path == "src/models.rs" and r.role == "modified" for r in results)
     assert ("src/models.rs", "imports") in {
         (r.path, r.role) for r in results
     }
-
-
-def test_default_depth_is_one() -> None:
-    sig = inspect.signature(detect_affected_files)
-    assert sig.parameters["depth"].default == 1
 
 
 def test_unsupported_language_gets_modified_role(tmp_path: Path) -> None:
@@ -287,7 +281,7 @@ def test_unsupported_language_gets_modified_role(tmp_path: Path) -> None:
     )
     (tmp_path / "lib").mkdir()
     (tmp_path / "lib" / "foo.rb").write_text("class Foo\n  def bar; end\nend\n")
-    results = detect_affected_files(diff_text, tmp_path, depth=1)
+    results = detect_affected_files(diff_text, tmp_path)
     assert len(results) == 1
     assert results[0].path == "lib/foo.rb"
     assert results[0].role == "modified"
@@ -303,7 +297,7 @@ def test_deleted_file_does_not_raise_filenotfound(tmp_path: Path) -> None:
         "@@ -1,1 +0,0 @@\n"
         "-print('bye')\n"
     )
-    results = detect_affected_files(diff_text, tmp_path, depth=1)
+    results = detect_affected_files(diff_text, tmp_path)
     assert len(results) == 1
     assert results[0].path == "gone.py"
     assert results[0].role == "modified"
@@ -320,7 +314,7 @@ def test_reverse_edge_finds_code_importer(tmp_path: Path) -> None:
     _git(repo, "add", "pkg/widget.py", "caller.py")
     _commit(repo, "add widget + caller")
 
-    results = detect_affected_files(_modified_diff("pkg/widget.py"), repo, depth=1)
+    results = detect_affected_files(_modified_diff("pkg/widget.py"), repo)
     assert "caller.py" in _importers(results)
 
 
@@ -332,7 +326,7 @@ def test_reverse_edge_skips_generic_stem(tmp_path: Path) -> None:
     _git(repo, "add", "app.py", "unrelated.py")
     _commit(repo, "add app + unrelated")
 
-    results = detect_affected_files(_modified_diff("app.py"), repo, depth=1)
+    results = detect_affected_files(_modified_diff("app.py"), repo)
     assert _importers(results) == set()
 
 
@@ -345,7 +339,7 @@ def test_reverse_edge_excludes_non_code_files(tmp_path: Path) -> None:
     _git(repo, "add", "widget.py", "notes.md", "caller.py")
     _commit(repo, "add code + docs")
 
-    importers = _importers(detect_affected_files(_modified_diff("widget.py"), repo, depth=1))
+    importers = _importers(detect_affected_files(_modified_diff("widget.py"), repo))
     assert "caller.py" in importers
     assert "notes.md" not in importers
 
@@ -379,7 +373,7 @@ def test_reverse_edge_capped_at_max(tmp_path: Path, monkeypatch: pytest.MonkeyPa
     monkeypatch.setattr(git_ops, "grep", no_legacy_grep)
 
     results = detect_affected_files(
-        _modified_diff("widget.py") + _modified_diff("gadget.py"), repo, depth=1
+        _modified_diff("widget.py") + _modified_diff("gadget.py"), repo
     )
     importers = _importers(results)
     widget = {p for p in importers if p.startswith("widget_importer_")}
@@ -444,7 +438,7 @@ def test_config_py_with_definition_receives_reverse_edges(tmp_path: Path) -> Non
     _configure_identity(tmp_path)
     _git(tmp_path, "add", ".")
     _commit(tmp_path, "init")
-    results = detect_affected_files(diff, tmp_path, depth=1)
+    results = detect_affected_files(diff, tmp_path)
     assert any(r.path == "app.py" and r.role == "imported_by" for r in results)
 
 


### PR DESCRIPTION
## Summary

Exploration now exposes its supported one-hop import/importer analysis directly. Passing the removed `RunConfig.exploration_depth` argument fails at construction instead of falling back to changed-file-only exploration.

## Motivation

Closes #1021. The depth setting was forwarded through several APIs even though static analysis implemented only depth one, and its unsupported-depth error was caught as a best-effort parser failure.

## Changes

- Remove depth parameters, forwarding, and cache-key input; bump the cache format version.
- Preserve genuine parser/filesystem failure fallback and exact HEAD/diff/tier/version cache reuse.
- Update callers and prove direct-neighbor exploration plus second-run reuse through the real runner path.

## Test Plan

- `uv run pytest -n auto tests/test_exploration.py tests/test_exploration_cache.py tests/test_exploration_runner.py tests/test_runner.py tests/test_deep_orchestrator.py tests/test_tree_sitter_index.py`: 509 passed.
- `make check`: 8,048 passed, 15 skipped, 88.76% coverage; lint, root/RL dead-code, types, and Docker workflow lint passed. A stalled local Docker engine was recovered; the affected real container test passed, followed by this complete successful rerun.
- `daydream . --precision --non-interactive --backend codex`: exit 0, zero findings, all 10 changed files read; exact reviewed diff and clean signed head `d2107153dce9316f5e569a76ff321d3a15734cdf` verified. Session `27949645-1162-4a89-b24c-129addf68ef6`; report, trajectories, phase outcomes, and coverage receipts retained in the backlog ledger. Optional flowchart generation exceeded its input byte budget; all code-review phases succeeded.
