### PR TITLE
refactor(runner): make interaction and output policy per-run

### DIFF
--- a/daydream/agent.py
+++ b/daydream/agent.py
@@ -11,7 +11,6 @@ import random
 import re
 from collections.abc import Callable
 from contextlib import nullcontext
-from dataclasses import dataclass, field
 from pathlib import Path
 from types import TracebackType
 from typing import TYPE_CHECKING, Any
@@ -45,6 +44,14 @@ from daydream.extensions import get_registry
 from daydream.json_utils import extract_json
 from daydream.observability.spans import agent_scope, attempt_scope
 from daydream.prompt_budget import PreparedSanctionedInputs
+from daydream.run_context import (
+    InteractionPolicy,
+    RunContext,
+    bind_run_context,
+    current_run_context,
+    resolve_run_context,
+)
+from daydream.run_context import resolve_gate as resolve_gate
 from daydream.trajectory import DaydreamPhase, get_current_recorder, redact_structured_text, redact_text, redact_value
 from daydream.ui import (
     NEON_THEME,
@@ -56,9 +63,6 @@ from daydream.ui import (
     print_error,
     print_thinking,
     print_warning,
-)
-from daydream.ui import (
-    prompt_user as prompt_user,
 )
 from daydream.ui.tools import _BASH_COMMAND_MAX_CHARS, _PRIMARY_TOOL_ARG
 
@@ -154,26 +158,6 @@ class _EventStreamScope:
             pass
 
 
-@dataclass
-class AgentState:
-    """Consolidated state for agent module.
-
-    Attributes:
-        assume: A forced yes/no answer for interactive gates — ``"yes"`` (``--yes``),
-            ``"no"`` (a future ``--no``), or ``None`` (no assumption). Orthogonal to
-            ``non_interactive``: ``non_interactive`` controls *whether* we may block on
-            stdin; ``assume`` supplies a *pre-decided answer* regardless of TTY.
-        log_mode: When True, bypass Rich UI and emit redacted agent events as plain text
-            to stdout (for CI log capture). Default False.
-    """
-
-    quiet_mode: bool = False
-    non_interactive: bool = False
-    assume: str | None = None
-    log_mode: bool = False
-    current_backends: list[Backend] = field(default_factory=list)
-
-
 class _LogRedactingConsole(Console):
     """Console that redacts string payloads while ``--log`` mode is active.
 
@@ -183,7 +167,8 @@ class _LogRedactingConsole(Console):
     """
 
     def print(self, *objects: Any, **kwargs: Any) -> None:
-        if _state.log_mode:
+        context = current_run_context()
+        if context is not None and context.policy.log_mode:
             objects = tuple(
                 redact_text(obj) if isinstance(obj, str) else obj
                 for obj in objects
@@ -191,91 +176,7 @@ class _LogRedactingConsole(Console):
         super().print(*objects, **kwargs)
 
 
-# Module-level singletons: access/mutate via the getter/setter functions below,
-# never _state directly. reset_state() restores defaults between test runs.
-
-_state = AgentState()
 console = _LogRedactingConsole(theme=NEON_THEME)
-
-
-def reset_state() -> None:
-    """Reset the global agent state to defaults (restores between test runs)."""
-    global _state
-    _state = AgentState()
-
-
-def set_quiet_mode(quiet: bool) -> None:
-    """Set quiet mode for agent output."""
-    _state.quiet_mode = quiet
-
-
-def get_quiet_mode() -> bool:
-    """Get current quiet mode setting."""
-    return _state.quiet_mode
-
-
-def set_non_interactive(value: bool) -> None:
-    """Set non-interactive mode for prompts."""
-    _state.non_interactive = value
-
-
-def get_non_interactive() -> bool:
-    """Get current non-interactive mode setting."""
-    return _state.non_interactive
-
-
-def set_assume(value: str | None) -> None:
-    """Set the forced yes/no answer for interactive gates.
-
-    Args:
-        value: ``"yes"`` to auto-approve gates (``--yes``), ``"no"`` to auto-decline,
-            or ``None`` for no assumption (gates fall back to prompting or their
-            unattended safe default).
-    """
-    _state.assume = value
-
-
-def get_assume() -> str | None:
-    """Get the forced yes/no answer for interactive gates.
-
-    Returns:
-        ``"yes"``, ``"no"``, or ``None`` when no assumption is set.
-    """
-    return _state.assume
-
-
-def set_log_mode(log_mode: bool) -> None:
-    """Set log mode for agent output."""
-    _state.log_mode = log_mode
-
-
-def get_log_mode() -> bool:
-    """Get current log mode setting."""
-    return _state.log_mode
-
-
-def resolve_gate(*, assume: str | None, interactive: bool, safe_default: bool) -> bool | None:
-    """Resolve a yes/no interaction gate across the two orthogonal axes.
-
-    Collapses *assume* (a forced answer) and *interactivity* (may we block on
-    stdin?) into a single decision. Pure — performs no I/O.
-
-    Args:
-        assume: A forced answer: ``"yes"`` → True, ``"no"`` → False, ``None`` →
-            no assumption (defer to interactivity).
-        interactive: True when prompts may read stdin.
-        safe_default: The answer to use when unattended and no assumption is set
-            (e.g. ``False`` to decline a fix-apply, ``True`` to auto-commit).
-
-    Returns:
-        ``True``/``False`` to use the resolved answer directly, or ``None`` when
-        the caller should fall back to an interactive prompt.
-    """
-    if assume is not None:
-        return assume == "yes"
-    if not interactive:
-        return safe_default
-    return None
 
 
 def resolve_or_prompt(
@@ -306,16 +207,21 @@ def resolve_or_prompt(
     Returns:
         ``True`` if the gate is approved, ``False`` if declined.
     """
-    decision = resolve_gate(assume=assume, interactive=interactive, safe_default=safe_default)
-    if decision is None:
-        response = prompt_user(console, question, default)
-        decision = response.strip().lower() in ("y", "yes")
-    return decision
-
-
-def get_current_backends() -> list[Backend]:
-    """Get all currently running backends."""
-    return list(_state.current_backends)
+    current = resolve_run_context()
+    context = RunContext(
+        InteractionPolicy(
+            assume=assume,
+            interactive=interactive,
+            quiet=current.policy.quiet,
+            log_mode=current.policy.log_mode,
+        )
+    )
+    return context.confirm(
+        question,
+        safe_default=safe_default,
+        default=default,
+        console=console,
+    )
 
 
 def detect_test_success(output: str) -> bool:
@@ -533,6 +439,7 @@ async def run_agent(
     tool_call_budget: int | None = None,
     validate_structured_output: bool = True,
     sanctioned_inputs: PreparedSanctionedInputs | None = None,
+    run_context: RunContext | None = None,
 ) -> tuple[str | Any, ContinuationToken | None, str | None]:
     """Run one logical agent, tracing its actual returned or salvaged result.
 
@@ -541,8 +448,11 @@ async def run_agent(
     """
     if sanctioned_inputs is not None:
         prompt = sanctioned_inputs.render_prompt(prompt)
+    context = resolve_run_context(run_context)
     backend_name = type(backend).__name__.removesuffix("Backend").lower()
-    with agent_scope(phase.value, backend=backend_name, model=backend.model) as observed:
+    with bind_run_context(context), agent_scope(
+        phase.value, backend=backend_name, model=backend.model
+    ) as observed:
         observed.content("traceloop.entity.input", {"prompt": prompt, "output_schema": output_schema})
         result = await _run_agent(
             backend, cwd, prompt, phase=phase, output_schema=output_schema, progress_callback=progress_callback,
@@ -550,6 +460,7 @@ async def run_agent(
             persist_session=persist_session, wall_budget_s=wall_budget_s, tool_call_budget=tool_call_budget,
             validate_structured_output=validate_structured_output,
             sanctioned_inputs=sanctioned_inputs,
+            run_context=context,
         )
         observed.output(result[0])
         observed.finish(1 if result[2] else 0, reason=result[2])
@@ -573,6 +484,7 @@ async def _run_agent(
     tool_call_budget: int | None = None,
     validate_structured_output: bool = True,
     sanctioned_inputs: PreparedSanctionedInputs | None = None,
+    run_context: RunContext,
 ) -> tuple[str | Any, ContinuationToken | None, str | None]:
     """Run agent with the given prompt and return output plus continuation token.
 
@@ -643,409 +555,411 @@ async def _run_agent(
     aborted_reason: str | None = None
     use_callback = progress_callback is not None
     tool_supervisor = get_registry().tool_supervisor_if_registered()
+    policy = run_context.policy
 
-    _state.current_backends.append(backend)
-    try:
-        # Open Invocation scope when a recorder is active; nullcontext keeps the
-        # with-shape uniform otherwise (CORE-09 no-op). D-19: no ATIF construction
-        # here — only inv.observe()/inv.observe_user_step() against the recorder.
-        recorder = get_current_recorder()
+    with run_context.backend_registration(backend):
         try:
-            _default_attempts = int(os.environ.get("DAYDREAM_PI_RETRY_ATTEMPTS", "20"))
-        except ValueError:
-            _default_attempts = 20
-        if _default_attempts < 0:
-            _default_attempts = 20
-
-        def _retry_delay_from_env(name: str, default: float) -> float:
+            # Open Invocation scope when a recorder is active; nullcontext keeps the
+            # with-shape uniform otherwise (CORE-09 no-op). D-19: no ATIF construction
+            # here — only inv.observe()/inv.observe_user_step() against the recorder.
+            recorder = get_current_recorder()
             try:
-                value = float(os.environ.get(name, str(default)))
+                _default_attempts = int(os.environ.get("DAYDREAM_PI_RETRY_ATTEMPTS", "20"))
             except ValueError:
-                return default
-            return value if math.isfinite(value) and value >= 0 else default
+                _default_attempts = 20
+            if _default_attempts < 0:
+                _default_attempts = 20
 
-        _default_delay = _retry_delay_from_env("DAYDREAM_PI_RETRY_BASE_DELAY_S", 2.0)
-        _default_max_delay = _retry_delay_from_env("DAYDREAM_PI_RETRY_MAX_DELAY_S", 120.0)
-        max_attempts = getattr(backend, "retry_attempts", _default_attempts)
-        base_delay = getattr(backend, "retry_base_delay_s", _default_delay)
-        max_delay = getattr(backend, "retry_max_delay_s", _default_max_delay)
-        if max_attempts < 0:
-            raise ValueError("retry attempts must be >= 0")
-        if not math.isfinite(base_delay):
-            raise ValueError("retry base delay must be finite")
-        if base_delay < 0:
-            raise ValueError("retry base delay must be >= 0")
-        if not math.isfinite(max_delay):
-            raise ValueError("retry max delay must be finite")
-        if max_delay < 0:
-            raise ValueError("retry max delay must be >= 0")
+            def _retry_delay_from_env(name: str, default: float) -> float:
+                try:
+                    value = float(os.environ.get(name, str(default)))
+                except ValueError:
+                    return default
+                return value if math.isfinite(value) and value >= 0 else default
 
-        for attempt in range(max_attempts + 1):
-            # Reset accumulated state so a failed attempt's partial output
-            # does not leak into the next attempt's return value.
-            output_parts = []
-            structured_result = None
-            result_continuation = None
-            tool_calls = 0
-            budget_reason: str | None = None
-            # Track tool names by id for log mode output
-            tool_names: dict[str, str] = {}
-            callback_text_parts: list[str] = []
+            _default_delay = _retry_delay_from_env("DAYDREAM_PI_RETRY_BASE_DELAY_S", 2.0)
+            _default_max_delay = _retry_delay_from_env("DAYDREAM_PI_RETRY_MAX_DELAY_S", 120.0)
+            max_attempts = getattr(backend, "retry_attempts", _default_attempts)
+            base_delay = getattr(backend, "retry_base_delay_s", _default_delay)
+            max_delay = getattr(backend, "retry_max_delay_s", _default_max_delay)
+            if max_attempts < 0:
+                raise ValueError("retry attempts must be >= 0")
+            if not math.isfinite(base_delay):
+                raise ValueError("retry base delay must be finite")
+            if base_delay < 0:
+                raise ValueError("retry base delay must be >= 0")
+            if not math.isfinite(max_delay):
+                raise ValueError("retry max delay must be finite")
+            if max_delay < 0:
+                raise ValueError("retry max delay must be >= 0")
 
-            async def _flush_callback_text() -> None:
-                """Render one line for a consecutive run of streamed text deltas."""
-                if progress_callback is None or not callback_text_parts:
-                    return
-                text = "".join(callback_text_parts)
-                callback_text_parts.clear()
-                last_line = text.strip().split("\n")[-1]
-                if last_line:
-                    result = progress_callback(format_callback_text(last_line))
-                    if inspect.isawaitable(result):
-                        await result
+            for attempt in range(max_attempts + 1):
+                # Reset accumulated state so a failed attempt's partial output
+                # does not leak into the next attempt's return value.
+                output_parts = []
+                structured_result = None
+                result_continuation = None
+                tool_calls = 0
+                budget_reason: str | None = None
+                # Track tool names by id for log mode output
+                tool_names: dict[str, str] = {}
+                callback_text_parts: list[str] = []
 
-            # Created per attempt so a failed retry's UI panels and task-label
-            # mappings cannot be flushed or reused by a later successful attempt.
-            tool_registry = LiveToolPanelRegistry(console, _state.quiet_mode)
-            agent_renderer = AgentTextRenderer(console)
+                async def _flush_callback_text() -> None:
+                    """Render one line for a consecutive run of streamed text deltas."""
+                    if progress_callback is None or not callback_text_parts:
+                        return
+                    text = "".join(callback_text_parts)
+                    callback_text_parts.clear()
+                    last_line = text.strip().split("\n")[-1]
+                    if last_line:
+                        result = progress_callback(format_callback_text(last_line))
+                        if inspect.isawaitable(result):
+                            await result
 
-            try:
-                if artifact_session_active():
-                    assert_model_cwd_clean(cwd)
-                if sanctioned_inputs is not None:
-                    sanctioned_inputs.revalidate(backend, cwd, read_only)
-                execute_kwargs: dict[str, Any] = {
-                    "agents": agents,
-                    "max_turns": max_turns,
-                    "read_only": read_only,
-                }
-                if not persist_session:
-                    execute_kwargs["persist_session"] = False
-                event_iter = backend.execute(
-                    cwd, prompt, output_schema, continuation,
-                    **execute_kwargs,
-                )
-                invocation_cm: Any = (
-                    recorder.invocation(phase=phase) if recorder is not None else nullcontext(None)
-                )
-                event_stream_scope = _EventStreamScope(event_iter)
+                # Created per attempt so a failed retry's UI panels and task-label
+                # mappings cannot be flushed or reused by a later successful attempt.
+                tool_registry = LiveToolPanelRegistry(console, policy.quiet)
+                agent_renderer = AgentTextRenderer(console)
 
-                async with (
-                    attempt_scope(attempt + 1) as observed,
-                    invocation_cm as inv,
-                    event_stream_scope,
-                ):
-                    if inv is not None:
-                        inv.observe_user_step(prompt=prompt)
-
-                    # Per-invocation abort controls live here so both backends are
-                    # covered without a backend-signature change. The wall budget
-                    # cancels the async-for via move_on_after; the tool-call ceiling
-                    # and supervisor veto break in-loop.
-                    wall_scope: Any = (
-                        anyio.move_on_after(wall_budget_s) if wall_budget_s is not None else nullcontext()
+                try:
+                    if artifact_session_active():
+                        assert_model_cwd_clean(cwd)
+                    if sanctioned_inputs is not None:
+                        sanctioned_inputs.revalidate(backend, cwd, read_only)
+                    execute_kwargs: dict[str, Any] = {
+                        "agents": agents,
+                        "max_turns": max_turns,
+                        "read_only": read_only,
+                    }
+                    if not persist_session:
+                        execute_kwargs["persist_session"] = False
+                    event_iter = backend.execute(
+                        cwd, prompt, output_schema, continuation,
+                        **execute_kwargs,
                     )
+                    invocation_cm: Any = (
+                        recorder.invocation(phase=phase) if recorder is not None else nullcontext(None)
+                    )
+                    event_stream_scope = _EventStreamScope(event_iter)
 
-                    with wall_scope:
-                        async for event in event_iter:
-                            # The sole telemetry observer runs before UI callbacks,
-                            # supervision and budgets can interrupt event handling.
-                            observed.observe(event)
-                            if use_callback and not isinstance(
-                                event, (TextEvent, DiagnosticEvent)
-                            ):
-                                await _flush_callback_text()
+                    async with (
+                        attempt_scope(attempt + 1) as observed,
+                        invocation_cm as inv,
+                        event_stream_scope,
+                    ):
+                        if inv is not None:
+                            inv.observe_user_step(prompt=prompt)
 
-                            if isinstance(event, DiagnosticEvent):
-                                # Recorder-only parser/transport evidence. It
-                                # must not affect UI, callbacks, supervision,
-                                # tool bookkeeping, or invocation budgets.
-                                if inv is not None:
-                                    inv.observe(event)
+                        # Per-invocation abort controls live here so both backends are
+                        # covered without a backend-signature change. The wall budget
+                        # cancels the async-for via move_on_after; the tool-call ceiling
+                        # and supervisor veto break in-loop.
+                        wall_scope: Any = (
+                            anyio.move_on_after(wall_budget_s) if wall_budget_s is not None else nullcontext()
+                        )
 
-                            elif isinstance(event, TextEvent):
-                                output_parts.append(event.text)
+                        with wall_scope:
+                            async for event in event_iter:
+                                # The sole telemetry observer runs before UI callbacks,
+                                # supervision and budgets can interrupt event handling.
+                                observed.observe(event)
+                                if use_callback and not isinstance(
+                                    event, (TextEvent, DiagnosticEvent)
+                                ):
+                                    await _flush_callback_text()
 
-                                if _state.log_mode:
-                                    _print_log(event.text)
-                                elif use_callback and progress_callback is not None:
-                                    callback_text_parts.append(event.text)
-                                elif output_schema is None:
-                                    # Structured-output text is the JSON payload, redundant with
-                                    # the returned structured result — don't echo it to the terminal.
-                                    agent_renderer.append(event.text)
+                                if isinstance(event, DiagnosticEvent):
+                                    # Recorder-only parser/transport evidence. It
+                                    # must not affect UI, callbacks, supervision,
+                                    # tool bookkeeping, or invocation budgets.
+                                    if inv is not None:
+                                        inv.observe(event)
 
-                                if inv is not None:
-                                    inv.observe(event)
+                                elif isinstance(event, TextEvent):
+                                    output_parts.append(event.text)
 
-                            elif isinstance(event, ThinkingEvent):
-                                if _state.log_mode:
-                                    _print_log(f"[thinking] {event.text}")
-                                elif not use_callback:
-                                    if agent_renderer.has_content:
-                                        agent_renderer.finish()
-                                    print_thinking(console, event.text)
+                                    if policy.log_mode:
+                                        _print_log(event.text)
+                                    elif use_callback and progress_callback is not None:
+                                        callback_text_parts.append(event.text)
+                                    elif output_schema is None:
+                                        # Structured-output text is the JSON payload, redundant with
+                                        # the returned structured result — don't echo it to the terminal.
+                                        agent_renderer.append(event.text)
 
-                                if inv is not None:
-                                    inv.observe(event)
+                                    if inv is not None:
+                                        inv.observe(event)
 
-                            elif isinstance(event, ToolStartEvent):
-                                if _state.log_mode:
-                                    tool_names[event.id] = event.name
-                                    _print_log(f"[tool:{event.name}] {_summarize_input(event.input, event.name)}")
-                                elif progress_callback is not None:
-                                    # Record the originating call so a backgrounded launch's result
-                                    # can later resolve a Task-family label for the progress line.
-                                    tool_registry.note_call(event.id, event.name, event.input)
-                                    label = tool_registry.resolve_call_label(event.name, event.input)
-                                    result = progress_callback(format_callback_progress(event.name, event.input, label))
-                                    if inspect.isawaitable(result):
-                                        await result
-                                else:
-                                    if agent_renderer.has_content:
-                                        agent_renderer.finish()
-                                    tool_registry.create(event.id, event.name, event.input)
+                                elif isinstance(event, ThinkingEvent):
+                                    if policy.log_mode:
+                                        _print_log(f"[thinking] {event.text}")
+                                    elif not use_callback:
+                                        if agent_renderer.has_content:
+                                            agent_renderer.finish()
+                                        print_thinking(console, event.text)
 
-                                if inv is not None:
-                                    inv.observe(event)
+                                    if inv is not None:
+                                        inv.observe(event)
 
-                                if tool_supervisor is not None:
-                                    try:
-                                        # Extension tool supervisors matched
-                                        # start-anchored deny patterns against the
-                                        # pre-#1124 wrapper-decoded, cd-stripped
-                                        # command value. The stored
-                                        # ToolStartEvent keeps the replayable
-                                        # cd-prefixed payload; hand the supervisor
-                                        # the display variant so e.g. '^make'
-                                        # keeps matching Codex shell commands.
-                                        supervisor_input = event.input
-                                        if event.name == "shell" and isinstance(event.input, dict):
-                                            command = event.input.get("command")
-                                            if isinstance(command, str):
-                                                from daydream.backends.codex import display_shell_command
+                                elif isinstance(event, ToolStartEvent):
+                                    if policy.log_mode:
+                                        tool_names[event.id] = event.name
+                                        _print_log(f"[tool:{event.name}] {_summarize_input(event.input, event.name)}")
+                                    elif progress_callback is not None:
+                                        # Record the originating call so a backgrounded launch's result
+                                        # can later resolve a Task-family label for the progress line.
+                                        tool_registry.note_call(event.id, event.name, event.input)
+                                        label = tool_registry.resolve_call_label(event.name, event.input)
+                                        result = progress_callback(
+                                            format_callback_progress(event.name, event.input, label)
+                                        )
+                                        if inspect.isawaitable(result):
+                                            await result
+                                    else:
+                                        if agent_renderer.has_content:
+                                            agent_renderer.finish()
+                                        tool_registry.create(event.id, event.name, event.input)
 
-                                                supervisor_input = dict(event.input)
-                                                supervisor_input["command"] = display_shell_command(command)
-                                        decision = tool_supervisor(event.name, supervisor_input, phase=phase)
-                                    except Exception as exc:  # noqa: BLE001 - policy failures must propagate
-                                        raise _ToolSupervisorFailure(exc) from exc
-                                    if decision.veto:
-                                        if recorder is not None:
-                                            recorder.emit_tool_veto(
-                                                event.name, decision.reason, phase=phase
-                                            )
-                                        budget_reason = f"tool_vetoed:{event.name}"
+                                    if inv is not None:
+                                        inv.observe(event)
+
+                                    if tool_supervisor is not None:
+                                        try:
+                                            # Extension tool supervisors matched
+                                            # start-anchored deny patterns against the
+                                            # pre-#1124 wrapper-decoded, cd-stripped
+                                            # command value. The stored
+                                            # ToolStartEvent keeps the replayable
+                                            # cd-prefixed payload; hand the supervisor
+                                            # the display variant so e.g. '^make'
+                                            # keeps matching Codex shell commands.
+                                            supervisor_input = event.input
+                                            if event.name == "shell" and isinstance(event.input, dict):
+                                                command = event.input.get("command")
+                                                if isinstance(command, str):
+                                                    from daydream.backends.codex import display_shell_command
+
+                                                    supervisor_input = dict(event.input)
+                                                    supervisor_input["command"] = display_shell_command(command)
+                                            decision = tool_supervisor(event.name, supervisor_input, phase=phase)
+                                        except Exception as exc:  # noqa: BLE001 - policy failures must propagate
+                                            raise _ToolSupervisorFailure(exc) from exc
+                                        if decision.veto:
+                                            if recorder is not None:
+                                                recorder.emit_tool_veto(
+                                                    event.name, decision.reason, phase=phase
+                                                )
+                                            budget_reason = f"tool_vetoed:{event.name}"
+                                            break
+
+                                    tool_calls += 1
+                                    if tool_call_budget is not None and tool_calls > tool_call_budget:
+                                        budget_reason = "tool_call_budget_exceeded"
                                         break
 
-                                tool_calls += 1
-                                if tool_call_budget is not None and tool_calls > tool_call_budget:
-                                    budget_reason = "tool_call_budget_exceeded"
-                                    break
+                                elif isinstance(event, ToolResultEvent):
+                                    if policy.log_mode:
+                                        tool_name = tool_names.get(event.id, "unknown")
+                                        prefix = (
+                                            f"[tool:{tool_name} ERROR]" if event.is_error
+                                            else f"[tool:{tool_name} result]"
+                                        )
+                                        _print_log(f"{prefix} {_summarize_output(event.output)}")
+                                    else:
+                                        # Populate the task_id→label map in both modes, so a later
+                                        # TaskOutput/TaskStop resolves its originating label.
+                                        tool_registry.observe_result(event.id, event.output)
+                                        if not use_callback:
+                                            panel = tool_registry.get(event.id)
+                                            if panel:
+                                                panel.set_result(event.output, event.is_error)
+                                                panel.finish()
+                                                tool_registry.remove(event.id)
 
-                            elif isinstance(event, ToolResultEvent):
-                                if _state.log_mode:
-                                    tool_name = tool_names.get(event.id, "unknown")
-                                    prefix = (
-                                        f"[tool:{tool_name} ERROR]" if event.is_error
-                                        else f"[tool:{tool_name} result]"
-                                    )
-                                    _print_log(f"{prefix} {_summarize_output(event.output)}")
-                                else:
-                                    # Populate the task_id→label map in both modes, so a later
-                                    # TaskOutput/TaskStop resolves its originating label.
-                                    tool_registry.observe_result(event.id, event.output)
-                                    if not use_callback:
-                                        panel = tool_registry.get(event.id)
-                                        if panel:
-                                            panel.set_result(event.output, event.is_error)
-                                            panel.finish()
-                                            tool_registry.remove(event.id)
+                                    if inv is not None:
+                                        inv.observe(event)
 
-                                if inv is not None:
-                                    inv.observe(event)
-
-                            elif isinstance(event, MetricsEvent):
-                                if _state.log_mode:
-                                    _print_log(
-                                        f"[metrics] prompt={event.prompt_tokens} completion={event.completion_tokens}",
-                                    )
-                                # EVNT-02 / MAP-06: recorder-only, no UI in normal mode. Must precede the
-                                # CostEvent branch so isinstance order is correct.
-                                if inv is not None:
-                                    inv.observe(event)
-
-                            elif isinstance(event, (GenerationStartEvent, GenerationEndEvent)):
-                                # P18 T1/T2 seam: the pending-generation ledger is
-                                # recorder-only evidence (no UI, no logging). The
-                                # telemetry observer already saw the event at the
-                                # top of the loop; forward it so the invocation
-                                # ledger seals drafts and resolves the single
-                                # billing owner before the attempt scope exits.
-                                if inv is not None:
-                                    inv.observe(event)
-
-                            elif isinstance(event, CostEvent):
-                                if _state.log_mode:
-                                    cost_str = f"${event.cost_usd:.4f}" if event.cost_usd is not None else "unknown"
-                                    _print_log(f"[cost] {cost_str}")
-                                elif event.cost_usd and not use_callback:
-                                    if agent_renderer.has_content:
-                                        agent_renderer.finish()
-                                    console.print()
-                                    print_cost(console, event.cost_usd)
-
-                                if inv is not None:
-                                    inv.observe(event)
-
-                            elif isinstance(event, TurnEndEvent):
-                                # Per-turn close (issue #747): forward the
-                                # turn boundary so each turn's already-emitted
-                                # MetricsEvent lands on its own Step instead of
-                                # collapsing into one. Pure recorder
-                                # forwarding — no UI, no logging. The recorder's
-                                # no-open-step no-op guard prevents empty-step
-                                # invention.
-                                if inv is not None:
-                                    inv.observe(event)
-
-                            elif isinstance(event, ResultEvent):
-                                # Capture the structured result unconditionally: the log-mode
-                                # print is an additive side effect, never a substitute for
-                                # capture (otherwise --log silently drops every structured
-                                # result — exploration conventions, review findings, etc.).
-                                structured_result = event.structured_output
-                                if event.structured_output is not None:
-                                    if _state.log_mode:
-                                        redacted = _redact_log_value(event.structured_output)
+                                elif isinstance(event, MetricsEvent):
+                                    if policy.log_mode:
                                         _print_log(
-                                            f"[result] {json.dumps(redacted)[:500]}",
+                                            f"[metrics] prompt={event.prompt_tokens} "
+                                            f"completion={event.completion_tokens}",
                                         )
-                                    elif not use_callback:
-                                        issues = (
-                                            structured_result.get("issues", [])
-                                            if isinstance(structured_result, dict)
-                                            else []
-                                        )
-                                        if issues:
-                                            formatted = []
-                                            for i in issues:
-                                                if "file" in i and "line" in i:
-                                                    desc = i.get("description", "")
-                                                    issue_id = i.get("id", "?")
-                                                    formatted.append(
-                                                        f"[{issue_id}] {i['file']}:{i['line']} - {desc}"
-                                                    )
-                                                else:
-                                                    label = i.get("title", i.get("description", ""))
-                                                    formatted.append(f"[{i.get('id', '?')}] {label}")
-                                            agent_renderer.append("\n".join(formatted))
-                                result_continuation = event.continuation
+                                    # EVNT-02 / MAP-06: recorder-only, no UI in normal mode. Must precede the
+                                    # CostEvent branch so isinstance order is correct.
+                                    if inv is not None:
+                                        inv.observe(event)
 
-                                if inv is not None:
-                                    inv.observe(event)
+                                elif isinstance(event, (GenerationStartEvent, GenerationEndEvent)):
+                                    # P18 T1/T2 seam: the pending-generation ledger is
+                                    # recorder-only evidence (no UI, no logging). The
+                                    # telemetry observer already saw the event at the
+                                    # top of the loop; forward it so the invocation
+                                    # ledger seals drafts and resolves the single
+                                    # billing owner before the attempt scope exits.
+                                    if inv is not None:
+                                        inv.observe(event)
 
-                        if use_callback:
-                            await _flush_callback_text()
+                                elif isinstance(event, CostEvent):
+                                    if policy.log_mode:
+                                        cost_str = f"${event.cost_usd:.4f}" if event.cost_usd is not None else "unknown"
+                                        _print_log(f"[cost] {cost_str}")
+                                    elif event.cost_usd and not use_callback:
+                                        if agent_renderer.has_content:
+                                            agent_renderer.finish()
+                                        console.print()
+                                        print_cost(console, event.cost_usd)
 
-                    # Abort handling: the wall scope cancelled the loop, a quantitative
-                    # tool ceiling fired, or a supervisor veto broke out. Mark the
-                    # ATIF turn aborted and let the invocation's event-stream scope
-                    # close its resources before returning partial output.
-                    wall_cancelled = bool(getattr(wall_scope, "cancelled_caught", False))
-                    if budget_reason is None and wall_cancelled:
-                        budget_reason = "wall_budget_exceeded"
-                    aborted_reason = budget_reason
-                    if budget_reason is not None:
-                        observed.abort(budget_reason)
-                        await event_stream_scope.aclose()
-                        if inv is not None:
-                            inv.mark_aborted(budget_reason)
-                            inv.observe(TurnEndEvent())
-                        if _state.log_mode:
-                            _print_log(f"[aborted] {budget_reason}")
+                                    if inv is not None:
+                                        inv.observe(event)
+
+                                elif isinstance(event, TurnEndEvent):
+                                    # Per-turn close (issue #747): forward the
+                                    # turn boundary so each turn's already-emitted
+                                    # MetricsEvent lands on its own Step instead of
+                                    # collapsing into one. Pure recorder
+                                    # forwarding — no UI, no logging. The recorder's
+                                    # no-open-step no-op guard prevents empty-step
+                                    # invention.
+                                    if inv is not None:
+                                        inv.observe(event)
+
+                                elif isinstance(event, ResultEvent):
+                                    # Capture the structured result unconditionally: the log-mode
+                                    # print is an additive side effect, never a substitute for
+                                    # capture (otherwise --log silently drops every structured
+                                    # result — exploration conventions, review findings, etc.).
+                                    structured_result = event.structured_output
+                                    if event.structured_output is not None:
+                                        if policy.log_mode:
+                                            redacted = _redact_log_value(event.structured_output)
+                                            _print_log(
+                                                f"[result] {json.dumps(redacted)[:500]}",
+                                            )
+                                        elif not use_callback:
+                                            issues = (
+                                                structured_result.get("issues", [])
+                                                if isinstance(structured_result, dict)
+                                                else []
+                                            )
+                                            if issues:
+                                                formatted = []
+                                                for i in issues:
+                                                    if "file" in i and "line" in i:
+                                                        desc = i.get("description", "")
+                                                        issue_id = i.get("id", "?")
+                                                        formatted.append(
+                                                            f"[{issue_id}] {i['file']}:{i['line']} - {desc}"
+                                                        )
+                                                    else:
+                                                        label = i.get("title", i.get("description", ""))
+                                                        formatted.append(f"[{i.get('id', '?')}] {label}")
+                                                agent_renderer.append("\n".join(formatted))
+                                    result_continuation = event.continuation
+
+                                    if inv is not None:
+                                        inv.observe(event)
+
+                            if use_callback:
+                                await _flush_callback_text()
+
+                        # Abort handling: the wall scope cancelled the loop, a quantitative
+                        # tool ceiling fired, or a supervisor veto broke out. Mark the
+                        # ATIF turn aborted and let the invocation's event-stream scope
+                        # close its resources before returning partial output.
+                        wall_cancelled = bool(getattr(wall_scope, "cancelled_caught", False))
+                        if budget_reason is None and wall_cancelled:
+                            budget_reason = "wall_budget_exceeded"
+                        aborted_reason = budget_reason
+                        if budget_reason is not None:
+                            observed.abort(budget_reason)
+                            await event_stream_scope.aclose()
+                            if inv is not None:
+                                inv.mark_aborted(budget_reason)
+                                inv.observe(TurnEndEvent())
+                            if policy.log_mode:
+                                _print_log(f"[aborted] {budget_reason}")
+                            elif use_callback and progress_callback is not None:
+                                result = progress_callback(format_callback_text(f"[budget] aborted: {budget_reason}"))
+                                if inspect.isawaitable(result):
+                                    await result
+                            elif not use_callback:
+                                print_warning(console, f"Turn aborted: {budget_reason}")
+
+                        if not use_callback and not policy.log_mode:
+                            if agent_renderer.has_content:
+                                agent_renderer.finish()
+                            tool_registry.finish_all()
+                            console.print()
+
+                    break  # success — exit the retry loop
+
+                except _ToolSupervisorFailure:
+                    raise
+                except Exception as exc:
+                    if use_callback:
+                        await _flush_callback_text()
+                    exception_max_retries = min(
+                        max_attempts, getattr(exc, "max_retries", max_attempts)
+                    )
+                    if attempt < exception_max_retries and getattr(exc, "retryable", False):
+                        delay = min(
+                            base_delay * (2 ** attempt) + random.uniform(0, 1),
+                            max_delay,
+                        )
+                        retry_msg = (
+                            f"Backend error ({type(exc).__name__}), retrying "
+                            f"attempt {attempt + 2}/{exception_max_retries + 1} after {delay:.1f}s..."
+                        )
+                        if policy.log_mode:
+                            _print_log(f"[retry] {retry_msg}")
                         elif use_callback and progress_callback is not None:
-                            result = progress_callback(format_callback_text(f"[budget] aborted: {budget_reason}"))
+                            result = progress_callback(format_callback_text(f"[retry] {retry_msg}"))
                             if inspect.isawaitable(result):
                                 await result
                         elif not use_callback:
-                            print_warning(console, f"Turn aborted: {budget_reason}")
+                            print_warning(console, retry_msg)
+                        # The event-stream scope has already closed only this failed
+                        # invocation. Backend-wide cancel() is reserved for shutdown.
+                        tool_registry.discard_all()
+                        await anyio.sleep(delay)
+                        continue
+                    raise
 
-                    if not use_callback and not _state.log_mode:
-                        if agent_renderer.has_content:
-                            agent_renderer.finish()
-                        tool_registry.finish_all()
-                        console.print()
-
-                break  # success — exit the retry loop
-
-            except _ToolSupervisorFailure:
-                raise
-            except Exception as exc:
-                if use_callback:
-                    await _flush_callback_text()
-                exception_max_retries = min(
-                    max_attempts, getattr(exc, "max_retries", max_attempts)
-                )
-                if attempt < exception_max_retries and getattr(exc, "retryable", False):
-                    delay = min(
-                        base_delay * (2 ** attempt) + random.uniform(0, 1),
-                        max_delay,
-                    )
-                    retry_msg = (
-                        f"Backend error ({type(exc).__name__}), retrying "
-                        f"attempt {attempt + 2}/{exception_max_retries + 1} after {delay:.1f}s..."
-                    )
-                    if _state.log_mode:
-                        _print_log(f"[retry] {retry_msg}")
-                    elif use_callback and progress_callback is not None:
-                        result = progress_callback(format_callback_text(f"[retry] {retry_msg}"))
-                        if inspect.isawaitable(result):
-                            await result
-                    elif not use_callback:
-                        print_warning(console, retry_msg)
-                    # The event-stream scope has already closed only this failed
-                    # invocation. Backend-wide cancel() is reserved for shutdown.
-                    tool_registry.discard_all()
-                    await anyio.sleep(delay)
-                    continue
-                raise
-
-    except _ToolSupervisorFailure as exc:
-        original = exc.original
-        print_error(
-            console, "Extension Failure", redact_text(f"{type(original).__name__}: {original}")
-        )
-        # The exception itself still propagates to outer handlers that re-print
-        # str(exc) without redaction (e.g. the CLI's "Fatal Error" panel on
-        # `daydream <target>`, improve-run retry checks). Rewriting .args in
-        # place is not enough: a supervisor can raise OSError (whose str() is
-        # built from errno/strerror) or a type overriding __str__/__repr__, for
-        # which the raw credential would survive. Rebuild a scrubbed exception
-        # here, failing closed instead of silently passing the raw value onward.
-        raise _scrubbed_supervisor_error(original) from original
-    except Exception as exc:
-        category = getattr(exc, "category", None)
-        msg = str(exc).strip()
-        diagnostic = f"{type(exc).__name__}: {msg}" if msg else type(exc).__name__
-        if isinstance(category, str):
-            diagnostic += f" [{category}]"
-        # Error messages can embed secrets (a leaked env var, an API key in a
-        # provider error); redact at this host boundary like every other surfaced text.
-        print_error(console, "Backend Execution Error", redact_text(diagnostic))
-        raise
-    except BaseException:
-        # Shutdown path: SIGINT (KeyboardInterrupt) / task cancellation
-        # (CancelledError) are BaseException, so the generic `except Exception`
-        # above never sees them. Deterministically reap the tracked subprocesses
-        # via backend.cancel() before unwinding.
-        try:
-            await backend.cancel()
-        except Exception:  # cancel() must not mask the original signal
-            _logger.exception("backend.cancel() failed during shutdown")
-        raise
-    finally:
-        _state.current_backends.remove(backend)
+        except _ToolSupervisorFailure as exc:
+            original = exc.original
+            print_error(
+                console, "Extension Failure", redact_text(f"{type(original).__name__}: {original}")
+            )
+            # The exception itself still propagates to outer handlers that re-print
+            # str(exc) without redaction (e.g. the CLI's "Fatal Error" panel on
+            # `daydream <target>`, improve-run retry checks). Rewriting .args in
+            # place is not enough: a supervisor can raise OSError (whose str() is
+            # built from errno/strerror) or a type overriding __str__/__repr__, for
+            # which the raw credential would survive. Rebuild a scrubbed exception
+            # here, failing closed instead of silently passing the raw value onward.
+            raise _scrubbed_supervisor_error(original) from original
+        except Exception as exc:
+            category = getattr(exc, "category", None)
+            msg = str(exc).strip()
+            diagnostic = f"{type(exc).__name__}: {msg}" if msg else type(exc).__name__
+            if isinstance(category, str):
+                diagnostic += f" [{category}]"
+            # Error messages can embed secrets (a leaked env var, an API key in a
+            # provider error); redact at this host boundary like every other surfaced text.
+            print_error(console, "Backend Execution Error", redact_text(diagnostic))
+            raise
+        except BaseException:
+            # Shutdown path: SIGINT (KeyboardInterrupt) / task cancellation
+            # (CancelledError) are BaseException, so the generic `except Exception`
+            # above never sees them. Deterministically reap the tracked subprocesses
+            # via backend.cancel() before unwinding.
+            try:
+                await backend.cancel()
+            except Exception:  # cancel() must not mask the original signal
+                _logger.exception("backend.cancel() failed during shutdown")
+            raise
 
     def _usable(value: Any) -> bool:
         """Whether ``value`` passes the structured-output gate.

--- a/daydream/cli.py
+++ b/daydream/cli.py
@@ -50,14 +50,12 @@ import anyio
 from rich.console import Console
 
 from daydream import git_ops
-from daydream.agent import (
-    console,
-    get_current_backends,
-)
+from daydream.agent import console
 from daydream.benchmark.cli import _handle_benchmark_command
 from daydream.config_file import DaydreamFileConfig, load_file_config
 from daydream.observability.config import ObservabilityConfig, ObservabilityError, resolve_observability_config
 from daydream.phases import UnconfinedFindingError
+from daydream.run_context import active_backends
 from daydream.runner import RunConfig, run
 from daydream.trajectory import flush_active_signal_recorders
 from daydream.ui import (
@@ -132,7 +130,7 @@ def _signal_handler(signum: int, _frame: object) -> None:
     set_shutdown_panel(panel)
     panel.start(f"Received {signal_name}, shutting down")
 
-    if get_current_backends():
+    if active_backends():
         panel.add_step("Terminating running agent(s)...")
 
     raise KeyboardInterrupt

--- a/daydream/deep/orchestrator.py
+++ b/daydream/deep/orchestrator.py
@@ -26,7 +26,7 @@ from typing import TYPE_CHECKING, Any, Literal, cast
 import anyio
 from rich.markup import escape as escape_markup
 
-from daydream.agent import console, get_assume, get_non_interactive, resolve_or_prompt, run_agent
+from daydream.agent import console, run_agent
 from daydream.artifact_visibility import artifact_dir_for, review_output_path_for
 from daydream.backends import effective_fanout_concurrency
 from daydream.config import (
@@ -170,6 +170,7 @@ from daydream.phases import (
 )
 from daydream.quote_scrub import scrub_smart_quotes_changed_files
 from daydream.review_profile import Pipeline
+from daydream.run_context import RunContext, bind_resolved_run_context, resolve_run_context
 from daydream.supervision import (
     RuleBasedSupervisor,
     apply_findings_verdicts,
@@ -1127,6 +1128,7 @@ async def _step_exploration(ctx: FlowContext) -> None:
                         "exploration.test_mapping": ctx.strategy("exploration.test_mapping"),
                         "exploration.repository_survey": ctx.strategy("exploration.repository_survey"),
                     },
+                    run_context=ctx.run_context,
                 )
             # Osprey resolves an omitted model from its own config and reports
             # the authoritative value in session_start, during safe_explore.
@@ -1240,6 +1242,7 @@ async def _step_intent(ctx: FlowContext) -> None:
             pr_description=pr_description,
             diff_text=_ttt_diff_text(ctx),
             strategy=ctx.strategy("intent"),
+            run_context=ctx.run_context,
         )
     # Each TTT step persists its own half, so a later step's failure cannot
     # discard an artifact this one already produced.
@@ -1266,6 +1269,7 @@ async def _wonder(ctx: FlowContext) -> None:
                 exploration_dir=ctx.data["exploration_dir"],
                 diff_text=_ttt_diff_text(ctx),
                 strategy=ctx.strategy("alternatives"),
+                run_context=ctx.run_context,
             )
 
     alts_p = _alternatives_path(ctx.data["dd"])
@@ -1341,6 +1345,7 @@ async def _per_stack_body(ctx: FlowContext, *, include_alternatives: bool) -> No
                 # the sweep credits reviewed files on every run (decoupled from
                 # sharding; #740 updates the evidence gate and bounds).
                 write_coverage_receipts=True,
+                run_context=ctx.run_context,
             )
         # Persist so a later `--start-at merge` resume can still surface
         # uncovered stacks (the in-memory failure map otherwise dies here).
@@ -1806,6 +1811,7 @@ async def _run_uncovered_sweep(
                                     tool_call_budget=DEFAULT_TOOL_CALL_BUDGET,
                                     wall_budget_s=DEFAULT_WALL_BUDGET_S,
                                     sanctioned_inputs=sanctioned_inputs,
+                                    run_context=ctx.run_context,
                                 )
                             if budget_reason:
                                 sweep_failures[file] = (
@@ -2128,6 +2134,7 @@ async def _step_arbiter(ctx: FlowContext) -> None:
                     exploration_dir=ctx.data["exploration_dir"],
                     intent_authoritative=ctx.data.get("intent_authoritative", False),
                     strategy=ctx.strategy("arbitration"),
+                    run_context=ctx.run_context,
                 )
                 # Identity gate: only resume when merge runs on the very same
                 # backend instance. A per-phase override that resolves a
@@ -2189,6 +2196,7 @@ async def _step_arbiter(ctx: FlowContext) -> None:
                         alternatives_path=ctx.data["alts_path"],
                         exploration_dir=ctx.data["exploration_dir"],
                         strategy=ctx.strategy("suppression"),
+                        run_context=ctx.run_context,
                     )
                 adjudicated, adjudicated_sources = _apply_adjudication_verdicts(
                     adjudicated, adjudicated_sources, suppression_targets, sup_verdicts,
@@ -2420,6 +2428,7 @@ async def _step_cross_stack_merge(ctx: FlowContext) -> Stop | None:
                 intent_authoritative=ctx.data.get("intent_authoritative", False),
                 continuation=ctx.data.get("arbiter_continuation"),
                 strategy=ctx.strategy("merge"),
+                run_context=ctx.run_context,
             )
         except CrossStackMergeError as exc:
             phase.finish(LifecycleStatus.FAILED, LifecycleReasonCode.DOMAIN_FAILURE)
@@ -2699,6 +2708,7 @@ async def _step_supervise(ctx: FlowContext) -> None:
                 alternatives_path=ctx.data["alts_path"],
                 exploration_dir=ctx.data["exploration_dir"],
                 strategy=ctx.strategy("supervision"),
+                run_context=ctx.run_context,
             )
     kept, held, events = apply_findings_verdicts(items, verdicts)
     items_file.write_text(json.dumps({"items": kept, "held": held}, indent=2))
@@ -2744,6 +2754,7 @@ async def _step_post_review(ctx: FlowContext) -> Stop | None:
         post=_mode_of(ctx) == "comment",
         approve_on_clean=_approve_on_clean(ctx.config),
         diagram_blocks=(ctx.data.get("diagrams") or {}).get("blocks"),
+        run_context=ctx.run_context,
         **pr_kwargs,
     )
     if _mode_of(ctx) == "comment" and outcome in (PostStatus.NO_PR, PostStatus.FAILED):
@@ -3074,6 +3085,7 @@ async def _run_diagram_kind(
             wall_budget_s=DEFAULT_WALL_BUDGET_S,
             tool_call_budget=DEFAULT_TOOL_CALL_BUDGET,
             sanctioned_inputs=sanctioned_inputs,
+            run_context=ctx.run_context,
         )
     read_paths |= _diagram_read_paths(getattr(fork, "path", None))
     if budget_reason:
@@ -3116,6 +3128,7 @@ async def _run_diagram_kind(
                 wall_budget_s=DEFAULT_WALL_BUDGET_S,
                 tool_call_budget=DEFAULT_TOOL_CALL_BUDGET,
                 sanctioned_inputs=sanctioned_inputs,
+                run_context=ctx.run_context,
             )
         read_paths |= _diagram_read_paths(getattr(repair_fork, "path", None))
         if not repair_budget and isinstance(repaired_output, dict):
@@ -3413,12 +3426,11 @@ async def _step_fix_gate(ctx: FlowContext) -> Stop | None:
     # Fix-apply gate across the two interaction axes. ``--yes`` auto-applies;
     # an unattended run with no assumption declines (safe_default=False) so a
     # piped/CI run never mutates without intent; otherwise prompt.
-    decision = resolve_or_prompt(
-        assume=get_assume(),
-        interactive=not get_non_interactive(),
+    decision = resolve_run_context(ctx.run_context).confirm(
         safe_default=False,
         question="Apply fixes now? [y/N]",
         default="n",
+        console=console,
     )
     if not decision:
         print_success(console, f"Report written to {ctx.data['merged_report']}. Exiting.")
@@ -3539,6 +3551,7 @@ async def _step_verify(ctx: FlowContext) -> None:
             merged_items_path=ctx.data["items_file"],
             deep_dir=dd,
             strategy=ctx.strategy("verification"),
+            run_context=ctx.run_context,
         )
     print_verification_summary(console, verdicts_file)
 
@@ -4432,6 +4445,7 @@ async def _step_fix_authorized(ctx: FlowContext, state: FixCycleState) -> Stop |
                 test_map_path=test_map_path,
                 footprint=state.footprint,
                 round_snapshot=round_snapshot,
+                run_context=ctx.run_context,
             )
         except Exception as exc:
             confinement_error = _enforce_terminal_confinement(
@@ -4586,6 +4600,7 @@ async def verify_retained_tree(
             items,
             snapshot.verifier_patch,
             round_number=pass_number,
+            run_context=ctx.run_context,
         )
     by_id = {
         item.get("id"): item
@@ -4770,16 +4785,17 @@ def _persist_test_verdict(
     )
 
 
-def _authorize_final_red_override() -> bool:
+def _authorize_final_red_override(ctx: FlowContext) -> bool:
     """Require a fresh interactive decision for a changed-tree red retest."""
-    if get_assume() is not None or get_non_interactive():
+    run_context = resolve_run_context(ctx.run_context)
+    policy = run_context.policy
+    if policy.assume is not None or not policy.interactive:
         return False
-    return resolve_or_prompt(
-        assume=None,
-        interactive=True,
+    return run_context.confirm(
         safe_default=False,
         question="Final no-heal validation is still red. Ignore and continue? [y/N]",
         default="n",
+        console=console,
     )
 
 
@@ -4853,6 +4869,7 @@ async def finalize_retained_tree_after_test(
                     config=ctx.config,
                     session_id=state.session_id,
                     capture_tree_key=lambda: _capture_full_delta_key(ctx.work, state),
+                    run_context=ctx.run_context,
                 )
             except Exception as exc:
                 return _stabilization_stop(
@@ -4863,7 +4880,7 @@ async def finalize_retained_tree_after_test(
                 )
             attempts.append(evidence)
             state.test_evidence = evidence
-            ignored = False if evidence.passed else _authorize_final_red_override()
+            ignored = False if evidence.passed else _authorize_final_red_override(ctx)
             ran_test = True
             _persist_test_verdict(
                 ctx,
@@ -4934,6 +4951,7 @@ async def _step_test(ctx: FlowContext) -> Stop | None:
                 session_id=state.session_id,
                 capture_tree_key=lambda: _capture_full_delta_key(ctx.work, state),
                 footprint=state.footprint,
+                run_context=ctx.run_context,
             )
             if not isinstance(result, TestAndHealResult):
                 raise TypeError("phase_test_and_heal returned an invalid evidence result")
@@ -5034,6 +5052,7 @@ async def _step_commit(ctx: FlowContext) -> Stop | None:
             retained_paths=snapshot.paths,
             retained_states=snapshot.states,
             initial_index=state.initial_index,
+            run_context=ctx.run_context,
         )
     except PushAttemptError as exc:
         try:
@@ -5322,12 +5341,11 @@ async def _perform_cleanup(ctx: FlowContext) -> None:
     elif config.cleanup is False:
         enabled = False
     else:
-        enabled = resolve_or_prompt(
-            assume=get_assume(),
-            interactive=not get_non_interactive(),
+        enabled = resolve_run_context(ctx.run_context).confirm(
             safe_default=False,
             question="Cleanup review output after completion? [y/N]",
             default="n",
+            console=console,
         )
 
     if not enabled:
@@ -5524,7 +5542,14 @@ DIAGRAM_STEPS: tuple[FlowStep, ...] = (
 )
 
 
-async def run_deep(config: RunConfig, work: WorkContext, *, run_artifacts: _RunArtifacts | None = None) -> int:
+@bind_resolved_run_context
+async def run_deep(
+    config: RunConfig,
+    work: WorkContext,
+    *,
+    run_artifacts: _RunArtifacts | None = None,
+    run_context: RunContext | None = None,
+) -> int:
     """Execute the deep-review pipeline (D-07) across every PR-process mode.
 
     The single ``deep`` flow (#330) handles ``review`` and ``comment`` through
@@ -5548,7 +5573,14 @@ async def run_deep(config: RunConfig, work: WorkContext, *, run_artifacts: _RunA
     Returns:
         Exit code (0 on success, 1 on failure).
     """
-    return await _run_review_spine(config, work, _resolve_mode(config), run_artifacts=run_artifacts)
+    run_context = resolve_run_context(run_context)
+    return await _run_review_spine(
+        config,
+        work,
+        _resolve_mode(config),
+        run_artifacts=run_artifacts,
+        run_context=run_context,
+    )
 
 
 def _collapse_stacks_for_shallow(
@@ -5607,10 +5639,17 @@ def _collapse_stacks_for_shallow(
     return [*structural, combined], True
 
 
+@bind_resolved_run_context
 async def _run_review_spine(
-    config: RunConfig, work: WorkContext, mode: str, *, run_artifacts: _RunArtifacts | None
+    config: RunConfig,
+    work: WorkContext,
+    mode: str,
+    *,
+    run_artifacts: _RunArtifacts | None,
+    run_context: RunContext | None = None,
 ) -> int:
     """Review-spine preamble for the deep pipeline (the former ``run_deep`` body)."""
+    run_context = resolve_run_context(run_context)
     # Late imports to avoid circular dependency with runner.
     from daydream import git_ops
     from daydream.backends import Backend
@@ -5858,6 +5897,7 @@ async def _run_review_spine(
             review_profile=config.review_profile,
             private_workspace_owner=None if run_artifacts is None else run_artifacts.owner,
             artifacts=None if run_artifacts is None else run_artifacts.session,
+            run_context=run_context,
             data={
                 "mode": mode,
                 "diff": bounded_diff,

--- a/daydream/exploration_runner.py
+++ b/daydream/exploration_runner.py
@@ -33,6 +33,7 @@ from daydream.prompts.exploration_subagents import (
     build_repo_survey_prompt,
     build_test_mapper_prompt,
 )
+from daydream.run_context import RunContext, bind_resolved_run_context, resolve_run_context
 from daydream.trajectory import (
     DaydreamPhase,
     DispatchHandle,
@@ -51,7 +52,6 @@ if TYPE_CHECKING:
 
 
 Tier: TypeAlias = Literal["skip", "single", "parallel"]
-
 
 # This regex parses git's own diff header output (not source code), so a
 # regex is the right tool here per D-04 (no tree-sitter for non-source text).
@@ -190,12 +190,15 @@ def _parse_envelope(envelope: dict[str, Any]) -> ExplorationContext:
     )
 
 
+@bind_resolved_run_context
 async def pre_scan(
     backend: Backend,
     repo_root: Path,
     diff_text: str,
     diff_ref: str = "HEAD",
     strategies: dict[str, str] | None = None,
+    *,
+    run_context: RunContext | None = None,
 ) -> ExplorationContext:
     """Run the pre-scan exploration pipeline for a diff.
 
@@ -219,6 +222,7 @@ async def pre_scan(
             When ``None`` (the default), the packaged default-profile contents
             are used, so non-profile callers stay operable.
     """
+    run_context = resolve_run_context(run_context)
     if strategies is None:
         defaults = _rp.build_default_profile().strategies
         strategies = {
@@ -286,6 +290,7 @@ async def pre_scan(
                     read_only=True,
                     wall_budget_s=DEFAULT_WALL_BUDGET_S,
                     tool_call_budget=DEFAULT_TOOL_CALL_BUDGET,
+                    run_context=run_context,
                 )
                 if isinstance(structured, dict):
                     results[name] = structured
@@ -405,12 +410,14 @@ def _sample_paths(paths: list[str], limit: int) -> list[str]:
     return [paths[int(i * stride)] for i in range(limit)]
 
 
+@bind_resolved_run_context
 async def repo_scan(
     backend: Backend,
     repo_root: Path,
     *,
     max_files: int = 500,
     strategies: dict[str, str] | None = None,
+    run_context: RunContext | None = None,
 ) -> ExplorationContext:
     """Discover repository conventions from a bounded tracked-file sample.
 
@@ -423,6 +430,7 @@ async def repo_scan(
             ``exploration.repository_survey`` strategy content. When ``None``
             (the default), the packaged default-profile content is used.
     """
+    run_context = resolve_run_context(run_context)
     if strategies is None:
         strategies = {
             "exploration.repository_survey": _rp.build_default_profile().strategies[
@@ -464,6 +472,7 @@ async def repo_scan(
                     read_only=True,
                     wall_budget_s=DEFAULT_WALL_BUDGET_S,
                     tool_call_budget=DEFAULT_TOOL_CALL_BUDGET,
+                    run_context=run_context,
                 )
                 if isinstance(structured, dict):
                     survey.update(structured)

--- a/daydream/flows/engine.py
+++ b/daydream/flows/engine.py
@@ -25,12 +25,14 @@ from daydream.extensions.api import (
     LoopGroup as LoopGroup,
 )
 from daydream.observability.spans import step_scope
+from daydream.run_context import bind_run_context, resolve_run_context
 
 if TYPE_CHECKING:
     from daydream.artifact_visibility import ArtifactSession, PrivateWorkspaceOwner
     from daydream.backends import Backend
     from daydream.extensions.registry import FlowEntry, Registry
     from daydream.review_profile import Pipeline, ResolvedProfile
+    from daydream.run_context import RunContext
     from daydream.runner import RunConfig
     from daydream.workspace import AuditWorkspace, WorkContext
 
@@ -48,6 +50,9 @@ class FlowContext:
             + source kind + digest), set by the runner composition root (R1).
             ``None`` before resolution; ``strategy()``/``pipeline()`` fall back
             to the packaged default so steps stay operable either way.
+        run_context: Runner-owned interaction policy and backend lifecycle.
+            Direct extension callers may omit it to use the bound runtime or
+            the standalone default when the flow begins.
     """
 
     config: RunConfig
@@ -58,6 +63,7 @@ class FlowContext:
     audit_workspace: AuditWorkspace | None = None
     private_workspace_owner: PrivateWorkspaceOwner | None = None
     artifacts: ArtifactSession | None = None
+    run_context: RunContext | None = field(default=None, kw_only=True)
     _backend_cache: dict[
         tuple[str, str | None, str | None, Path | None], Backend
     ] = field(
@@ -170,13 +176,16 @@ async def run_flow(registry: Registry, flow_name: str, ctx: FlowContext) -> int:
     falling off the end returns 0. A ``BreakLoop`` outside a loop group is
     ignored.
     """
-    entries = registry.flow(flow_name)
-    steps = _resolve_steps(registry, flow_name, entries)
-    for entry in entries:
-        if isinstance(entry, str):
-            signal = await _run_step(steps[entry], ctx)
-        else:
-            signal = await _run_group(entry, steps, ctx)
-        if isinstance(signal, Stop):
-            return signal.exit_code
-    return 0
+    runtime = resolve_run_context(ctx.run_context)
+    ctx.run_context = runtime
+    with bind_run_context(runtime):
+        entries = registry.flow(flow_name)
+        steps = _resolve_steps(registry, flow_name, entries)
+        for entry in entries:
+            if isinstance(entry, str):
+                signal = await _run_step(steps[entry], ctx)
+            else:
+                signal = await _run_group(entry, steps, ctx)
+            if isinstance(signal, Stop):
+                return signal.exit_code
+        return 0

--- a/daydream/improve/orchestrator.py
+++ b/daydream/improve/orchestrator.py
@@ -13,7 +13,7 @@ import anyio
 
 import daydream.agent as agent
 from daydream import git_ops
-from daydream.agent import console, get_non_interactive, run_agent
+from daydream.agent import console, run_agent
 from daydream.backends import effective_fanout_concurrency
 from daydream.config import (
     AUDIT_CATEGORIES,
@@ -88,6 +88,7 @@ from daydream.improve.services import Service, enumerate_services, filter_scope
 from daydream.pr_review import compute_fingerprint
 from daydream.prompts.grounding import UNTRUSTED_REPOSITORY_CONTENT_BOUNDARY
 from daydream.repository_paths import canonicalize_working_directory
+from daydream.run_context import resolve_run_context
 from daydream.trajectory import (
     DaydreamPhase,
     LifecycleReasonCode,
@@ -454,7 +455,7 @@ async def _step_recon(ctx: FlowContext) -> Stop | None:
         async with phase_scope(
             DaydreamPhase.EXPLORATION, stage="repo-survey"
         ):
-            exploration = await repo_scan(backend, target)
+            exploration = await repo_scan(backend, target, run_context=ctx.run_context)
         recon, _, _ = await run_agent(
             backend,
             target,
@@ -466,6 +467,7 @@ async def _step_recon(ctx: FlowContext) -> Stop | None:
             read_only=True,
             persist_session=False,
             validate_structured_output=False,
+            run_context=ctx.run_context,
         )
 
     total_candidates = 0
@@ -1022,6 +1024,7 @@ async def _run_audit_assignments(
                                 ),
                                 read_only=True,
                                 persist_session=False,
+                                run_context=ctx.run_context,
                             )
                             raw_findings = (
                                 output.get("findings", [])
@@ -1406,6 +1409,7 @@ async def _step_vet(ctx: FlowContext) -> None:
                                         ),
                                         read_only=True,
                                         persist_session=False,
+                                        run_context=ctx.run_context,
                                     )
                                 except Exception:  # noqa: BLE001 - no verdict fails closed
                                     output = {}
@@ -1584,12 +1588,14 @@ def _selection_prompt(
 async def _step_select(ctx: FlowContext) -> Stop | None:
     """Persist the user's plan selection or the silent unattended default."""
     default_findings: list[dict[str, Any]] = ctx.data["defects"]
-    publish_all = get_non_interactive() and _automatic_issue_publishing(ctx)
+    run_context = resolve_run_context(ctx.run_context)
+    interactive = run_context.policy.interactive
+    publish_all = not interactive and _automatic_issue_publishing(ctx)
     default_numbers = list(range(1, len(default_findings) + 1)) if publish_all else _default_selection(default_findings)
     mode = (
         "automatic-publishing"
         if publish_all
-        else ("non-interactive-default" if get_non_interactive() else "interactive")
+        else ("non-interactive-default" if not interactive else "interactive")
     )
     selected_numbers = default_numbers
 
@@ -1609,19 +1615,25 @@ async def _step_select(ctx: FlowContext) -> Stop | None:
         print_success(console, "No vetted defect findings -- done.")
         return None
 
-    if not get_non_interactive():
+    if interactive:
         default_text = f"1-{len(default_numbers)}" if len(default_numbers) > 1 else "1"
         prompt = _selection_prompt(default_findings)
-        raw = agent.prompt_user(console, prompt, default=default_text)
+        raw = run_context.choice(
+            prompt,
+            default=default_text,
+            safe_default=default_text,
+            console=console,
+        )
         parsed = _parse_selection(
             raw,
             total=len(default_findings),
         )
         if parsed is None:
-            raw = agent.prompt_user(
-                console,
+            raw = run_context.choice(
                 "Invalid selection; try once more",
                 default=default_text,
+                safe_default=default_text,
+                console=console,
             )
             parsed = _parse_selection(
                 raw,
@@ -1869,6 +1881,7 @@ async def _step_write_plans(ctx: FlowContext) -> None:
                             read_only=True,
                             persist_session=False,
                             validate_structured_output=False,
+                            run_context=ctx.run_context,
                         )
                     return output, aborted_reason
 

--- a/daydream/phases.py
+++ b/daydream/phases.py
@@ -23,12 +23,8 @@ from daydream import review_profile as _rp
 from daydream.agent import (
     console,
     detect_test_success,
-    get_assume,
-    get_non_interactive,
-    get_quiet_mode,
     is_environmental_failure,
     resolve_gate,
-    resolve_or_prompt,
     run_agent,
 )
 from daydream.artifact_visibility import artifact_dir_for, artifact_session_active, review_output_path_for
@@ -39,6 +35,13 @@ from daydream.backends import (
 )
 from daydream.backends.claude import READ_ONLY_BASH_ALLOWLIST
 from daydream.clipboard import clipboard_available, copy_to_clipboard
+from daydream.config import (
+    DEFAULT_GROUP_MAX_SERIAL_ITEMS,
+    DEFAULT_GROUP_MAX_WALL_S,
+    DEFAULT_TOOL_CALL_BUDGET,
+    DEFAULT_WALL_BUDGET_S,
+    TEST_WALL_BUDGET_S,
+)
 from daydream.eval.analyzer import _records_issues, _records_issues_or_empty
 from daydream.extensions import get_registry
 from daydream.file_group_budget import FileGroupBudget
@@ -72,6 +75,7 @@ from daydream.repository_paths import (
 from daydream.repository_paths import (
     path_is_confined,
 )
+from daydream.run_context import RunContext, bind_resolved_run_context, resolve_run_context
 from daydream.severity import SEVERITY_RANK, SEVERITY_RUBRIC, normalize_severity, stronger_severity
 from daydream.test_execution import (
     MissingTestCommandError,
@@ -89,17 +93,6 @@ from daydream.trajectory import (
     host_phase_scope,
     maybe_fork,
 )
-from daydream.workspace import WorkContext
-
-if TYPE_CHECKING:
-    from daydream.deep.detection import StackAssignment
-from daydream.config import (
-    DEFAULT_GROUP_MAX_SERIAL_ITEMS,
-    DEFAULT_GROUP_MAX_WALL_S,
-    DEFAULT_TOOL_CALL_BUDGET,
-    DEFAULT_WALL_BUDGET_S,
-    TEST_WALL_BUDGET_S,
-)
 from daydream.ui import (
     phase_subtitle,
     print_dim,
@@ -114,8 +107,11 @@ from daydream.ui import (
     print_phase_hero,
     print_success,
     print_warning,
-    prompt_user,
 )
+from daydream.workspace import WorkContext
+
+if TYPE_CHECKING:
+    from daydream.deep.detection import StackAssignment
 
 _logger = logging.getLogger(__name__)
 
@@ -396,10 +392,13 @@ def _sanitize_suggested_command(raw: str) -> str:
     return " ".join(raw.replace("`", "").split())
 
 
+@bind_resolved_run_context
 async def _run_setup_investigator(
     backend: Backend,
     work: WorkContext,
     test_output: str,
+    *,
+    run_context: RunContext | None = None,
 ) -> dict[str, Any] | None:
     """Run the read-only setup-investigator subagent and return its verdict.
 
@@ -413,6 +412,7 @@ async def _run_setup_investigator(
         Parsed verdict dict with keys ``verdict``, ``suggested_command``,
         ``reason`` on success, or ``None`` on any failure.
     """
+    run_context = resolve_run_context(run_context)
     recorder = get_current_recorder()
     prompt = _build_setup_investigator_prompt(test_output)
 
@@ -425,6 +425,7 @@ async def _run_setup_investigator(
                 output_schema=SETUP_INVESTIGATOR_SCHEMA,
                 phase=DaydreamPhase.TEST,
                 read_only=True,
+                run_context=run_context,
             )
         except Exception:  # noqa: BLE001 - investigator failure is non-fatal
             _logger.debug("setup-investigator agent failed", exc_info=True)
@@ -878,10 +879,13 @@ def _replace_known_handoff_paths(text: str, mappings: list[tuple[Path, Path]]) -
     return text
 
 
+@bind_resolved_run_context
 async def _run_failure_summarizer(
     backend: Backend,
     work: WorkContext,
     test_output: str,
+    *,
+    run_context: RunContext | None = None,
 ) -> tuple[str, Path, bool]:
     """Run the read-only failure-summarizer and write ``handoff.md``.
 
@@ -897,6 +901,7 @@ async def _run_failure_summarizer(
         the body inline in that case so the user does not lose it. The
         body is what was written to disk on success.
     """
+    run_context = resolve_run_context(run_context)
     recorder = get_current_recorder()
     (
         handoff_path,
@@ -990,6 +995,7 @@ async def _run_failure_summarizer(
                 phase=DaydreamPhase.TEST,
                 read_only=True,
                 sanctioned_inputs=sanctioned_inputs,
+                run_context=run_context,
             )
         except Exception:  # noqa: BLE001 - summarizer failure is non-fatal
             _logger.debug("failure-summarizer agent failed", exc_info=True)
@@ -2029,6 +2035,7 @@ async def phase_parse_feedback(
     output_schema: dict[str, Any] | None = None,
     include_verdicts: Literal[False] = False,
     strategy: str | None = None,
+    run_context: RunContext | None = None,
 ) -> list[dict[str, Any]]: ...
 
 
@@ -2041,9 +2048,11 @@ async def phase_parse_feedback(
     output_schema: dict[str, Any] | None = None,
     include_verdicts: Literal[True],
     strategy: str | None = None,
+    run_context: RunContext | None = None,
 ) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]: ...
 
 
+@bind_resolved_run_context
 async def phase_parse_feedback(
     backend: Backend,
     work: WorkContext,
@@ -2052,6 +2061,7 @@ async def phase_parse_feedback(
     output_schema: dict[str, Any] | None = None,
     include_verdicts: bool = False,
     strategy: str | None = None,
+    run_context: RunContext | None = None,
 ) -> list[dict[str, Any]] | tuple[list[dict[str, Any]], list[dict[str, Any]]]:
     """Phase 2: Parse feedback from review output and return validated items.
 
@@ -2094,6 +2104,7 @@ async def phase_parse_feedback(
         and emits a warning rather than raising ``ValueError``.
 
     """
+    run_context = resolve_run_context(run_context)
     print_phase_hero(console, "REFLECT", phase_subtitle("REFLECT"))
     print_dim(console, f"Model: {backend.model}")
 
@@ -2148,6 +2159,7 @@ async def phase_parse_feedback(
         tool_call_budget=DEFAULT_TOOL_CALL_BUDGET,
         wall_budget_s=DEFAULT_WALL_BUDGET_S,
         sanctioned_inputs=sanctioned_inputs,
+        run_context=run_context,
     )
 
     # A truncated parse would silently drop the whole stack's findings, so it
@@ -2227,6 +2239,7 @@ def _coerce_verdicts_payload(value: Any) -> dict[str, Any]:
     return {"verdicts": [entry for entry in raw if isinstance(entry, dict)]}
 
 
+@bind_resolved_run_context
 async def phase_verify_recommendations(
     backend: Backend,
     work: WorkContext,
@@ -2234,6 +2247,7 @@ async def phase_verify_recommendations(
     merged_items_path: Path,
     deep_dir: Path,
     strategy: str | None = None,
+    run_context: RunContext | None = None,
 ) -> tuple[Path, dict[str, Any]]:
     """Audit each non-structural item's recommendation against the codebase.
 
@@ -2273,6 +2287,7 @@ async def phase_verify_recommendations(
         written so downstream code does not need to handle a missing file.
 
     """
+    run_context = resolve_run_context(run_context)
     # Late imports avoid circular dependency with daydream.deep (which imports
     # from daydream.phases). Same pattern used by phase_per_stack_reviews and
     # phase_cross_stack_merge above.
@@ -2309,6 +2324,7 @@ async def phase_verify_recommendations(
         wall_budget_s=DEFAULT_WALL_BUDGET_S,
         phase=DaydreamPhase.VERIFY,
         read_only=True,
+        run_context=run_context,
     )
 
     candidate: Any = result
@@ -2324,6 +2340,7 @@ async def phase_verify_recommendations(
     return output_path, payload
 
 
+@bind_resolved_run_context
 async def phase_fix_verify(
     backend: Backend,
     work: WorkContext,
@@ -2332,6 +2349,7 @@ async def phase_fix_verify(
     *,
     console_lock: anyio.Lock | None = None,
     round_number: int = 1,
+    run_context: RunContext | None = None,
 ) -> list[dict[str, Any]]:
     """Read-only verifier: one verdict per supplied canonical finding.
 
@@ -2375,6 +2393,7 @@ async def phase_fix_verify(
         each ``{"issue_id": int, "verdict": str, "reason": str, "path"?: str}``.
     """
     del console_lock  # interactive progress is not printed per finding here
+    run_context = resolve_run_context(run_context)
     if not items:
         return []
 
@@ -2394,6 +2413,7 @@ async def phase_fix_verify(
         wall_budget_s=DEFAULT_WALL_BUDGET_S,
         phase=DaydreamPhase.VERIFY,
         read_only=True,
+        run_context=run_context,
     )
 
     candidate: Any = result
@@ -2791,6 +2811,7 @@ def _preflight_finding_file_refs(repo: Path, items: list[dict[str, Any]]) -> str
     return file_ref
 
 
+@bind_resolved_run_context
 async def phase_fix(
     backend: Backend,
     work: WorkContext,
@@ -2804,6 +2825,7 @@ async def phase_fix(
     intent_path: Path | None = None,
     exploration_dir: Path | None = None,
     test_map: dict[str, str] | None = None,
+    run_context: RunContext | None = None,
 ) -> None:
     """Phase 3: Apply a single fix for one feedback item.
 
@@ -2829,6 +2851,7 @@ async def phase_fix(
             (built once by ``_parse_test_map`` at the fan-out root); ``None``
             yields no hint. Invalid maps are ignored.
     """
+    run_context = resolve_run_context(run_context)
     if edit_scope is None or read_scope is None:
         raise TypeError("phase_fix requires explicit edit_scope and read_scope")
     description = item.get("description", "No description")
@@ -2883,6 +2906,7 @@ Make the minimal change needed. {_FIX_GUARDRAILS}"""
         wall_budget_s=DEFAULT_WALL_BUDGET_S,
         progress_callback=progress_cb,
         sanctioned_inputs=sanctioned_inputs,
+        run_context=run_context,
     )
     async with (console_lock if console_lock is not None else anyio.Lock()):
         # Verdict unknown at fix time (issue #744); the post-fix fix-verify
@@ -2890,6 +2914,7 @@ Make the minimal change needed. {_FIX_GUARDRAILS}"""
         print_fix_complete(console, item_num, total, outcome=None)
 
 
+@bind_resolved_run_context
 async def phase_fix_batched(
     backend: Backend,
     work: WorkContext,
@@ -2903,6 +2928,7 @@ async def phase_fix_batched(
     intent_path: Path | None = None,
     exploration_dir: Path | None = None,
     test_map: dict[str, str] | None = None,
+    run_context: RunContext | None = None,
 ) -> None:
     """Phase 3 (batched): Apply all findings for ONE file in a single fix turn.
 
@@ -2934,6 +2960,7 @@ async def phase_fix_batched(
             (built once by ``_parse_test_map`` at the fan-out root); ``None``
             yields no hint. Invalid maps are ignored.
     """
+    run_context = resolve_run_context(run_context)
     if edit_scope is None or read_scope is None:
         raise TypeError("phase_fix_batched requires explicit edit_scope and read_scope")
     if len(items) == 1:
@@ -2943,6 +2970,7 @@ async def phase_fix_batched(
             console_lock=console_lock, intent_path=intent_path,
             exploration_dir=exploration_dir,
             test_map=test_map,
+            run_context=run_context,
         )
         return
 
@@ -3013,6 +3041,7 @@ Make the minimal changes needed to address ALL of the above findings in one cohe
         wall_budget_s=scaled_wall_budget,
         progress_callback=progress_cb,
         sanctioned_inputs=sanctioned_inputs,
+        run_context=run_context,
     )
 
     if budget_reason is not None:
@@ -3048,6 +3077,7 @@ async def _restore_round_index_after_fanout(
         git_ops.restore_index(repo, index)
 
 
+@bind_resolved_run_context
 async def phase_fix_parallel(
     backend: Backend,
     work: WorkContext,
@@ -3061,6 +3091,7 @@ async def phase_fix_parallel(
     group_max_serial_items: int = DEFAULT_GROUP_MAX_SERIAL_ITEMS,
     exploration_dir: Path | None = None,
     test_map_path: Path | None = None,
+    run_context: RunContext | None = None,
 ) -> dict[str, str]:
     """Phase 3 (parallel): Apply fixes file-partitioned and concurrently.
 
@@ -3114,6 +3145,7 @@ async def phase_fix_parallel(
         full success.
 
     """
+    run_context = resolve_run_context(run_context)
     if footprint is None or round_snapshot is None:
         raise TypeError("phase_fix_parallel requires footprint and round_snapshot")
     # Preflight confinement gate: validate EVERY item's file reference before
@@ -3200,6 +3232,7 @@ async def phase_fix_parallel(
                 intent_path=intent_path,
                 exploration_dir=exploration_dir,
                 test_map=test_map,
+                run_context=run_context,
             )
             budget.record_item()
             successful_groups.add(fkey)
@@ -3260,6 +3293,7 @@ async def phase_fix_parallel(
                                             intent_path=intent_path,
                                             exploration_dir=exploration_dir,
                                             test_map=test_map,
+                                            run_context=run_context,
                                         )
                                         budget.record_item()
                                         successful_groups.add(fkey)
@@ -3321,12 +3355,14 @@ async def phase_fix_parallel(
     return failures
 
 
+@bind_resolved_run_context
 async def _emit_failure_handoff(
     backend: Backend,
     work: WorkContext,
     output: str,
     *,
     offer_clipboard: bool,
+    run_context: RunContext | None = None,
 ) -> None:
     """Run the failure summarizer, display the handoff body, and optionally
     offer to copy it to the clipboard.
@@ -3339,8 +3375,9 @@ async def _emit_failure_handoff(
             the clipboard (interactive mode).  When ``False``, skip the prompt
             (non-interactive mode).
     """
+    run_context = resolve_run_context(run_context)
     body, handoff_path, handoff_written = await _run_failure_summarizer(
-        backend, work, output,
+        backend, work, output, run_context=run_context,
     )
     if handoff_written:
         preview_lines = body.splitlines()
@@ -3364,12 +3401,11 @@ async def _emit_failure_handoff(
 
     if offer_clipboard:
         if clipboard_available():
-            if resolve_or_prompt(
-                assume=get_assume(),
-                interactive=not get_non_interactive(),
+            if run_context.confirm(
                 safe_default=False,
                 question="Copy handoff to clipboard?",
                 default="y",
+                console=console,
             ):
                 if await anyio.to_thread.run_sync(copy_to_clipboard, body):
                     print_success(console, "Handoff copied to clipboard")
@@ -3612,6 +3648,7 @@ class TestAndHealResult:
         return iter((self.passed, self.retries, self.proceed))
 
 
+@bind_resolved_run_context
 async def phase_test_once(
     backend: Backend,
     work: WorkContext,
@@ -3621,6 +3658,7 @@ async def phase_test_once(
     capture_tree_key: Callable[[], str],
     continuation: ContinuationToken | None = None,
     command_override: list[str] | None = None,
+    run_context: RunContext | None = None,
 ) -> tuple[TestAttemptEvidence, ContinuationToken | None, str]:
     """Execute exactly one canonical test attempt and bind it to tree identity.
 
@@ -3628,6 +3666,7 @@ async def phase_test_once(
     the established TEST-agent/prose path is used. Both paths capture the same
     before/after identity projection supplied by the fix-cycle orchestrator.
     """
+    run_context = resolve_run_context(run_context)
     cmd = command_override if command_override is not None else _canonical_test_cmd(config)
     input_tree_key = capture_tree_key()
     next_continuation: ContinuationToken | None = None
@@ -3658,6 +3697,7 @@ async def phase_test_once(
             phase=DaydreamPhase.TEST,
             tool_call_budget=DEFAULT_TOOL_CALL_BUDGET,
             wall_budget_s=TEST_WALL_BUDGET_S,
+            run_context=run_context,
         )
         passed = detect_test_success(output)
         kind = "agent"
@@ -3677,6 +3717,7 @@ async def phase_test_once(
     )
 
 
+@bind_resolved_run_context
 async def phase_test_and_heal(
     backend: Backend,
     work: WorkContext,
@@ -3686,6 +3727,7 @@ async def phase_test_and_heal(
     session_id: str | None = None,
     capture_tree_key: Callable[[], str] | None = None,
     footprint: AuthorizedFixFootprint | None = None,
+    run_context: RunContext | None = None,
 ) -> TestAndHealResult:
     """Phase 4: Run tests and prompt user on failure for action.
 
@@ -3710,6 +3752,7 @@ async def phase_test_and_heal(
         identity evidence for every actual host or agent test attempt.
 
     """
+    run_context = resolve_run_context(run_context)
     if session_id is None or capture_tree_key is None or footprint is None:
         raise TypeError(
             "phase_test_and_heal requires session_id, capture_tree_key, and footprint"
@@ -3752,6 +3795,7 @@ async def phase_test_and_heal(
             backend, work.repo, fix_prompt, phase=DaydreamPhase.FIX,
             tool_call_budget=DEFAULT_TOOL_CALL_BUDGET,
             wall_budget_s=DEFAULT_WALL_BUDGET_S,
+            run_context=run_context,
         )
         retries_used += 1
         continuation = None
@@ -3784,6 +3828,7 @@ async def phase_test_and_heal(
                 session_id=session_id,
                 capture_tree_key=capture_tree_key,
                 continuation=continuation,
+                run_context=run_context,
             )
             attempts.append(evidence)
             test_passed = evidence.passed
@@ -3813,15 +3858,17 @@ async def phase_test_and_heal(
         # to abort so the loop still terminates. Only an interactive run with no
         # assumption shows the menu.
         decision = resolve_gate(
-            assume=get_assume(),
-            interactive=not get_non_interactive(),
+            assume=run_context.policy.assume,
+            interactive=run_context.policy.interactive,
             safe_default=False,
         )
         if decision is False or (decision is True and retries_used > 0):
             print_error(
                 console, "Tests failed", "Aborting heal loop (no further auto-retries)",
             )
-            await _emit_failure_handoff(backend, work, output, offer_clipboard=False)
+            await _emit_failure_handoff(
+                backend, work, output, offer_clipboard=False, run_context=run_context,
+            )
             return TestAndHealResult(False, retries_used, False, False, tuple(attempts))
         if decision is True:
             # Bounded auto fix-and-retry: launch one fix attempt, then loop.
@@ -3838,10 +3885,19 @@ async def phase_test_and_heal(
             ("4", "Abort (exit with failure)"),
         ])
 
-        choice = prompt_user(console, "Choice", "2")
+        choice = run_context.choice(
+            "Choice",
+            default="2",
+            safe_default="4",
+            assume_yes="2",
+            assume_no="4",
+            console=console,
+        )
 
         if choice == "1":
-            verdict = await _run_setup_investigator(backend, work, output)
+            verdict = await _run_setup_investigator(
+                backend, work, output, run_context=run_context,
+            )
 
             if verdict is None:
                 print_warning(
@@ -3861,12 +3917,11 @@ async def phase_test_and_heal(
                     print_info(
                         console, f"Suggested command: {sanitized_preview}",
                     )
-                    if resolve_or_prompt(
-                        assume=get_assume(),
-                        interactive=not get_non_interactive(),
+                    if run_context.confirm(
                         safe_default=False,
                         question="Use suggested command instead?",
                         default="n",
+                        console=console,
                     ):
                         # Trust boundary: the approved command is executed
                         # host-side exactly once, as a real subprocess — it is
@@ -3897,6 +3952,7 @@ async def phase_test_and_heal(
                                 session_id=session_id,
                                 capture_tree_key=capture_tree_key,
                                 command_override=cmd,
+                                run_context=run_context,
                             )
                         except (OSError, ValueError) as exc:
                             print_warning(console, f"Approved test command could not be run: {exc}")
@@ -3928,7 +3984,9 @@ async def phase_test_and_heal(
 
         elif choice == "4":
             print_error(console, "Aborted", "User requested abort")
-            await _emit_failure_handoff(backend, work, output, offer_clipboard=True)
+            await _emit_failure_handoff(
+                backend, work, output, offer_clipboard=True, run_context=run_context,
+            )
             return TestAndHealResult(False, retries_used, False, False, tuple(attempts))
 
         else:
@@ -4160,6 +4218,7 @@ class PushAttemptError(GitError):
         self.receipt = receipt
 
 
+@bind_resolved_run_context
 async def _do_commit(
     backend: Backend,
     work: WorkContext,
@@ -4172,6 +4231,7 @@ async def _do_commit(
     retained_paths: frozenset[str] | None = None,
     retained_states: tuple[git_ops.GitPathState, ...] | None = None,
     initial_index: git_ops.IndexSnapshot | None = None,
+    run_context: RunContext | None = None,
 ) -> CommitPushResult:
     """Stage, commit, and optionally push — all host-side, no agent turn.
 
@@ -4219,6 +4279,7 @@ async def _do_commit(
 
     """
     del backend  # host-native commit: no agent turn (issue #726)
+    run_context = resolve_run_context(run_context)
 
     if interactive:
         # Commit/push gate across the two interaction axes. ``--yes`` commits
@@ -4226,12 +4287,11 @@ async def _do_commit(
         # (safe_default=False — the interactive default is decline); otherwise
         # prompt. Routed here (not at the caller) so every interactive commit
         # path honours both axes.
-        decision = resolve_or_prompt(
-            assume=get_assume(),
-            interactive=not get_non_interactive(),
+        decision = run_context.confirm(
             safe_default=False,
             question="Commit and push changes? [y/N]",
             default="n",
+            console=console,
         )
         if not decision:
             print_dim(console, "Skipping commit and push")
@@ -4431,6 +4491,7 @@ async def _do_commit(
     return CommitPushResult(committed=True, push=push_receipt)
 
 
+@bind_resolved_run_context
 async def phase_commit_push(
     backend: Backend,
     work: WorkContext,
@@ -4441,6 +4502,7 @@ async def phase_commit_push(
     retained_paths: frozenset[str] | None = None,
     retained_states: tuple[git_ops.GitPathState, ...] | None = None,
     initial_index: git_ops.IndexSnapshot | None = None,
+    run_context: RunContext | None = None,
 ) -> PushReceipt | None:
     """Prompt user to commit and push changes.
 
@@ -4459,6 +4521,7 @@ async def phase_commit_push(
         initial_index: Empty pre-dispatch index snapshot. Supplying these three
             selects strict stage-once and post-hook validation.
     """
+    run_context = resolve_run_context(run_context)
     console.print()
     print_info(console, "Committing and pushing changes...")
     result = await _do_commit(
@@ -4469,12 +4532,14 @@ async def phase_commit_push(
         retained_paths=retained_paths,
         retained_states=retained_states,
         initial_index=initial_index,
+        run_context=run_context,
     )
     if result.push is not None:
         print_success(console, "Changes pushed; verifying remote CI...")
     return result.push
 
 
+@bind_resolved_run_context
 async def phase_understand_intent(
     backend: Backend,
     work: WorkContext,
@@ -4486,6 +4551,7 @@ async def phase_understand_intent(
     pr_description: str | None = None,
     diff_text: str | None = None,
     strategy: str | None = None,
+    run_context: RunContext | None = None,
 ) -> str:
     """Phase: Understand the intent of the PR through conversational confirmation.
 
@@ -4511,6 +4577,7 @@ async def phase_understand_intent(
         The confirmed intent summary string.
 
     """
+    run_context = resolve_run_context(run_context)
     print_phase_hero(console, "LISTEN", phase_subtitle("LISTEN"))
     print_dim(console, f"Model: {backend.model}")
 
@@ -4590,6 +4657,7 @@ async def phase_understand_intent(
             wall_budget_s=DEFAULT_WALL_BUDGET_S,
             read_only=True,
             sanctioned_inputs=sanctioned_inputs,
+            run_context=run_context,
         )
         if budget_reason is not None:
             raise RuntimeError(f"Intent analysis hit its budget: {budget_reason}")
@@ -4609,19 +4677,20 @@ async def phase_understand_intent(
         # a forced "no" in a non-interactive run also proceeds rather than
         # blocking on stdin.
         gate = resolve_gate(
-            assume=get_assume(),
-            interactive=not get_non_interactive(),
+            assume=run_context.policy.assume,
+            interactive=run_context.policy.interactive,
             safe_default=True,
         )
         if gate is True:
             return intent_text
-        if gate is False and get_non_interactive():
+        if gate is False and not run_context.policy.interactive:
             return intent_text
 
-        response = prompt_user(
-            console,
+        response = run_context.choice(
             "Is this understanding correct? [y/provide correction]",
-            "y",
+            default="y",
+            safe_default="y",
+            console=console,
         )
 
         if response.lower() in ("y", "yes"):
@@ -4663,6 +4732,7 @@ Commit log:
 """
 
 
+@bind_resolved_run_context
 async def phase_alternative_review(
     backend: Backend,
     work: WorkContext,
@@ -4672,6 +4742,7 @@ async def phase_alternative_review(
     exploration_dir: Path | None = None,
     diff_text: str | None = None,
     strategy: str | None = None,
+    run_context: RunContext | None = None,
 ) -> list[dict[str, Any]]:
     """Phase: Evaluate whether there's a better way to implement the PR.
 
@@ -4683,6 +4754,7 @@ async def phase_alternative_review(
         List of issue dicts, each with id, title, description, recommendation,
         severity, and files keys.
     """
+    run_context = resolve_run_context(run_context)
     print_phase_hero(console, "WONDER", phase_subtitle("WONDER"))
     print_dim(console, f"Model: {backend.model}")
 
@@ -4722,6 +4794,7 @@ async def phase_alternative_review(
         tool_call_budget=DEFAULT_TOOL_CALL_BUDGET,
         wall_budget_s=DEFAULT_WALL_BUDGET_S,
         sanctioned_inputs=sanctioned_inputs,
+        run_context=run_context,
     )
 
     # A budget-truncated wonder pass is a run failure, not an empty lens: the
@@ -4737,7 +4810,7 @@ async def phase_alternative_review(
     else:
         # Only genuinely unusable model output degrades to an empty lens; the
         # budget case above already failed the run.
-        if not get_quiet_mode():
+        if not run_context.policy.quiet:
             print_warning(console, f"TTT review returned unexpected result type: {type(result).__name__}")
         issues = []
 
@@ -4753,6 +4826,7 @@ async def phase_alternative_review(
 # Deep-mode: per-stack fan-out
 
 
+@bind_resolved_run_context
 async def phase_per_stack_reviews(
     backend: Backend,
     work: WorkContext,
@@ -4767,6 +4841,7 @@ async def phase_per_stack_reviews(
     include_alternatives: bool = True,
     write_coverage_receipts: bool = False,
     strategies: dict[str, str] | None = None,
+    run_context: RunContext | None = None,
 ) -> tuple[dict[str, Path], dict[str, str]]:
     """Run one review agent per detected stack concurrently (D-17).
 
@@ -4808,6 +4883,7 @@ async def phase_per_stack_reviews(
             dropped.
 
     """
+    run_context = resolve_run_context(run_context)
     # Every ``daydream.deep.*`` import in this module is function-local, and must
     # stay that way: ``daydream.deep.__init__`` imports ``orchestrator``, which
     # imports this module, so a module-level import here closes an import cycle.
@@ -4981,6 +5057,7 @@ async def phase_per_stack_reviews(
                                     tool_call_budget=DEFAULT_TOOL_CALL_BUDGET,
                                     wall_budget_s=DEFAULT_WALL_BUDGET_S,
                                     sanctioned_inputs=task_inputs,
+                                    run_context=run_context,
                                 )
                         except Exception as e:  # noqa: BLE001 -- intentionally broad for parallel isolation
                             failures[stack_name] = f"{type(e).__name__}: {e}"
@@ -5128,6 +5205,7 @@ SUPERVISE_SCHEMA: dict[str, Any] = {
 }
 
 
+@bind_resolved_run_context
 async def phase_supervise_review(
     backend: Backend,
     work: WorkContext,
@@ -5138,8 +5216,10 @@ async def phase_supervise_review(
     alternatives_path: Path,
     exploration_dir: Path | None = None,
     strategy: str | None = None,
+    run_context: RunContext | None = None,
 ) -> dict[int, dict[str, Any]]:
     """Adjudicate canonical merged findings in one batched LLM call."""
+    run_context = resolve_run_context(run_context)
     from daydream.deep.artifacts import deep_dir
 
     print_phase_hero(console, "SUPERVISE", phase_subtitle("SUPERVISE"))
@@ -5182,6 +5262,7 @@ async def phase_supervise_review(
         tool_call_budget=DEFAULT_TOOL_CALL_BUDGET,
         wall_budget_s=DEFAULT_WALL_BUDGET_S,
         sanctioned_inputs=sanctioned_inputs,
+        run_context=run_context,
     )
     if not isinstance(result, dict) or not isinstance(result.get("verdicts"), list):
         raise ValueError(f"Supervisor returned no verdicts list (got {type(result).__name__})")
@@ -5262,6 +5343,7 @@ def _rekey_verdicts(
     return verdicts
 
 
+@bind_resolved_run_context
 async def phase_arbiter_review(
     backend: Backend,
     work: WorkContext,
@@ -5273,6 +5355,7 @@ async def phase_arbiter_review(
     exploration_dir: Path | None = None,
     intent_authoritative: bool = False,
     strategy: str | None = None,
+    run_context: RunContext | None = None,
 ) -> tuple[dict[int, dict[str, Any]], ContinuationToken | None]:
     """Re-review high-severity / contested per-stack findings with the arbiter (#168).
 
@@ -5312,6 +5395,7 @@ async def phase_arbiter_review(
         merge can resume this conversation instead of paying for a cold prompt.
 
     """
+    run_context = resolve_run_context(run_context)
     from daydream.deep.artifacts import arbiter_input_path, deep_dir
 
     print_phase_hero(console, "ARBITRATE", phase_subtitle("ARBITRATE"))
@@ -5348,6 +5432,7 @@ async def phase_arbiter_review(
         tool_call_budget=DEFAULT_TOOL_CALL_BUDGET,
         wall_budget_s=DEFAULT_WALL_BUDGET_S,
         sanctioned_inputs=sanctioned_inputs,
+        run_context=run_context,
     )
 
     if not isinstance(result, dict) or not isinstance(result.get("findings"), list):
@@ -5386,6 +5471,7 @@ SUPPRESSION_SCHEMA: dict[str, Any] = {
 }
 
 
+@bind_resolved_run_context
 async def phase_suppression_review(
     backend: Backend,
     work: WorkContext,
@@ -5396,6 +5482,7 @@ async def phase_suppression_review(
     alternatives_path: Path,
     exploration_dir: Path | None = None,
     strategy: str | None = None,
+    run_context: RunContext | None = None,
 ) -> dict[int, dict[str, Any]]:
     """Skeptical precision-mode second opinion over borderline findings (#232).
 
@@ -5425,6 +5512,7 @@ async def phase_suppression_review(
         DROPPED (a borderline finding the reviewer never confirmed must not
         survive on precision runs).
     """
+    run_context = resolve_run_context(run_context)
     from daydream.deep.artifacts import deep_dir, suppression_input_path
 
     print_phase_hero(console, "SUPPRESS", phase_subtitle("SUPPRESS"))
@@ -5460,6 +5548,7 @@ async def phase_suppression_review(
         tool_call_budget=DEFAULT_TOOL_CALL_BUDGET,
         wall_budget_s=DEFAULT_WALL_BUDGET_S,
         sanctioned_inputs=sanctioned_inputs,
+        run_context=run_context,
     )
 
     if not isinstance(result, dict) or not isinstance(result.get("findings"), list):
@@ -6071,6 +6160,7 @@ def _validate_agent_source_uids(
         )
 
 
+@bind_resolved_run_context
 async def phase_cross_stack_merge(
     backend: Backend,
     work: WorkContext,
@@ -6085,6 +6175,7 @@ async def phase_cross_stack_merge(
     intent_authoritative: bool = False,
     continuation: ContinuationToken | None = None,
     strategy: str | None = None,
+    run_context: RunContext | None = None,
 ) -> Path:
     """Run the cross-stack merge agent and return the merged-report path (D-23..D-27).
 
@@ -6138,6 +6229,7 @@ async def phase_cross_stack_merge(
             (no silent ``[]`` fallback that would mask a broken merge).
 
     """
+    run_context = resolve_run_context(run_context)
     from daydream.deep.artifacts import deep_dir, merged_items_path, merged_report_path
     from daydream.deep.records import stack_name_from_records_source
 
@@ -6193,6 +6285,7 @@ async def phase_cross_stack_merge(
         tool_call_budget=DEFAULT_TOOL_CALL_BUDGET,
         wall_budget_s=DEFAULT_WALL_BUDGET_S,
         sanctioned_inputs=sanctioned_inputs,
+        run_context=run_context,
     )
 
     # Fail loudly on empty/invalid output -- a silent [] would hide a broken

--- a/daydream/pr_review.py
+++ b/daydream/pr_review.py
@@ -41,7 +41,6 @@ import jsonschema
 
 import daydream
 from daydream import git_ops
-from daydream.agent import get_assume, get_non_interactive, resolve_or_prompt
 from daydream.config import DIAGRAM_KINDS
 from daydream.extensions import (
     CommentFinding,
@@ -53,6 +52,7 @@ from daydream.extensions import (
 from daydream.git_ops import GitError, PathAbsentError
 from daydream.pr_comment_renderer import render_run_info_block
 from daydream.repository_paths import valid_repository_file_path
+from daydream.run_context import RunContext, bind_resolved_run_context, resolve_run_context
 from daydream.severity import normalize_severity
 from daydream.trajectory import TrajectoryRecorder, get_current_recorder
 from daydream.ui import print_error, print_info, print_success, print_warning
@@ -64,7 +64,6 @@ if TYPE_CHECKING:
 
 
 _logger = logging.getLogger(__name__)
-
 
 # --- Data shapes ------------------------------------------------------------
 
@@ -198,6 +197,7 @@ class _ClassifiedIssues:
 # --- Public entry points ----------------------------------------------------
 
 
+@bind_resolved_run_context
 async def post_review_to_pr_from_report(
     target_dir: Path,
     merged_items_path: Path,
@@ -207,6 +207,7 @@ async def post_review_to_pr_from_report(
     approve_on_clean: bool = False,
     pr_number: int | None = None,
     diagram_blocks: str | None = None,
+    run_context: RunContext | None = None,
 ) -> PostStatus:
     """Read canonical `merged-items.json` and offer to post to the PR.
 
@@ -234,6 +235,7 @@ async def post_review_to_pr_from_report(
         whether a non-posting run is a failure (comment mode) or a
         warn-and-continue (default deep flow).
     """
+    run_context = resolve_run_context(run_context)
     if not merged_items_path.exists():
         return PostStatus.NOTHING_TO_POST
     try:
@@ -259,6 +261,7 @@ async def post_review_to_pr_from_report(
         approve_on_clean=approve_on_clean,
         pr_number=pr_number,
         diagram_blocks=diagram_blocks,
+        run_context=run_context,
     )
 
 
@@ -1611,6 +1614,7 @@ def _resolve_pr(
     return pr
 
 
+@bind_resolved_run_context
 async def _post(
     target_dir: Path,
     issues: list[ParsedIssue],
@@ -1620,7 +1624,9 @@ async def _post(
     approve_on_clean: bool = False,
     pr_number: int | None = None,
     diagram_blocks: str | None = None,
+    run_context: RunContext | None = None,
 ) -> PostStatus:
+    run_context = resolve_run_context(run_context)
     try:
         pr = _resolve_pr(target_dir, console, pr_number)
     except GitError as exc:
@@ -1651,9 +1657,7 @@ async def _post(
     event_note = " — will post event: APPROVE" if clean else ""
     print_info(console, f"PR #{pr.number}: {summary}{event_note}")
 
-    if not post and not resolve_or_prompt(
-        assume=get_assume(),
-        interactive=not get_non_interactive(),
+    if not post and not run_context.confirm(
         safe_default=False,
         question=(
             "Post an APPROVE review for this clean PR? [y/N]"
@@ -1661,6 +1665,7 @@ async def _post(
             else "Post these as a PR review? [y/N]"
         ),
         default="n",
+        console=console,
     ):
         print_info(console, "Skipped posting to PR.")
         return PostStatus.NOTHING_TO_POST

--- a/daydream/run_context.py
+++ b/daydream/run_context.py
@@ -1,0 +1,201 @@
+"""Run-local interaction policy and active-backend lifecycle state."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable, Coroutine, Iterator
+from contextlib import contextmanager
+from contextvars import ContextVar
+from dataclasses import dataclass
+from functools import wraps
+from threading import RLock
+from typing import TYPE_CHECKING, Any, ParamSpec, TypeVar, cast
+
+if TYPE_CHECKING:
+    from rich.console import Console
+
+    from daydream.backends import Backend
+
+
+@dataclass(frozen=True, kw_only=True)
+class InteractionPolicy:
+    """Immutable interaction and presentation choices for one run."""
+
+    assume: str | None = None
+    interactive: bool = True
+    quiet: bool = False
+    log_mode: bool = False
+
+
+@dataclass
+class _BackendRegistration:
+    run_token: object
+    backend: Backend
+
+
+# Signal handling needs a process-wide view across task-local run contexts. The
+# registry deliberately stores only an opaque run token and backend lifecycle
+# entries; interaction and presentation policy never enter this structure.
+_registry_lock = RLock()
+_active_registrations: dict[object, _BackendRegistration] = {}
+_current_context: ContextVar[RunContext | None] = ContextVar(
+    "daydream_run_context", default=None
+)
+_P = ParamSpec("_P")
+_T = TypeVar("_T")
+
+
+class RunContext:
+    """Own the immutable policy and active backend counts for one run."""
+
+    __slots__ = ("_policy", "_run_token")
+
+    def __init__(self, policy: InteractionPolicy) -> None:
+        self._policy = policy
+        self._run_token = object()
+
+    @property
+    def policy(self) -> InteractionPolicy:
+        """Return this run's immutable interaction policy."""
+        return self._policy
+
+    def confirm(
+        self,
+        question: str,
+        *,
+        safe_default: bool,
+        default: str = "n",
+        console: Console | None = None,
+    ) -> bool:
+        """Resolve a yes/no gate and prompt only when policy permits it."""
+        decision = resolve_gate(
+            assume=self.policy.assume,
+            interactive=self.policy.interactive,
+            safe_default=safe_default,
+        )
+        if decision is not None:
+            return decision
+        with bind_run_context(self):
+            response = _prompt_user(console, question, default)
+        return response.strip().lower() in ("y", "yes")
+
+    def choice(
+        self,
+        question: str,
+        *,
+        default: str,
+        safe_default: str,
+        assume_yes: str | None = None,
+        assume_no: str | None = None,
+        console: Console | None = None,
+    ) -> str:
+        """Resolve a menu or free-form choice through this run's policy."""
+        if self.policy.assume == "yes" and assume_yes is not None:
+            return assume_yes
+        if self.policy.assume == "no" and assume_no is not None:
+            return assume_no
+        if not self.policy.interactive:
+            return safe_default
+        with bind_run_context(self):
+            return _prompt_user(console, question, default)
+
+    @contextmanager
+    def backend_registration(self, backend: Backend) -> Iterator[None]:
+        """Register one backend invocation until its entire lifecycle exits."""
+        registration_token = object()
+        try:
+            with _registry_lock:
+                _active_registrations[registration_token] = _BackendRegistration(
+                    self._run_token, backend
+                )
+            yield
+        finally:
+            with _registry_lock:
+                _active_registrations.pop(registration_token, None)
+
+    def active_backends(self) -> tuple[Backend, ...]:
+        """Return the unique backend identities active in this run."""
+        with _registry_lock:
+            return _unique_backends(
+                entry.backend
+                for entry in _active_registrations.values()
+                if entry.run_token is self._run_token
+            )
+
+
+def current_run_context() -> RunContext | None:
+    """Return the context bound to this task, if any."""
+    return _current_context.get()
+
+
+def resolve_run_context(context: RunContext | None = None) -> RunContext:
+    """Resolve an explicit, bound, or fresh standalone run context."""
+    if context is not None:
+        return context
+    bound = current_run_context()
+    if bound is not None:
+        return bound
+    return RunContext(InteractionPolicy())
+
+
+@contextmanager
+def bind_run_context(context: RunContext) -> Iterator[RunContext]:
+    """Bind a context for the current task and restore the prior binding."""
+    token = _current_context.set(context)
+    try:
+        yield context
+    finally:
+        _current_context.reset(token)
+
+
+def bind_resolved_run_context(
+    function: Callable[_P, Awaitable[_T]],
+) -> Callable[_P, Coroutine[Any, Any, _T]]:
+    """Bind a standalone async entry's explicit or ambient runtime for its body."""
+
+    @wraps(function)
+    async def wrapped(*args: _P.args, **kwargs: _P.kwargs) -> _T:
+        run_context = resolve_run_context(cast("RunContext | None", kwargs.get("run_context")))
+        with bind_run_context(run_context):
+            return await function(*args, **kwargs)
+
+    return wrapped
+
+
+def active_backends() -> tuple[Backend, ...]:
+    """Return a process-wide snapshot of unique active backend identities."""
+    with _registry_lock:
+        return _unique_backends(
+            entry.backend for entry in _active_registrations.values()
+        )
+
+
+def _unique_backends(backends: Iterator[Backend]) -> tuple[Backend, ...]:
+    """Deduplicate a registration snapshot by object identity."""
+    seen: set[int] = set()
+    snapshot: list[Backend] = []
+    for backend in backends:
+        identity = id(backend)
+        if identity not in seen:
+            seen.add(identity)
+            snapshot.append(backend)
+    return tuple(snapshot)
+
+
+def resolve_gate(*, assume: str | None, interactive: bool, safe_default: bool) -> bool | None:
+    """Resolve a yes/no interaction gate without performing I/O."""
+    if assume is not None:
+        return assume == "yes"
+    if not interactive:
+        return safe_default
+    return None
+
+
+def _prompt_user(console: Console | None, message: str, default: str) -> str:
+    """Call the sole raw prompt reader, resolving the shared console lazily."""
+    if console is None:
+        from daydream.agent import console as agent_console
+
+        console = agent_console
+    from daydream.ui.messages import _read_user_input
+
+    return _read_user_input(console, message, default)

--- a/daydream/runner.py
+++ b/daydream/runner.py
@@ -37,13 +37,7 @@ import anyio
 from rich.markup import escape as escape_markup
 
 from daydream import git_ops, github_app
-from daydream.agent import (
-    console,
-    set_assume,
-    set_log_mode,
-    set_non_interactive,
-    set_quiet_mode,
-)
+from daydream.agent import console
 from daydream.artifact_visibility import (
     ArtifactDisposition,
     ArtifactSession,
@@ -88,6 +82,7 @@ from daydream.phases import (
     _git_log,
 )
 from daydream.review_profile import ResolvedProfile, resolve_from_runconfig
+from daydream.run_context import InteractionPolicy, RunContext, bind_run_context
 from daydream.trajectory import (
     DaydreamRunFlow,
     RunWriteSnapshot,
@@ -103,7 +98,6 @@ from daydream.ui import (
     print_info,
     print_phase_hero,
     print_success,
-    prompt_user,
 )
 from daydream.workspace import (
     AuditWorkspace,
@@ -1016,8 +1010,6 @@ async def run(config: RunConfig | None = None, *, private_roots: PrivateRootLoca
     if config is None:
         config = RunConfig()
 
-    print_phase_hero(console, "DAYDREAM", phase_subtitle("DAYDREAM"))
-
     # Codex backends need shell output visible (the commands ARE the signal), so
     # disable quiet when any phase resolves to codex. Done before backend construction.
     quiet = config.quiet
@@ -1028,12 +1020,24 @@ async def run(config: RunConfig | None = None, *, private_roots: PrivateRootLoca
         )
         if codex_in_use:
             quiet = False
-    set_quiet_mode(quiet)
-    # Interactivity (--non-interactive flag, else non-TTY stdin, else CI) and the
-    # orthogonal ``assume`` axis (--yes) both feed ``resolve_gate`` at each gate.
-    set_non_interactive(not _resolve_interactive(config))
-    set_assume(config.assume)
-    set_log_mode(config.log_mode)
+    run_context = RunContext(InteractionPolicy(
+        assume=config.assume,
+        interactive=_resolve_interactive(config),
+        quiet=quiet,
+        log_mode=config.log_mode,
+    ))
+    with bind_run_context(run_context):
+        return await _run_with_context(
+            config, private_roots=private_roots, run_context=run_context,
+        )
+
+
+async def _run_with_context(
+    config: RunConfig, *, private_roots: PrivateRootLocations | None,
+    run_context: RunContext,
+) -> int:
+    """Execute with the runner's immutable policy bound before any output."""
+    print_phase_hero(console, "DAYDREAM", phase_subtitle("DAYDREAM"))
 
     # Build the per-run registry (builtins + optional daydream_ext) and set it
     # on the ContextVar so every downstream phase resolves through it.
@@ -1066,7 +1070,9 @@ async def run(config: RunConfig | None = None, *, private_roots: PrivateRootLoca
     if config.target is not None:
         target_dir = Path(config.target).resolve()
     else:
-        target_input = prompt_user(console, "Enter target directory", ".")
+        target_input = run_context.choice(
+            "Enter target directory", default=".", safe_default=".",
+        )
         target_dir = Path(target_input).resolve()
 
     if not target_dir.is_dir():
@@ -1103,6 +1109,7 @@ async def run(config: RunConfig | None = None, *, private_roots: PrivateRootLoca
             skip_tests = config.output_mode != "loop" or config.flow_name in ("review", "improve")
             result = await _run_workspace(
                 config, target_dir, skip_tests=skip_tests, private_owner=private_owner,
+                run_context=run_context,
             )
             observed.finish(result)
             return result
@@ -1167,7 +1174,8 @@ def _finalize_run_artifacts(
 
 
 async def _run_workspace(
-    config: RunConfig, target_dir: Path, *, skip_tests: bool, private_owner: PrivateWorkspaceOwner
+    config: RunConfig, target_dir: Path, *, skip_tests: bool,
+    private_owner: PrivateWorkspaceOwner, run_context: RunContext,
 ) -> int:
     """Keep workspace errors inside the run span so returned failures are recorded."""
     # ``open_workspace`` runs ``assert_is_worktree`` and surfaces
@@ -1203,7 +1211,9 @@ async def _run_workspace(
                 primary: BaseException | None = None
                 result = 1
                 try:
-                    result = await _dispatch(work, dispatch_config, run_artifacts)
+                    result = await _dispatch(
+                        work, dispatch_config, run_artifacts, run_context=run_context,
+                    )
                 except BaseException as exc:
                     primary = exc
 
@@ -1293,7 +1303,10 @@ def _require_reviewable_branch(work: WorkContext, config: RunConfig) -> None:
 _DEEP_FLOW_ALIASES = ("review", "shallow", "deep")
 
 
-async def _dispatch_selected_flow(work: WorkContext, config: RunConfig, run_artifacts: _RunArtifacts) -> int:
+async def _dispatch_selected_flow(
+    work: WorkContext, config: RunConfig, run_artifacts: _RunArtifacts, *,
+    run_context: RunContext,
+) -> int:
     """Route an explicit ``--flow <name>`` selection.
 
     ``review`` / ``shallow`` / ``deep`` route to the single deep flow (as
@@ -1312,14 +1325,14 @@ async def _dispatch_selected_flow(work: WorkContext, config: RunConfig, run_arti
     if name in _DEEP_FLOW_ALIASES:
         if name in ("shallow", "deep"):
             _require_reviewable_branch(work, config)
-        return await _run_loop_deep(work, config, run_artifacts)
+        return await _run_loop_deep(work, config, run_artifacts, run_context=run_context)
     if name == "improve":
-        return await _run_improve(work, config, run_artifacts)
+        return await _run_improve(work, config, run_artifacts, run_context=run_context)
 
     # Resolve-check first; unknown names raise UnresolvedExtensionError, caught
     # by run()'s Extension Error panel (exit 1). Do not swallow it here.
     get_registry().flow(name)
-    return await _run_custom_flow(work, config, run_artifacts)
+    return await _run_custom_flow(work, config, run_artifacts, run_context=run_context)
 
 
 def _verify_approved_head(work: WorkContext, config: RunConfig) -> int:
@@ -1335,7 +1348,10 @@ def _verify_approved_head(work: WorkContext, config: RunConfig) -> int:
     return 1
 
 
-async def _dispatch(work: WorkContext, config: RunConfig, run_artifacts: _RunArtifacts) -> int:
+async def _dispatch(
+    work: WorkContext, config: RunConfig, run_artifacts: _RunArtifacts, *,
+    run_context: RunContext,
+) -> int:
     """Verify the approved head, then route to the resolved flow.
 
     Every PR-process mode routes to :func:`_run_loop_deep` (which delegates to
@@ -1356,25 +1372,25 @@ async def _dispatch(work: WorkContext, config: RunConfig, run_artifacts: _RunArt
     if work.is_unborn:
         if config.flow_name != "improve" or config.approved_head_sha is not None:
             raise GitError("unborn checkout cannot satisfy a commit-anchored review")
-        return await _run_improve(work, config, run_artifacts)
+        return await _run_improve(work, config, run_artifacts, run_context=run_context)
     head_status = _verify_approved_head(work, config)
     if head_status != 0:
         return head_status
 
     if config.flow_name is not None:
-        return await _dispatch_selected_flow(work, config, run_artifacts)
+        return await _dispatch_selected_flow(work, config, run_artifacts, run_context=run_context)
 
     # ``diagram`` joins comment/review in skipping ``_require_reviewable_branch``:
     # it neither fixes nor commits, so a base-branch invocation is a legitimate
     # (if empty) request rather than a ``WrongBranchError``.
     if config.output_mode in ("comment", "review", "diagram"):
-        return await _run_loop_deep(work, config, run_artifacts)
+        return await _run_loop_deep(work, config, run_artifacts, run_context=run_context)
 
     # output_mode == "loop" (default deep) and --shallow both fix against a
     # base branch, so both must refuse to review the base branch against
     # itself (the guard was shared by loop + shallow pre-collapse, #330).
     _require_reviewable_branch(work, config)
-    return await _run_loop_deep(work, config, run_artifacts)
+    return await _run_loop_deep(work, config, run_artifacts, run_context=run_context)
 
 
 def _emit_diagram_findings(
@@ -1516,7 +1532,10 @@ def _gather_diff_seed(work: WorkContext, config: RunConfig) -> tuple[str | None,
 # Helper: generic custom flow (--flow <name>)
 
 
-async def _run_improve(work: WorkContext, config: RunConfig, run_artifacts: _RunArtifacts) -> int:
+async def _run_improve(
+    work: WorkContext, config: RunConfig, run_artifacts: _RunArtifacts, *,
+    run_context: RunContext,
+) -> int:
     """Preamble for the registered repository-wide improve flow."""
     from daydream.improve.artifacts import improve_dir
 
@@ -1570,6 +1589,7 @@ async def _run_improve(work: WorkContext, config: RunConfig, run_artifacts: _Run
                 audit_workspace=audit,
                 private_workspace_owner=run_artifacts.owner,
                 artifacts=run_artifacts.session,
+                run_context=run_context,
             )
             ctx.data["audit_repo"] = audit.repo
             ctx.data["improve_dir"] = directory
@@ -1611,7 +1631,10 @@ async def _run_improve(work: WorkContext, config: RunConfig, run_artifacts: _Run
             return await run_flow(ctx.registry, "improve", ctx)
 
 
-async def _run_custom_flow(work: WorkContext, config: RunConfig, run_artifacts: _RunArtifacts) -> int:
+async def _run_custom_flow(
+    work: WorkContext, config: RunConfig, run_artifacts: _RunArtifacts, *,
+    run_context: RunContext,
+) -> int:
     """Generic preamble for a fork-registered flow selected via ``--flow``.
 
     Mirrors :func:`_run_review_or_comment`'s diff seed so custom flows composed
@@ -1649,6 +1672,7 @@ async def _run_custom_flow(work: WorkContext, config: RunConfig, run_artifacts: 
             review_profile=config.review_profile,
             private_workspace_owner=run_artifacts.owner,
             artifacts=run_artifacts.session,
+            run_context=run_context,
         )
         ctx.data["post_to_pr"] = False  # custom flows do not post to PR by default
         ctx.data["diff"] = diff
@@ -1671,9 +1695,14 @@ async def _run_custom_flow(work: WorkContext, config: RunConfig, run_artifacts: 
 # Helper: deep (single-flow dispatch)
 
 
-async def _run_loop_deep(work: WorkContext, config: RunConfig, run_artifacts: _RunArtifacts) -> int:
+async def _run_loop_deep(
+    work: WorkContext, config: RunConfig, run_artifacts: _RunArtifacts, *,
+    run_context: RunContext,
+) -> int:
     """Delegate to the deep-mode orchestrator (the only PR-process flow, #330)."""
     from daydream.deep.orchestrator import run_deep
 
     _resolve_review_profile(config)
-    return await run_deep(config, work, run_artifacts=run_artifacts)
+    return await run_deep(
+        config, work, run_artifacts=run_artifacts, run_context=run_context,
+    )

--- a/daydream/ui/messages.py
+++ b/daydream/ui/messages.py
@@ -194,8 +194,8 @@ def print_intent_summary(console: Console, text: str) -> None:
     console.print(panel)
 
 
-def prompt_user(console: Console, message: str, default: str = "") -> str:
-    """Display a styled input prompt and get user input.
+def _read_user_input(console: Console, message: str, default: str) -> str:
+    """Display a styled input prompt and read stdin without policy lookup.
 
     Args:
         default: Default value if user enters nothing.
@@ -204,12 +204,6 @@ def prompt_user(console: Console, message: str, default: str = "") -> str:
         User's input string, or default if empty.
 
     """
-    # Lazy import to avoid the ui -> agent import cycle (agent.py imports ui).
-    from daydream.agent import get_non_interactive
-
-    if get_non_interactive():
-        return default
-
     prompt_text = Text()
     prompt_text.append("▶ ", style=STYLE_CYAN)
     prompt_text.append(message, style=STYLE_CYAN)
@@ -227,3 +221,15 @@ def prompt_user(console: Console, message: str, default: str = "") -> str:
         )
         return default
     return user_input if user_input else default
+
+
+def prompt_user(console: Console, message: str, default: str = "") -> str:
+    """Resolve a free-form prompt through the current run's interaction gateway."""
+    from daydream.run_context import resolve_run_context
+
+    return resolve_run_context().choice(
+        message,
+        default=default,
+        safe_default=default,
+        console=console,
+    )

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -598,6 +598,7 @@ async def explain_note(ctx: FlowContext) -> None:
         phase=DaydreamPhase.REVIEW,
         read_only=True,
         sanctioned_inputs=inputs,
+        run_context=ctx.run_context,
     )
 
 def register(registry: Registry) -> None:
@@ -614,6 +615,29 @@ published under the checkout's untracked `.daydream/` at finalization).
 `review_output_path_for(ctx.work.repo)` routes the review-output file the same
 way: private while the session is active, published as `.review-output.md` at
 finalization.
+
+### Interaction and output policy
+
+Runner-created flows receive `ctx.run_context`, which owns a frozen policy
+(`assume`, `interactive`, `quiet`, and `log_mode`) and active backend registrations.
+Pass it to `run_agent` and built-in phase calls. Use its `confirm()` and `choice()`
+methods for input so unattended runs take the call site's safe default.
+
+For example, `ctx.run_context.confirm("Apply this change?", safe_default=False)`
+honors a forced answer, declines unattended changes, and otherwise prompts.
+`choice()` accepts explicit `assume_yes` and `assume_no` mappings for menus;
+free-form input without those mappings follows the run's interactivity policy.
+
+The runner binds this context for the run, so the shared console and API v6
+extensions that omit the new argument still use the emitting run's policy.
+Built-in phases also bind an explicitly supplied `run_context` for the entire
+invocation, including output before and after agent execution.
+Standalone callers can use `with bind_run_context(RunContext(InteractionPolicy(...)))`
+from `daydream.run_context` to scope several calls together. Without an explicit
+or bound context, standalone calls use a fresh interactive, non-quiet, non-log
+default with no assumed answer. Binding restores the previous context on exit,
+including exceptions. This additive field does not change API version 6,
+`ctx.artifacts`, or the shared `ctx.data` mapping.
 
 ### Stable `ctx.data` keys
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -610,24 +610,6 @@ def mute_side_effects(monkeypatch: pytest.MonkeyPatch) -> Callable[..., None]:
 
 
 @pytest.fixture(autouse=True)
-def _reset_agent_state() -> Iterator[Any]:
-    """Reset the ``AgentState`` singleton before AND after every test.
-
-    The interaction axes (``non_interactive``, ``assume``) and ``quiet_mode``
-    live on a module-level ``AgentState`` singleton in ``daydream.agent``. A test
-    that drives ``run()`` calls ``set_non_interactive``/``set_assume``, leaving
-    the singleton dirty for the next test — which silently changes the resolved
-    answer at every ``resolve_gate`` call site. Reset on both edges so each test
-    starts from defaults regardless of order.
-    """
-    from daydream.agent import reset_state
-
-    reset_state()
-    yield
-    reset_state()
-
-
-@pytest.fixture(autouse=True)
 def _reset_gh_token_env() -> Iterator[Any]:
     """Reset the ``gh`` token-env singleton before AND after every test.
 
@@ -697,7 +679,6 @@ def _hermetic_skill_availability(
 def _reset_trajectory_recorder() -> Iterator[Any]:
     """Clear the trajectory ContextVar before AND after every test.
 
-    Mirrors ``daydream.agent.reset_state()`` for ``AgentState`` (CORE-10 / D-17).
     Prevents cross-test bleed when a test forgets to wrap recorder usage in
     ``async with TrajectoryRecorder(...)``.
 

--- a/tests/harness/stub_backend.py
+++ b/tests/harness/stub_backend.py
@@ -1171,17 +1171,17 @@ class StubBackend:
 def silence(monkeypatch: pytest.MonkeyPatch, *, prompts: bool = True) -> None:
     """Silence noise-only UI helpers in deep orchestrator + phases.
 
-    ``prompts=False`` leaves the real ``prompt_user`` in place at both seams, for
+    ``prompts=False`` leaves the real interaction gateway input in place, for
     tests that drive a genuine gate.
     """
     monkeypatch.setattr("daydream.deep.orchestrator.print_stage_progress", lambda *a, **kw: None)
     monkeypatch.setattr("daydream.deep.orchestrator.print_preflight_notice", lambda *a, **kw: None)
     monkeypatch.setattr("daydream.deep.orchestrator.print_verification_summary", lambda *a, **kw: None)
     if prompts:
-        monkeypatch.setattr("daydream.phases.prompt_user", lambda *a, **kw: "y")
-        # resolve_or_prompt routes through agent.prompt_user; patch it too so those
-        # gates don't block on stdin.
-        monkeypatch.setattr("daydream.agent.prompt_user", lambda *a, **kw: "n")
+        def answer(_console: Any, message: str, default: str = "") -> str:
+            return "y" if "understanding correct" in message.lower() else "n"
+
+        monkeypatch.setattr("daydream.run_context._prompt_user", answer)
 
 
 def force_interactive(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/harness/test_phase_backend.py
+++ b/tests/harness/test_phase_backend.py
@@ -19,8 +19,7 @@ ISSUE = {"id": 1, "description": "Add type hints", "file": "main.py", "line": 1}
 @pytest.fixture
 def mock_ui_loop(monkeypatch: pytest.MonkeyPatch) -> None:
     """Decline interactive gates so the run runs unattended."""
-    monkeypatch.setattr("daydream.phases.prompt_user", lambda *a, **kw: "n")
-    monkeypatch.setattr("daydream.runner.prompt_user", lambda *a, **kw: "n")
+    monkeypatch.setattr("daydream.run_context._prompt_user", lambda *a, **kw: "n")
 
 
 @pytest.mark.asyncio

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -1,20 +1,19 @@
-"""Tests for daydream.agent module-level state accessors."""
+"""Tests for agent execution and supporting helpers."""
 
 import os
+import sys
 from collections.abc import Callable
 from io import StringIO
 from pathlib import Path
+from types import FrameType
 from typing import Any
 
 import pytest
 from rich.console import Console
 
 from daydream.agent import (
-    get_non_interactive,
     is_environmental_failure,
-    reset_state,
     run_agent,
-    set_non_interactive,
 )
 from daydream.backends import DiagnosticEvent, ResultEvent
 from daydream.extensions import ToolDecision, get_registry, set_registry
@@ -27,6 +26,12 @@ from daydream.prompt_budget import (
     SanctionedInputTransport,
     SanctionedInputUnavailable,
     prepare_sanctioned_inputs,
+)
+from daydream.run_context import (
+    InteractionPolicy,
+    RunContext,
+    active_backends,
+    current_run_context,
 )
 from daydream.trajectory import DaydreamPhase
 from tests.harness.backend import ScriptedBackend
@@ -58,6 +63,116 @@ async def _run_with_inputs(backend: Any, root: Path, prepared: Any) -> Any:
     return await run_agent(
         backend, root, "inspect", phase=DaydreamPhase.REVIEW, sanctioned_inputs=prepared
     )
+
+
+@pytest.mark.anyio
+async def test_run_agent_binds_context_and_keeps_backend_registered_across_retry(
+    tmp_path: Path,
+) -> None:
+    context = RunContext(InteractionPolicy(quiet=True))
+    observations: list[tuple[RunContext | None, tuple[object, ...], tuple[object, ...]]] = []
+
+    class RetryableFailure(RuntimeError):
+        retryable = True
+
+    class RetryBackend:
+        model = "test-model"
+        retry_attempts = 1
+        retry_base_delay_s = 0
+        retry_max_delay_s = 0
+
+        def __init__(self) -> None:
+            self.calls = 0
+
+        async def execute(self, *_args: Any, **_kwargs: Any) -> Any:
+            self.calls += 1
+            observations.append(
+                (current_run_context(), context.active_backends(), active_backends())
+            )
+            if self.calls == 1:
+                raise RetryableFailure("retry")
+            yield ResultEvent(structured_output=None, continuation=None)
+
+        async def cancel(self) -> None:
+            pass
+
+    backend = RetryBackend()
+    assert current_run_context() is None
+
+    result = await run_agent(
+        backend,
+        tmp_path,
+        "inspect",
+        phase=DaydreamPhase.REVIEW,
+        run_context=context,
+    )
+
+    assert result == ("", None, None)
+    assert observations == [
+        (context, (backend,), (backend,)),
+        (context, (backend,), (backend,)),
+    ]
+    assert context.active_backends() == ()
+    assert active_backends() == ()
+    assert current_run_context() is None
+
+
+@pytest.mark.anyio
+async def test_run_agent_unregisters_backend_after_exception(tmp_path: Path) -> None:
+    context = RunContext(InteractionPolicy(quiet=True))
+    backend = ScriptedBackend(
+        events=[RuntimeError("boom")],
+        retry_attempts=0,
+    )
+
+    with pytest.raises(RuntimeError, match="boom"):
+        await run_agent(
+            backend,
+            tmp_path,
+            "inspect",
+            phase=DaydreamPhase.REVIEW,
+            run_context=context,
+        )
+
+    assert context.active_backends() == ()
+    assert active_backends() == ()
+
+
+async def test_run_agent_interrupt_after_registration_cleans_up(tmp_path: Path) -> None:
+    """A signal between registration and execution must not retain a backend."""
+    from daydream.agent import _run_agent
+
+    class InjectedInterrupt(BaseException):
+        pass
+
+    context = RunContext(InteractionPolicy())
+    backend = ScriptedBackend()
+    previous_trace = sys.gettrace()
+
+    def interrupt(frame: FrameType, event: str, _arg: Any) -> Any:
+        if (
+            event == "line"
+            and frame.f_code is _run_agent.__code__
+            and context.active_backends()
+        ):
+            raise InjectedInterrupt("after registration")
+        return interrupt
+
+    try:
+        sys.settrace(interrupt)
+        with pytest.raises(InjectedInterrupt) as caught:
+            await run_agent(
+                backend, tmp_path, "inspect", phase=DaydreamPhase.REVIEW,
+                run_context=context,
+            )
+    finally:
+        sys.settrace(previous_trace)
+
+    # Keep the traceback alive: cleanup must not depend on collecting frames.
+    assert caught.value.__traceback__ is not None
+    assert context.active_backends() == ()
+    assert active_backends() == ()
+    assert current_run_context() is None
 
 
 def _sized_inputs(tmp_path: Path, count: int, size: int) -> dict[str, Path]:
@@ -373,20 +488,6 @@ async def test_run_agent_rejects_same_backend_object_when_transport_mode_changes
     assert backend.call_count == 0
 
 
-def test_set_and_get_non_interactive() -> None:
-    try:
-        set_non_interactive(True)
-        assert get_non_interactive() is True
-    finally:
-        reset_state()
-
-
-def test_reset_state_clears_non_interactive() -> None:
-    set_non_interactive(True)
-    reset_state()
-    assert get_non_interactive() is False
-
-
 def test_is_environmental_failure_both_directions() -> None:
     environmental = [
         "The dev Postgres container is not running",
@@ -499,7 +600,6 @@ async def test_diagnostic_event_is_recorder_only_and_has_no_agent_side_effects(
             )
     finally:
         set_registry(previous_registry)
-        reset_state()
 
     assert result == ("", None, None)
     assert callback_events == []

--- a/tests/test_agent_structured_render.py
+++ b/tests/test_agent_structured_render.py
@@ -29,6 +29,7 @@ from daydream.backends import (
     ToolResultEvent,
     ToolStartEvent,
 )
+from daydream.run_context import InteractionPolicy, RunContext
 from daydream.trajectory import DaydreamPhase
 from tests.test_agent_recorder_integration import MockBackend
 
@@ -87,7 +88,6 @@ async def test_plain_text_still_renders(monkeypatch: pytest.MonkeyPatch, tmp_pat
 
 
 async def test_log_mode_emission_redacts_sentinels_on_agent_path(
-    monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
@@ -105,9 +105,9 @@ async def test_log_mode_emission_redacts_sentinels_on_agent_path(
             ResultEvent(structured_output=payload, continuation=None),
         ]
     )
-    monkeypatch.setattr("daydream.agent._state.log_mode", True)
     result, _, _ = await run_agent(
-        backend, tmp_path, "scan", phase=DaydreamPhase.REVIEW, output_schema={"type": "object"}
+        backend, tmp_path, "scan", phase=DaydreamPhase.REVIEW, output_schema={"type": "object"},
+        run_context=RunContext(InteractionPolicy(log_mode=True)),
     )
     assert result == payload          # returned object is raw/unchanged
     out = capsys.readouterr().out
@@ -116,7 +116,6 @@ async def test_log_mode_emission_redacts_sentinels_on_agent_path(
 
 
 async def test_log_mode_captures_structured_output(
-    monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
@@ -128,10 +127,10 @@ async def test_log_mode_captures_structured_output(
         "token": sentinel,
         "nested": {"path": f"/Users/{sentinel}"},
     }
-    monkeypatch.setattr("daydream.agent._state.log_mode", True)
     backend = MockBackend([ResultEvent(structured_output=payload, continuation=None)])
     result, _, _ = await run_agent(
-        backend, tmp_path, "scan", phase=DaydreamPhase.REVIEW, output_schema={"type": "object"}
+        backend, tmp_path, "scan", phase=DaydreamPhase.REVIEW, output_schema={"type": "object"},
+        run_context=RunContext(InteractionPolicy(log_mode=True)),
     )
     assert result == payload        # captured AND returned raw (never redacted)
     out = capsys.readouterr().out
@@ -141,7 +140,6 @@ async def test_log_mode_captures_structured_output(
 
 
 async def test_log_mode_structured_result_wins_over_prose_stray_json(
-    monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
     """Under --log, prose containing stray JSON must not be scraped over the real result.
@@ -157,7 +155,6 @@ async def test_log_mode_structured_result_wins_over_prose_stray_json(
     With the fix the captured structured result wins, so the payload survives as a
     dict and the fallback never runs.
     """
-    monkeypatch.setattr("daydream.agent._state.log_mode", True)
     merge_prose = "All source artifacts are empty: `stack-python-records.json` is `[]`. Nothing to merge."
     payload: dict[str, Any] = {"items": []}
     backend = MockBackend(
@@ -167,7 +164,8 @@ async def test_log_mode_structured_result_wins_over_prose_stray_json(
         ]
     )
     result, _, _ = await run_agent(
-        backend, tmp_path, "merge", phase=DaydreamPhase.DEEP, output_schema={"type": "object"}
+        backend, tmp_path, "merge", phase=DaydreamPhase.DEEP, output_schema={"type": "object"},
+        run_context=RunContext(InteractionPolicy(log_mode=True)),
     )
     assert result == payload  # the captured dict, NOT the stray [] scraped from prose
     assert isinstance(result, dict)  # the exact type the merge phase gate requires

--- a/tests/test_arbiter_prose_extraction.py
+++ b/tests/test_arbiter_prose_extraction.py
@@ -26,10 +26,10 @@ from typing import Any, cast
 
 import pytest
 
-from daydream.agent import set_log_mode
 from daydream.backends import AgentEvent, Backend, ResultEvent, TextEvent
 from daydream.json_utils import extract_json
 from daydream.phases import phase_arbiter_review
+from daydream.run_context import InteractionPolicy, RunContext
 from daydream.workspace import WorkContext
 
 SELECTED_RECORDS: list[dict[str, Any]] = [
@@ -240,7 +240,6 @@ async def test_arbiter_captures_structured_output_in_log_mode(
     phase received the prose-fallback string. Drives the real production path
     (phase_arbiter_review -> run_agent -> backend events) with log_mode on.
     """
-    set_log_mode(True)  # reset by the autouse _reset_agent_state fixture
     diff_path, intent_path, alternatives_path = _write_inputs(tmp_path)
     verdicts, _ = await phase_arbiter_review(
         cast(Backend, _SplitTextBackend(PROSE_WITH_TRUNCATED_JSON, STRUCTURED_OUTPUT)),
@@ -249,6 +248,7 @@ async def test_arbiter_captures_structured_output_in_log_mode(
         diff_path=diff_path,
         intent_path=intent_path,
         alternatives_path=alternatives_path,
+        run_context=RunContext(InteractionPolicy(log_mode=True)),
     )
     assert set(verdicts) == {1, 2}
     assert verdicts[1]["keep"] is True

--- a/tests/test_archive_data_capture.py
+++ b/tests/test_archive_data_capture.py
@@ -969,8 +969,7 @@ async def test_shallow_run_captures_recommended_patch(
     the distinct artifact carrying daydream's own edit (the deep test asserts
     the same distinctness where both artifacts exist).
     """
-    monkeypatch.setattr("daydream.phases.prompt_user", lambda *a, **kw: "n")
-    monkeypatch.setattr("daydream.runner.prompt_user", lambda *a, **kw: "n")
+    monkeypatch.setattr("daydream.run_context._prompt_user", lambda *a, **kw: "n")
     # Host-native commit/push (issue #726): the shallow --yes run commits and
     # pushes to 'origin' for real, so give the repo a bare remote.
     remote = bare_remote(archive_dir.parent / "origin.git")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -17,6 +17,42 @@ from daydream.runner import RunConfig, _resolved_backend_name, _resolved_model
 from tests.harness.git_helpers import bare_remote, commit, git, init_repo
 
 
+def test_signal_handler_flushes_before_backend_registry_snapshot(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from daydream import cli
+
+    events: list[str] = []
+
+    class FakePanel:
+        def __init__(self, _console: object) -> None:
+            pass
+
+        def start(self, _message: str) -> None:
+            events.append("panel-start")
+
+        def add_step(self, _message: str) -> None:
+            events.append("backend-step")
+
+    monkeypatch.setattr(
+        cli,
+        "flush_active_signal_recorders",
+        lambda: events.append("flush"),
+    )
+    def snapshot() -> tuple[object, ...]:
+        events.append("snapshot")
+        return (object(),)
+
+    monkeypatch.setattr(cli, "active_backends", snapshot)
+    monkeypatch.setattr(cli, "ShutdownPanel", FakePanel)
+    monkeypatch.setattr(cli, "set_shutdown_panel", lambda _panel: None)
+
+    with pytest.raises(KeyboardInterrupt):
+        cli._signal_handler(signal.SIGTERM, None)
+
+    assert events == ["flush", "panel-start", "snapshot", "backend-step"]
+
+
 def test_approved_head_sha_flag_populates_config(monkeypatch: pytest.MonkeyPatch) -> None:
     """--approved-head-sha pins config.approved_head_sha (no normalization)."""
     monkeypatch.setattr(sys, "argv", ["daydream", "--review", "--approved-head-sha", "a" * 40, "/tmp/repo"])

--- a/tests/test_cli_main_integration.py
+++ b/tests/test_cli_main_integration.py
@@ -247,24 +247,23 @@ def test_non_tty_auto_enables_non_interactive(
     This drives the production entrypoint (``cli.main`` -> ``runner.run``) with a
     bare target and a non-TTY stdin. The interactivity axis must resolve from the
     environment (non-TTY) rather than requiring an explicit ``--non-interactive``
-    flag, so the captured ``set_non_interactive`` value is ``True``.
+    flag. The raw input boundary must never be called, and the review completes.
     """
     _silence(monkeypatch)
     _silence_cli_and_runner(monkeypatch)
     _install_stub_backend(monkeypatch, multi_stack_target)
     monkeypatch.setattr("sys.stdin.isatty", lambda: False)  # piped stdin
     monkeypatch.delenv("CI", raising=False)
-    captured: dict[str, bool] = {}
-    monkeypatch.setattr(
-        "daydream.runner.set_non_interactive",
-        lambda v: captured.__setitem__("v", v),
-    )
+    def forbidden_input(*args: Any, **kwargs: Any) -> str:
+        raise AssertionError("non-TTY run must not prompt")
+
+    monkeypatch.setattr("daydream.run_context._prompt_user", forbidden_input)
     monkeypatch.setattr(sys, "argv", ["daydream", str(multi_stack_target)])
 
     with pytest.raises(SystemExit):
         cli.main()
 
-    assert captured["v"] is True  # auto-enabled with no flag
+    assert (multi_stack_target / ".review-output.md").exists()
 
 
 def test_cli_main_prune_reanchor_removes_and_exits_0(

--- a/tests/test_cutover_ast.py
+++ b/tests/test_cutover_ast.py
@@ -4,8 +4,8 @@ Walks the AST of every .py file under daydream/ and tests/ and rejects:
 
 1. Name nodes referencing forbidden symbols (catches direct calls and
    references)
-2. Attribute nodes accessing .debug_log (catches AgentState.debug_log
-   and similar attribute lookups even on aliased objects)
+2. Attribute nodes accessing .debug_log (catches attribute lookups even
+   on aliased objects)
 3. ImportFrom nodes importing forbidden names (catches the canonical
    Pitfall 13 lazy import in codex.py:_raw_log that grep alone misses)
 4. String-literal Constant nodes containing forbidden log prefixes
@@ -34,7 +34,7 @@ FORBIDDEN_NAMES: set[str] = {
     "get_debug_log",
 }
 FORBIDDEN_ATTRS: set[str] = {
-    "debug_log",  # AgentState.debug_log
+    "debug_log",
 }
 
 # String-literal forbidden prefixes — re-introducing any would resurrect the legacy log format.

--- a/tests/test_deep_integration.py
+++ b/tests/test_deep_integration.py
@@ -216,35 +216,16 @@ def _silence_ui(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def _wire_mocks(monkeypatch: pytest.MonkeyPatch, backend: _DeepMockBackend) -> None:
-    """Install the mock backend + silence prompts and UI.
-
-    ``phase_understand_intent`` loops on ``prompt_user`` until the user confirms
-    with ``y`` -- so ``daydream.phases.prompt_user`` must return ``y``.
-    The orchestrator's fix gate must return ``n`` so we skip the fix pass.
-    """
+    """Install the backend, accept intent, and decline other interactive gates."""
     monkeypatch.setattr(
         "daydream.runner.create_backend",
         lambda name, model=None, **kwargs: backend,
     )
-    # Orchestrator fix gate: decline to apply fixes.
-    monkeypatch.setattr(
-        "daydream.deep.orchestrator.prompt_user",
-        lambda *a, **kw: "n",
-        raising=False,
-    )
-    # Intent confirmation loop: accept the first answer.
-    monkeypatch.setattr(
-        "daydream.phases.prompt_user",
-        lambda *a, **kw: "y",
-        raising=False,
-    )
-    # Runner-level prompts (target dir, cleanup): never reached when `target`
-    # and `cleanup` are explicit on RunConfig, but be defensive.
-    monkeypatch.setattr(
-        "daydream.runner.prompt_user",
-        lambda *a, **kw: "n",
-        raising=False,
-    )
+
+    def answer(_console: Any, message: str, default: str = "") -> str:
+        return "y" if "understanding correct" in message.lower() else "n"
+
+    monkeypatch.setattr("daydream.run_context._prompt_user", answer)
     _silence_ui(monkeypatch)
 
 

--- a/tests/test_deep_merge_recovery.py
+++ b/tests/test_deep_merge_recovery.py
@@ -406,11 +406,13 @@ async def test_merge_failure_relaunch_picks_up_salvage(
     assert await _run_deep(multi_stack_target) != 0  # merge salvaged -> Stop(1)
     stub.calls.clear()
     stub.merge_emit_str = None
-    # Force the fix gate to accept so the resume reaches the fix phase and
-    # consumes the salvaged partial items; without this the gate declines in
-    # non-interactive mode and the run stops (0) before any fix prompt exists.
+    # Accept the interactive fix gate so the resume consumes the salvaged
+    # partial items; decline the later commit and posting gates.
+    monkeypatch.setattr("daydream.runner._stdin_isatty", lambda: True)
+    monkeypatch.delenv("CI", raising=False)
     monkeypatch.setattr(
-        "daydream.deep.orchestrator.resolve_or_prompt", lambda *_a, **_k: True
+        "daydream.run_context._prompt_user",
+        lambda _console, message, _default: "y" if "Apply fixes" in message else "n",
     )
     assert await _run_deep(multi_stack_target, start_at="fix") == 0
     # Reopen #361: the resume loader surfaces the prior merge failure.

--- a/tests/test_deep_orchestrator.py
+++ b/tests/test_deep_orchestrator.py
@@ -61,6 +61,13 @@ MakeConfig = Callable[..., "RunConfig"]
 Mute = Callable[..., None]
 
 
+def _accept_intent_decline_other(
+    _console: Any, message: str, _default: str = ""
+) -> str:
+    """Accept intent confirmation while declining later optional gates."""
+    return "y" if "understanding correct" in message.lower() else "n"
+
+
 def _default_strategy(stage: str) -> str:
     from daydream import review_profile as _rp
 
@@ -2323,7 +2330,7 @@ async def test_fix_guard_reverts_generated_migration_edit(
     head_before = _git(project, "rev-parse", "HEAD")
     untouched_untracked = project / "migrations" / "0000_untouched.sql"
     untouched_untracked.write_bytes(b"-- untouched draft\r\n")
-    monkeypatch.setattr("daydream.agent.prompt_user", lambda *a, **kw: "y")
+    monkeypatch.setattr("daydream.run_context._prompt_user", lambda *a, **kw: "y")
     mute_side_effects(heal=False, commit=False)
     stub = _PushingCommittingStubBackend(project)
     monkeypatch.setattr("daydream.runner.create_backend", lambda name, model=None, **kwargs: stub)
@@ -2398,7 +2405,7 @@ async def test_fix_scrub_normalizes_smart_quote_in_changed_go_comment(
     no_ci_remote.connect(project, bare)
     notes_before = (project / "notes.md").read_bytes()
     head_before = _git(project, "rev-parse", "HEAD")
-    monkeypatch.setattr("daydream.agent.prompt_user", lambda *a, **kw: "y")
+    monkeypatch.setattr("daydream.run_context._prompt_user", lambda *a, **kw: "y")
     mute_side_effects(heal=False, commit=False)
     stub = _PushingCommittingStubBackend(project)
     monkeypatch.setattr("daydream.runner.create_backend", lambda name, model=None, **kwargs: stub)
@@ -2440,7 +2447,7 @@ async def test_test_healing_guard_reverts_generated_migration_edit(
 
     project, migration = _migration_project(tmp_path, "heal_migration_repo")
     pre_migration = migration.read_bytes()
-    monkeypatch.setattr("daydream.agent.prompt_user", lambda *a, **kw: "y")
+    monkeypatch.setattr("daydream.run_context._prompt_user", lambda *a, **kw: "y")
     mute_side_effects(heal=False)
     stub = _StubBackend(project)
     monkeypatch.setattr("daydream.runner.create_backend", lambda name, model=None, **kwargs: stub)
@@ -3379,7 +3386,7 @@ async def test_non_interactive_intent_prompt_carries_pr_body(
     ``prompt_user`` is left intact; ``builtins.input`` is a forbidden sentinel
     proving stdin is never touched in non-interactive mode.
     """
-    from daydream.agent import get_non_interactive, reset_state
+    from daydream.run_context import current_run_context
     from daydream.runner import run
 
     _silence_gate_noise(monkeypatch)
@@ -3395,14 +3402,9 @@ async def test_non_interactive_intent_prompt_carries_pr_body(
 
     monkeypatch.setattr("builtins.input", _forbidden_input)
 
-    reset_state()
-    rc = -1
-    try:
-        assert get_non_interactive() is False
-        rc = await run(make_config(multi_stack_target, pr_number=7))
-        assert get_non_interactive() is True
-    finally:
-        reset_state()
+    assert current_run_context() is None
+    rc = await run(make_config(multi_stack_target, pr_number=7))
+    assert current_run_context() is None
 
     assert rc == 0
     assert PR_SENTINEL in _intent_prompt(stub)
@@ -3422,8 +3424,8 @@ async def test_non_interactive_instruction_like_pr_body_stays_framed_and_read_on
     the run must still produce all five finding prompts, carry the untrusted framing
     + author-intent rule, and run the intent turn on the read-only profile.
     """
-    from daydream.agent import get_non_interactive, reset_state
     from daydream.prompts.authorial_intent import PR_DESCRIPTION_UNTRUSTED_FRAMING
+    from daydream.run_context import current_run_context
     from daydream.runner import run
 
     _silence_gate_noise(monkeypatch)
@@ -3440,14 +3442,9 @@ async def test_non_interactive_instruction_like_pr_body_stays_framed_and_read_on
 
     monkeypatch.setattr("builtins.input", _forbidden_input)
 
-    reset_state()
-    rc = -1
-    try:
-        assert get_non_interactive() is False
-        rc = await run(make_config(multi_stack_target, pr_number=7))
-        assert get_non_interactive() is True
-    finally:
-        reset_state()
+    assert current_run_context() is None
+    rc = await run(make_config(multi_stack_target, pr_number=7))
+    assert current_run_context() is None
 
     assert rc == 0  # instruction-like body does NOT break or steer the run
     intent = _intent_prompt(stub)
@@ -3502,15 +3499,15 @@ async def test_fix_gate_prompt(multi_stack_target: Path, monkeypatch: pytest.Mon
 
     asked: list[str] = []
 
-    def _record_prompt(console: Any, message: Any, default: Any="") -> str:
+    def _record_prompt(_console: Any, message: str, _default: str = "") -> str:
+        if "understanding correct" in message.lower():
+            return "y"
         asked.append(message)
         return "n"  # decline the fix gate
 
     monkeypatch.setattr("daydream.deep.orchestrator.print_stage_progress", lambda *a, **kw: None)
     monkeypatch.setattr("daydream.deep.orchestrator.print_preflight_notice", lambda *a, **kw: None)
-    # resolve_or_prompt routes through agent.prompt_user; capture it there.
-    monkeypatch.setattr("daydream.agent.prompt_user", _record_prompt)
-    monkeypatch.setattr("daydream.phases.prompt_user", lambda *a, **kw: "y")
+    monkeypatch.setattr("daydream.run_context._prompt_user", _record_prompt)
 
     exit_code = await _run_deep(multi_stack_target)
     assert exit_code == 0
@@ -3542,13 +3539,8 @@ async def test_yes_auto_applies_fix(
 
     monkeypatch.setattr("daydream.deep.orchestrator.print_stage_progress", lambda *a, **kw: None)
     monkeypatch.setattr("daydream.deep.orchestrator.print_preflight_notice", lambda *a, **kw: None)
-    # The fix gate routes through agent.prompt_user; under --yes it must never
-    # be reached. The intent gate must also be suppressed -- fail loudly if hit.
-    monkeypatch.setattr("daydream.agent.prompt_user", _record_prompt)
-    monkeypatch.setattr(
-        "daydream.phases.prompt_user",
-        lambda *a, **kw: (_ for _ in ()).throw(AssertionError("phases.prompt_user called under --yes")),
-    )
+    # Forced yes resolves both gates before the sole raw prompt seam.
+    monkeypatch.setattr("daydream.run_context._prompt_user", _record_prompt)
 
     exit_code = await run(make_config(multi_stack_target, assume="yes", output_mode="loop"))
 
@@ -3800,8 +3792,7 @@ async def test_preflight_notice(multi_stack_target: Path, monkeypatch: pytest.Mo
 
     monkeypatch.setattr("daydream.deep.orchestrator.print_stage_progress", lambda *a, **kw: None)
     monkeypatch.setattr("daydream.deep.orchestrator.print_preflight_notice", _capture)
-    monkeypatch.setattr("daydream.agent.prompt_user", lambda *a, **kw: "n")
-    monkeypatch.setattr("daydream.phases.prompt_user", lambda *a, **kw: "y")
+    monkeypatch.setattr("daydream.run_context._prompt_user", _accept_intent_decline_other)
     _install_stub_backend(monkeypatch, multi_stack_target)
 
     exit_code = await _run_deep(multi_stack_target)
@@ -3858,8 +3849,7 @@ async def test_preflight_notice_sweep_note_disabled_when_sweep_off(
 
     monkeypatch.setattr("daydream.deep.orchestrator.print_stage_progress", lambda *a, **kw: None)
     monkeypatch.setattr("daydream.deep.orchestrator.print_preflight_notice", _capture)
-    monkeypatch.setattr("daydream.agent.prompt_user", lambda *a, **kw: "n")
-    monkeypatch.setattr("daydream.phases.prompt_user", lambda *a, **kw: "y")
+    monkeypatch.setattr("daydream.run_context._prompt_user", _accept_intent_decline_other)
     _install_stub_backend(monkeypatch, multi_stack_target)
 
     exit_code = await _run_deep(
@@ -3948,8 +3938,7 @@ async def test_stage_ui_surfacing(multi_stack_target: Path, monkeypatch: pytest.
 
     monkeypatch.setattr("daydream.deep.orchestrator.print_stage_progress", _capture)
     monkeypatch.setattr("daydream.deep.orchestrator.print_preflight_notice", lambda *a, **kw: None)
-    monkeypatch.setattr("daydream.agent.prompt_user", lambda *a, **kw: "n")
-    monkeypatch.setattr("daydream.phases.prompt_user", lambda *a, **kw: "y")
+    monkeypatch.setattr("daydream.run_context._prompt_user", _accept_intent_decline_other)
     _install_stub_backend(monkeypatch, multi_stack_target)
 
     exit_code = await _run_deep(multi_stack_target)
@@ -4717,8 +4706,7 @@ async def test_resolve_backend_called_with_each_phase_in_deep_flow(
     _force_interactive(monkeypatch)
     monkeypatch.setattr("daydream.deep.orchestrator.print_stage_progress", lambda *a, **kw: None)
     monkeypatch.setattr("daydream.deep.orchestrator.print_preflight_notice", lambda *a, **kw: None)
-    monkeypatch.setattr("daydream.agent.prompt_user", lambda *a, **kw: "y")
-    monkeypatch.setattr("daydream.phases.prompt_user", lambda *a, **kw: "y")
+    monkeypatch.setattr("daydream.run_context._prompt_user", lambda *a, **kw: "y")
 
     _install_stub_backend(monkeypatch, multi_stack_target)
 
@@ -4950,14 +4938,11 @@ async def test_heal_loop_receives_feedback_items_in_fix_prompt(
     # Drives the REAL interactive heal menu; pin interactivity so non-TTY pytest
     # stdin doesn't auto-resolve to non-interactive and bypass it.
     _force_interactive(monkeypatch)
-    monkeypatch.setattr("daydream.agent.prompt_user", lambda *a, **kw: "y")
-
-    # phases.prompt_user is shared: intent-confirmation needs "y"; the heal menu
-    # ("Choice") needs "2" (fix-and-retry). Dispatch on the message arg.
-    def _phases_prompt(console: Any, message: str, default: str = "") -> str:  # noqa: ARG001
+    # The single gateway handles both intent confirmation and the heal menu.
+    def _prompt(_console: Any, message: str, _default: str = "") -> str:
         return "2" if "Choice" in message else "y"
 
-    monkeypatch.setattr("daydream.phases.prompt_user", _phases_prompt)
+    monkeypatch.setattr("daydream.run_context._prompt_user", _prompt)
 
     stub = _install_stub_backend(monkeypatch, multi_stack_target)
     stub.fail_first_test_run = True  # first run fails, second passes
@@ -5131,8 +5116,8 @@ async def test_start_at_fix_recovers_merged_items(
 
 # Real-path integration: non-interactive / EOF-safe apply-fixes gate.
 # Both tests drive the REAL deep pipeline to the apply-fixes prompt with the real
-# ui.prompt_user (NOT mocked): non-interactive must short-circuit on
-# get_non_interactive(); interactive must catch EOF on stdin. Both resolve to the
+# prompt gateway (not mocked): unattended policy must avoid stdin, while
+# interactive policy must catch EOF. Both resolve to the
 # safe default. Only the backend and PR post are mocked. A phase_fix spy proves
 # the fix loop never ran; builtins.input fails the test if stdin is touched.
 
@@ -5168,8 +5153,8 @@ async def test_apply_fixes_gate_non_interactive_takes_safe_default(
     no ``recommendation-verdicts.json`` on disk. Verify lives inside the
     fix-accept branch; a declined run skips it (and its cost).
     """
-    from daydream.agent import get_non_interactive, reset_state
     from daydream.config import REVIEW_OUTPUT_FILE
+    from daydream.run_context import current_run_context
     from daydream.runner import run
 
     _silence_gate_noise(monkeypatch)
@@ -5193,14 +5178,9 @@ async def test_apply_fixes_gate_non_interactive_takes_safe_default(
     monkeypatch.setattr("builtins.input", _forbidden_input)
 
     traj = tmp_path / "trajectory.json"
-    reset_state()
-    exit_code = -1
-    try:
-        assert get_non_interactive() is False
-        exit_code = await run(make_config(multi_stack_target, trajectory_path=traj))
-        assert get_non_interactive() is True
-    finally:
-        reset_state()
+    assert current_run_context() is None
+    exit_code = await run(make_config(multi_stack_target, trajectory_path=traj))
+    assert current_run_context() is None
 
     assert exit_code == 0
     assert fix_calls == [], f"phase_fix ran despite the gate declining: {fix_calls!r}"
@@ -5238,8 +5218,8 @@ async def test_apply_fixes_gate_eof_declines_cleanly_no_crash(
     EOF-safety end-to-end through the real orchestrator, not just the unit
     ``prompt_user``.
     """
-    from daydream.agent import get_non_interactive, reset_state
     from daydream.config import REVIEW_OUTPUT_FILE
+    from daydream.run_context import current_run_context
     from daydream.runner import run
 
     _silence_gate_noise(monkeypatch)
@@ -5264,14 +5244,10 @@ async def test_apply_fixes_gate_eof_declines_cleanly_no_crash(
     # auto non-interactive short-circuit non-TTY pytest stdin would trigger.
     _force_interactive(monkeypatch)
 
-    reset_state()
-    exit_code = -1
-    try:
-        assert get_non_interactive() is False
-        # If the gate did not catch EOFError, this await would raise.
-        exit_code = await run(make_config(multi_stack_target, non_interactive=False))
-    finally:
-        reset_state()
+    assert current_run_context() is None
+    # If the gate did not catch EOFError, this await would raise.
+    exit_code = await run(make_config(multi_stack_target, non_interactive=False))
+    assert current_run_context() is None
 
     assert exit_code == 0
     assert fix_calls == [], f"phase_fix ran despite EOF at the gate: {fix_calls!r}"
@@ -5292,15 +5268,15 @@ async def test_apply_fixes_gate_interactive_yes_applies_fixes(
     non-interactive and EOF defaults but never prove the ACCEPT branch through
     the real prompt. ``assume="yes"`` (``test_yes_auto_applies_fix``) skips
     ``prompt_user`` entirely, so without this test nothing covers the path an
-    interactive operator actually takes: real ``prompt_user`` -> real
-    ``input()`` -> ``resolve_or_prompt`` coercion -> ``phase_fix``.
+    interactive operator actually takes: real ``prompt_user`` -> runtime
+    confirmation gateway -> real ``input()`` -> ``phase_fix``.
 
     ``precision_mode=True`` mirrors ``daydream . --precision``: the extra
     suppression pass must not consume the gate's stdin answer or drop every
     finding before the gate. The observable consequence is a recorded fixer
     prompt; run-wide scope enforcement removes the stub's sentinel afterward.
     """
-    from daydream.agent import reset_state
+    from daydream.run_context import current_run_context
     from daydream.runner import run
 
     _silence_gate_noise(monkeypatch)
@@ -5316,18 +5292,16 @@ async def test_apply_fixes_gate_interactive_yes_applies_fixes(
 
     monkeypatch.setattr("builtins.input", _yes_input)
 
-    reset_state()
-    try:
-        exit_code = await run(
-            make_config(
-                multi_stack_target,
-                non_interactive=False,
-                precision_mode=True,
-                output_mode="loop",
-            )
+    assert current_run_context() is None
+    exit_code = await run(
+        make_config(
+            multi_stack_target,
+            non_interactive=False,
+            precision_mode=True,
+            output_mode="loop",
         )
-    finally:
-        reset_state()
+    )
+    assert current_run_context() is None
 
     assert exit_code == 0
     assert reads, "the apply-fixes gate never reached input() -- no prompt was answered"
@@ -5458,14 +5432,13 @@ async def test_cleanup_none_interactive_prompts_before_keeping(
 
     asked: list[str] = []
 
-    def _record_prompt(console: Any, message: Any, default: Any="") -> str:
+    def _record_prompt(_console: Any, message: str, _default: str = "") -> str:
+        if "understanding correct" in message.lower():
+            return "y"
         asked.append(message)
         return "n"  # decline cleanup
 
-    monkeypatch.setattr("daydream.agent.prompt_user", _record_prompt)
-    # Confirm the intent gate so the review spine proceeds; the cleanup prompt is
-    # the one under observation (routed through daydream.agent.prompt_user).
-    monkeypatch.setattr("daydream.phases.prompt_user", lambda *a, **kw: "y")
+    monkeypatch.setattr("daydream.run_context._prompt_user", _record_prompt)
 
     report = multi_stack_target / REVIEW_OUTPUT_FILE
     exit_code = await run(
@@ -5508,11 +5481,7 @@ async def test_cleanup_gate_declines_honors_cleanup_flag(
     # returns None when interactive with no assumption, then prompts).
     _force_interactive(monkeypatch)
 
-    # Decline the apply-fixes gate: the fix-gate prompt is the one under
-    # observation (routed through daydream.agent.prompt_user).
-    monkeypatch.setattr("daydream.agent.prompt_user", lambda *a, **kw: "n")
-    # Accept the intent gate so the review spine proceeds.
-    monkeypatch.setattr("daydream.phases.prompt_user", lambda *a, **kw: "y")
+    monkeypatch.setattr("daydream.run_context._prompt_user", _accept_intent_decline_other)
 
     report = multi_stack_target / REVIEW_OUTPUT_FILE
     exit_code = await run(
@@ -6053,6 +6022,7 @@ def _install_post_recorder(monkeypatch: pytest.MonkeyPatch, received: list[bool]
         post: Any,
         approve_on_clean: Any=False,
         diagram_blocks: Any=None,
+        run_context: Any=None,
     ) -> None:
         received.append(approve_on_clean)
 
@@ -6696,8 +6666,7 @@ async def test_environmental_failure_aborts_heal_loop(
     failure exit code, and a TEST-phase trajectory step is recorded with no fix.
     """
     _silence(monkeypatch, prompts=False)
-    monkeypatch.setattr("daydream.phases.prompt_user", lambda *a, **kw: "y")
-    monkeypatch.setattr("daydream.agent.prompt_user", lambda *a, **kw: "y")
+    monkeypatch.setattr("daydream.run_context._prompt_user", lambda *a, **kw: "y")
 
     stub = _install_stub_backend(monkeypatch, multi_stack_target)
     stub.environmental_test_failure = True  # every test run reports infra-down
@@ -6764,8 +6733,7 @@ async def test_ephemeral_failure_handoff_projects_public_refs_without_private_pa
 ) -> None:
     """The real runner reads live bytes and persists only durable handoff paths."""
     _silence(monkeypatch, prompts=False)
-    monkeypatch.setattr("daydream.phases.prompt_user", lambda *a, **kw: "y")
-    monkeypatch.setattr("daydream.agent.prompt_user", lambda *a, **kw: "y")
+    monkeypatch.setattr("daydream.run_context._prompt_user", lambda *a, **kw: "y")
     summarizer_observations: list[dict[str, str]] = []
     private_partial_payloads: list[bytes] = []
 
@@ -6905,8 +6873,7 @@ def _install_accept_gate_pipeline(
     """
     _force_interactive(monkeypatch)
     _silence(monkeypatch, prompts=False)
-    monkeypatch.setattr("daydream.agent.prompt_user", lambda *a, **kw: "y")
-    monkeypatch.setattr("daydream.phases.prompt_user", lambda *a, **kw: "y")
+    monkeypatch.setattr("daydream.run_context._prompt_user", lambda *a, **kw: "y")
     mute()
 
     return _install_stub_backend(monkeypatch, target)
@@ -7535,7 +7502,7 @@ async def test_ac_fix_resume_on_tiny_diff(
     # Phase 2: resume with --start-at fix and accept the gate; the fix loop
     # must read the canonical JSON and dispatch at least one fix prompt.
     _force_interactive(monkeypatch)
-    monkeypatch.setattr("daydream.agent.prompt_user", lambda *a, **kw: "y")
+    monkeypatch.setattr("daydream.run_context._prompt_user", lambda *a, **kw: "y")
 
     rc = await run(
         make_config(tiny_diff_target, start_at="fix", assume="yes", non_interactive=False)
@@ -8081,7 +8048,7 @@ async def test_test_verdict_artifact_written_on_passing_suite(
 
     _silence(monkeypatch)
     _force_interactive(monkeypatch)
-    monkeypatch.setattr("daydream.agent.prompt_user", lambda *a, **kw: "y")
+    monkeypatch.setattr("daydream.run_context._prompt_user", lambda *a, **kw: "y")
     monkeypatch.setattr("daydream.remote_ci.platform.system", lambda: "Darwin")
     monkeypatch.setattr("daydream.remote_ci.platform.release", lambda: "25.1.0")
     monkeypatch.setattr("daydream.remote_ci.platform.machine", lambda: "arm64")
@@ -8130,7 +8097,7 @@ async def test_test_verdict_artifact_written_on_failing_suite(
 
     _silence(monkeypatch)
     _force_interactive(monkeypatch)
-    monkeypatch.setattr("daydream.agent.prompt_user", lambda *a, **kw: "y")
+    monkeypatch.setattr("daydream.run_context._prompt_user", lambda *a, **kw: "y")
     stub = _install_stub_backend(monkeypatch, tiny_diff_target)
     stub.fail_all_test_runs = True  # suite never goes green, even after the heal fix
     mute_side_effects(heal=False)
@@ -8220,14 +8187,11 @@ async def test_test_verdict_records_failure_when_operator_ignores_it(
 
     _silence(monkeypatch, prompts=False)
     _force_interactive(monkeypatch)
-    monkeypatch.setattr("daydream.agent.prompt_user", lambda *a, **kw: "y")
-
-    # phases.prompt_user is shared: intent-confirmation needs "y"; the heal menu
-    # ("Choice") needs "3" (ignore and continue).
-    def _phases_prompt(console: Any, message: str, default: str = "") -> str:  # noqa: ARG001
+    # The single gateway accepts intent and chooses ignore in the heal menu.
+    def _prompt(_console: Any, message: str, _default: str = "") -> str:
         return "3" if "Choice" in message else "y"
 
-    monkeypatch.setattr("daydream.phases.prompt_user", _phases_prompt)
+    monkeypatch.setattr("daydream.run_context._prompt_user", _prompt)
 
     stub = _CommittingStubBackend(tiny_diff_target)
     _add_bare_remote(tiny_diff_target)
@@ -11447,6 +11411,7 @@ async def test_fix_cycle_malformed_related_stops_before_backend_and_clears_stale
     from daydream import git_ops
     from daydream.deep.orchestrator import _step_fix_gate
     from daydream.extensions import Stop
+    from daydream.run_context import InteractionPolicy, RunContext
 
     repo = tmp_path / "malformed-related"
     _init_repo(repo)
@@ -11457,12 +11422,11 @@ async def test_fix_cycle_malformed_related_stops_before_backend_and_clears_stale
     item = _merge_item(1, "a.py", "high")
     item["related_files"] = ["../outside.py"]
     ctx = _direct_fix_context(repo, [item], changed_files={"a.py"}, start_at="fix")
+    ctx.run_context = RunContext(InteractionPolicy(assume="yes"))
     stale = ctx.data["dd"] / "test-verdict.json"
     stale.write_text(json.dumps({"session_id": "prior", "passed": True}))
     index_before = git_ops.snapshot_index(repo)
     bytes_before = (repo / "a.py").read_bytes()
-    monkeypatch.setattr("daydream.deep.orchestrator.resolve_or_prompt", lambda **_k: True)
-
     result = await _step_fix_gate(ctx)
 
     assert isinstance(result, Stop) and result.exit_code == 1
@@ -11479,6 +11443,7 @@ async def test_fix_cycle_nonempty_index_stops_before_backend_without_mutation(
     from daydream import git_ops
     from daydream.deep.orchestrator import _step_fix_gate
     from daydream.extensions import Stop
+    from daydream.run_context import InteractionPolicy, RunContext
 
     repo = tmp_path / "staged-preflight"
     _init_repo(repo)
@@ -11489,13 +11454,12 @@ async def test_fix_cycle_nonempty_index_stops_before_backend_without_mutation(
     _git(repo, "add", "a.py")
     item = _merge_item(1, "a.py", "high")
     ctx = _direct_fix_context(repo, [item], changed_files={"a.py"})
+    ctx.run_context = RunContext(InteractionPolicy(assume="yes"))
     stale = ctx.data["dd"] / "test-verdict.json"
     stale_bytes = b'{"session_id":"prior","passed":true}\n'
     stale.write_bytes(stale_bytes)
     index_before = git_ops.snapshot_index(repo)
     bytes_before = (repo / "a.py").read_bytes()
-    monkeypatch.setattr("daydream.deep.orchestrator.resolve_or_prompt", lambda **_k: True)
-
     result = await _step_fix_gate(ctx)
 
     assert isinstance(result, Stop) and result.exit_code == 1
@@ -11947,7 +11911,7 @@ async def test_changed_tree_red_retest_requires_new_override(
     monkeypatch.setattr("daydream.deep.orchestrator.phase_test_once", _red_retest)
     monkeypatch.setattr(
         "daydream.deep.orchestrator._authorize_final_red_override",
-        lambda: new_override,
+        lambda _ctx: new_override,
     )
     monkeypatch.setattr(ctx, "backend_for", lambda _phase: object())
 
@@ -11964,31 +11928,46 @@ async def test_changed_tree_red_retest_requires_new_override(
     assert verdict["ignored"] is new_override
 
 
-def test_final_red_override_requires_fresh_interactive_prompt(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+def test_final_red_override_requires_fresh_interactive_prompt(tmp_path: Path) -> None:
     from daydream.deep.orchestrator import _authorize_final_red_override
+    from daydream.run_context import InteractionPolicy, RunContext
 
     prompts: list[dict[str, Any]] = []
 
-    def accept_prompt(**kwargs: Any) -> bool:
-        prompts.append(kwargs)
-        return True
+    class RecordingContext(RunContext):
+        def confirm(
+            self,
+            question: str,
+            *,
+            safe_default: bool,
+            default: str = "n",
+            console: Any = None,
+        ) -> bool:
+            prompts.append(
+                {
+                    "question": question,
+                    "safe_default": safe_default,
+                    "default": default,
+                    "console": console,
+                }
+            )
+            return True
 
-    monkeypatch.setattr("daydream.deep.orchestrator.get_assume", lambda: None)
-    monkeypatch.setattr("daydream.deep.orchestrator.get_non_interactive", lambda: False)
-    monkeypatch.setattr(
-        "daydream.deep.orchestrator.resolve_or_prompt",
-        accept_prompt,
-    )
+    repo = tmp_path / "red-override"
+    _init_repo(repo)
+    (repo / "a.py").write_text("A = 1\n")
+    _git(repo, "add", "a.py")
+    _commit(repo, "base")
+    ctx = _direct_fix_context(repo, [], changed_files=set())
+    ctx.run_context = RecordingContext(InteractionPolicy())
 
-    assert _authorize_final_red_override() is True
+    assert _authorize_final_red_override(ctx) is True
     assert len(prompts) == 1
     assert prompts[0]["safe_default"] is False
     assert "still red" in prompts[0]["question"]
 
-    monkeypatch.setattr("daydream.deep.orchestrator.get_assume", lambda: "yes")
-    assert _authorize_final_red_override() is False
+    ctx.run_context = RunContext(InteractionPolicy(assume="yes"))
+    assert _authorize_final_red_override(ctx) is False
     assert len(prompts) == 1
 
 
@@ -12123,7 +12102,7 @@ async def test_related_regression_real_runner_stabilizes_and_commits(
     }
     monkeypatch.setattr("daydream.runner.create_backend", lambda *_a, **_k: backend)
     monkeypatch.setattr("daydream.deep.orchestrator.EXPLORATION_AVAILABLE", False)
-    monkeypatch.setattr("daydream.phases.prompt_user", lambda *_a, **_k: "2")
+    monkeypatch.setattr("daydream.run_context._prompt_user", lambda *_a, **_k: "2")
     _silence(monkeypatch, prompts=False)
 
     rc = await run(

--- a/tests/test_deep_pr_comment_integration.py
+++ b/tests/test_deep_pr_comment_integration.py
@@ -557,51 +557,14 @@ def _silence_ui(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def _answer_prompts(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Phase prompts: y for intent confirmation + PR post; n for fix gate.
-
-    In pytest stdin is not a TTY, so ``runner._resolve_interactive`` returns
-    False and ``set_non_interactive(True)`` is called. Every gate that uses
-    ``resolve_or_prompt(safe_default=False)`` then auto-declines without
-    prompting -- including the PR-post gate. We must force interactive mode
-    the same way ``_force_interactive`` does (in test_deep_orchestrator.py).
-
-    Both the orchestrator fix gate ("Apply fixes now?") and the PR-post gate
-    ("Post these as a PR review?") route through resolve_or_prompt in agent.py,
-    which calls prompt_user from its own (agent) namespace. We dispatch on the
-    question text so the fix gate gets "n" (skip fixes) and PR-post gets "y".
-    """
-    # Force interactive mode so resolve_gate defers to prompt_user.
+    """Accept intent and PR posting through the shared gateway; decline fixes."""
     monkeypatch.setattr("daydream.runner._stdin_isatty", lambda: True)
     monkeypatch.delenv("CI", raising=False)
 
-    monkeypatch.setattr(
-        "daydream.phases.prompt_user", lambda *a, **kw: "y", raising=False,
-    )
-    monkeypatch.setattr(
-        "daydream.deep.orchestrator.prompt_user",
-        lambda *a, **kw: "n",
-        raising=False,
-    )
-    monkeypatch.setattr(
-        "daydream.pr_review.prompt_user",
-        lambda *a, **kw: "y",
-        raising=False,
-    )
-    monkeypatch.setattr(
-        "daydream.runner.prompt_user", lambda *a, **kw: "n", raising=False,
-    )
+    def answer(_console: Any, message: str, default: str = "") -> str:
+        return "n" if "apply fix" in message.lower() else "y"
 
-    def _agent_prompt(console: Any, message: str, default: str = "") -> str:  # noqa: ARG001
-        # Decline the fix gate (proceed to PR post without fixes); approve PR post.
-        if "apply fixes" in message.lower() or "apply fix" in message.lower():
-            return "n"
-        if "post these" in message.lower() or "pr review" in message.lower():
-            return "y"
-        return "y"  # all other gates (intent confirmation, etc.)
-
-    monkeypatch.setattr(
-        "daydream.agent.prompt_user", _agent_prompt, raising=False,
-    )
+    monkeypatch.setattr("daydream.run_context._prompt_user", answer)
 
 
 # Markdown extraction helpers.

--- a/tests/test_extension_seam_integration.py
+++ b/tests/test_extension_seam_integration.py
@@ -22,6 +22,7 @@ from daydream.deep.orchestrator import _step_post_review
 from daydream.extensions.registry import Registry
 from daydream.flows.engine import FlowContext
 from daydream.pr_review import ParsedIssue
+from daydream.run_context import InteractionPolicy, RunContext
 from daydream.runner import RunConfig
 from daydream.workspace import WorkContext
 from tests.conftest import ExtDir
@@ -77,6 +78,7 @@ def _post_context(*, dd: Path, items_file: Path) -> FlowContext:
         ),
         registry=Registry(),
         data={"dd": dd, "items_file": items_file},
+        run_context=RunContext(InteractionPolicy()),
     )
 
 
@@ -152,12 +154,20 @@ async def test_post_review_uses_published_items_path(
     stable_items = tmp_path / "stable-merged-items.json"
     ctx = _post_context(dd=private_dir, items_file=stable_items)
     posted_paths: list[Path] = []
-    monkeypatch.setattr(
-        "daydream.pr_review.post_review_to_pr_from_report",
-        lambda repo, path, *, console, post, approve_on_clean=False, diagram_blocks=None: (
-            _record_path(posted_paths, path)
-        ),
-    )
+    async def _record_post(
+        repo: Path,
+        path: Path,
+        *,
+        console: Any,
+        post: bool,
+        approve_on_clean: bool = False,
+        diagram_blocks: str | None = None,
+        run_context: RunContext | None = None,
+    ) -> None:
+        assert run_context is ctx.run_context
+        await _record_path(posted_paths, path)
+
+    monkeypatch.setattr("daydream.pr_review.post_review_to_pr_from_report", _record_post)
 
     await _step_post_review(ctx)
 
@@ -442,7 +452,9 @@ async def test_fork_disables_arbiter_in_deep(
         post: bool = False,
         approve_on_clean: bool = False,
         diagram_blocks: str | None = None,
+        run_context: RunContext | None = None,
     ) -> None:
+        assert run_context is not None
         return None
 
     monkeypatch.setattr("daydream.pr_review.post_review_to_pr_from_report", _no_post)
@@ -789,7 +801,9 @@ async def test_custom_phase_full_stack(
         post: bool = False,
         approve_on_clean: bool = False,
         diagram_blocks: str | None = None,
+        run_context: RunContext | None = None,
     ) -> None:
+        assert run_context is not None
         return None
 
     monkeypatch.setattr("daydream.pr_review.post_review_to_pr_from_report", _no_post)
@@ -825,7 +839,9 @@ async def test_flow_deep_routes_to_deep_helper(
         post: bool = False,
         approve_on_clean: bool = False,
         diagram_blocks: str | None = None,
+        run_context: RunContext | None = None,
     ) -> None:
+        assert run_context is not None
         return None
     monkeypatch.setattr("daydream.pr_review.post_review_to_pr_from_report", _no_post)
 

--- a/tests/test_improve_flow.py
+++ b/tests/test_improve_flow.py
@@ -2434,7 +2434,7 @@ async def test_capable_improve_stub_retains_commands_and_avoids_provider_overloa
 ) -> None:
     _force_interactive(monkeypatch)
     monkeypatch.setattr(
-        "daydream.agent.prompt_user",
+        "daydream.run_context._prompt_user",
         lambda *args, **kwargs: "1-5",
     )
     backend = ProductionPathBackend(improve_monorepo_target)
@@ -2478,7 +2478,7 @@ async def test_capable_improve_stub_partial_failure_is_successful_and_safe(
 ) -> None:
     _force_interactive(monkeypatch)
     monkeypatch.setattr(
-        "daydream.agent.prompt_user",
+        "daydream.run_context._prompt_user",
         lambda *args, **kwargs: "1-5",
     )
     backend = ProductionPathBackend(
@@ -3123,7 +3123,7 @@ async def test_interactive_selection_honors_user_choice(
     make_config: MakeConfig,
 ) -> None:
     _force_interactive(monkeypatch)
-    monkeypatch.setattr("daydream.agent.prompt_user", lambda *a, **kw: "2")
+    monkeypatch.setattr("daydream.run_context._prompt_user", lambda *a, **kw: "2")
     install_improve_stub(
         monkeypatch,
         improve_monorepo_target,

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -23,6 +23,7 @@ from daydream.backends import (
     ToolResultEvent,
     ToolStartEvent,
 )
+from daydream.run_context import RunContext
 from daydream.runner import RunConfig, run
 from daydream.trajectory import DaydreamPhase
 from daydream.ui import NEON_THEME
@@ -63,14 +64,15 @@ async def render_agent(
 
     The tool-panel / quiet-mode tests all repeated the same harness: a scripted
     event-yielding backend, a ``StringIO``-backed ``Console`` bound over
-    ``daydream.agent.console``, and ``set_quiet_mode``. The console is pinned
+    ``daydream.agent.console``, and an explicit interaction policy. The console is pinned
     (``force_terminal=True``, ``width=120``, ``NEON_THEME``) so wrapping and
     styling are identical regardless of the host terminal.
 
     Returns the output with ANSI codes INTACT -- the border/styling assertions
     read them. Callers comparing plain text pass the result to ``strip_ansi``.
     """
-    from daydream.agent import run_agent, set_quiet_mode
+    from daydream.agent import run_agent
+    from daydream.run_context import InteractionPolicy, RunContext
 
     output = StringIO()
     extra: dict[str, Any] = {} if color_system is None else {"color_system": color_system}
@@ -78,13 +80,13 @@ async def render_agent(
         "daydream.agent.console",
         Console(file=output, force_terminal=True, width=120, theme=NEON_THEME, **extra),
     )
-    set_quiet_mode(quiet)
 
     await run_agent(
         ScriptedBackend(events=events, model="mock-model"),
         Path("/tmp"),
         prompt,
         phase=DaydreamPhase.REVIEW,
+        run_context=RunContext(InteractionPolicy(quiet=quiet)),
     )
     return output.getvalue()
 
@@ -98,14 +100,14 @@ async def test_five_thinking_panels_render_in_order(monkeypatch: pytest.MonkeyPa
         ResultEvent(structured_output=None, continuation=None),
     ]
 
-    from daydream.agent import run_agent, set_quiet_mode
+    from daydream.agent import run_agent
+    from daydream.run_context import InteractionPolicy, RunContext
 
     output = StringIO()
     monkeypatch.setattr(
         "daydream.agent.console",
         Console(file=output, force_terminal=True, width=120, theme=NEON_THEME),
     )
-    set_quiet_mode(False)
 
     async def run_() -> None:
         await run_agent(
@@ -113,6 +115,7 @@ async def test_five_thinking_panels_render_in_order(monkeypatch: pytest.MonkeyPa
             Path("/tmp"),
             "Test prompt",
             phase=DaydreamPhase.REVIEW,
+            run_context=RunContext(InteractionPolicy(quiet=False)),
         )
 
     await run_()
@@ -142,8 +145,7 @@ def mock_backend(install_backend: Callable[[object], object]) -> Any:
 @pytest.fixture
 def mock_ui(monkeypatch: pytest.MonkeyPatch) -> None:
     """Patch UI functions that require user input."""
-    monkeypatch.setattr("daydream.phases.prompt_user", lambda *args, **kwargs: "n")
-    monkeypatch.setattr("daydream.runner.prompt_user", lambda *args, **kwargs: "n")
+    monkeypatch.setattr("daydream.run_context._prompt_user", lambda *args, **kwargs: "n")
 
 
 @pytest.fixture
@@ -1506,6 +1508,7 @@ async def test_run_comment_full_flow(
         approve_on_clean: Any=False,
         pr_number: int | None = None,
         diagram_blocks: Any=None,
+        run_context: RunContext | None = None,
     ) -> None:
         posted.extend(json.loads(merged_items_path.read_text())["items"])
         posted_posts.append(post)
@@ -1672,12 +1675,10 @@ async def test_run_comment_does_not_prompt_for_skill(
     silence_console("daydream.phases")
     silence_console("daydream.runner")
 
-    monkeypatch.setattr("daydream.phases.prompt_user", lambda *a, **kw: "y")  # confirm intent
-
     # Trap: skill selection must never prompt in --comment mode.
     def runner_prompt_trap(*args: Any, **kwargs: Any) -> None:
         raise AssertionError("Should not prompt for skill selection in --comment mode")
-    monkeypatch.setattr("daydream.runner.prompt_user", runner_prompt_trap)
+    monkeypatch.setattr("daydream.run_context._prompt_user", runner_prompt_trap)
 
     config = make_config(tmp_path, output_mode="comment")
     exit_code = await run(config)
@@ -1797,8 +1798,7 @@ async def test_run_loop_submission_failure_warns_and_continues(
             return "n"
         return "y"
 
-    monkeypatch.setattr("daydream.agent.prompt_user", _gate_prompt)
-    monkeypatch.setattr("daydream.phases.prompt_user", lambda *a, **kw: "y")
+    monkeypatch.setattr("daydream.run_context._prompt_user", _gate_prompt)
 
     config = make_config(tmp_path, output_mode="loop")
 

--- a/tests/test_integration_workspace.py
+++ b/tests/test_integration_workspace.py
@@ -32,6 +32,7 @@ from daydream.backends import (
     ResultEvent,
     TextEvent,
 )
+from daydream.run_context import current_run_context
 from daydream.runner import RunConfig
 from tests.harness.git_helpers import git as _git
 
@@ -178,7 +179,14 @@ async def test_branch_only_on_origin_creates_ephemeral_runs_review_cleans_up(
     captured: dict[str, Any] = {}
     worktree_path_at_dispatch: dict[str, Path] = {}
 
-    async def fake_run_loop_deep(work: Any, config: Any, run_artifacts: Any = None) -> int:
+    async def fake_run_loop_deep(
+        work: Any,
+        config: Any,
+        run_artifacts: Any = None,
+        *,
+        run_context: Any,
+    ) -> int:
+        assert run_context is current_run_context()
         captured["base_branch"] = work.base_branch
         captured["is_ephemeral"] = work.is_ephemeral
         captured["head_sha"] = work.head_sha
@@ -250,7 +258,14 @@ async def test_branch_also_checked_out_locally_warns_uses_origin(
 
     captured: dict[str, Any] = {}
 
-    async def fake_run_loop_deep(work: Any, config: Any, run_artifacts: Any = None) -> int:
+    async def fake_run_loop_deep(
+        work: Any,
+        config: Any,
+        run_artifacts: Any = None,
+        *,
+        run_context: Any,
+    ) -> int:
+        assert run_context is current_run_context()
         captured["head_sha"] = work.head_sha
         captured["is_ephemeral"] = work.is_ephemeral
         captured["repo"] = work.repo
@@ -306,7 +321,14 @@ async def test_comment_mode_without_open_pr_runs_deep_flow(
     )
     captured: dict[str, Any] = {}
 
-    async def fake_run_loop_deep(work: Any, config: Any, run_artifacts: Any = None) -> int:
+    async def fake_run_loop_deep(
+        work: Any,
+        config: Any,
+        run_artifacts: Any = None,
+        *,
+        run_context: Any,
+    ) -> int:
+        assert run_context is current_run_context()
         captured["is_ephemeral"] = work.is_ephemeral
         captured["head_sha"] = work.head_sha
         captured["output_mode"] = config.output_mode
@@ -367,7 +389,14 @@ async def test_comment_mode_with_open_pr_uses_pr_base(
     # the resolved WorkContext.
     captured: dict[str, Any] = {}
 
-    async def fake_run_loop_deep(work: Any, config: Any, run_artifacts: Any = None) -> int:
+    async def fake_run_loop_deep(
+        work: Any,
+        config: Any,
+        run_artifacts: Any = None,
+        *,
+        run_context: Any,
+    ) -> int:
+        assert run_context is current_run_context()
         captured["base_branch"] = work.base_branch
         captured["is_ephemeral"] = work.is_ephemeral
         return 0
@@ -414,7 +443,14 @@ async def test_review_mode_on_base_branch_does_not_error(
     # WrongBranchError guard into the deep flow.
     routed: dict[str, Any] = {}
 
-    async def fake_run_loop_deep(work: Any, config: Any, run_artifacts: Any = None) -> int:
+    async def fake_run_loop_deep(
+        work: Any,
+        config: Any,
+        run_artifacts: Any = None,
+        *,
+        run_context: Any,
+    ) -> int:
+        assert run_context is current_run_context()
         routed["base_branch"] = work.base_branch
         routed["head_branch"] = work.head_branch
         return 0
@@ -434,4 +470,3 @@ async def test_review_mode_on_base_branch_does_not_error(
     # _run_loop_deep was reached.
     assert routed["base_branch"] == "main"
     assert routed["head_branch"] == "main"
-

--- a/tests/test_log_mode.py
+++ b/tests/test_log_mode.py
@@ -289,22 +289,22 @@ def test_log_mode_console_redacts_string_payloads() -> None:
     """phases.py imports agent's module-level console; in --log mode that
     console redacts string payloads, so phase/UI output (e.g. the failure
     handoff body) cannot bypass the log-mode redaction boundary."""
-    from daydream.agent import _LogRedactingConsole, set_log_mode
+    from daydream.agent import _LogRedactingConsole
+    from daydream.run_context import InteractionPolicy, RunContext, bind_run_context
 
     sentinel = REDACTION_SENTINEL
     buffer = io.StringIO()
     rec = _LogRedactingConsole(file=buffer, force_terminal=True, width=100)
 
-    set_log_mode(False)
-    try:
+    with bind_run_context(RunContext(InteractionPolicy())):
         # Normal mode: raw pass-through (Rich UI is unredacted by design).
         rec.print(f"handoff token={sentinel}")
         assert sentinel in buffer.getvalue()
 
-        # --log mode: the same emission path is redacted at the console boundary.
-        buffer.truncate(0)
-        buffer.seek(0)
-        set_log_mode(True)
+    # --log mode: the same emission path is redacted at the console boundary.
+    buffer.truncate(0)
+    buffer.seek(0)
+    with bind_run_context(RunContext(InteractionPolicy(log_mode=True))):
         rec.print(f"handoff token={sentinel}")
         out = buffer.getvalue()
         # Rich's highlighter splits the marker's brackets into styled spans, so
@@ -312,8 +312,6 @@ def test_log_mode_console_redacts_string_payloads() -> None:
         # exact bracketed string.
         assert "REDACTED_API_KEY" in out
         assert sentinel not in out
-    finally:
-        set_log_mode(False)
 
 
 class _CredentialSummarizerBackend(ScriptedBackend):
@@ -349,8 +347,8 @@ async def test_log_mode_failure_handoff_redacts_credential_body(
     raw token to stdout. The console-level _LogRedactingConsole boundary is the
     mechanism (RD-1); this proves it on the real handoff path."""
     from daydream.agent import console as phases_console
-    from daydream.agent import set_log_mode
     from daydream.phases import _emit_failure_handoff
+    from daydream.run_context import InteractionPolicy, RunContext, bind_run_context
 
     # False-pass trap: the module console phases.py binds MUST be the redacting
     # console, otherwise a passing test would mean nothing.
@@ -365,8 +363,7 @@ async def test_log_mode_failure_handoff_redacts_credential_body(
     # handoff_prompt (real run_agent path, backend mocked only).
     backend = _CredentialSummarizerBackend(f"token {sentinel}")
 
-    set_log_mode(True)
-    try:
+    with bind_run_context(RunContext(InteractionPolicy(log_mode=True))):
         await _emit_failure_handoff(
             backend, work, "failing test output", offer_clipboard=False,
         )
@@ -374,8 +371,6 @@ async def test_log_mode_failure_handoff_redacts_credential_body(
         out = captured.out + captured.err
         assert sentinel not in out   # raw token never reaches stdout
         assert "REDACTED" in out     # redaction marker present
-    finally:
-        set_log_mode(False)
 
 
 def test_log_mode_trajectory_still_written(

--- a/tests/test_phases.py
+++ b/tests/test_phases.py
@@ -1117,7 +1117,7 @@ async def test_phase_test_and_heal_fix_uses_fresh_context(
 
     # fail -> choice "2" (fix and retry) -> pass
     choices = iter(["2"])
-    monkeypatch.setattr("daydream.phases.prompt_user", lambda *a, **kw: next(choices, "3"))
+    monkeypatch.setattr("daydream.run_context._prompt_user", lambda *a, **kw: next(choices, "3"))
 
     feedback_items = [
         {"id": 1, "description": "Bug in handler", "file": "src/handler.py", "line": 10},
@@ -1152,7 +1152,7 @@ async def test_phase_test_and_heal_aborts_when_generated_restore_fails(
 
     silence_console("daydream.phases")
     backend = ScriptedBackend(script=[_FAIL_TURN, _FIX_TURN, _PASS_TURN])
-    monkeypatch.setattr("daydream.phases.prompt_user", lambda *a, **kw: "2")
+    monkeypatch.setattr("daydream.run_context._prompt_user", lambda *a, **kw: "2")
     monkeypatch.setattr(
         "daydream.phases._reject_test_healing_generated_file_edits",
         lambda *args, **kwargs: None,
@@ -1194,7 +1194,7 @@ async def test_phase_test_and_heal_fix_prompt_absolute_path_and_no_turn_cap(
     ])
 
     choices = iter(["2"])  # fail -> fix-and-retry -> pass
-    monkeypatch.setattr("daydream.phases.prompt_user", lambda *a, **kw: next(choices, "3"))
+    monkeypatch.setattr("daydream.run_context._prompt_user", lambda *a, **kw: next(choices, "3"))
 
     feedback_items = [{"id": 1, "description": "Bug", "file": "src/handler.py", "line": 10}]
 
@@ -2592,7 +2592,7 @@ async def test_phase_understand_intent_confirmed_first_try(
         _RESULT,
     ])
 
-    monkeypatch.setattr("daydream.phases.prompt_user", lambda *a, **kw: "y")
+    monkeypatch.setattr("daydream.run_context._prompt_user", lambda *a, **kw: "y")
 
     diff_file = tmp_path / "diff.patch"
     diff_file.write_text("diff --git a/login.py ...")
@@ -2624,7 +2624,7 @@ async def test_phase_understand_intent_rejects_budget_truncated_summary(
 
     monkeypatch.setattr("daydream.phases.run_agent", _truncated_run_agent)
     monkeypatch.setattr(
-        "daydream.phases.prompt_user",
+        "daydream.run_context._prompt_user",
         lambda *args, **kwargs: pytest.fail("a truncated response must not reach confirmation"),
     )
 
@@ -2659,7 +2659,7 @@ async def test_phase_understand_intent_correction_then_confirm(
 
     # First: correction, second: confirm.
     responses = iter(["No, it's a login page with OAuth, not signup", "y"])
-    monkeypatch.setattr("daydream.phases.prompt_user", lambda *a, **kw: next(responses))
+    monkeypatch.setattr("daydream.run_context._prompt_user", lambda *a, **kw: next(responses))
 
     diff_file = tmp_path / "diff.patch"
     diff_file.write_text("diff --git ...")
@@ -2704,7 +2704,7 @@ async def test_phase_understand_intent_codex_read_only_inlines_diff_and_explorat
         return "This PR adds a login page.", None, None
 
     monkeypatch.setattr("daydream.phases.run_agent", _capture_run_agent)
-    monkeypatch.setattr("daydream.phases.prompt_user", lambda *a, **kw: "y")
+    monkeypatch.setattr("daydream.run_context._prompt_user", lambda *a, **kw: "y")
 
     diff_file = tmp_path / ".daydream" / "deep" / "diff.patch"
     diff_file.parent.mkdir(parents=True)
@@ -2764,7 +2764,7 @@ async def test_phase_understand_intent_codex_correction_loop_inlines_diff_under_
 
     monkeypatch.setattr("daydream.phases.run_agent", _capture_run_agent)
     responses = iter(["No, it's a login page with OAuth, not signup", "y"])
-    monkeypatch.setattr("daydream.phases.prompt_user", lambda *a, **kw: next(responses))
+    monkeypatch.setattr("daydream.run_context._prompt_user", lambda *a, **kw: next(responses))
 
     diff_file = tmp_path / ".daydream" / "deep" / "diff.patch"
     diff_file.parent.mkdir(parents=True)
@@ -2808,7 +2808,7 @@ async def test_phase_understand_intent_non_codex_keeps_budget_gated_diff_pointer
         TextEvent(text="This PR adds a login page."),
         _RESULT,
     ])
-    monkeypatch.setattr("daydream.phases.prompt_user", lambda *a, **kw: "y")
+    monkeypatch.setattr("daydream.run_context._prompt_user", lambda *a, **kw: "y")
 
     diff_file = tmp_path / ".daydream" / "deep" / "diff.patch"
     diff_file.parent.mkdir(parents=True)
@@ -2848,7 +2848,7 @@ async def test_phase_understand_intent_correction_prompt_keeps_no_pr_no_skill_di
 
     correction = "No, it's a login page with OAuth, not signup"
     responses = iter([correction, "y"])
-    monkeypatch.setattr("daydream.phases.prompt_user", lambda *a, **kw: next(responses))
+    monkeypatch.setattr("daydream.run_context._prompt_user", lambda *a, **kw: next(responses))
 
     diff_file = tmp_path / "diff.patch"
     diff_file.write_text("diff --git ...")
@@ -2889,13 +2889,12 @@ async def test_phase_understand_intent_forced_no_interactive_falls_through(
     the prompt when interactive, so the user is consulted. Observable: the
     correction prompt is reached (prompt_user is called), not bypassed.
     """
-    from daydream.agent import reset_state, set_assume
     from daydream.phases import phase_understand_intent
+    from daydream.run_context import InteractionPolicy, RunContext
 
     silence_console("daydream.phases")
 
-    reset_state()
-    set_assume("no")
+    run_context = RunContext(InteractionPolicy(assume="no"))
     try:
         backend = ScriptedBackend(events=[TextEvent(text="This PR adds a signup page."), _RESULT])
 
@@ -2905,7 +2904,7 @@ async def test_phase_understand_intent_forced_no_interactive_falls_through(
             prompt_calls.append(message)
             return "y"
 
-        monkeypatch.setattr("daydream.phases.prompt_user", _record)
+        monkeypatch.setattr("daydream.run_context._prompt_user", _record)
 
         diff_file = tmp_path / "diff.patch"
         diff_file.write_text("diff --git ...")
@@ -2915,13 +2914,14 @@ async def test_phase_understand_intent_forced_no_interactive_falls_through(
             diff_path=diff_file,
             log="abc1234 add signup",
             branch="feat/signup",
+            run_context=run_context,
         )
 
         # The forced "no" did not bypass the gate: the correction prompt was reached.
         assert prompt_calls, "forced 'no' short-circuited without offering a correction"
         assert "signup" in result.lower()
     finally:
-        reset_state()
+        pass
 
 
 def _make_intent_backend(summary: str) -> ScriptedBackend:
@@ -2951,7 +2951,7 @@ async def test_phase_understand_intent_renders_summary_panel_before_gate(
     monkeypatch.setattr("daydream.phases.console", recording)
 
     summary = "This change adds a login page with email and password authentication."
-    monkeypatch.setattr("daydream.phases.prompt_user", lambda *a, **kw: "y")
+    monkeypatch.setattr("daydream.run_context._prompt_user", lambda *a, **kw: "y")
 
     diff_file = tmp_path / "diff.patch"
     diff_file.write_text("diff --git ...")
@@ -2985,7 +2985,7 @@ async def test_phase_understand_intent_renders_placeholder_for_empty_summary(
     recording = Console(file=StringIO(), record=True, force_terminal=True, width=200)
     monkeypatch.setattr("daydream.phases.console", recording)
 
-    monkeypatch.setattr("daydream.phases.prompt_user", lambda *a, **kw: "y")
+    monkeypatch.setattr("daydream.run_context._prompt_user", lambda *a, **kw: "y")
 
     diff_file = tmp_path / "diff.patch"
     diff_file.write_text("diff --git ...")
@@ -3298,9 +3298,7 @@ async def test_phase_commit_push_writes_daydream_trailers_host_side(
     from daydream.phases import phase_commit_push
 
     silence_console("daydream.phases")
-    monkeypatch.setattr("daydream.phases.prompt_user", lambda *a, **kw: "y")
-    # _do_commit uses resolve_or_prompt which calls prompt_user from agent's namespace.
-    monkeypatch.setattr("daydream.agent.prompt_user", lambda *a, **kw: "y")
+    monkeypatch.setattr("daydream.run_context._prompt_user", lambda *a, **kw: "y")
 
     repo = tmp_path / "repo"
     repo.mkdir()
@@ -3357,7 +3355,7 @@ async def test_declined_commit_still_runs_host_validation_before_success(
     from daydream.test_execution import TestExecutionResult
 
     silence_console("daydream.phases")
-    monkeypatch.setattr("daydream.phases.resolve_or_prompt", lambda **k: False)
+    monkeypatch.setattr("daydream.run_context.RunContext.confirm", lambda self, **k: False)
 
     calls: list[dict[str, Any]] = []
 
@@ -3392,7 +3390,7 @@ async def test_declined_commit_surfaces_failed_validation(
     from daydream.test_execution import TestExecutionResult
 
     silence_console("daydream.phases")
-    monkeypatch.setattr("daydream.phases.resolve_or_prompt", lambda **k: False)
+    monkeypatch.setattr("daydream.run_context.RunContext.confirm", lambda self, **k: False)
 
     async def fake_run(*a: Any, **k: Any) -> TestExecutionResult:
         return TestExecutionResult(exit_status=1, timed_out=False, merged_output="1 failed")
@@ -3419,7 +3417,7 @@ async def test_declined_commit_without_configured_command_skips_validation(
     from daydream.phases import phase_commit_push
 
     silence_console("daydream.phases")
-    monkeypatch.setattr("daydream.phases.resolve_or_prompt", lambda **k: False)
+    monkeypatch.setattr("daydream.run_context.RunContext.confirm", lambda self, **k: False)
 
     async def fake_run(*a: Any, **k: Any) -> None:
         raise AssertionError("run_test_command must not be called without a command")
@@ -3457,8 +3455,7 @@ async def test_approved_investigator_command_runs_once_host_side(
         }),
     ])
 
-    monkeypatch.setattr("daydream.phases.prompt_user", lambda *a, **kw: "1")
-    monkeypatch.setattr("daydream.agent.prompt_user", lambda *a, **kw: "y")
+    monkeypatch.setattr("daydream.run_context._prompt_user", lambda *a, **kw: "1" if "Choice" in a[1] else "y")
     calls: list[dict[str, Any]] = []
 
     async def fake_run(*args: Any, **kwargs: Any) -> TestExecutionResult:
@@ -3510,8 +3507,7 @@ async def test_approved_investigator_backtick_only_command_is_skipped_not_crash(
         _PASS_TURN,
     ])
 
-    monkeypatch.setattr("daydream.phases.prompt_user", lambda *a, **kw: "1")
-    monkeypatch.setattr("daydream.agent.prompt_user", lambda *a, **kw: "y")
+    monkeypatch.setattr("daydream.run_context._prompt_user", lambda *a, **kw: "1" if "Choice" in a[1] else "y")
     calls: list[list[str]] = []
 
     async def fake_run(*args: Any, **kwargs: Any) -> TestExecutionResult:
@@ -3592,7 +3588,7 @@ async def test_phase_test_and_heal_option1_verdict_correct_uses_original_prompt(
 
     choices = iter(["1"])  # user picks option 1 once
     monkeypatch.setattr(
-        "daydream.phases.prompt_user", lambda *a, **kw: next(choices, "3"),
+        "daydream.run_context._prompt_user", lambda *a, **kw: next(choices, "3"),
     )
 
     success, retries, _ = await phase_test_and_heal(backend, make_work(tmp_path))
@@ -3632,11 +3628,8 @@ async def test_phase_test_and_heal_option1_verdict_replace_user_confirms(
         }),
     ])
 
-    # First prompt_user call: "Choice" -> "1" (goes through phases.prompt_user).
-    # Second: "Use suggested command?" -> "y" goes through resolve_or_prompt
-    # which calls agent.prompt_user, not phases.prompt_user.
-    monkeypatch.setattr("daydream.phases.prompt_user", lambda *a, **kw: "1")
-    monkeypatch.setattr("daydream.agent.prompt_user", lambda *a, **kw: "y")
+    # The shared gateway returns "1" for the menu and "y" for approval.
+    monkeypatch.setattr("daydream.run_context._prompt_user", lambda *a, **kw: "1" if "Choice" in a[1] else "y")
     cmds: list[list[str]] = []
 
     async def fake_run(*args: Any, **kwargs: Any) -> TestExecutionResult:
@@ -3683,8 +3676,7 @@ async def test_phase_test_and_heal_prompts_require_foreground_run_and_summary_li
             "reason": "Makefile defines `check` as the CI test target",
         }),
     ])
-    monkeypatch.setattr("daydream.phases.prompt_user", lambda *a, **kw: "1")
-    monkeypatch.setattr("daydream.agent.prompt_user", lambda *a, **kw: "y")
+    monkeypatch.setattr("daydream.run_context._prompt_user", lambda *a, **kw: "1" if "Choice" in a[1] else "y")
     monkeypatch.setattr(
         "daydream.phases.run_test_command",
         _fake_passed_run,
@@ -3723,10 +3715,8 @@ async def test_phase_test_and_heal_option1_verdict_replace_user_declines(
         _PASS_TURN,
     ])
 
-    # "Choice" -> "1" via phases.prompt_user; "Use suggested command?" -> "n"
-    # via agent.prompt_user (resolve_or_prompt routes through agent's namespace).
-    monkeypatch.setattr("daydream.phases.prompt_user", lambda *a, **kw: "1")
-    monkeypatch.setattr("daydream.agent.prompt_user", lambda *a, **kw: "n")
+    # Select the investigator, then decline its replacement command.
+    monkeypatch.setattr("daydream.run_context._prompt_user", lambda *a, **kw: "1" if "Choice" in a[1] else "n")
 
     success, retries, _ = await phase_test_and_heal(backend, make_work(tmp_path))
 
@@ -3763,7 +3753,7 @@ async def test_phase_test_and_heal_option1_investigator_failure_falls_back(
 
     choices = iter(["1"])
     monkeypatch.setattr(
-        "daydream.phases.prompt_user", lambda *a, **kw: next(choices, "3"),
+        "daydream.run_context._prompt_user", lambda *a, **kw: next(choices, "3"),
     )
 
     success, retries, _ = await phase_test_and_heal(backend, make_work(tmp_path))
@@ -3818,7 +3808,7 @@ async def test_summarizer_invoked_read_only_normal_calls_mutating(
     _install_recorder(monkeypatch, tmp_path)
     monkeypatch.setattr("daydream.phases.clipboard_available", lambda: False)
     backend = _HealBackend(script=[_FAIL_TURN, _handoff_turn("# H")])
-    monkeypatch.setattr("daydream.phases.prompt_user", lambda *a, **k: "4")
+    monkeypatch.setattr("daydream.run_context._prompt_user", lambda *a, **k: "4")
 
     await phase_test_and_heal(backend, make_work(tmp_path))
 
@@ -3879,7 +3869,7 @@ async def test_phase_test_and_heal_option4_writes_handoff_to_live_path(
 
     choices = iter(["4"])
     monkeypatch.setattr(
-        "daydream.phases.prompt_user", lambda *a, **kw: next(choices, "3"),
+        "daydream.run_context._prompt_user", lambda *a, **kw: next(choices, "3"),
     )
 
     success, retries, _ = await phase_test_and_heal(backend, make_work(tmp_path))
@@ -3917,10 +3907,8 @@ async def test_phase_test_and_heal_option4_clipboard_offer_fires_on_confirm(
         _handoff_turn("BODY"),
     ])
 
-    # "Choice" -> "4" via phases.prompt_user (direct call).
-    # Clipboard confirm -> "y" via agent.prompt_user (resolve_or_prompt path).
-    monkeypatch.setattr("daydream.phases.prompt_user", lambda *a, **kw: "4")
-    monkeypatch.setattr("daydream.agent.prompt_user", lambda *a, **kw: "y")
+    # Abort at the menu, then approve copying the handoff.
+    monkeypatch.setattr("daydream.run_context._prompt_user", lambda *a, **kw: "4" if "Choice" in a[1] else "y")
 
     success, _, _ = await phase_test_and_heal(backend, make_work(tmp_path))
 
@@ -3955,7 +3943,7 @@ async def test_phase_test_and_heal_option4_no_clipboard_skip_message(
         user_prompts.append(message)
         return next(answers, "n")
 
-    monkeypatch.setattr("daydream.phases.prompt_user", fake_prompt)
+    monkeypatch.setattr("daydream.run_context._prompt_user", fake_prompt)
 
     copy_called = False
 
@@ -4000,7 +3988,7 @@ async def test_phase_test_and_heal_option4_no_recorder_writes_fallback_handoff(
 
     choices = iter(["4"])
     monkeypatch.setattr(
-        "daydream.phases.prompt_user", lambda *a, **kw: next(choices, "3"),
+        "daydream.run_context._prompt_user", lambda *a, **kw: next(choices, "3"),
     )
 
     success, _, _ = await phase_test_and_heal(backend, make_work(tmp_path))
@@ -4038,7 +4026,7 @@ async def test_phase_test_and_heal_option4_summarizer_failure_writes_minimal(
 
     choices = iter(["4"])
     monkeypatch.setattr(
-        "daydream.phases.prompt_user", lambda *a, **kw: next(choices, "3"),
+        "daydream.run_context._prompt_user", lambda *a, **kw: next(choices, "3"),
     )
 
     success, _, _ = await phase_test_and_heal(backend, make_work(tmp_path))
@@ -4074,7 +4062,7 @@ async def test_phase_test_and_heal_option4_summarizer_garbage_writes_minimal(
 
     choices = iter(["4"])
     monkeypatch.setattr(
-        "daydream.phases.prompt_user", lambda *a, **kw: next(choices, "3"),
+        "daydream.run_context._prompt_user", lambda *a, **kw: next(choices, "3"),
     )
 
     success, _, _ = await phase_test_and_heal(backend, make_work(tmp_path))
@@ -4100,7 +4088,7 @@ async def test_option4_handoff_has_facts_and_hypotheses_on_disk(
     _install_recorder(monkeypatch, tmp_path)
     monkeypatch.setattr("daydream.phases.clipboard_available", lambda: False)
     backend = _HealBackend(script=[_FAIL_TURN, _handoff_turn("# H\nbody")])
-    monkeypatch.setattr("daydream.phases.prompt_user", lambda *a, **k: "4")
+    monkeypatch.setattr("daydream.run_context._prompt_user", lambda *a, **k: "4")
 
     await phase_test_and_heal(backend, make_work(tmp_path))
 
@@ -4132,7 +4120,7 @@ async def test_option4_fallback_puts_unknown_cause_in_hypotheses(
     _install_recorder(monkeypatch, tmp_path)
     monkeypatch.setattr("daydream.phases.clipboard_available", lambda: False)
     backend = _HealBackend(script=[_FAIL_TURN, (RuntimeError("scripted summarizer failure"),)])
-    monkeypatch.setattr("daydream.phases.prompt_user", lambda *a, **k: "4")
+    monkeypatch.setattr("daydream.run_context._prompt_user", lambda *a, **k: "4")
 
     await phase_test_and_heal(backend, make_work(tmp_path))
 
@@ -4359,7 +4347,7 @@ async def test_phase_test_and_heal_option4_inlines_body_when_write_fails(
 
     choices = iter(["4"])
     monkeypatch.setattr(
-        "daydream.phases.prompt_user", lambda *a, **kw: next(choices, "3"),
+        "daydream.run_context._prompt_user", lambda *a, **kw: next(choices, "3"),
     )
 
     success, _, _ = await phase_test_and_heal(backend, make_work(tmp_path))
@@ -4396,11 +4384,10 @@ async def test_phase_test_and_heal_non_interactive_writes_handoff_without_menu(
     Observable contract (CLAUDE.md S3.1): the handoff file lands on disk, the
     menu prompt is never consulted, and the fix agent is never launched.
     """
-    from daydream.agent import reset_state, set_non_interactive
     from daydream.phases import phase_test_and_heal
+    from daydream.run_context import InteractionPolicy, RunContext
 
-    reset_state()
-    set_non_interactive(True)
+    run_context = RunContext(InteractionPolicy(interactive=False))
     try:
         silence_console("daydream.phases")
         _install_recorder(monkeypatch, tmp_path)
@@ -4412,8 +4399,7 @@ async def test_phase_test_and_heal_non_interactive_writes_handoff_without_menu(
         prompt_sentinel = Mock(
             side_effect=AssertionError("prompt_user must not be called in non-interactive mode"),
         )
-        monkeypatch.setattr("daydream.phases.prompt_user", prompt_sentinel)
-        monkeypatch.setattr("daydream.agent.prompt_user", prompt_sentinel)
+        monkeypatch.setattr("daydream.run_context._prompt_user", prompt_sentinel)
 
         # First call: failing test run (menu would otherwise appear). Second
         # call: the read-only failure-summarizer producing the handoff body —
@@ -4424,7 +4410,9 @@ async def test_phase_test_and_heal_non_interactive_writes_handoff_without_menu(
             _handoff_turn("# Handoff\n\nnon-interactive failure context"),
         ])
 
-        passed, retries, _ = await phase_test_and_heal(backend, make_work(tmp_path))
+        passed, retries, _ = await phase_test_and_heal(
+            backend, make_work(tmp_path), run_context=run_context,
+        )
 
         # Took the abort/terminate path (choice "4" semantics, no mutation).
         assert passed is False
@@ -4452,7 +4440,7 @@ async def test_phase_test_and_heal_non_interactive_writes_handoff_without_menu(
         # did not). Same contract as the interactive option-4 path.
         assert backend.read_only_calls == [False, True]
     finally:
-        reset_state()
+        pass
 
 
 @pytest.mark.asyncio
@@ -4468,11 +4456,10 @@ async def test_phase_test_and_heal_non_interactive_fallback_has_facts_hypotheses
     branch: no menu, no fix agent, but the written handoff still separates
     Verified facts from Hypotheses and never invents a cause.
     """
-    from daydream.agent import reset_state, set_non_interactive
     from daydream.phases import phase_test_and_heal
+    from daydream.run_context import InteractionPolicy, RunContext
 
-    reset_state()
-    set_non_interactive(True)
+    run_context = RunContext(InteractionPolicy(interactive=False))
     try:
         silence_console("daydream.phases")
         _install_recorder(monkeypatch, tmp_path)
@@ -4483,12 +4470,13 @@ async def test_phase_test_and_heal_non_interactive_fallback_has_facts_hypotheses
         prompt_sentinel = Mock(
             side_effect=AssertionError("prompt_user must not be called in non-interactive mode"),
         )
-        monkeypatch.setattr("daydream.phases.prompt_user", prompt_sentinel)
-        monkeypatch.setattr("daydream.agent.prompt_user", prompt_sentinel)
+        monkeypatch.setattr("daydream.run_context._prompt_user", prompt_sentinel)
 
         backend = _HealBackend(script=[_FAIL_TURN, (RuntimeError("scripted summarizer failure"),)])
 
-        passed, retries, _ = await phase_test_and_heal(backend, make_work(tmp_path))
+        passed, retries, _ = await phase_test_and_heal(
+            backend, make_work(tmp_path), run_context=run_context,
+        )
         assert passed is False
         assert retries == 0
 
@@ -4502,7 +4490,7 @@ async def test_phase_test_and_heal_non_interactive_fallback_has_facts_hypotheses
         assert backend.read_only_calls == [False, True]
         prompt_sentinel.assert_not_called()
     finally:
-        reset_state()
+        pass
 
 
 # phase_test_and_heal — --yes bounded auto fix-and-retry (Task assume="yes")
@@ -4528,11 +4516,10 @@ async def test_phase_test_and_heal_yes_bounded_loop_exactly_one_auto_attempt(
     implements the bounded-loop invariant: ``decision is True and retries_used > 0``
     → abort, preventing an unbounded mutating fix loop under ``--yes``.
     """
-    from daydream.agent import reset_state, set_assume
     from daydream.phases import phase_test_and_heal
+    from daydream.run_context import InteractionPolicy, RunContext
 
-    reset_state()
-    set_assume("yes")
+    run_context = RunContext(InteractionPolicy(assume="yes"))
     try:
         silence_console("daydream.phases")
         _install_recorder(monkeypatch, tmp_path)
@@ -4543,8 +4530,7 @@ async def test_phase_test_and_heal_yes_bounded_loop_exactly_one_auto_attempt(
         prompt_sentinel = Mock(
             side_effect=AssertionError("prompt_user must not be called under --yes"),
         )
-        monkeypatch.setattr("daydream.phases.prompt_user", prompt_sentinel)
-        monkeypatch.setattr("daydream.agent.prompt_user", prompt_sentinel)
+        monkeypatch.setattr("daydream.run_context._prompt_user", prompt_sentinel)
 
         # Script: fail → fix (no-op) → fail → handoff (summarizer).
         backend = _HealBackend(script=[
@@ -4553,7 +4539,9 @@ async def test_phase_test_and_heal_yes_bounded_loop_exactly_one_auto_attempt(
             _FAIL_TURN,
             _handoff_turn("# Handoff\nauto-mode failure"),
         ])
-        success, retries, _ = await phase_test_and_heal(backend, make_work(tmp_path))
+        success, retries, _ = await phase_test_and_heal(
+            backend, make_work(tmp_path), run_context=run_context,
+        )
 
         # Loop terminated after exactly one auto fix attempt.
         assert success is False
@@ -4569,7 +4557,7 @@ async def test_phase_test_and_heal_yes_bounded_loop_exactly_one_auto_attempt(
         assert backend.read_only_calls == [False, False, False, True], backend.read_only_calls
         prompt_sentinel.assert_not_called()
     finally:
-        reset_state()
+        pass
 
 
 # _sanitize_suggested_command — fence-break hardening + whitespace collapse
@@ -4672,9 +4660,8 @@ async def test_phase_test_and_heal_option1_strips_backticks_from_host_command(
         }),
     ])
 
-    # "Choice" -> "1" via phases.prompt_user; confirm "y" via agent.prompt_user.
-    monkeypatch.setattr("daydream.phases.prompt_user", lambda *a, **kw: "1")
-    monkeypatch.setattr("daydream.agent.prompt_user", lambda *a, **kw: "y")
+    # Select the investigator, then approve its replacement command.
+    monkeypatch.setattr("daydream.run_context._prompt_user", lambda *a, **kw: "1" if "Choice" in a[1] else "y")
     cmds: list[list[str]] = []
 
     async def fake_run(*args: Any, **kwargs: Any) -> TestExecutionResult:
@@ -4728,12 +4715,8 @@ async def test_phase_test_and_heal_option1_shows_suggested_command_before_confir
             return "1"  # menu Choice
         return "n"
 
-    # Menu choice ("Choice") goes through phases.prompt_user (direct call).
-    monkeypatch.setattr("daydream.phases.prompt_user", _prompt)
-    # Confirm gate ("Use suggested command?") goes through agent.prompt_user
-    # (via resolve_or_prompt). Route it through the same _prompt so
-    # prompt_called_at tracks both calls and the ordering assertion holds.
-    monkeypatch.setattr("daydream.agent.prompt_user", _prompt)
+    # Both the menu and confirmation use the single runtime prompt gateway.
+    monkeypatch.setattr("daydream.run_context._prompt_user", _prompt)
 
     backend = _HealBackend(script=[
         _FAIL_TURN,
@@ -4959,7 +4942,7 @@ async def test_option4_calls_write_partial_before_summarizer(
 
     choices = iter(["4"])
     monkeypatch.setattr(
-        "daydream.phases.prompt_user", lambda *a, **kw: next(choices, "3"),
+        "daydream.run_context._prompt_user", lambda *a, **kw: next(choices, "3"),
     )
 
     success, _, _ = await phase_test_and_heal(backend, make_work(tmp_path))
@@ -5089,7 +5072,7 @@ async def test_phase_prints_model_line_after_hero(
 
     silence_console("daydream.phases", keep=("print_phase_hero", "print_dim"))
     heroes, dim_messages = _install_hero_dim_spies(monkeypatch)
-    monkeypatch.setattr("daydream.phases.prompt_user", lambda *a, **kw: "y")
+    monkeypatch.setattr("daydream.run_context._prompt_user", lambda *a, **kw: "y")
 
     kwargs = setup(tmp_path)
     backend = ScriptedBackend(events=events, model=model)
@@ -5262,7 +5245,7 @@ async def test_phase_understand_intent_inline_exploration_budget_degrades(
     from daydream.prompt_budget import SANCTIONED_INLINE_INPUT_AGGREGATE_MAX_BYTES
 
     silence_console("daydream.phases")
-    monkeypatch.setattr("daydream.phases.prompt_user", lambda *a, **kw: "y")
+    monkeypatch.setattr("daydream.run_context._prompt_user", lambda *a, **kw: "y")
     repo = tmp_path / "repo"
     repo.mkdir()
     init_repo(repo)
@@ -5329,7 +5312,7 @@ async def test_phase_understand_intent_inline_pair_over_budget_drops_tail(
     from daydream.prompt_budget import SANCTIONED_INLINE_INPUT_AGGREGATE_MAX_BYTES
 
     silence_console("daydream.phases")
-    monkeypatch.setattr("daydream.phases.prompt_user", lambda *a, **kw: "y")
+    monkeypatch.setattr("daydream.run_context._prompt_user", lambda *a, **kw: "y")
     repo = tmp_path / "repo"
     repo.mkdir()
     init_repo(repo)
@@ -5415,7 +5398,7 @@ async def test_phase_understand_intent_non_clone_inline_correction_omits_diff_pa
     owner = resolve_private_workspace_owner(repo, locations=locations)
 
     responses = iter(["No, it's a login page with OAuth, not signup", "y"])
-    monkeypatch.setattr("daydream.phases.prompt_user", lambda *a, **kw: next(responses))
+    monkeypatch.setattr("daydream.run_context._prompt_user", lambda *a, **kw: next(responses))
 
     async with open_artifact_session(work, session_id="intent-inline-correction", owner=owner):
         exploration = artifact_dir_for(repo) / "exploration"
@@ -5920,7 +5903,7 @@ async def test_phase_test_and_heal_records_each_agent_attempt_and_heal_scope(
     feedback = [{"id": 1, "item_uid": "item:1", "file": "a.py"}]
     footprint = AuthorizedFixFootprint.build(tmp_path, {"readme.md"}, feedback)
     backend = ScriptedBackend(script=[_FAIL_TURN, _FIX_TURN, _PASS_TURN])
-    monkeypatch.setattr(phases, "prompt_user", lambda *args, **kwargs: "2")
+    monkeypatch.setattr("daydream.run_context._prompt_user", lambda *args, **kwargs: "2")
     keys = iter(["in-1", "out-1", "in-2", "out-2"])
 
     result = await phases.phase_test_and_heal(

--- a/tests/test_pr_review.py
+++ b/tests/test_pr_review.py
@@ -29,6 +29,7 @@ from daydream.pr_review import (
     parsed_issues_from_items,
     snap_to_hunk,
 )
+from daydream.run_context import InteractionPolicy, RunContext
 from tests.harness.git_helpers import git as _git
 
 # gh-gated: tests that stub gh's subprocess are skipped when gh is not installed.
@@ -1091,6 +1092,10 @@ class _FakeConsole:
         pass
 
 
+def _assumed_context(answer: str) -> RunContext:
+    return RunContext(InteractionPolicy(assume=answer))
+
+
 @pytest.mark.asyncio
 async def test_post_skips_when_no_pr(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
@@ -1152,8 +1157,6 @@ async def test_post_succeeds_and_prints_url(
             body_only=[],
         ),
     )
-    monkeypatch.setattr(pr_review, "resolve_or_prompt", lambda **_k: True)
-
     captured: dict[str, Any] = {}
 
     def fake_submit(
@@ -1175,6 +1178,7 @@ async def test_post_succeeds_and_prints_url(
         tmp_path,
         [ParsedIssue(path="a.py", line=1, title="t", body="b")],
         console=_FakeConsole(),  # type: ignore[arg-type]
+        run_context=_assumed_context("yes"),
     )
     # The payload that would be POSTed was assembled and forwarded.
     assert captured["payload"]["commit_id"] == pr.head_sha
@@ -1208,7 +1212,6 @@ async def test_post_payload_approves_when_clean_and_enabled(
             ],
         ),
     )
-    monkeypatch.setattr(pr_review, "resolve_or_prompt", lambda **_k: True)
     captured: dict[str, Any] = {}
 
     def fake_submit(
@@ -1226,6 +1229,7 @@ async def test_post_payload_approves_when_clean_and_enabled(
         [ParsedIssue(path="a.py", line=1, title="t", body="b", severity="low")],
         console=_FakeConsole(),  # type: ignore[arg-type]
         approve_on_clean=True,
+        run_context=_assumed_context("yes"),
     )
     assert captured["payload"]["event"] == "APPROVE"
     assert "no high/medium findings" in captured["payload"]["body"]
@@ -1250,7 +1254,6 @@ async def test_post_warns_with_preserved_payload_path_on_failure(
             body_only=[],
         ),
     )
-    monkeypatch.setattr(pr_review, "resolve_or_prompt", lambda **_k: True)
     err = "gh api /repos/acme/widgets/pulls/42/reviews failed: HTTP 422 (payload preserved at /tmp/x.json)"
     monkeypatch.setattr(
         pr_review, "_submit_review", lambda *_a, **_k: (None, err)
@@ -1267,6 +1270,7 @@ async def test_post_warns_with_preserved_payload_path_on_failure(
         tmp_path,
         [ParsedIssue(path="a.py", line=1, title="t", body="b")],
         console=_FakeConsole(),  # type: ignore[arg-type]
+        run_context=_assumed_context("yes"),
     )
     assert warnings
     assert "no comments were posted" in warnings[0].lower()
@@ -1288,7 +1292,6 @@ async def test_post_skipped_when_user_declines(
             body_only=[],
         ),
     )
-    monkeypatch.setattr(pr_review, "resolve_or_prompt", lambda **_k: False)
     submit_called = False
 
     def fake_submit(*_a: Any, **_k: Any) -> tuple[str | None, str | None]:
@@ -1303,6 +1306,7 @@ async def test_post_skipped_when_user_declines(
         tmp_path,
         [ParsedIssue(path="a.py", line=1, title="t", body="b")],
         console=_FakeConsole(),  # type: ignore[arg-type]
+        run_context=_assumed_context("no"),
     )
     assert not submit_called
     assert status == pr_review.PostStatus.NOTHING_TO_POST

--- a/tests/test_run_context.py
+++ b/tests/test_run_context.py
@@ -1,0 +1,220 @@
+"""Focused tests for run-local interaction and backend lifecycle state."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import textwrap
+from dataclasses import FrozenInstanceError
+from typing import Any
+
+import pytest
+
+from daydream.run_context import (
+    InteractionPolicy,
+    RunContext,
+    active_backends,
+    bind_run_context,
+    current_run_context,
+    resolve_gate,
+    resolve_run_context,
+)
+from tests.harness.backend import ScriptedBackend
+
+
+class _EqualBackend(ScriptedBackend):
+    """Unhashable backend that compares equal to every sibling instance."""
+
+    def __eq__(self, _other: object) -> bool:
+        return True
+
+
+def test_interaction_policy_is_frozen_and_keyword_only() -> None:
+    policy = InteractionPolicy(assume="yes", interactive=False, quiet=True, log_mode=True)
+
+    with pytest.raises(FrozenInstanceError):
+        policy.quiet = False  # type: ignore[misc]
+    with pytest.raises(TypeError):
+        InteractionPolicy("yes")  # type: ignore[call-arg]
+
+
+@pytest.mark.parametrize(
+    ("assume", "interactive", "safe_default", "expected"),
+    [
+        ("yes", True, False, True),
+        ("no", True, True, False),
+        (None, False, True, True),
+        (None, True, False, None),
+    ],
+)
+def test_resolve_gate_remains_pure(
+    assume: str | None, interactive: bool, safe_default: bool, expected: bool | None
+) -> None:
+    assert resolve_gate(assume=assume, interactive=interactive, safe_default=safe_default) is expected
+
+
+def test_nested_binding_restores_the_previous_context() -> None:
+    outer = RunContext(InteractionPolicy(quiet=True))
+    inner = RunContext(InteractionPolicy(log_mode=True))
+
+    assert current_run_context() is None
+    with bind_run_context(outer):
+        assert current_run_context() is outer
+        assert resolve_run_context() is outer
+        with bind_run_context(inner):
+            assert current_run_context() is inner
+            assert resolve_run_context(outer) is outer
+        assert current_run_context() is outer
+    assert current_run_context() is None
+
+
+def test_resolve_run_context_creates_a_fresh_standalone_default() -> None:
+    first = resolve_run_context()
+    second = resolve_run_context()
+
+    assert first is not second
+    assert first.policy == InteractionPolicy()
+    assert second.policy == InteractionPolicy()
+
+
+def test_confirm_uses_forced_and_unattended_answers_without_prompting(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    prompts: list[tuple[Any, str, str]] = []
+
+    def prompt(console: Any, message: str, default: str) -> str:
+        prompts.append((console, message, default))
+        return "y"
+
+    monkeypatch.setattr("daydream.run_context._prompt_user", prompt)
+
+    assert RunContext(InteractionPolicy(assume="yes")).confirm("continue?", safe_default=False)
+    assert not RunContext(InteractionPolicy(assume="no")).confirm("continue?", safe_default=True)
+    assert RunContext(InteractionPolicy(interactive=False)).confirm("continue?", safe_default=True)
+    assert prompts == []
+
+
+def test_confirm_prompts_through_the_single_gateway_with_its_context_bound(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    context = RunContext(InteractionPolicy(log_mode=True))
+    observed: list[RunContext | None] = []
+
+    def prompt(_console: Any, _message: str, _default: str) -> str:
+        observed.append(current_run_context())
+        return "YES"
+
+    monkeypatch.setattr("daydream.run_context._prompt_user", prompt)
+
+    assert context.confirm("continue?", safe_default=False, default="n")
+    assert observed == [context]
+    assert current_run_context() is None
+
+
+def test_choice_forces_only_supplied_assume_mapping(monkeypatch: pytest.MonkeyPatch) -> None:
+    prompts: list[str] = []
+
+    def prompt(_console: Any, message: str, _default: str) -> str:
+        prompts.append(message)
+        return "typed"
+
+    monkeypatch.setattr("daydream.run_context._prompt_user", prompt)
+
+    assumed = RunContext(InteractionPolicy(assume="yes"))
+    assert assumed.choice("menu", default="3", safe_default="4", assume_yes="2") == "2"
+    assert assumed.choice("free form", default=".", safe_default=".") == "typed"
+    unattended = RunContext(InteractionPolicy(assume="yes", interactive=False))
+    assert unattended.choice("free form", default=".", safe_default="safe") == "safe"
+    assert prompts == ["free form"]
+
+
+def test_backend_registration_is_identity_aware_and_reference_counted() -> None:
+    backend = ScriptedBackend()
+    sibling = ScriptedBackend()
+    first = RunContext(InteractionPolicy())
+    second = RunContext(InteractionPolicy())
+
+    with first.backend_registration(backend):
+        with first.backend_registration(backend):
+            with second.backend_registration(backend):
+                with second.backend_registration(sibling):
+                    assert first.active_backends() == (backend,)
+                    assert second.active_backends() == (backend, sibling)
+                    assert active_backends() == (backend, sibling)
+            assert first.active_backends() == (backend,)
+            assert active_backends() == (backend,)
+        assert active_backends() == (backend,)
+    assert first.active_backends() == ()
+    assert active_backends() == ()
+
+
+def test_backend_registration_does_not_collapse_equal_distinct_objects() -> None:
+    first_backend = _EqualBackend()
+    second_backend = _EqualBackend()
+    context = RunContext(InteractionPolicy())
+
+    with context.backend_registration(first_backend), context.backend_registration(second_backend):
+        local = context.active_backends()
+        process = active_backends()
+        assert len(local) == len(process) == 2
+        assert local[0] is process[0] is first_backend
+        assert local[1] is process[1] is second_backend
+
+    assert active_backends() == ()
+
+
+def test_backend_registration_cleans_up_after_exception() -> None:
+    backend = ScriptedBackend()
+    context = RunContext(InteractionPolicy())
+
+    with pytest.raises(RuntimeError, match="boom"):
+        with context.backend_registration(backend):
+            assert active_backends() == (backend,)
+            raise RuntimeError("boom")
+
+    assert context.active_backends() == ()
+    assert active_backends() == ()
+
+
+def test_signal_snapshot_reenters_registration_and_interrupted_enter_cleans_up() -> None:
+    """A same-thread signal snapshot must neither deadlock nor leak membership."""
+    script = textwrap.dedent(
+        """
+        import signal
+
+        import daydream.run_context as runtime
+
+        backend = object()
+        context = runtime.RunContext(runtime.InteractionPolicy())
+
+        def interrupt(_signum, _frame):
+            assert runtime.active_backends() == (backend,)
+            raise KeyboardInterrupt
+
+        class InterruptingRegistry(dict):
+            def __setitem__(self, key, value):
+                super().__setitem__(key, value)
+                signal.raise_signal(signal.SIGINT)
+
+        signal.signal(signal.SIGINT, interrupt)
+        runtime._active_registrations = InterruptingRegistry()
+        try:
+            with context.backend_registration(backend):
+                raise AssertionError("registration enter should have been interrupted")
+        except KeyboardInterrupt:
+            pass
+        else:
+            raise AssertionError("signal did not interrupt registration enter")
+
+        assert context.active_backends() == ()
+        assert runtime.active_backends() == ()
+        """
+    )
+
+    subprocess.run(
+        [sys.executable, "-c", script],
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=5,
+    )

--- a/tests/test_run_context_integration.py
+++ b/tests/test_run_context_integration.py
@@ -1,0 +1,240 @@
+"""Interaction isolation through real runner, extension, and agent boundaries."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator, Callable
+from pathlib import Path
+from typing import Any
+
+import anyio
+import pytest
+
+from daydream import runner
+from daydream.agent import console
+from daydream.backends import AgentEvent, ResultEvent
+from daydream.phases import phase_alternative_review
+from daydream.run_context import (
+    InteractionPolicy,
+    RunContext,
+    active_backends,
+    bind_run_context,
+    current_run_context,
+)
+from daydream.runner import RunConfig
+from daydream.ui import prompt_user
+from daydream.workspace import WorkContext
+from tests.conftest import ExtDir
+from tests.harness.backend import ScriptedBackend
+from tests.test_runner import _feature_repo
+
+
+def _write_policy_flow(ext_dir: ExtDir) -> None:
+    ext_dir.write_module(
+        "from daydream.agent import run_agent\n"
+        "from daydream.extensions import FlowStep\n"
+        "from daydream.trajectory import DaydreamPhase\n"
+        "async def probe(ctx):\n"
+        "    data = ctx.data\n"
+        "    data['extension_marker'] = 'retained'\n"
+        "    runtime = ctx.run_context\n"
+        "    assert runtime is not None\n"
+        "    assert ctx.artifacts is not None\n"
+        "    await run_agent(ctx.backend_for('probe'), ctx.work.repo, 'PROBE',\n"
+        "        phase=DaydreamPhase.REVIEW, run_context=runtime)\n"
+        "    assert ctx.data is data\n"
+        "    assert data['extension_marker'] == 'retained'\n"
+        "    assert ctx.run_context is runtime\n"
+        "def register(registry):\n"
+        "    registry.register_phase(FlowStep(name='probe', run=probe))\n"
+        "    registry.set_flow('policy-probe', ['probe'])\n"
+    )
+
+
+async def test_standalone_phase_binds_explicit_policy_for_surrounding_output(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    make_work: Callable[..., WorkContext],
+) -> None:
+    """The phase's own output uses its runtime before and after the agent."""
+    outer = RunContext(InteractionPolicy(log_mode=False))
+    explicit = RunContext(InteractionPolicy(log_mode=True))
+    sentinel = "ghp_" + "x" * 16
+    backend = ScriptedBackend(
+        model=sentinel,
+        events=[ResultEvent(structured_output={"issues": []}, continuation=None)],
+    )
+    diff_path = tmp_path / "diff.patch"
+    diff_path.write_text("diff --git a/app.py b/app.py\n")
+    observed: dict[str, RunContext | None] = {}
+    original_print = console.print
+
+    def record_output(*objects: Any, **kwargs: Any) -> None:
+        for value in objects:
+            if isinstance(value, str):
+                if "Agent is evaluating" in value:
+                    observed["before"] = current_run_context()
+                if "No issues found" in value:
+                    observed["after"] = current_run_context()
+        original_print(*objects, **kwargs)
+
+    monkeypatch.setattr(console, "print", record_output)
+    with bind_run_context(outer), console.capture() as captured:
+        assert await phase_alternative_review(
+            backend, make_work(tmp_path), diff_path, "Update app",
+            run_context=explicit,
+        ) == []
+        assert current_run_context() is outer
+
+    assert observed == {"before": explicit, "after": explicit}
+    assert sentinel not in captured.get()
+    assert "REDACTED_API_KEY" in captured.get()
+    assert current_run_context() is None
+
+
+async def test_overlapping_runs_keep_prompt_and_console_policy(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    ext_dir: ExtDir,
+    make_config: Callable[..., RunConfig],
+) -> None:
+    """An interactive sibling cannot enable stdin or disable log redaction."""
+    logged_repo = _feature_repo(tmp_path / "logged")
+    plain_repo = _feature_repo(tmp_path / "plain")
+    _write_policy_flow(ext_dir)
+    monkeypatch.setattr(runner, "_stdin_isatty", lambda: True)
+    monkeypatch.delenv("CI", raising=False)
+    input_calls: list[str] = []
+
+    def answer() -> str:
+        input_calls.append("read")
+        return "interactive-answer"
+
+    monkeypatch.setattr("builtins.input", answer)
+    logged_entered = anyio.Event()
+    plain_entered = anyio.Event()
+    logged_observed = anyio.Event()
+    release_plain = anyio.Event()
+    logged_finished = anyio.Event()
+    choices: dict[str, str] = {}
+    contexts: dict[str, RunContext] = {}
+    results: dict[str, int] = {}
+    sentinel = "ghp_" + "x" * 16
+
+    class SharedBackend(ScriptedBackend):
+        async def execute(
+            self, cwd: Path, prompt: str, *args: Any, **kwargs: Any,
+        ) -> AsyncGenerator[AgentEvent, None]:
+            label = "logged" if cwd == logged_repo else "plain"
+            runtime = current_run_context()
+            assert runtime is not None
+            contexts[label] = runtime
+            if label == "logged":
+                logged_entered.set()
+                await plain_entered.wait()
+            else:
+                plain_entered.set()
+                await logged_observed.wait()
+            choices[label] = prompt_user(console, f"{label} choice", "safe-default")
+            console.print(f"{label}-token={sentinel}", markup=False, highlight=False)
+            if label == "logged":
+                logged_observed.set()
+            else:
+                await release_plain.wait()
+            yield ResultEvent(structured_output=None, continuation=None)
+
+    backend = SharedBackend()
+    monkeypatch.setattr(runner, "create_backend", lambda *args, **kwargs: backend)
+    logged_config = make_config(
+        logged_repo, flow_name="policy-probe", backend="claude",
+        log_mode=True, quiet=True, non_interactive=True,
+    )
+    plain_config = make_config(
+        plain_repo, flow_name="policy-probe", backend="claude",
+        log_mode=False, quiet=False, non_interactive=False, assume="yes",
+    )
+
+    async def run_logged() -> None:
+        try:
+            results["logged"] = await runner.run(logged_config)
+        finally:
+            logged_finished.set()
+
+    async def run_plain() -> None:
+        results["plain"] = await runner.run(plain_config)
+
+    with console.capture() as captured, anyio.fail_after(30):
+        async with anyio.create_task_group() as tasks:
+            tasks.start_soon(run_logged)
+            await logged_entered.wait()
+            tasks.start_soon(run_plain)
+            await logged_finished.wait()
+            assert contexts["logged"].active_backends() == ()
+            assert contexts["plain"].active_backends() == (backend,)
+            assert active_backends() == (backend,)
+            release_plain.set()
+
+    assert results == {"logged": 0, "plain": 0}
+    assert choices == {"logged": "safe-default", "plain": "interactive-answer"}
+    assert input_calls == ["read"]
+    output = captured.get()
+    assert f"logged-token={sentinel}" not in output
+    assert "logged-token=[REDACTED_API_KEY]" in output
+    assert f"plain-token={sentinel}" in output
+    assert contexts["logged"] is not contexts["plain"]
+    assert contexts["logged"].policy.quiet is True
+    assert contexts["logged"].policy.log_mode is True
+    assert contexts["logged"].policy.interactive is False
+    assert contexts["plain"].policy.assume == "yes"
+    assert contexts["plain"].policy.log_mode is False
+    assert contexts["plain"].policy.interactive is True
+    assert active_backends() == ()
+    assert current_run_context() is None
+
+
+async def test_failed_run_releases_policy_and_backends_before_later_run(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    ext_dir: ExtDir,
+    make_config: Callable[..., RunConfig],
+) -> None:
+    """A failed logged run cannot leave policy or active backends behind."""
+    failed_repo = _feature_repo(tmp_path / "failed")
+    later_repo = _feature_repo(tmp_path / "later")
+    _write_policy_flow(ext_dir)
+    monkeypatch.setattr(runner, "_stdin_isatty", lambda: True)
+    monkeypatch.delenv("CI", raising=False)
+    choices: list[str] = []
+    sentinel = "ghp_" + "y" * 16
+    monkeypatch.setattr("builtins.input", lambda: "later-answer")
+
+    class FailingThenSuccessfulBackend(ScriptedBackend):
+        async def execute(
+            self, cwd: Path, prompt: str, *args: Any, **kwargs: Any,
+        ) -> AsyncGenerator[AgentEvent, None]:
+            if cwd == failed_repo:
+                console.print(f"failed-token={sentinel}", markup=False, highlight=False)
+                raise ValueError("intentional backend failure")
+            choices.append(prompt_user(console, "Later choice", "safe-default"))
+            console.print(f"later-token={sentinel}", markup=False, highlight=False)
+            yield ResultEvent(structured_output=None, continuation=None)
+
+    backend = FailingThenSuccessfulBackend()
+    monkeypatch.setattr(runner, "create_backend", lambda *args, **kwargs: backend)
+    with console.capture() as captured:
+        with pytest.raises(ValueError, match="intentional backend failure"):
+            await runner.run(make_config(
+                failed_repo, flow_name="policy-probe", backend="claude",
+                log_mode=True, non_interactive=True,
+            ))
+        assert current_run_context() is None
+        assert active_backends() == ()
+        assert await runner.run(make_config(
+            later_repo, flow_name="policy-probe", backend="claude",
+            log_mode=False, non_interactive=False,
+        )) == 0
+    assert choices == ["later-answer"]
+    assert f"failed-token={sentinel}" not in captured.get()
+    assert "failed-token=[REDACTED_API_KEY]" in captured.get()
+    assert f"later-token={sentinel}" in captured.get()
+    assert current_run_context() is None
+    assert active_backends() == ()

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -37,6 +37,7 @@ from daydream.backends import (
 from daydream.exploration import ExplorationContext
 from daydream.extensions.loader import build_registry
 from daydream.flows.engine import FlowContext
+from daydream.run_context import RunContext, current_run_context
 from daydream.runner import RunConfig
 from daydream.trajectory import (
     DaydreamRunFlow,
@@ -944,7 +945,11 @@ async def test_run_dispatches_to_expected_flow(
     called: list[tuple[str, WorkContext, RunConfig]] = []
 
     def _record(name: str) -> Any:
-        async def stub(work: Any, config: Any, _run_artifacts: Any = None) -> int:
+        async def stub(
+            work: Any, config: Any, _run_artifacts: Any = None, *,
+            run_context: RunContext,
+        ) -> int:
+            assert run_context is current_run_context()
             called.append((name, work, config))
             return 0
 
@@ -976,7 +981,11 @@ async def test_run_rejects_head_mismatch_before_dispatch(
     called: list[str] = []
 
     def _record(name: str) -> Any:
-        async def stub(work: Any, config: Any, _run_artifacts: Any = None) -> int:
+        async def stub(
+            work: Any, config: Any, _run_artifacts: Any = None, *,
+            run_context: RunContext,
+        ) -> int:
+            assert run_context is current_run_context()
             called.append(name)
             return 0
 
@@ -1003,7 +1012,11 @@ async def test_run_allows_matching_approved_head(
     called: list[str] = []
 
     def _record(name: str) -> Any:
-        async def stub(work: Any, config: Any, _run_artifacts: Any = None) -> int:
+        async def stub(
+            work: Any, config: Any, _run_artifacts: Any = None, *,
+            run_context: RunContext,
+        ) -> int:
+            assert run_context is current_run_context()
             called.append(name)
             return 0
 
@@ -1036,7 +1049,11 @@ async def test_run_rejects_head_mismatch_on_real_worktree(
     called: list[str] = []
 
     def _record(name: str) -> Any:
-        async def stub(work: Any, config: Any, _run_artifacts: Any = None) -> int:
+        async def stub(
+            work: Any, config: Any, _run_artifacts: Any = None, *,
+            run_context: RunContext,
+        ) -> int:
+            assert run_context is current_run_context()
             called.append(name)
             return 0
 
@@ -1068,7 +1085,11 @@ async def test_run_allows_matching_approved_head_on_real_worktree(
     head_shas: list[str] = []
 
     def _record(name: str) -> Any:
-        async def stub(work: Any, config: Any, _run_artifacts: Any = None) -> int:
+        async def stub(
+            work: Any, config: Any, _run_artifacts: Any = None, *,
+            run_context: RunContext,
+        ) -> int:
+            assert run_context is current_run_context()
             called.append(name)
             head_shas.append(work.head_sha)
             return 0
@@ -1198,7 +1219,9 @@ async def test_review_run_does_not_mint_app_identity(
         _work: WorkContext,
         config: RunConfig,
         _run_artifacts: Any = None,
+        *, run_context: RunContext,
     ) -> int:
+        assert run_context is current_run_context()
         assert config.identity == "operator"
         return 0
 
@@ -1304,7 +1327,9 @@ async def test_comment_mode_without_open_pr_dispatches_to_deep_flow(
         work: WorkContext,
         config: RunConfig,
         _run_artifacts: Any = None,
+        *, run_context: RunContext,
     ) -> int:
+        assert run_context is current_run_context()
         seen["output_mode"] = config.output_mode
         seen["branch"] = config.branch
         return 0
@@ -1779,7 +1804,7 @@ def test_runconfig_defaults_non_interactive_false() -> None:
     ],
     ids=["deep_loop", "shallow", "comment", "improve"],
 )
-async def test_run_threads_non_interactive_into_agent_state(
+async def test_run_threads_non_interactive_into_runtime(
     dispatch_target: Any,
     config_kwargs: Any,
     monkeypatch: pytest.MonkeyPatch,
@@ -1788,27 +1813,25 @@ async def test_run_threads_non_interactive_into_agent_state(
     tmp_path: Path,
     make_config: Callable[..., 'RunConfig'],
 ) -> None:
-    """``config.non_interactive=True`` flips the agent singleton flag before any
-    promptable phase, on every dispatch branch ``run()`` can take. Each case
-    patches one dispatch fn so ``run()`` reaches the run-start setup (where
-    ``set_non_interactive`` fires) without executing real phases.
-    """
-    from daydream.agent import get_non_interactive, reset_state
+    """Every dispatch receives the runner's bound unattended policy explicitly."""
+    previous = current_run_context()
+    received: list[RunContext] = []
 
-    reset_state()
-    try:
+    async def stub(
+        work: Any, config: Any, _run_artifacts: Any = None, *,
+        run_context: RunContext,
+    ) -> int:
+        assert current_run_context() is run_context
+        received.append(run_context)
+        return 0
 
-        async def stub(work: Any, config: Any, _run_artifacts: Any = None) -> int:
-            return 0
+    monkeypatch.setattr(dispatch_target, stub)
+    config = make_config(tmp_path, non_interactive=True, **config_kwargs)
 
-        monkeypatch.setattr(dispatch_target, stub)
-        config = make_config(tmp_path, non_interactive=True, **config_kwargs)
-
-        exit_code = await runner.run(config)
-        assert exit_code == 0
-        assert get_non_interactive() is True
-    finally:
-        reset_state()
+    assert await runner.run(config) == 0
+    assert len(received) == 1
+    assert received[0].policy.interactive is False
+    assert current_run_context() is previous
 
 
 # --- Deep fix-cycle commit gate semantics ----------------------------------
@@ -1981,8 +2004,6 @@ async def _drive_fix_cycle_failing(
     Returns:
         ``(exit_code, test_backend, commit_calls)``.
     """
-    from daydream.agent import reset_state
-
     _seed_fix_resume(target, [_fix_item()])
 
     # Silence the flow's terminal noise; the test phase is observed through the
@@ -2039,11 +2060,7 @@ async def _drive_fix_cycle_failing(
 
         monkeypatch.setattr("builtins.input", _forbidden_input)
 
-    reset_state()
-    try:
-        exit_code = await runner.run(config)
-    finally:
-        reset_state()
+    exit_code = await runner.run(config)
 
     return exit_code, test_backend, commit_calls
 

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -102,10 +102,8 @@ def test_prompt_user_returns_default_on_eof(monkeypatch: pytest.MonkeyPatch) -> 
 
     from rich.console import Console
 
-    from daydream.agent import reset_state
     from daydream.ui import prompt_user
 
-    reset_state()
     monkeypatch.setattr("builtins.input", Mock(side_effect=EOFError("EOF when reading a line")))
     # Issue #126 exact repro expectation:
     console = Console(file=StringIO(), record=True)
@@ -120,24 +118,22 @@ def test_prompt_user_non_interactive_skips_stdin(monkeypatch: pytest.MonkeyPatch
 
     from rich.console import Console
 
-    from daydream.agent import reset_state, set_non_interactive
+    from daydream.run_context import InteractionPolicy, RunContext, bind_run_context
     from daydream.ui import prompt_user
 
-    set_non_interactive(True)
     sentinel = Mock(side_effect=AssertionError("input() must not be called"))
     monkeypatch.setattr("builtins.input", sentinel)
-    assert prompt_user(Console(), "Apply fixes now?", default="n") == "n"
+    context = RunContext(InteractionPolicy(interactive=False))
+    with bind_run_context(context):
+        assert prompt_user(Console(), "Apply fixes now?", default="n") == "n"
     sentinel.assert_not_called()
-    reset_state()
 
 
 def test_prompt_user_returns_typed_value_interactively(monkeypatch: pytest.MonkeyPatch) -> None:
     from rich.console import Console
 
-    from daydream.agent import reset_state
     from daydream.ui import prompt_user
 
-    reset_state()
     monkeypatch.setattr("builtins.input", lambda: "y")
     assert prompt_user(Console(), "Confirm?", default="n") == "y"
 


### PR DESCRIPTION
## Summary

- Give each runner invocation an immutable interaction/output policy, passed through flows, phases, exploration, agents, and PR prompts.
- Track backend invocations with separate lifecycle tokens so overlapping uses of one backend remain registered until each finishes. Preserve signal recorder flushing and cancellation order.
- Route confirmations and menu input through one gateway, and bind explicit standalone phase contexts around their complete output. Keep API v6 flow data and artifact access intact.

## Motivation

Overlapping runs could overwrite the shared agent state and change each other's stdin behavior, log redaction, or active backend membership. This makes those decisions local to the emitting run and removes the old mutable AgentState and test reset fixture.

Closes #1008.

## Test Plan

- Real temporary Git repositories and API v6 extension flows exercise opposing overlapping policies, shared backend membership, output redaction, and recovery after a failed run.
- Regressions cover retry/exception cleanup, signal re-entry and interrupted registration, standalone phase binding, and real SIGINT/SIGTERM flushing of root and fork trajectories.
- Existing test/heal, rendering, prompt, flow, and observability behavior remains covered.
- Full repository check: `make check` passed (8,070 passed, 15 skipped; 88.78% coverage). Ruff, mypy across 532 files, root/RL dead-code scans, and Docker actionlint passed.
- Required local review: `daydream . --precision --non-interactive --backend codex` — completed on signed head `287e180d10359ab523fb3dc928e001228a1a4c9f`, session `02cb0477-3cfe-44c8-aee4-50b72e748af8`; all 37 changed files read. The first review's signal-test finding was fixed and fully rechecked. The final report's existing `LoopGroup` self-alias finding was rejected: strict mypy needs the typed re-export, Ruff requires the current formatting, and it already exists on the base. A reviewer using outdated mypy was separately disproved with the locked version. Zero actionable findings remain. The optional flowchart exceeded its input-size budget.

## Checklist

- [x] Root lint, typing, tests, coverage, root/RL dead-code scans, and Docker workflow lint pass through `make check`.
- [x] Extension documentation updated.
