### PR TITLE
refactor(harbor): isolate reviewer execution environments

### DIFF
--- a/daydream/agent.py
+++ b/daydream/agent.py
@@ -563,25 +563,39 @@ async def _run_agent(
             # with-shape uniform otherwise (CORE-09 no-op). D-19: no ATIF construction
             # here — only inv.observe()/inv.observe_user_step() against the recorder.
             recorder = get_current_recorder()
-            try:
-                _default_attempts = int(os.environ.get("DAYDREAM_PI_RETRY_ATTEMPTS", "20"))
-            except ValueError:
-                _default_attempts = 20
-            if _default_attempts < 0:
-                _default_attempts = 20
-
-            def _retry_delay_from_env(name: str, default: float) -> float:
+            retry_policy = getattr(backend, "retry_policy", None)
+            if retry_policy is not None:
+                max_attempts = retry_policy.attempts
+                base_delay = retry_policy.base_delay_s
+                max_delay = retry_policy.max_delay_s
+            else:
                 try:
-                    value = float(os.environ.get(name, str(default)))
+                    _default_attempts = int(
+                        os.environ.get("DAYDREAM_PI_RETRY_ATTEMPTS", "20")
+                    )
                 except ValueError:
-                    return default
-                return value if math.isfinite(value) and value >= 0 else default
+                    _default_attempts = 20
+                if _default_attempts < 0:
+                    _default_attempts = 20
 
-            _default_delay = _retry_delay_from_env("DAYDREAM_PI_RETRY_BASE_DELAY_S", 2.0)
-            _default_max_delay = _retry_delay_from_env("DAYDREAM_PI_RETRY_MAX_DELAY_S", 120.0)
-            max_attempts = getattr(backend, "retry_attempts", _default_attempts)
-            base_delay = getattr(backend, "retry_base_delay_s", _default_delay)
-            max_delay = getattr(backend, "retry_max_delay_s", _default_max_delay)
+                def _retry_delay_from_env(name: str, default: float) -> float:
+                    try:
+                        value = float(os.environ.get(name, str(default)))
+                    except ValueError:
+                        return default
+                    return value if math.isfinite(value) and value >= 0 else default
+
+                _default_delay = _retry_delay_from_env(
+                    "DAYDREAM_PI_RETRY_BASE_DELAY_S", 2.0
+                )
+                _default_max_delay = _retry_delay_from_env(
+                    "DAYDREAM_PI_RETRY_MAX_DELAY_S", 120.0
+                )
+                max_attempts = getattr(backend, "retry_attempts", _default_attempts)
+                base_delay = getattr(backend, "retry_base_delay_s", _default_delay)
+                max_delay = getattr(
+                    backend, "retry_max_delay_s", _default_max_delay
+                )
             if max_attempts < 0:
                 raise ValueError("retry attempts must be >= 0")
             if not math.isfinite(base_delay):

--- a/daydream/backends/__init__.py
+++ b/daydream/backends/__init__.py
@@ -31,14 +31,160 @@ import os
 import re
 import unicodedata
 import uuid
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Mapping
 from dataclasses import dataclass, field
 from pathlib import Path
+from types import MappingProxyType
 from typing import TYPE_CHECKING, Any, Literal, Protocol, Union
 
 from daydream.trajectory import now_iso
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class RetryPolicy:
+    """Complete retry settings owned by one constructed backend."""
+
+    attempts: int
+    base_delay_s: float
+    max_delay_s: float
+
+
+def _parsed_nonnegative_int(
+    environment: Mapping[str, str], name: str, default: int
+) -> int:
+    raw = environment.get(name)
+    if raw is None:
+        return default
+    try:
+        value = int(raw)
+    except ValueError:
+        logger.warning("%s=%r is not a valid integer; using default %d", name, raw, default)
+        return default
+    if value < 0:
+        logger.warning("%s=%r is negative; using default %d", name, raw, default)
+        return default
+    return value
+
+
+def _parsed_nonnegative_float(
+    environment: Mapping[str, str], name: str, default: float
+) -> float:
+    raw = environment.get(name)
+    if raw is None:
+        return default
+    try:
+        value = float(raw)
+    except ValueError:
+        logger.warning("%s=%r is not a valid float; using default %g", name, raw, default)
+        return default
+    if not math.isfinite(value):
+        logger.warning("%s=%r is not finite; using default %g", name, raw, default)
+        return default
+    if value < 0:
+        logger.warning("%s=%r is negative; using default %g", name, raw, default)
+        return default
+    return value
+
+
+def _parsed_positive_int(
+    environment: Mapping[str, str], name: str, default: int
+) -> int:
+    value = _parsed_nonnegative_int(environment, name, default)
+    if value == 0:
+        logger.warning("%s must be positive; using default %d", name, default)
+        return default
+    return value
+
+
+@dataclass(frozen=True)
+class BackendExecutionInput:
+    """Run-owned native process settings for one backend kind.
+
+    The complete environment is copied into an immutable private mapping.
+    Native transports receive a fresh mutable copy for each invocation.
+    """
+
+    _environment: Mapping[str, str] = field(repr=False, compare=False)
+    retry_policy: RetryPolicy
+    fanout_concurrency: int
+    pi_provider: str | None
+    pi_thinking: str | None
+    pi_agent_dir: Path | None
+    stream_idle_timeout_s: float | None
+    pi_response_idle_timeout_s: float | None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self, "_environment", MappingProxyType(dict(self._environment))
+        )
+
+    @classmethod
+    def from_environment(
+        cls, environment: Mapping[str, str], *, backend: str
+    ) -> BackendExecutionInput:
+        """Parse one complete environment without consulting process globals."""
+        from daydream.backends._subprocess import (
+            DEFAULT_PI_RESPONSE_IDLE_TIMEOUT_S,
+            DEFAULT_STREAM_IDLE_TIMEOUT_S,
+        )
+
+        if backend not in {"pi", "codex", "claude"}:
+            if backend == "osprey":
+                raise ValueError("explicit BackendExecutionInput is not supported for osprey")
+            raise ValueError(f"unsupported backend for execution input: {backend!r}")
+
+        copied = dict(environment)
+        base_delay_default = 10.0 if backend == "pi" else 2.0
+        fanout_name = (
+            "DAYDREAM_PI_FANOUT_CONCURRENCY"
+            if backend == "pi"
+            else "DAYDREAM_FANOUT_CONCURRENCY"
+        )
+        fanout_default = 10 if backend == "pi" else 8
+        idle = _parsed_nonnegative_float(
+            copied, "DAYDREAM_STREAM_IDLE_TIMEOUT_S", DEFAULT_STREAM_IDLE_TIMEOUT_S
+        )
+        response_idle = _parsed_nonnegative_float(
+            copied,
+            "DAYDREAM_STREAM_IDLE_TIMEOUT_S",
+            DEFAULT_PI_RESPONSE_IDLE_TIMEOUT_S,
+        )
+        home = copied.get("HOME")
+        agent_dir_raw = copied.get("PI_CODING_AGENT_DIR")
+        pi_agent_dir = (
+            Path(agent_dir_raw)
+            if agent_dir_raw
+            else Path(home) / ".pi" / "agent"
+            if home
+            else None
+        )
+
+        return cls(
+            copied,
+            RetryPolicy(
+                attempts=_parsed_nonnegative_int(
+                    copied, "DAYDREAM_PI_RETRY_ATTEMPTS", 20
+                ),
+                base_delay_s=_parsed_nonnegative_float(
+                    copied, "DAYDREAM_PI_RETRY_BASE_DELAY_S", base_delay_default
+                ),
+                max_delay_s=_parsed_nonnegative_float(
+                    copied, "DAYDREAM_PI_RETRY_MAX_DELAY_S", 120.0
+                ),
+            ),
+            _parsed_positive_int(copied, fanout_name, fanout_default),
+            copied.get("PI_PROVIDER") or None,
+            copied.get("PI_THINKING") or None,
+            pi_agent_dir,
+            None if idle == 0 else idle,
+            None if response_idle == 0 else response_idle,
+        )
+
+    def child_environment(self) -> dict[str, str]:
+        """Return a fresh complete environment for one native transport."""
+        return dict(self._environment)
 
 AUDIT_ROOT_ISOLATION_V1 = "claude-pretooluse-v1"
 AuditIsolationReason = Literal[
@@ -1178,6 +1324,7 @@ def create_backend(
     osprey_binary: str | None = None,
     audit_root: Path | None = None,
     audit_outward_symlinks: frozenset[Path] = frozenset(),
+    execution_input: BackendExecutionInput | None = None,
 ) -> Backend:
     """Create a backend by name.
 
@@ -1214,18 +1361,30 @@ def create_backend(
             reasoning_effort=reasoning_effort,
             audit_root=audit_root,
             audit_outward_symlinks=audit_outward_symlinks,
+            execution_input=execution_input,
         )
     if audit_root is not None and name in {"codex", "pi", "osprey"}:
         raise AuditIsolationError(name, "unsupported_backend")
     if name == "codex":
         from daydream.backends.codex import CodexBackend
 
-        return CodexBackend(model=model or DEFAULT_CODEX_MODEL, reasoning_effort=reasoning_effort)
+        return CodexBackend(
+            model=model or DEFAULT_CODEX_MODEL,
+            reasoning_effort=reasoning_effort,
+            execution_input=execution_input,
+        )
     if name == "pi":
         from daydream.backends.pi import PiBackend
 
-        return PiBackend(model=model, cwd=cwd, reasoning_effort=reasoning_effort)
+        return PiBackend(
+            model=model,
+            cwd=cwd,
+            reasoning_effort=reasoning_effort,
+            execution_input=execution_input,
+        )
     if name == "osprey":
+        if execution_input is not None:
+            raise ValueError("explicit BackendExecutionInput is not supported for osprey")
         from daydream.backends.osprey import OspreyBackend
 
         return OspreyBackend(
@@ -1249,6 +1408,7 @@ __all__ = [
     "AuditIsolationError",
     "AuditIsolationReason",
     "Backend",
+    "BackendExecutionInput",
     "ClaudeBackend",
     "ClaudeRequestConfig",
     "CodexRequestConfig",
@@ -1269,6 +1429,7 @@ __all__ = [
     "PiRequestConfig",
     "ReasoningChoicePart",
     "RequestEvent",
+    "RetryPolicy",
     "ResultEvent",
     "TextChoicePart",
     "TextEvent",

--- a/daydream/backends/claude.py
+++ b/daydream/backends/claude.py
@@ -5,13 +5,25 @@ from __future__ import annotations
 
 import json
 import os
+import platform
 import re
 import shlex
-from collections.abc import AsyncGenerator
+import shutil
+from collections.abc import AsyncGenerator, AsyncIterable
+from contextlib import suppress
+from dataclasses import asdict
 from pathlib import Path, PureWindowsPath
+from subprocess import PIPE
 from typing import Any, cast
 
+import anyio
+from anyio.streams.text import TextReceiveStream, TextSendStream
 from claude_agent_sdk import ClaudeAgentOptions, ClaudeSDKClient, HookJSONOutput, HookMatcher
+from claude_agent_sdk._errors import CLIConnectionError, CLINotFoundError
+from claude_agent_sdk._internal._task_compat import spawn_detached
+from claude_agent_sdk._internal.query import Query
+from claude_agent_sdk._internal.transport import subprocess_cli as _sdk_subprocess
+from claude_agent_sdk._version import __version__ as _sdk_version
 from claude_agent_sdk.types import (
     AgentDefinition,
     AssistantMessage,
@@ -23,11 +35,13 @@ from claude_agent_sdk.types import (
     ToolResultBlock,
     ToolUseBlock,
     UserMessage,
+    _hooks_to_internal_format,
 )
 
 from daydream.backends import (
     AUDIT_ROOT_ISOLATION_V1,
     AgentEvent,
+    BackendExecutionInput,
     ClaudeRequestConfig,
     ContinuationToken,
     CostEvent,
@@ -139,10 +153,13 @@ _AUDIT_GREP_BOOL_FIELDS = frozenset({"-n", "-i", "multiline"})
 _AUDIT_GREP_INT_FIELDS = frozenset({"head_limit", "offset"})
 
 
-def _audit_cli_env(root: Path) -> dict[str, str]:
+def _audit_cli_env(
+    root: Path, *, base_environment: dict[str, str] | None = None
+) -> dict[str, str]:
     """Return SDK environment overrides bound to one standalone audit repo."""
     git_dir = root / ".git"
     return {
+        **(base_environment or {}),
         **_CLI_ENV,
         "PWD": str(root),
         "OLDPWD": str(root),
@@ -159,6 +176,280 @@ def _audit_cli_env(root: Path) -> dict[str, str]:
 
 def _nonnegative_int(value: Any) -> bool:
     return isinstance(value, int) and not isinstance(value, bool) and value >= 0
+
+
+class _RunLocalSubprocessCLITransport(_sdk_subprocess.SubprocessCLITransport):
+    """SDK subprocess transport that never merges the host process environment."""
+
+    def __init__(
+        self,
+        options: ClaudeAgentOptions,
+        *,
+        environment: dict[str, str],
+    ) -> None:
+        self._run_environment = dict(environment)
+
+        async def _empty_prompt() -> AsyncGenerator[dict[str, Any], None]:
+            messages: tuple[dict[str, Any], ...] = ()
+            for message in messages:
+                yield message
+
+        prompt: AsyncIterable[dict[str, Any]] = _empty_prompt()
+        super().__init__(prompt=prompt, options=options)
+
+    def _find_cli(self) -> str:
+        bundled_cli = self._find_bundled_cli()
+        if bundled_cli:
+            return bundled_cli
+
+        search_path = self._run_environment.get("PATH", "")
+        which_hit = shutil.which("claude", path=search_path)
+        if which_hit and (
+            platform.system() != "Windows" or self._is_windows_native_exe(which_hit)
+        ):
+            return which_hit
+        if platform.system() == "Windows":
+            exe = shutil.which("claude.exe", path=search_path)
+            if exe and self._is_windows_native_exe(exe):
+                return exe
+
+        home_raw = self._run_environment.get("HOME") or self._run_environment.get(
+            "USERPROFILE"
+        )
+        if home_raw:
+            home = Path(home_raw)
+            locations = (
+                [home / ".local/bin/claude.exe"]
+                if platform.system() == "Windows"
+                else [
+                    home / ".npm-global/bin/claude",
+                    home / ".local/bin/claude",
+                    home / "node_modules/.bin/claude",
+                    home / ".yarn/bin/claude",
+                    home / ".claude/local/claude",
+                ]
+            )
+            for path in locations:
+                if path.exists() and path.is_file():
+                    return str(path)
+        if platform.system() != "Windows":
+            for path in (Path("/usr/local/bin/claude"),):
+                if path.exists() and path.is_file():
+                    return str(path)
+        if which_hit is not None:
+            return which_hit
+        raise CLINotFoundError(
+            "Claude Code not found in the run-owned execution environment"
+        )
+
+    def _native_environment(self) -> dict[str, str]:
+        process_env = {
+            key: value
+            for key, value in self._run_environment.items()
+            if key != "CLAUDECODE"
+        }
+        process_env.setdefault("CLAUDE_CODE_ENTRYPOINT", "sdk-py")
+        process_env["CLAUDE_AGENT_SDK_VERSION"] = _sdk_version
+
+        try:
+            from opentelemetry import propagate
+
+            carrier: dict[str, str] = {}
+            propagate.inject(carrier)
+            if "traceparent" in carrier:
+                for key in ("TRACEPARENT", "TRACESTATE"):
+                    if key not in self._run_environment:
+                        process_env.pop(key, None)
+                for key, value in carrier.items():
+                    upper = key.upper()
+                    if upper not in self._run_environment:
+                        process_env[upper] = value
+        except Exception:  # noqa: BLE001 - tracing remains best effort
+            _sdk_subprocess.logger.debug(
+                "OTEL trace context injection failed", exc_info=True
+            )
+
+        if self._options.enable_file_checkpointing:
+            process_env["CLAUDE_CODE_ENABLE_SDK_FILE_CHECKPOINTING"] = "true"
+        if self._cwd:
+            process_env["PWD"] = self._cwd
+        return process_env
+
+    async def connect(self) -> None:
+        """Start the SDK CLI with only the run-owned complete environment."""
+        if self._process:
+            return
+        if self._cli_path is None:
+            self._cli_path = await anyio.to_thread.run_sync(self._find_cli)
+        self._reject_windows_batch_cli(self._cli_path)
+        if not self._run_environment.get("CLAUDE_AGENT_SDK_SKIP_VERSION_CHECK"):
+            await self._check_claude_version()
+
+        cmd = self._build_command()
+        try:
+            stderr_dest = PIPE if self._options.stderr is not None else None
+            self._process = await anyio.open_process(
+                cmd,
+                stdin=PIPE,
+                stdout=PIPE,
+                stderr=stderr_dest,
+                cwd=self._cwd,
+                env=self._native_environment(),
+                user=self._options.user,
+            )
+            _sdk_subprocess._ACTIVE_CHILDREN.add(self._process)
+            if self._process.stdout:
+                self._stdout_stream = TextReceiveStream(self._process.stdout)
+            if stderr_dest is PIPE and self._process.stderr:
+                self._stderr_stream = TextReceiveStream(self._process.stderr)
+                self._stderr_task = spawn_detached(self._handle_stderr())
+            if self._process.stdin:
+                self._stdin_stream = TextSendStream(self._process.stdin)
+            self._ready = True
+        except FileNotFoundError as exc:
+            if self._cwd and not Path(self._cwd).exists():
+                error = CLIConnectionError(
+                    f"Working directory does not exist: {self._cwd}"
+                )
+                self._exit_error = error
+                raise error from exc
+            error = CLINotFoundError(f"Claude Code not found at: {self._cli_path}")
+            self._exit_error = error
+            raise error from exc
+        except Exception as exc:
+            error = CLIConnectionError(f"Failed to start Claude Code: {exc}")
+            self._exit_error = error
+            raise error from exc
+
+    async def _check_claude_version(self) -> None:
+        """Run the SDK version probe with the same run-owned environment."""
+        if self._cli_path is None:
+            raise CLINotFoundError("CLI path not resolved. Call connect() first.")
+        version_process = None
+        try:
+            with anyio.fail_after(2):
+                version_process = await anyio.open_process(
+                    [self._cli_path, "-v"],
+                    stdout=PIPE,
+                    stderr=PIPE,
+                    env=self._native_environment(),
+                )
+                if version_process.stdout:
+                    stdout_bytes = await version_process.stdout.receive()
+                    version_output = stdout_bytes.decode().strip()
+                    match = re.match(r"([0-9]+\.[0-9]+\.[0-9]+)", version_output)
+                    if match:
+                        version_parts = [int(value) for value in match.group(1).split(".")]
+                        minimum_parts = [
+                            int(value)
+                            for value in _sdk_subprocess.MINIMUM_CLAUDE_CODE_VERSION.split(
+                                "."
+                            )
+                        ]
+                        if version_parts < minimum_parts:
+                            _sdk_subprocess.logger.warning(
+                                "Claude Code version %s at %s is unsupported; minimum is %s",
+                                match.group(1),
+                                self._cli_path,
+                                _sdk_subprocess.MINIMUM_CLAUDE_CODE_VERSION,
+                            )
+        except Exception:
+            pass
+        finally:
+            if version_process:
+                with suppress(Exception):
+                    version_process.terminate()
+                with suppress(Exception):
+                    await version_process.wait()
+
+
+class _RunLocalClaudeSDKClient(ClaudeSDKClient):
+    """Pinned-SDK startup that keeps initialization timing run-owned.
+
+    The SDK accepts a custom transport but still reads
+    ``CLAUDE_CODE_STREAM_CLOSE_TIMEOUT`` from ``os.environ`` while constructing
+    its Query. This narrow override mirrors that startup sequence for the
+    options Daydream uses and substitutes the value parsed from the owning
+    execution environment. The inherited connect error unwind, message API,
+    disconnect, and context-manager lifecycle remain unchanged.
+    """
+
+    def __init__(
+        self,
+        *,
+        options: ClaudeAgentOptions,
+        transport: _RunLocalSubprocessCLITransport,
+        initialize_timeout_s: float,
+    ) -> None:
+        super().__init__(options=options, transport=transport)
+        self._run_initialize_timeout_s = initialize_timeout_s
+
+    async def _connect_inner(
+        self,
+        prompt: str | AsyncIterable[dict[str, Any]] | None,
+        actual_prompt: AsyncIterable[dict[str, Any]],
+    ) -> None:
+        assert self._custom_transport is not None
+        self._transport = self._custom_transport
+        await self._transport.connect()
+
+        agents_dict = (
+            {
+                name: {
+                    key: value
+                    for key, value in asdict(agent_definition).items()
+                    if value is not None
+                }
+                for name, agent_definition in self.options.agents.items()
+            }
+            if self.options.agents
+            else None
+        )
+        exclude_dynamic_sections: bool | None = None
+        system_prompt = self.options.system_prompt
+        if isinstance(system_prompt, dict) and system_prompt.get("type") == "preset":
+            candidate = system_prompt.get("exclude_dynamic_sections")
+            if isinstance(candidate, bool):
+                exclude_dynamic_sections = candidate
+
+        self._query = Query(
+            transport=self._transport,
+            is_streaming_mode=True,
+            can_use_tool=self.options.can_use_tool,
+            hooks=(
+                _hooks_to_internal_format(self.options.hooks)
+                if self.options.hooks
+                else None
+            ),
+            sdk_mcp_servers={},
+            initialize_timeout=self._run_initialize_timeout_s,
+            agents=agents_dict,
+            exclude_dynamic_sections=exclude_dynamic_sections,
+            skills=self.options.skills,
+            forward_subagent_text=self.options.forward_subagent_text,
+        )
+        await self._query.start()
+        await self._query.initialize()
+        if isinstance(prompt, str):
+            message = {
+                "type": "user",
+                "message": {"role": "user", "content": prompt},
+                "parent_tool_use_id": None,
+                "session_id": "default",
+            }
+            await self._transport.write(json.dumps(message) + "\n")
+        elif prompt is not None and isinstance(prompt, AsyncIterable):
+            self._query.spawn_task(self._query.stream_input(actual_prompt))
+
+
+def _run_local_initialize_timeout_s(environment: dict[str, str]) -> float:
+    """Parse the SDK initialization window from one run-owned environment."""
+    raw = environment.get("CLAUDE_CODE_STREAM_CLOSE_TIMEOUT", "60000")
+    try:
+        timeout_ms = int(raw)
+    except ValueError:
+        timeout_ms = 60000
+    return max(timeout_ms / 1000.0, 60.0)
 
 
 def _valid_relative_audit_path(value: str) -> bool:
@@ -648,9 +939,11 @@ class ClaudeBackend:
         reasoning_effort: str | None = None,
         audit_root: Path | None = None,
         audit_outward_symlinks: frozenset[Path] = frozenset(),
+        execution_input: BackendExecutionInput | None = None,
     ):
         self.model = model
         self.reasoning_effort = _claude_effort(reasoning_effort)
+        self._execution_input = execution_input
         self.audit_root = audit_root.resolve(strict=True) if audit_root is not None else None
         self.audit_root_isolation = (
             AUDIT_ROOT_ISOLATION_V1 if self.audit_root is not None else None
@@ -675,7 +968,13 @@ class ClaudeBackend:
             if self.audit_root is not None
             else None
         )
-        self.fanout_concurrency = resolve_fanout_concurrency("DAYDREAM_FANOUT_CONCURRENCY", 8)
+        if execution_input is not None:
+            self.fanout_concurrency = execution_input.fanout_concurrency
+            self.retry_policy = execution_input.retry_policy
+        else:
+            self.fanout_concurrency = resolve_fanout_concurrency(
+                "DAYDREAM_FANOUT_CONCURRENCY", 8
+            )
         self._active_clients: set[ClaudeSDKClient] = set()
 
     async def execute(
@@ -750,6 +1049,11 @@ class ClaudeBackend:
         # separate branch below and denies Skill along with every unhandled tool.
         if audit_guard is not None:
             assert audit_root is not None
+            base_environment = (
+                self._execution_input.child_environment()
+                if self._execution_input is not None
+                else None
+            )
             options = ClaudeAgentOptions(
                 cwd=str(audit_root),
                 permission_mode="bypassPermissions",
@@ -767,7 +1071,9 @@ class ClaudeBackend:
                 max_turns=max_turns,
                 extra_args={"no-session-persistence": None},
                 effort=self.reasoning_effort,
-                env=_audit_cli_env(audit_root),
+                env=_audit_cli_env(
+                    audit_root, base_environment=base_environment
+                ),
                 hooks={
                     "PreToolUse": [
                         HookMatcher(matcher=_READ_ONLY_HOOK_MATCHER, hooks=[audit_guard])
@@ -775,6 +1081,14 @@ class ClaudeBackend:
                 },
             )
         else:
+            sdk_environment = (
+                {
+                    **self._execution_input.child_environment(),
+                    **_CLI_ENV,
+                }
+                if self._execution_input is not None
+                else dict(_CLI_ENV)
+            )
             pre_tool_use_hooks: list[HookCallback] = [
                 _dangerous_command_guard,
                 _background_bash_guard,
@@ -793,7 +1107,7 @@ class ClaudeBackend:
                 extra_args={"no-session-persistence": None} if not persist_session else {},
                 # None leaves the CLI's ambient default; the SDK omits --effort.
                 effort=self.reasoning_effort,
-                env=dict(_CLI_ENV),
+                env=sdk_environment,
                 hooks={
                     "PreToolUse": [
                         HookMatcher(
@@ -873,7 +1187,21 @@ class ClaudeBackend:
             session_source="host_generated" if resume_applied else None,
         )
 
-        async with ClaudeSDKClient(options=options) as client:
+        if self._execution_input is not None:
+            client: ClaudeSDKClient
+            client = _RunLocalClaudeSDKClient(
+                options=options,
+                transport=_RunLocalSubprocessCLITransport(
+                    options, environment=dict(options.env)
+                ),
+                initialize_timeout_s=_run_local_initialize_timeout_s(
+                    dict(options.env)
+                ),
+            )
+        else:
+            client = ClaudeSDKClient(options=options)
+
+        async with client:
             self._active_clients.add(client)
             response = client.receive_response()
             response_terminated = False

--- a/daydream/backends/codex.py
+++ b/daydream/backends/codex.py
@@ -19,13 +19,14 @@ import tempfile
 import threading
 import uuid
 from collections import Counter
-from collections.abc import AsyncGenerator
+from collections.abc import AsyncGenerator, Mapping
 from pathlib import Path
 from typing import Any
 
 from daydream import git_ops
 from daydream.backends import (
     AgentEvent,
+    BackendExecutionInput,
     CodexRequestConfig,
     ContinuationToken,
     CostEvent,
@@ -47,7 +48,7 @@ from daydream.backends._transport import (
     StdinMode,
     TransportExitError,
 )
-from daydream.pricing import compute_cost_from_totals, load_user_prices, resolve_prices
+from daydream.pricing import ModelPrice, compute_cost_from_totals, load_user_prices, resolve_prices
 
 _CODEX_STDOUT_LIMIT_BYTES = 10 * 1024 * 1024
 _DIAGNOSTIC_LABEL_MAX_CHARS = 64
@@ -111,18 +112,53 @@ _REAL_GIT_RESOLUTION_LOCK = threading.Lock()
 _XCRUN_TIMEOUT_S = 5
 
 
-def _resolve_real_git_dir() -> str | None:
-    """Resolve the directory of the real (non-shim) ``git`` on macOS (issue #1122).
+def _probe_real_git_dir(environment: Mapping[str, str] | None) -> str | None:
+    """Run and validate one bounded ``xcrun --find git`` probe.
 
-    Runs ``xcrun --find git`` in the **parent** process — never inside the
-    sandboxed child, where ``xcrun`` itself is blocked — validates the target is
-    an existing executable file, and returns its parent directory. Resolved at
-    most once per process (negative results are cached too). On non-Darwin, or
-    whenever resolution fails (including the bounded timeout on a hung
-    ``xcrun``), returns ``None`` with a warning and the caller leaves the child
-    PATH unchanged (fail-open). The call never stalls the event loop:
-    ``execute()`` builds the child env through ``asyncio.to_thread``. Never
-    raises.
+    ``None`` preserves ordinary subprocess inheritance. An explicit mapping is
+    complete and is passed through without merging process globals.
+    """
+    kwargs: dict[str, Any] = {
+        "capture_output": True,
+        "text": True,
+        "check": False,
+        "timeout": _XCRUN_TIMEOUT_S,
+    }
+    if environment is not None:
+        kwargs["env"] = dict(environment)
+    try:
+        proc = subprocess.run(["xcrun", "--find", "git"], **kwargs)
+    except (OSError, subprocess.SubprocessError) as exc:
+        _logger.warning(
+            "codex: could not resolve real git via 'xcrun --find git' (%s); leaving child PATH unchanged",
+            exc,
+        )
+        return None
+    if proc.returncode != 0:
+        _logger.warning(
+            "codex: could not resolve real git via 'xcrun --find git' (exit %s: %s); "
+            "leaving child PATH unchanged",
+            proc.returncode,
+            proc.stderr.strip(),
+        )
+        return None
+    git_path = proc.stdout.strip()
+    if not git_path or not Path(git_path).is_file() or not os.access(git_path, os.X_OK):
+        _logger.warning(
+            "codex: could not resolve real git via 'xcrun --find git' (invalid target %r); "
+            "leaving child PATH unchanged",
+            git_path,
+        )
+        return None
+    return str(Path(git_path).parent)
+
+
+def _resolve_real_git_dir() -> str | None:
+    """Resolve and cache the ambient real-git directory on macOS (issue #1122).
+
+    Ordinary calls inherit the parent environment and cache positive and
+    negative results at most once per process. Explicit execution environments
+    use :func:`_probe_real_git_dir` directly and never consult this cache.
     """
     global _REAL_GIT_DIR, _REAL_GIT_RESOLVED
     with _REAL_GIT_RESOLUTION_LOCK:
@@ -131,36 +167,7 @@ def _resolve_real_git_dir() -> str | None:
         _REAL_GIT_RESOLVED = True
         if sys.platform != "darwin":
             return None
-        try:
-            proc = subprocess.run(
-                ["xcrun", "--find", "git"],
-                capture_output=True,
-                text=True,
-                check=False,
-                timeout=_XCRUN_TIMEOUT_S,
-            )
-        except (OSError, subprocess.SubprocessError) as exc:
-            _logger.warning(
-                "codex: could not resolve real git via 'xcrun --find git' (%s); leaving child PATH unchanged",
-                exc,
-            )
-            return None
-        if proc.returncode != 0:
-            _logger.warning(
-                "codex: could not resolve real git via 'xcrun --find git' (exit %s: %s); "
-                "leaving child PATH unchanged",
-                proc.returncode, proc.stderr.strip(),
-            )
-            return None
-        git_path = proc.stdout.strip()
-        if not git_path or not Path(git_path).is_file() or not os.access(git_path, os.X_OK):
-            _logger.warning(
-                "codex: could not resolve real git via 'xcrun --find git' (invalid target %r); "
-                "leaving child PATH unchanged",
-                git_path,
-            )
-            return None
-        _REAL_GIT_DIR = str(Path(git_path).parent)
+        _REAL_GIT_DIR = _probe_real_git_dir(None)
         return _REAL_GIT_DIR
 
 
@@ -190,7 +197,12 @@ class _SharedCheckout:
         self.refs = 0
 
 
-def _isolated_child_env(cwd: Path, execution_cwd: Path) -> dict[str, str] | None:
+def _isolated_child_env(
+    cwd: Path,
+    execution_cwd: Path,
+    *,
+    base_environment: dict[str, str] | None = None,
+) -> dict[str, str] | None:
     """Return the isolated subprocess environment, or ``None`` when no isolation.
 
     When *execution_cwd* differs from *cwd* (the disposable-clone case), the
@@ -199,25 +211,56 @@ def _isolated_child_env(cwd: Path, execution_cwd: Path) -> dict[str, str] | None
     vars that could point the clone's git ops at the source. On Darwin only
     (issue #1122), the directory of the parent-resolved real git binary is
     prepended to the child PATH so the sandboxed child bypasses the xcrun shim;
-    resolution failure leaves PATH unchanged (fail-open). Returns ``None``
-    when the process runs in *cwd* unchanged (nothing to strip). The isolation is
+    resolution failure leaves PATH unchanged (fail-open). When the process runs
+    in *cwd* unchanged, an explicit base environment is returned intact; the
+    ordinary ambient-inheritance path returns ``None``. The isolation is
     path-hiding, not physical — a model that independently discovers the source
     path could still write to its refs.
     """
     if execution_cwd == cwd:
-        return None
-    child_env = os.environ.copy()
+        return dict(base_environment) if base_environment is not None else None
+    child_env = (
+        dict(base_environment) if base_environment is not None else os.environ.copy()
+    )
     for var in _GIT_REDIRECT_STRIP_VARS:
         child_env.pop(var, None)
     # Issue #1122: on macOS the default ``git`` on PATH is an xcrun shim that
-    # sprays diagnostic noise when invoked inside the Seatbelt sandbox. Prepend
-    # the parent-resolved real git directory so the child resolves the real
-    # binary directly. Fail-open: when resolution fails, PATH is unchanged.
+    # sprays diagnostic noise when invoked inside the Seatbelt sandbox. An
+    # explicit execution environment gets an uncached probe with that exact
+    # mapping; ordinary callers retain the ambient process cache. Fail-open:
+    # when resolution fails, PATH is unchanged.
     if sys.platform == "darwin":
-        real_git_dir = _resolve_real_git_dir()
+        real_git_dir = (
+            _probe_real_git_dir(child_env)
+            if base_environment is not None
+            else _resolve_real_git_dir()
+        )
         if real_git_dir and "PATH" in child_env:
             child_env["PATH"] = real_git_dir + os.pathsep + child_env["PATH"]
     return child_env
+
+
+def _resolved_prices_for_execution(
+    execution_input: BackendExecutionInput | None,
+) -> dict[str, ModelPrice]:
+    """Load per-turn prices from the owning run environment.
+
+    Ordinary direct callers retain the ambient override behavior. An injected
+    execution environment is complete, so absence of both its explicit prices
+    path and HOME means built-in pricing with no user override.
+    """
+    if execution_input is None:
+        return resolve_prices(load_user_prices())
+
+    environment = execution_input.child_environment()
+    prices_path = environment.get("DAYDREAM_PRICES_FILE")
+    if prices_path:
+        overrides = load_user_prices(Path(prices_path))
+    elif home := environment.get("HOME"):
+        overrides = load_user_prices(Path(home) / ".daydream" / "prices.toml")
+    else:
+        overrides = {}
+    return resolve_prices(overrides)
 
 
 def _rebind_source_paths(prompt: str, source: Path, execution: Path) -> str:
@@ -428,10 +471,23 @@ class CodexBackend:
     # summaries inlined rather than pointed at on-disk artifact files.
     read_only_disposable_clone = True
 
-    def __init__(self, model: str, reasoning_effort: str | None = None):
+    def __init__(
+        self,
+        model: str,
+        reasoning_effort: str | None = None,
+        *,
+        execution_input: BackendExecutionInput | None = None,
+    ):
         self.model = model
         self.reasoning_effort = reasoning_effort
-        self.fanout_concurrency = resolve_fanout_concurrency("DAYDREAM_FANOUT_CONCURRENCY", 8)
+        self._execution_input = execution_input
+        if execution_input is not None:
+            self.fanout_concurrency = execution_input.fanout_concurrency
+            self.retry_policy = execution_input.retry_policy
+        else:
+            self.fanout_concurrency = resolve_fanout_concurrency(
+                "DAYDREAM_FANOUT_CONCURRENCY", 8
+            )
         self._transports: list[CliTransport] = []
         # Disposable read-only checkouts shared across concurrent execute() calls
         # (built once per cwd, refcounted; cleaned up when the last holder exits).
@@ -672,7 +728,17 @@ class CodexBackend:
             # Built off the event loop (asyncio.to_thread, like the sibling git
             # calls above): the env copy and the bounded xcrun resolution must
             # never stall concurrent fan-out execute() calls.
-            child_env = await asyncio.to_thread(_isolated_child_env, cwd, execution_cwd)
+            base_environment = (
+                self._execution_input.child_environment()
+                if self._execution_input is not None
+                else None
+            )
+            child_env = await asyncio.to_thread(
+                _isolated_child_env,
+                cwd,
+                execution_cwd,
+                base_environment=base_environment,
+            )
 
             if execution_cwd != cwd:
                 # Rebind the prompt so no rendering of the caller's source
@@ -721,7 +787,11 @@ class CodexBackend:
             self._transports.append(transport)
             await transport.start()
 
-            idle_timeout_s = stream_idle_timeout_s()
+            idle_timeout_s = (
+                self._execution_input.stream_idle_timeout_s
+                if self._execution_input is not None
+                else stream_idle_timeout_s()
+            )
             async for raw_line in transport.lines(lambda: idle_timeout_s):
                 try:
                     event = json.loads(raw_line)
@@ -1113,7 +1183,7 @@ class CodexBackend:
                         total_input_tokens=in_tok or 0,
                         cached_input_tokens=cached_tokens or 0,
                         output_tokens=out_tok or 0,
-                        prices=resolve_prices(load_user_prices()),
+                        prices=_resolved_prices_for_execution(self._execution_input),
                     )
                     if in_tok is not None and out_tok is not None:
                         yield MetricsEvent(

--- a/daydream/backends/pi.py
+++ b/daydream/backends/pi.py
@@ -37,6 +37,7 @@ from typing import Any
 
 from daydream.backends import (
     AgentEvent,
+    BackendExecutionInput,
     ContinuationToken,
     CostEvent,
     GenerationEndEvent,
@@ -116,15 +117,28 @@ def _read_pi_default_model(path: Path) -> str | None:
     return model.strip() if isinstance(model, str) and model.strip() else None
 
 
-def _configured_pi_model(cwd: Path) -> str | None:
+_AMBIENT_AGENT_DIR = object()
+
+
+def _configured_pi_model(
+    cwd: Path, *, agent_dir: Path | None | object = _AMBIENT_AGENT_DIR
+) -> str | None:
     """Return the effective Pi settings default, if one is configured.
 
     Pi merges project settings over global settings. We mirror only the
     ``defaultModel`` field because that is the setting daydream must not replace
     with its DeepSeek fallback.
     """
-    agent_dir = Path(os.environ.get("PI_CODING_AGENT_DIR", Path.home() / ".pi" / "agent"))
-    settings_paths = (cwd / ".pi" / "settings.json", agent_dir / "settings.json")
+    if agent_dir is _AMBIENT_AGENT_DIR:
+        resolved_agent_dir: Path | None = Path(
+            os.environ.get("PI_CODING_AGENT_DIR", Path.home() / ".pi" / "agent")
+        )
+    else:
+        assert agent_dir is None or isinstance(agent_dir, Path)
+        resolved_agent_dir = agent_dir
+    settings_paths = [cwd / ".pi" / "settings.json"]
+    if resolved_agent_dir is not None:
+        settings_paths.append(resolved_agent_dir / "settings.json")
     for settings_path in settings_paths:
         model = _read_pi_default_model(settings_path)
         if model:
@@ -476,6 +490,7 @@ class PiBackend:
         *,
         cwd: Path | None = None,
         reasoning_effort: str | None = None,
+        execution_input: BackendExecutionInput | None = None,
     ):
         """Initialize the backend with an optional explicit model override.
 
@@ -488,21 +503,36 @@ class PiBackend:
         """
         self._model_override = model
         self.reasoning_effort = reasoning_effort
+        self._execution_input = execution_input
         # ``.model`` must be resolved at construction (runner/recorder read it
         # before execute); cache the settings lookup so execute() need not
         # re-read settings.json for the same workspace.
         self._configured_cache: tuple[Path, str | None] | None = None
         configured: str | None = None
         if model is None and cwd is not None:
-            configured = _configured_pi_model(cwd)
+            configured = _configured_pi_model(
+                cwd,
+                agent_dir=(
+                    execution_input.pi_agent_dir
+                    if execution_input is not None
+                    else _AMBIENT_AGENT_DIR
+                ),
+            )
             self._configured_cache = (cwd, configured)
         self.model = model or configured or DEFAULT_PI_MODEL
-        self.fanout_concurrency = resolve_fanout_concurrency(
-            "DAYDREAM_PI_FANOUT_CONCURRENCY", _PI_DEFAULT_FANOUT_CONCURRENCY
-        )
-        self.retry_attempts = _pi_retry_attempts()
-        self.retry_base_delay_s = _pi_retry_base_delay()
-        self.retry_max_delay_s = _pi_retry_max_delay()
+        if execution_input is not None:
+            self.fanout_concurrency = execution_input.fanout_concurrency
+            self.retry_policy = execution_input.retry_policy
+            self.retry_attempts = self.retry_policy.attempts
+            self.retry_base_delay_s = self.retry_policy.base_delay_s
+            self.retry_max_delay_s = self.retry_policy.max_delay_s
+        else:
+            self.fanout_concurrency = resolve_fanout_concurrency(
+                "DAYDREAM_PI_FANOUT_CONCURRENCY", _PI_DEFAULT_FANOUT_CONCURRENCY
+            )
+            self.retry_attempts = _pi_retry_attempts()
+            self.retry_base_delay_s = _pi_retry_base_delay()
+            self.retry_max_delay_s = _pi_retry_max_delay()
         self._transports: list[CliTransport] = []
 
     async def execute(
@@ -555,7 +585,11 @@ class PiBackend:
         if self._model_override is not None:
             self.model = self._model_override
             args.extend(["--model", self.model])
-            provider = os.environ.get("PI_PROVIDER")
+            provider = (
+                self._execution_input.pi_provider
+                if self._execution_input is not None
+                else os.environ.get("PI_PROVIDER")
+            )
             if provider is None:
                 provider = _PI_DEFAULT_PROVIDER
                 if self.model.casefold().startswith("glm-"):
@@ -577,11 +611,22 @@ class PiBackend:
             if self._configured_cache is not None and self._configured_cache[0] == cwd:
                 configured_model = self._configured_cache[1]
             else:
-                configured_model = _configured_pi_model(cwd)
+                configured_model = _configured_pi_model(
+                    cwd,
+                    agent_dir=(
+                        self._execution_input.pi_agent_dir
+                        if self._execution_input is not None
+                        else _AMBIENT_AGENT_DIR
+                    ),
+                )
             self.model = configured_model or DEFAULT_PI_MODEL
             if configured_model is None:
                 args.extend(["--model", self.model])
-            provider = os.environ.get("PI_PROVIDER")
+            provider = (
+                self._execution_input.pi_provider
+                if self._execution_input is not None
+                else os.environ.get("PI_PROVIDER")
+            )
             if provider is None and configured_model is None:
                 provider = _PI_DEFAULT_PROVIDER
             elif configured_model is None and provider and provider != _PI_DEFAULT_PROVIDER:
@@ -603,14 +648,22 @@ class PiBackend:
                     _PI_DEFAULT_PROVIDER,
                 )
 
-        api_key = os.environ.get("PI_API_KEY")
-        thinking = self.reasoning_effort or os.environ.get("PI_THINKING")
+        child_env = (
+            self._execution_input.child_environment()
+            if self._execution_input is not None
+            else os.environ.copy()
+        )
+        api_key = child_env.get("PI_API_KEY")
+        thinking = self.reasoning_effort or (
+            self._execution_input.pi_thinking
+            if self._execution_input is not None
+            else os.environ.get("PI_THINKING")
+        )
         if provider:
             args.extend(["--provider", provider])
         if thinking:
             args.extend(["--thinking", thinking])
 
-        child_env = os.environ.copy()
         child_env.pop("PI_API_KEY", None)
         if api_key:
             native_key_name = _PI_PROVIDER_API_KEY_ENV.get(provider.casefold()) if provider else None
@@ -745,8 +798,18 @@ class PiBackend:
             self._transports.append(transport)
             await transport.start()
 
-            response_idle_timeout_s = stream_idle_timeout_s(default=DEFAULT_PI_RESPONSE_IDLE_TIMEOUT_S)
-            tool_idle_timeout_s = stream_idle_timeout_s(default=DEFAULT_STREAM_IDLE_TIMEOUT_S)
+            if self._execution_input is not None:
+                response_idle_timeout_s = (
+                    self._execution_input.pi_response_idle_timeout_s
+                )
+                tool_idle_timeout_s = self._execution_input.stream_idle_timeout_s
+            else:
+                response_idle_timeout_s = stream_idle_timeout_s(
+                    default=DEFAULT_PI_RESPONSE_IDLE_TIMEOUT_S
+                )
+                tool_idle_timeout_s = stream_idle_timeout_s(
+                    default=DEFAULT_STREAM_IDLE_TIMEOUT_S
+                )
             active_tool_calls = 0
             is_first_line = True
             async for raw_line in transport.lines(

--- a/daydream/benchmark/harbor/entrypoint.py
+++ b/daydream/benchmark/harbor/entrypoint.py
@@ -22,12 +22,16 @@ import json
 import os
 import sys
 import urllib.parse
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Mapping
 
+from daydream.backends import BackendExecutionInput
 from daydream.benchmark.harbor import candidate
 from daydream.config_file import DaydreamFileConfig
-from daydream.runner import RunConfig
+from daydream.git_ops import StaticGitHubAuth
+from daydream.github_app import GitHubExecutionInput
+from daydream.runner import RunConfig, RunnerExecutionInput
 
 _DEFAULT_REPO_DIR = "/workspace/repo"
 _DEFAULT_ARTIFACT_PATH = "/logs/artifacts/review.json"
@@ -61,104 +65,79 @@ class EntrypointError(Exception):
     """
 
 
-def build_run_config(
-    repo_dir: str,
-    trajectory_path: str | Path,
-    *,
-    backend: str,
-    model: str | None,
-    base_ref: str = "base",
-) -> RunConfig:
-    """Build the fully controlled in-process :class:`RunConfig`.
+@dataclass(frozen=True)
+class ParsedReviewerInput:
+    """Validated container controls and opaque per-run execution inputs."""
 
-    Review-only (``output_mode="review"``), headless, with archiving and
-    evaluation disabled and a controlled-empty :class:`DaydreamFileConfig` so
-    the target repository's ``.daydream.toml`` is never loaded. ``findings_out``
-    stays ``None`` -- the ``--findings-out`` emission path performs a live PR
-    lookup and must be forbidden for an offline snapshot. ``base_ref`` carries
-    the ``DAYDREAM_REVIEW_BASE_REF`` value rendered into the container env.
-
-    The review profile is resolved through the Harbor explicit-only resolver
-    (R10): the control-plane ``DAYDREAM_REVIEW_PROFILE_CANDIDATE`` env (or the
-    packaged default) is parsed + validated BEFORE the run, so an invalid
-    candidate aborts here — no review ever starts and no artifact is written.
-    The target repo's own config can never change the candidate.
-
-    Raises:
-        EntrypointError: On an invalid review-profile candidate (the process
-            exits non-zero and ``publish_review`` is never reached).
-    """
-    from daydream.review_profile import ProfileError, resolve_harbor_profile
-
-    try:
-        resolved = resolve_harbor_profile(candidate_env=_CANDIDATE_ENV)
-    except ProfileError as exc:
-        raise EntrypointError(
-            f"invalid review-profile candidate: {exc}"
-        ) from exc
-    config = RunConfig(
-        target=str(repo_dir),
-        output_mode="review",
-        base=base_ref,
-        non_interactive=True,
-        archive=False,
-        run_eval=False,
-        findings_out=None,
-        trajectory_path=Path(trajectory_path),
-        backend=backend,
-        model=model,
-        file_config=DaydreamFileConfig(),
-    )
-    config.review_profile = resolved
-    return config
+    backend: str
+    model: str | None
+    repo_dir: Path
+    artifact_path: Path
+    trajectory_path: Path
+    case_id: str
+    base_ref: str
+    head_ref: str
+    profile_candidate: str | None
+    execution: RunnerExecutionInput = field(repr=False, compare=False)
 
 
-def require_supported_backend() -> str:
-    """Refuse any backend other than ``pi`` or ``claude``, before any reviewing.
+_GITHUB_CREDENTIAL_VARS = (
+    "GITHUB_TOKEN",
+    "GH_TOKEN",
+    "GITHUB_ENTERPRISE_TOKEN",
+    "GH_ENTERPRISE_TOKEN",
+    "GH_HOST",
+    "DAYDREAM_APP_ID",
+    "DAYDREAM_APP_PRIVATE_KEY",
+)
+_UNSELECTED_PI_CREDENTIALS = ("ZAI_API_KEY", "NOUS_API_KEY")
+_SCRUB_PREFIXES = (
+    "DAYDREAM_JUDGE_",
+    "ANTHROPIC_",
+    "CLAUDE_CODE_",
+    "OPENAI_",
+    "OPENROUTER_",
+    "PI_",
+    "DAYDREAM_APP_",
+)
 
-    Reads ``DAYDREAM_REVIEW_BACKEND`` (default ``"pi"``). An unsupported
-    backend raises :class:`EntrypointError` before tools are installed or
-    network access is widened.
-    """
-    backend = os.environ.get(_BACKEND_ENV, "pi").strip().lower()
+
+def require_supported_backend(environment: Mapping[str, str]) -> str:
+    """Validate the selected Harbor reviewer backend from its container map."""
+    backend = environment.get(_BACKEND_ENV, "pi").strip().lower()
     if backend not in _SUPPORTED_BACKENDS:
-        supported = ", ".join(repr(b) for b in _SUPPORTED_BACKENDS)
+        supported = ", ".join(repr(item) for item in _SUPPORTED_BACKENDS)
         raise EntrypointError(
             f"unsupported DAYDREAM_REVIEW_BACKEND={backend!r}; supported backends: {supported}"
         )
     return backend
 
 
+def _required_env(environment: Mapping[str, str], name: str) -> str:
+    value = environment.get(name, "").strip()
+    if not value:
+        raise EntrypointError(f"missing required environment variable {name!r}")
+    return value
 
-def apply_reviewer_env(env: Mapping[str, str] | None = None, *, backend: str = "pi") -> None:
-    """Map only reviewer config/credential into the selected backend's env.
 
-    The mapping is backend-aware. For ``pi`` (default) the reviewer is
-    intentionally OpenRouter-only: the control-plane credential becomes Pi's
-    generic ``PI_API_KEY`` and the Daydream Pi backend maps it to
-    ``OPENROUTER_API_KEY`` only in the child process. For ``claude`` the
-    ``ANTHROPIC_API_KEY`` / ``ANTHROPIC_AUTH_TOKEN`` / ``ANTHROPIC_BASE_URL``
-    credentials are preserved into the environment and the openrouter.ai
-    base-URL requirement does not apply (any HTTPS ``ANTHROPIC_BASE_URL`` with
-    a concrete hostname is accepted). In both branches any inherited raw provider or judge credential
-    is cleared first so it cannot leak into the reviewed scope; a bad base URL
-    or a missing credential fails closed.
+def _sanitize_reviewer_environment(
+    environment: Mapping[str, str], *, backend: str,
+) -> dict[str, str]:
+    """Return a native backend map with all unrelated credentials removed."""
+    source = dict(environment)
+    sanitized = {
+        key: value
+        for key, value in source.items()
+        if key not in _GITHUB_CREDENTIAL_VARS
+        and key not in _UNSELECTED_PI_CREDENTIALS
+        and not any(key.startswith(prefix) for prefix in _SCRUB_PREFIXES)
+    }
+    # Credentials are mapped into the backend-native names below. Keeping their
+    # control-plane aliases would let downstream code choose an ambient path.
+    sanitized.pop(_API_KEY_ENV, None)
+    sanitized.pop(_BASE_URL_ENV, None)
+    sanitized.pop("DAYDREAM_SKILLS_DIR", None)
 
-    The caller must pass an already-validated *backend* (see
-    :func:`require_supported_backend`); credential mapping never substitutes a
-    fallback for a missing credential.
-    """
-    source = dict(os.environ if env is None else env)
-    for prefix in (
-        "DAYDREAM_JUDGE_",
-        "ANTHROPIC_",
-        "CLAUDE_CODE_",
-        "OPENAI_",
-        "OPENROUTER_",
-        "PI_",
-    ):
-        for key in [k for k in os.environ if k.startswith(prefix)]:
-            os.environ.pop(key, None)
     if backend == "claude":
         api_key = (source.get("ANTHROPIC_API_KEY") or "").strip()
         auth_token = (source.get("ANTHROPIC_AUTH_TOKEN") or "").strip()
@@ -176,15 +155,14 @@ def apply_reviewer_env(env: Mapping[str, str] | None = None, *, backend: str = "
                 or parsed.username is not None
                 or parsed.password is not None
             ):
-                raise EntrypointError(
-                    "ANTHROPIC_BASE_URL must be an HTTPS endpoint"
-                )
-            os.environ["ANTHROPIC_BASE_URL"] = base_url
+                raise EntrypointError("ANTHROPIC_BASE_URL must be an HTTPS endpoint")
+            sanitized["ANTHROPIC_BASE_URL"] = base_url
         if api_key:
-            os.environ["ANTHROPIC_API_KEY"] = api_key
+            sanitized["ANTHROPIC_API_KEY"] = api_key
         if auth_token:
-            os.environ["ANTHROPIC_AUTH_TOKEN"] = auth_token
-        return
+            sanitized["ANTHROPIC_AUTH_TOKEN"] = auth_token
+        return sanitized
+
     api_key = (source.get(_API_KEY_ENV) or "").strip()
     base_url = (source.get(_BASE_URL_ENV) or "").strip()
     if not base_url:
@@ -205,16 +183,78 @@ def apply_reviewer_env(env: Mapping[str, str] | None = None, *, backend: str = "
         raise EntrypointError(
             "missing required environment variable 'DAYDREAM_REVIEW_API_KEY'"
         )
-    os.environ["PI_PROVIDER"] = "openrouter"
-    os.environ["PI_API_KEY"] = api_key
-    os.environ["PI_TELEMETRY"] = "0"
+    sanitized["PI_PROVIDER"] = "openrouter"
+    sanitized["PI_API_KEY"] = api_key
+    sanitized["PI_TELEMETRY"] = "0"
+    for control in ("PI_THINKING", "PI_CODING_AGENT_DIR"):
+        if control in source:
+            sanitized[control] = source[control]
+    return sanitized
 
 
-def _required_env(name: str) -> str:
-    value = os.environ.get(name, "").strip()
-    if not value:
-        raise EntrypointError(f"missing required environment variable {name!r}")
-    return value
+def parse_reviewer_environment(environment: Mapping[str, str]) -> ParsedReviewerInput:
+    """Parse one Harbor container map without reading or mutating process state."""
+    source = dict(environment)
+    backend = require_supported_backend(source)
+    sanitized = _sanitize_reviewer_environment(source, backend=backend)
+    backend_execution = BackendExecutionInput.from_environment(sanitized, backend=backend)
+    github_environment = dict(sanitized)
+    for credential in ("PI_API_KEY", "ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN"):
+        github_environment.pop(credential, None)
+    execution = RunnerExecutionInput(
+        backend=backend_execution,
+        github=GitHubExecutionInput(auth=StaticGitHubAuth(github_environment)),
+    )
+    return ParsedReviewerInput(
+        backend=backend,
+        model=source.get("DAYDREAM_REVIEW_MODEL"),
+        repo_dir=Path(source.get(_REPO_DIR_ENV, _DEFAULT_REPO_DIR)),
+        artifact_path=Path(source.get(_ARTIFACT_PATH_ENV, _DEFAULT_ARTIFACT_PATH)),
+        trajectory_path=Path(source.get(_TRAJECTORY_PATH_ENV, str(_DEFAULT_TRAJECTORY_PATH))),
+        case_id=_required_env(source, _CASE_ID_ENV),
+        base_ref=source.get(_BASE_REF_ENV, "base").strip() or "base",
+        head_ref=source.get(_HEAD_REF_ENV, "head").strip() or "head",
+        profile_candidate=source.get(_CANDIDATE_ENV) or None,
+        execution=execution,
+    )
+
+
+def build_run_config(
+    repo_dir: str | Path,
+    trajectory_path: str | Path,
+    *,
+    backend: str,
+    model: str | None,
+    profile_candidate: str | None,
+    base_ref: str = "base",
+) -> RunConfig:
+    """Build the fixed review configuration from already parsed controls."""
+    from daydream.review_profile import ProfileError, resolve_harbor_profile
+
+    try:
+        profile_environment = (
+            {} if profile_candidate is None else {_CANDIDATE_ENV: profile_candidate}
+        )
+        resolved = resolve_harbor_profile(
+            candidate_env=_CANDIDATE_ENV, env=profile_environment
+        )
+    except ProfileError as exc:
+        raise EntrypointError(f"invalid review-profile candidate: {exc}") from exc
+    config = RunConfig(
+        target=str(repo_dir),
+        output_mode="review",
+        base=base_ref,
+        non_interactive=True,
+        archive=False,
+        run_eval=False,
+        findings_out=None,
+        trajectory_path=Path(trajectory_path),
+        backend=backend,
+        model=model,
+        file_config=DaydreamFileConfig(),
+    )
+    config.review_profile = resolved
+    return config
 
 
 def publish_review(
@@ -225,13 +265,7 @@ def publish_review(
     base_ref: str = "base",
     head_ref: str = "head",
 ) -> None:
-    """Publish the candidate artifact from the runner's merged-items output.
-
-    Locates ``<repo_dir>/.daydream/deep/merged-items.json``; raises
-    :class:`CandidateError` (via its ``kind``) on a missing/corrupt merged
-    output, an over-limit candidate set, or a failed artifact write -- never
-    silently truncates or substitutes a fallback artifact.
-    """
+    """Publish the candidate artifact from the runner's merged-items output."""
     repo_dir = Path(repo_dir)
     merged = repo_dir / ".daydream" / "deep" / "merged-items.json"
     try:
@@ -259,45 +293,28 @@ def publish_review(
     candidate.write_candidate_artifact_atomic(artifact_path, artifact)
 
 
-async def main(*, monkeypatch_env: Mapping[str, str] | None = None) -> int:
-    """Run the in-process reviewer and publish the candidate artifact.
-
-    Returns an exit code (0 on a completed review, non-zero on any failure).
-    *monkeypatch_env* is a test-only seam overriding/augmenting the process
-    environment from the caller; production defaults remain the fixed
-    in-container paths.
-    """
-    saved_env = None
-    if monkeypatch_env is not None:
-        saved_env = os.environ.copy()
-        for key, value in monkeypatch_env.items():
-            os.environ[key] = value
+async def main(environment: Mapping[str, str]) -> int:
+    """Run one parsed Harbor container input and publish its candidate artifact."""
     try:
-        backend = require_supported_backend()
-        apply_reviewer_env(backend=backend)
-        case_id = _required_env(_CASE_ID_ENV)
-        repo_dir = os.environ.get(_REPO_DIR_ENV, _DEFAULT_REPO_DIR)
-        artifact_path = os.environ.get(_ARTIFACT_PATH_ENV, _DEFAULT_ARTIFACT_PATH)
-        trajectory_path = os.environ.get(_TRAJECTORY_PATH_ENV, str(_DEFAULT_TRAJECTORY_PATH))
-        base_ref = os.environ.get(_BASE_REF_ENV, "base").strip() or "base"
-        head_ref = os.environ.get(_HEAD_REF_ENV, "head").strip() or "head"
+        parsed = parse_reviewer_environment(environment)
         config = build_run_config(
-            repo_dir=repo_dir,
-            trajectory_path=trajectory_path,
-            backend=backend,
-            model=os.environ.get("DAYDREAM_REVIEW_MODEL"),
-            base_ref=base_ref,
+            repo_dir=parsed.repo_dir,
+            trajectory_path=parsed.trajectory_path,
+            backend=parsed.backend,
+            model=parsed.model,
+            profile_candidate=parsed.profile_candidate,
+            base_ref=parsed.base_ref,
         )
         from daydream import runner
 
-        if await runner.run(config) != 0:
+        if await runner.run(config, execution=parsed.execution) != 0:
             raise EntrypointError("daydream runner exited non-zero")
         publish_review(
-            repo_dir=repo_dir,
-            artifact_path=artifact_path,
-            case_id=case_id,
-            base_ref=base_ref,
-            head_ref=head_ref,
+            repo_dir=parsed.repo_dir,
+            artifact_path=parsed.artifact_path,
+            case_id=parsed.case_id,
+            base_ref=parsed.base_ref,
+            head_ref=parsed.head_ref,
         )
         return 0
     except (EntrypointError, candidate.CandidateError) as exc:
@@ -306,13 +323,7 @@ async def main(*, monkeypatch_env: Mapping[str, str] | None = None) -> int:
             file=sys.stderr,
         )
         return 1
-    finally:
-        # Test-only seam hygiene: never leak monkeypatched vars (or the
-        # reviewer env vars) into the surrounding process after main returns.
-        if saved_env is not None:
-            os.environ.clear()
-            os.environ.update(saved_env)
 
 
 if __name__ == "__main__":
-    raise SystemExit(asyncio.run(main()))
+    raise SystemExit(asyncio.run(main(dict(os.environ))))

--- a/daydream/deep/orchestrator.py
+++ b/daydream/deep/orchestrator.py
@@ -136,7 +136,7 @@ from daydream.eval.analyzer import _agent_label, _records_issues_or_empty, load_
 from daydream.extensions import get_registry
 from daydream.extensions.api import BreakLoop, FlowStep, Stop
 from daydream.fix_footprint import AuthorizedFixFootprint
-from daydream.flows.engine import FlowContext, run_flow
+from daydream.flows.engine import BackendFactory, FlowContext, run_flow
 from daydream.generated_files import (
     is_generated_file,
     related_manifest_paths,
@@ -5571,6 +5571,7 @@ async def run_deep(
     run_artifacts: _RunArtifacts | None = None,
     run_context: RunContext | None = None,
     github_execution: GitHubExecutionInput | None = None,
+    backend_factory: BackendFactory | None = None,
 ) -> int:
     """Execute the deep-review pipeline (D-07) across every PR-process mode.
 
@@ -5604,6 +5605,7 @@ async def run_deep(
         run_artifacts=run_artifacts,
         run_context=run_context,
         github_execution=execution,
+        backend_factory=backend_factory,
     )
 
 
@@ -5672,6 +5674,7 @@ async def _run_review_spine(
     run_artifacts: _RunArtifacts | None,
     run_context: RunContext | None = None,
     github_execution: GitHubExecutionInput,
+    backend_factory: BackendFactory | None = None,
 ) -> int:
     """Review-spine preamble for the deep pipeline (the former ``run_deep`` body)."""
     run_context = resolve_run_context(run_context)
@@ -5924,6 +5927,7 @@ async def _run_review_spine(
             artifacts=None if run_artifacts is None else run_artifacts.session,
             run_context=run_context,
             github_execution=github_execution,
+            _backend_factory=backend_factory,
             data={
                 "mode": mode,
                 "diff": bounded_diff,

--- a/daydream/flows/engine.py
+++ b/daydream/flows/engine.py
@@ -11,6 +11,7 @@ bodies, exactly where the flow helpers' try/excepts sit today.
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -38,6 +39,10 @@ if TYPE_CHECKING:
     from daydream.workspace import AuditWorkspace, WorkContext
 
 
+type BackendCache = dict[tuple[str, str | None, str | None, Path | None], Backend]
+type BackendFactory = Callable[[RunConfig, str, BackendCache, Path, AuditWorkspace | None], Backend]
+
+
 @dataclass
 class FlowContext:
     """Shared state a flow's steps read and write.
@@ -58,6 +63,9 @@ class FlowContext:
             Omitted by standalone extensions, it inherits the parent environment.
             This runtime capability is excluded from repr and must not enter data
             or artifact serializers.
+        _backend_factory: Runner-bound transport factory. It receives this
+            context's configuration, cache, workspace, and audit boundary;
+            omission keeps ordinary backend resolution.
     """
 
     config: RunConfig
@@ -72,9 +80,10 @@ class FlowContext:
     github_execution: GitHubExecutionInput = field(
         default_factory=GitHubExecutionInput, repr=False, compare=False, kw_only=True,
     )
-    _backend_cache: dict[
-        tuple[str, str | None, str | None, Path | None], Backend
-    ] = field(
+    _backend_factory: BackendFactory | None = field(
+        default=None, repr=False, compare=False, kw_only=True,
+    )
+    _backend_cache: BackendCache = field(
         default_factory=dict, repr=False
     )
 
@@ -86,6 +95,11 @@ class FlowContext:
         ``(backend_name, model, reasoning_effort, audit_root)`` tuple for the
         lifetime of this context.
         """
+        if self._backend_factory is not None:
+            return self._backend_factory(
+                self.config, phase, self._backend_cache, self.work.repo, self.audit_workspace,
+            )
+
         from daydream.runner import _resolve_backend
 
         return _resolve_backend(

--- a/daydream/runner.py
+++ b/daydream/runner.py
@@ -56,6 +56,7 @@ from daydream.backends import (
     AUDIT_ROOT_ISOLATION_V1,
     AuditIsolationError,
     Backend,
+    BackendExecutionInput,
     create_backend,
 )
 from daydream.config import EFFORT_TIERS, PHASE_DEFAULT_EFFORT, PHASE_DEFAULT_MODELS, REVIEW_OUTPUT_FILE
@@ -68,6 +69,7 @@ from daydream.extensions import (
     set_registry,
 )
 from daydream.flows import FlowContext, run_flow
+from daydream.flows.engine import BackendCache, BackendFactory
 from daydream.git_ops import GitError
 from daydream.hunk_index import write_hunk_index
 from daydream.observability.config import (
@@ -113,6 +115,18 @@ if TYPE_CHECKING:
 # comments and exits; ``review`` writes a report and exits; ``diagram``
 # (issue #1113) runs the diagram-only flow and posts a standalone comment.
 OutputMode = Literal["loop", "comment", "review", "diagram"]
+
+
+@dataclass(frozen=True)
+class RunnerExecutionInput:
+    """Runtime-only backend and GitHub capabilities for an embedded run.
+
+    Kept outside RunConfig and all persisted run metadata. Ordinary callers
+    omit this input and retain native environment inheritance.
+    """
+
+    backend: BackendExecutionInput = field(repr=False, compare=False)
+    github: github_app.GitHubExecutionInput = field(repr=False, compare=False)
 
 
 @dataclass
@@ -777,12 +791,11 @@ def _resolved_reasoning_effort(config: RunConfig, phase: str) -> str | None:
 def _resolve_backend(
     config: RunConfig,
     phase: str,
-    cache: dict[
-        tuple[str, str | None, str | None, Path | None], Backend
-    ] | None = None,
+    cache: BackendCache | None = None,
     *,
     cwd: Path | None = None,
     audit_workspace: AuditWorkspace | None = None,
+    execution_input: BackendExecutionInput | None = None,
 ) -> Backend:
     """Get or create the backend for a given phase, respecting all precedence tiers.
 
@@ -815,6 +828,8 @@ def _resolve_backend(
             differing models, effort levels, or audit roots yield distinct
             instances.
         cwd: Target workspace used for backend-specific configuration.
+        execution_input: Optional immutable settings for native transports.
+            The owning FlowContext keeps the cache local to this input.
     """
     backend_name = _resolved_backend_name(config, phase)
     resolved_model = _resolved_model(config, phase)
@@ -831,6 +846,16 @@ def _resolve_backend(
     )
 
     def _make() -> Backend:
+        if execution_input is not None:
+            return create_backend(
+                backend_name,
+                model=resolved_model,
+                cwd=cwd if backend_name == "pi" else None,
+                reasoning_effort=resolved_effort,
+                audit_root=audit_root,
+                audit_outward_symlinks=audit_outward_symlinks,
+                execution_input=execution_input,
+            )
         # ``cwd`` stays pi-only: it exists solely to resolve Pi's configured
         # default model, and widening it churns every patched create_backend.
         if backend_name == "pi":
@@ -995,7 +1020,10 @@ def _run_posts_to_github(config: RunConfig) -> bool:
 # Public entry points
 
 
-async def run(config: RunConfig | None = None, *, private_roots: PrivateRootLocations | None = None) -> int:
+async def run(
+    config: RunConfig | None = None, *, private_roots: PrivateRootLocations | None = None,
+    execution: RunnerExecutionInput | None = None,
+) -> int:
     """Execute a daydream run end-to-end.
 
     Opens the workspace via :func:`open_workspace` and dispatches to the single
@@ -1006,9 +1034,27 @@ async def run(config: RunConfig | None = None, *, private_roots: PrivateRootLoca
     Args:
         config: Optional configuration. Defaults to a fresh :class:`RunConfig`
             (interactive prompts for target dir, skill, cleanup).
+        execution: Optional immutable execution capabilities for an embedded
+            caller. Backend transports and GitHub requests use its complete
+            environments. Omission preserves ordinary CLI inheritance.
     """
     if config is None:
         config = RunConfig()
+
+    backend_factory: BackendFactory | None = None
+    if execution is not None:
+        backend_execution = execution.backend
+
+        def create_for_context(
+            flow_config: RunConfig, phase: str, cache: BackendCache,
+            cwd: Path, audit: AuditWorkspace | None,
+        ) -> Backend:
+            return _resolve_backend(
+                flow_config, phase, cache, cwd=cwd, audit_workspace=audit,
+                execution_input=backend_execution,
+            )
+
+        backend_factory = create_for_context
 
     # Codex backends need shell output visible (the commands ARE the signal), so
     # disable quiet when any phase resolves to codex. Done before backend construction.
@@ -1029,12 +1075,16 @@ async def run(config: RunConfig | None = None, *, private_roots: PrivateRootLoca
     with bind_run_context(run_context):
         return await _run_with_context(
             config, private_roots=private_roots, run_context=run_context,
+            backend_factory=backend_factory,
+            github_execution=None if execution is None else execution.github,
         )
 
 
 async def _run_with_context(
     config: RunConfig, *, private_roots: PrivateRootLocations | None,
     run_context: RunContext,
+    backend_factory: BackendFactory | None = None,
+    github_execution: github_app.GitHubExecutionInput | None = None,
 ) -> int:
     """Execute with the runner's immutable policy bound before any output."""
     print_phase_hero(console, "DAYDREAM", phase_subtitle("DAYDREAM"))
@@ -1094,12 +1144,20 @@ async def _run_with_context(
                 return 1
 
             # Resolve the active GitHub identity only after source ownership
-            # succeeds. Posting flows may acquire an installation token here;
-            # read-only flows preserve the ambient identity.
+            # succeeds. Ordinary posting flows may acquire an installation
+            # token; embedded callers retain their supplied auth capability.
             try:
-                session = github_app.resolve_run_identity(
-                    target_dir, config.pr_repo, is_posting=_run_posts_to_github(config),
-                )
+                if github_execution is None:
+                    session = github_app.resolve_run_identity(
+                        target_dir, config.pr_repo, is_posting=_run_posts_to_github(config),
+                    )
+                else:
+                    session = github_app.ResolvedGitHubSession(
+                        identity=github_app.GitHubIdentity(github_app.resolve_user_identity(
+                            target_dir, auth=github_execution.auth,
+                        )),
+                        execution=github_execution,
+                    )
             except github_app.GitHubAppError as exc:
                 print_error(console, "GitHub App", str(exc))
                 observed.finish(1)
@@ -1113,6 +1171,7 @@ async def _run_with_context(
             result = await _run_workspace(
                 config, target_dir, skip_tests=skip_tests, private_owner=private_owner,
                 run_context=run_context, github_execution=session.execution,
+                backend_factory=backend_factory,
             )
             observed.finish(result)
             return result
@@ -1180,6 +1239,7 @@ async def _run_workspace(
     config: RunConfig, target_dir: Path, *, skip_tests: bool,
     private_owner: PrivateWorkspaceOwner, run_context: RunContext,
     github_execution: github_app.GitHubExecutionInput,
+    backend_factory: BackendFactory | None = None,
 ) -> int:
     """Keep workspace errors inside the run span so returned failures are recorded."""
     # ``open_workspace`` runs ``assert_is_worktree`` and surfaces
@@ -1217,7 +1277,7 @@ async def _run_workspace(
                 try:
                     result = await _dispatch(
                         work, dispatch_config, run_artifacts, run_context=run_context,
-                        github_execution=github_execution,
+                        github_execution=github_execution, backend_factory=backend_factory,
                     )
                 except BaseException as exc:
                     primary = exc
@@ -1312,6 +1372,7 @@ async def _dispatch_selected_flow(
     work: WorkContext, config: RunConfig, run_artifacts: _RunArtifacts, *,
     run_context: RunContext,
     github_execution: github_app.GitHubExecutionInput,
+    backend_factory: BackendFactory | None = None,
 ) -> int:
     """Route an explicit ``--flow <name>`` selection.
 
@@ -1333,10 +1394,12 @@ async def _dispatch_selected_flow(
             _require_reviewable_branch(work, config)
         return await _run_loop_deep(
             work, config, run_artifacts, run_context=run_context, github_execution=github_execution,
+            backend_factory=backend_factory,
         )
     if name == "improve":
         return await _run_improve(
             work, config, run_artifacts, run_context=run_context, github_execution=github_execution,
+            backend_factory=backend_factory,
         )
 
     # Resolve-check first; unknown names raise UnresolvedExtensionError, caught
@@ -1344,6 +1407,7 @@ async def _dispatch_selected_flow(
     get_registry().flow(name)
     return await _run_custom_flow(
         work, config, run_artifacts, run_context=run_context, github_execution=github_execution,
+        backend_factory=backend_factory,
     )
 
 
@@ -1364,6 +1428,7 @@ async def _dispatch(
     work: WorkContext, config: RunConfig, run_artifacts: _RunArtifacts, *,
     run_context: RunContext,
     github_execution: github_app.GitHubExecutionInput,
+    backend_factory: BackendFactory | None = None,
 ) -> int:
     """Verify the approved head, then route to the resolved flow.
 
@@ -1387,6 +1452,7 @@ async def _dispatch(
             raise GitError("unborn checkout cannot satisfy a commit-anchored review")
         return await _run_improve(
             work, config, run_artifacts, run_context=run_context, github_execution=github_execution,
+            backend_factory=backend_factory,
         )
     head_status = _verify_approved_head(work, config)
     if head_status != 0:
@@ -1395,6 +1461,7 @@ async def _dispatch(
     if config.flow_name is not None:
         return await _dispatch_selected_flow(
             work, config, run_artifacts, run_context=run_context, github_execution=github_execution,
+            backend_factory=backend_factory,
         )
 
     # ``diagram`` joins comment/review in skipping ``_require_reviewable_branch``:
@@ -1403,13 +1470,17 @@ async def _dispatch(
     if config.output_mode in ("comment", "review", "diagram"):
         return await _run_loop_deep(
             work, config, run_artifacts, run_context=run_context, github_execution=github_execution,
+            backend_factory=backend_factory,
         )
 
     # output_mode == "loop" (default deep) and --shallow both fix against a
     # base branch, so both must refuse to review the base branch against
     # itself (the guard was shared by loop + shallow pre-collapse, #330).
     _require_reviewable_branch(work, config)
-    return await _run_loop_deep(work, config, run_artifacts, run_context=run_context, github_execution=github_execution)
+    return await _run_loop_deep(
+        work, config, run_artifacts, run_context=run_context, github_execution=github_execution,
+        backend_factory=backend_factory,
+    )
 
 
 def _emit_diagram_findings(
@@ -1559,6 +1630,7 @@ async def _run_improve(
     work: WorkContext, config: RunConfig, run_artifacts: _RunArtifacts, *,
     run_context: RunContext,
     github_execution: github_app.GitHubExecutionInput,
+    backend_factory: BackendFactory | None = None,
 ) -> int:
     """Preamble for the registered repository-wide improve flow."""
     from daydream.improve.artifacts import improve_dir
@@ -1614,6 +1686,7 @@ async def _run_improve(
                 private_workspace_owner=run_artifacts.owner,
                 artifacts=run_artifacts.session,
                 run_context=run_context, github_execution=github_execution,
+                _backend_factory=backend_factory,
             )
             ctx.data["audit_repo"] = audit.repo
             ctx.data["improve_dir"] = directory
@@ -1659,6 +1732,7 @@ async def _run_custom_flow(
     work: WorkContext, config: RunConfig, run_artifacts: _RunArtifacts, *,
     run_context: RunContext,
     github_execution: github_app.GitHubExecutionInput,
+    backend_factory: BackendFactory | None = None,
 ) -> int:
     """Generic preamble for a fork-registered flow selected via ``--flow``.
 
@@ -1698,6 +1772,7 @@ async def _run_custom_flow(
             private_workspace_owner=run_artifacts.owner,
             artifacts=run_artifacts.session,
             run_context=run_context, github_execution=github_execution,
+            _backend_factory=backend_factory,
         )
         ctx.data["post_to_pr"] = False  # custom flows do not post to PR by default
         ctx.data["diff"] = diff
@@ -1724,6 +1799,7 @@ async def _run_loop_deep(
     work: WorkContext, config: RunConfig, run_artifacts: _RunArtifacts, *,
     run_context: RunContext,
     github_execution: github_app.GitHubExecutionInput,
+    backend_factory: BackendFactory | None = None,
 ) -> int:
     """Delegate to the deep-mode orchestrator (the only PR-process flow, #330)."""
     from daydream.deep.orchestrator import run_deep
@@ -1731,4 +1807,5 @@ async def _run_loop_deep(
     _resolve_review_profile(config)
     return await run_deep(
         config, work, run_artifacts=run_artifacts, run_context=run_context, github_execution=github_execution,
+        backend_factory=backend_factory,
     )

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -72,6 +72,21 @@ material in your control.
 - Credentials are **never written into the workspace or the compiled task** —
   they stay in the environment that launched the command.
 
+The in-container reviewer snapshots its environment once at the process entry
+point. Parsing produces immutable runtime inputs for the selected backend and
+GitHub transport, without changing the parent process environment. Native
+subprocesses receive fresh copies of that complete environment, including the
+owning run's provider, retry policy, paths, and idle limits. Concurrent embedded
+reviews therefore keep separate credentials and execution settings.
+
+Harbor removes unrelated provider keys, GitHub tokens, App credentials, and
+`GH_HOST` even for read-only reviews. The GitHub transport also omits the selected
+model provider's credential. Supplied home and configuration paths retain their
+normal filesystem lookup behavior. A profile candidate comes only from the
+explicit control-plane input. These runtime capabilities stay outside
+configuration, artifacts, and trajectories. Ordinary Daydream CLI callers omit
+the runtime input and retain their existing environment inheritance.
+
 ### Privacy rule
 
 Every example in this runbook uses placeholders only: `OWNER/REPO`, `<40-hex>`,

--- a/tests/harness/claude_sdk.py
+++ b/tests/harness/claude_sdk.py
@@ -96,6 +96,18 @@ def patch_claude_sdk(
         result_message: Class the backend treats as ``ResultMessage``.
     """
     monkeypatch.setattr("daydream.backends.claude.ClaudeSDKClient", client_class)
+
+    def _injected_client(
+        *,
+        options: Any,
+        transport: Any,
+        initialize_timeout_s: float,
+    ) -> Any:
+        return client_class(options=options)
+
+    monkeypatch.setattr(
+        "daydream.backends.claude._RunLocalClaudeSDKClient", _injected_client
+    )
     monkeypatch.setattr("daydream.backends.claude.AssistantMessage", assistant_message)
     monkeypatch.setattr("daydream.backends.claude.UserMessage", MockUserMessage)
     monkeypatch.setattr("daydream.backends.claude.ResultMessage", result_message)

--- a/tests/test_agent_retry.py
+++ b/tests/test_agent_retry.py
@@ -10,6 +10,7 @@ import json
 from collections.abc import AsyncIterator
 from io import StringIO
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any, cast
 
 import anyio
@@ -128,6 +129,41 @@ async def test_run_agent_ignores_malformed_retry_environment(monkeypatch: pytest
     )
 
     assert output == "Review complete"
+    assert backend.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_run_agent_uses_backend_retry_policy_without_reading_ambient_environment(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """An injected backend policy is complete; ambient retry values are untouched."""
+    from daydream.backends import RetryPolicy
+
+    backend = _fail_then_succeed(
+        PiError("429 overloaded", retryable=True),
+        text="done",
+    )
+    backend_with_policy: Any = backend
+    backend_with_policy.retry_policy = RetryPolicy(
+        attempts=1, base_delay_s=0.0, max_delay_s=0.0
+    )
+
+    class _ForbiddenEnvironment:
+        def get(self, key: str, default: Any = None) -> Any:
+            if key.startswith("DAYDREAM_PI_RETRY_"):
+                raise AssertionError(f"ambient retry read: {key}")
+            return default
+
+    monkeypatch.setattr(
+        "daydream.agent.os", SimpleNamespace(environ=_ForbiddenEnvironment()),
+    )
+
+    output, _, _ = await run_agent(
+        backend, tmp_path, "review", phase=DaydreamPhase.REVIEW
+    )
+
+    assert output == "done"
     assert backend.call_count == 2
 
 

--- a/tests/test_backend_claude.py
+++ b/tests/test_backend_claude.py
@@ -1,5 +1,6 @@
 """Tests for ClaudeBackend."""
 import json
+import sys
 from collections.abc import AsyncIterator
 from pathlib import Path
 from typing import Any, cast
@@ -91,6 +92,169 @@ def _capturing_client(captured: dict[str, Any]) -> type:
         ],
         captured=captured,
     )
+
+
+@pytest.mark.parametrize(
+    "version_admission_delay_s",
+    [pytest.param(0.0, id="version-completes"), pytest.param(2.1, id="version-times-out")],
+)
+@pytest.mark.asyncio
+async def test_injected_claude_uses_run_local_transport_for_version_and_main_spawn(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    version_admission_delay_s: float,
+) -> None:
+    import anyio
+    from claude_agent_sdk import ClaudeAgentOptions, HookMatcher
+
+    from daydream.backends.claude import (
+        _RunLocalClaudeSDKClient,
+        _RunLocalSubprocessCLITransport,
+    )
+
+    capture = tmp_path / "native-env.jsonl"
+    cli = tmp_path / "claude"
+    cli.write_text(
+        f"#!{sys.executable}\n"
+        "import json, os, sys\n"
+        "with open(os.environ['CAPTURE_LOG'], 'a', encoding='utf-8') as out:\n"
+        "    out.write(json.dumps({'kind': 'env', 'version': '-v' in sys.argv, "
+        "'anthropic': os.environ.get('ANTHROPIC_API_KEY'), "
+        "'ambient': os.environ.get('AMBIENT_ONLY'), "
+        "'path': os.environ.get('PATH'), 'pwd': os.environ.get('PWD')}) + '\\n')\n"
+        "if '-v' in sys.argv:\n"
+        "    print('2.1.0', flush=True)\n"
+        "else:\n"
+        "    for line in sys.stdin:\n"
+        "        message = json.loads(line)\n"
+        "        with open(os.environ['CAPTURE_LOG'], 'a', encoding='utf-8') as out:\n"
+        "            out.write(json.dumps({'kind': 'protocol', 'message': message}) + '\\n')\n"
+        "        if message.get('type') == 'control_request':\n"
+        "            print(json.dumps({'type': 'control_response', 'response': {"
+        "'subtype': 'success', 'request_id': message['request_id'], "
+        "'response': {}}}), flush=True)\n"
+        "        elif message.get('type') == 'user':\n"
+        "            print(json.dumps({'type': 'assistant', 'message': {"
+        "'id': 'm1', 'model': 'fixture-model', 'role': 'assistant', "
+        "'content': [{'type': 'text', 'text': 'OK'}], "
+        "'stop_reason': 'end_turn', 'usage': {}}}), flush=True)\n"
+        "            print(json.dumps({'type': 'result', 'subtype': 'success', "
+        "'duration_ms': 1, 'duration_api_ms': 1, 'is_error': False, "
+        "'num_turns': 1, 'session_id': 's1', 'total_cost_usd': 0, "
+        "'usage': {}, 'result': 'OK'}), flush=True)\n",
+        encoding="utf-8",
+    )
+    cli.chmod(0o755)
+    environment = {
+        "PATH": str(tmp_path),
+        "HOME": str(tmp_path / "run-home"),
+        "CAPTURE_LOG": str(capture),
+        "ANTHROPIC_API_KEY": "run-key",
+        "PWD": "/run/pwd",
+    }
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "ambient-key")
+    monkeypatch.setenv("AMBIENT_ONLY", "must-not-cross")
+    monkeypatch.setenv("CLAUDE_CODE_STREAM_CLOSE_TIMEOUT", "malformed-ambient")
+
+    open_process = anyio.open_process
+    spawn_attempts: list[tuple[bool, dict[str, str]]] = []
+
+    async def _record_open_process(
+        command: list[str], *args: Any, **kwargs: Any
+    ) -> Any:
+        native_environment = kwargs.get("env")
+        assert isinstance(native_environment, dict)
+        is_version = command == [str(cli), "-v"]
+        spawn_attempts.append((is_version, dict(native_environment)))
+        if is_version and version_admission_delay_s:
+            # The SDK's version check is explicitly best-effort and capped at
+            # two seconds. Model an overloaded host where process admission
+            # misses that window; the main SDK session must still start.
+            await anyio.sleep(version_admission_delay_s)
+        return await open_process(command, *args, **kwargs)
+
+    monkeypatch.setattr(anyio, "open_process", _record_open_process)
+
+    async def _hook(*args: Any, **kwargs: Any) -> dict[str, Any]:
+        return {"continue": True}
+
+    options = ClaudeAgentOptions(
+        cli_path=str(cli),
+        cwd=str(tmp_path),
+        env=dict(environment),
+        hooks={
+            "PreToolUse": [HookMatcher(matcher=None, hooks=[cast(Any, _hook)])]
+        },
+    )
+    transport = _RunLocalSubprocessCLITransport(options, environment=environment)
+
+    async with _RunLocalClaudeSDKClient(
+        options=options,
+        transport=transport,
+        initialize_timeout_s=60.0,
+    ) as client:
+        await client.query("review")
+        messages = [message async for message in client.receive_response()]
+
+    observations = [json.loads(line) for line in capture.read_text().splitlines()]
+    native = [item for item in observations if item["kind"] == "env"]
+    protocol = [item["message"] for item in observations if item["kind"] == "protocol"]
+    assert len(spawn_attempts) == 2
+    assert {is_version for is_version, _ in spawn_attempts} == {False, True}
+    for _, attempted_environment in spawn_attempts:
+        assert attempted_environment["ANTHROPIC_API_KEY"] == "run-key"
+        assert "AMBIENT_ONLY" not in attempted_environment
+        assert attempted_environment["PATH"] == str(tmp_path)
+        assert attempted_environment["PWD"] == str(tmp_path)
+        assert attempted_environment["HOME"] == str(tmp_path / "run-home")
+
+    main_native = [item for item in native if not item["version"]]
+    assert len(main_native) == 1
+    assert all(item["anthropic"] == "run-key" for item in native)
+    assert all(item["ambient"] is None for item in native)
+    assert all(item["path"] == str(tmp_path) for item in native)
+    assert main_native[0]["pwd"] == str(tmp_path)
+    initialize = next(item for item in protocol if item["type"] == "control_request")
+    assert initialize["request"]["hooks"]["PreToolUse"][0]["hookCallbackIds"]
+    assert len(messages) == 2
+
+
+@pytest.mark.asyncio
+async def test_claude_backend_injected_environment_reaches_sdk_options_and_policy(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from daydream.backends import BackendExecutionInput, RetryPolicy
+
+    captured: dict[str, Any] = {}
+    base_client = scripted_client(
+        [MockAssistantMessage(content=[MockTextBlock(text="OK")]), MockResultMessage()]
+    )
+
+    class CapturingClient(base_client):  # type: ignore[misc,valid-type]
+        def __init__(self, options: Any = None, transport: Any = None) -> None:
+            super().__init__(options=options)
+            captured["options"] = options
+            captured["transport"] = transport
+
+    patch_claude_sdk(monkeypatch, CapturingClient)
+    execution = BackendExecutionInput.from_environment(
+        {
+            "HOME": str(tmp_path / "home"),
+            "PATH": "/run/bin",
+            "ANTHROPIC_API_KEY": "run-key",
+            "DAYDREAM_FANOUT_CONCURRENCY": "4",
+            "DAYDREAM_PI_RETRY_ATTEMPTS": "3",
+        },
+        backend="claude",
+    )
+    backend = ClaudeBackend(model="opus", execution_input=execution)
+
+    _ = [event async for event in backend.execute(tmp_path, "review")]
+
+    assert captured["options"].env["ANTHROPIC_API_KEY"] == "run-key"
+    assert captured["options"].env["CLAUDE_CODE_DISABLE_BACKGROUND_TASKS"] == "1"
+    assert backend.fanout_concurrency == 4
+    assert backend.retry_policy == RetryPolicy(3, 2.0, 120.0)
 
 
 async def _drive_claude_backend_to_list(

--- a/tests/test_backend_codex.py
+++ b/tests/test_backend_codex.py
@@ -721,6 +721,43 @@ def test_isolated_child_env_strips_redirect_vars(monkeypatch: pytest.MonkeyPatch
     assert env["PATH"] == "/usr/bin"
 
 
+@pytest.mark.asyncio
+async def test_codex_execution_input_supplies_complete_native_environment(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from daydream.backends import BackendExecutionInput, RetryPolicy
+
+    execution = BackendExecutionInput.from_environment(
+        {
+            "HOME": str(tmp_path / "run-home"),
+            "PATH": "/run/bin",
+            "OPENAI_API_KEY": "run-key",
+            "DAYDREAM_FANOUT_CONCURRENCY": "5",
+            "DAYDREAM_PI_RETRY_ATTEMPTS": "2",
+        },
+        backend="codex",
+    )
+    monkeypatch.setenv("OPENAI_API_KEY", "ambient-key")
+    process = make_mock_process_from_fixture("simple_text.jsonl")
+    backend = CodexBackend(model="fixture-model", execution_input=execution)
+
+    with patch(
+        "daydream.backends._transport.asyncio.create_subprocess_exec",
+        return_value=process,
+    ) as mock_exec:
+        _ = [event async for event in backend.execute(tmp_path, "review")]
+
+    assert mock_exec.call_args.kwargs["env"] == {
+        "HOME": str(tmp_path / "run-home"),
+        "PATH": "/run/bin",
+        "OPENAI_API_KEY": "run-key",
+        "DAYDREAM_FANOUT_CONCURRENCY": "5",
+        "DAYDREAM_PI_RETRY_ATTEMPTS": "2",
+    }
+    assert backend.fanout_concurrency == 5
+    assert backend.retry_policy == RetryPolicy(2, 2.0, 120.0)
+
+
 @pytest.mark.skipif(
     sys.platform == "darwin",
     reason="darwin behavior is covered by TestIsolatedChildEnvDarwinPath (issue #1122 M3)",
@@ -1129,6 +1166,171 @@ async def test_codex_synthesizes_cost_for_known_model() -> None:
     assert mev.prompt_tokens == 15_000
     assert mev.completion_tokens == 2_000
     assert mev.cached_tokens == 5_000
+
+
+def _write_model_prices(path: Path, *, model: str, input_price: float, output_price: float) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        f'[prices."{model}"]\ninput = {input_price}\noutput = {output_price}\n',
+        encoding="utf-8",
+    )
+    return path
+
+
+async def _codex_cost_for_execution_input(model: str, environment: dict[str, str]) -> float | None:
+    from daydream.backends import BackendExecutionInput
+
+    backend = CodexBackend(
+        model=model,
+        execution_input=BackendExecutionInput.from_environment(environment, backend="codex"),
+    )
+    events = [event async for event in backend.execute(Path("/tmp"), "price this turn")]
+    costs = [event for event in events if isinstance(event, CostEvent)]
+    metrics = [event for event in events if isinstance(event, MetricsEvent)]
+    assert len(costs) == 1
+    assert len(metrics) == 1
+    assert metrics[0].cost_usd == costs[0].cost_usd
+    return costs[0].cost_usd
+
+
+def _codex_price_process() -> Any:
+    return make_mock_process([
+        '{"type":"thread.started","thread_id":"th_price"}',
+        '{"type":"item.completed","item":{"type":"agent_message","text":"ok"}}',
+        '{"type":"turn.completed","usage":{"input_tokens":1000000,'
+        '"cached_input_tokens":0,"output_tokens":1000000}}',
+    ])
+
+
+@pytest.mark.asyncio
+async def test_codex_injected_pricing_uses_each_captured_override(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Concurrent run inputs select their own price file, never the parent override."""
+    model = "run-local-price-model"
+    first = _write_model_prices(tmp_path / "first.toml", model=model, input_price=1.0, output_price=2.0)
+    second = _write_model_prices(tmp_path / "second.toml", model=model, input_price=10.0, output_price=20.0)
+    hostile = _write_model_prices(tmp_path / "ambient.toml", model=model, input_price=100.0, output_price=200.0)
+    monkeypatch.setenv("DAYDREAM_PRICES_FILE", str(hostile))
+    monkeypatch.setenv("HOME", str(tmp_path / "ambient-home"))
+
+    with patch(
+        "daydream.backends._transport.asyncio.create_subprocess_exec",
+        side_effect=[_codex_price_process(), _codex_price_process()],
+    ):
+        first_cost, second_cost = await asyncio.gather(
+            _codex_cost_for_execution_input(model, {"DAYDREAM_PRICES_FILE": str(first)}),
+            _codex_cost_for_execution_input(model, {"DAYDREAM_PRICES_FILE": str(second)}),
+        )
+
+    assert first_cost == pytest.approx(3.0)
+    assert second_cost == pytest.approx(30.0)
+
+
+@pytest.mark.asyncio
+async def test_codex_injected_pricing_falls_back_to_captured_home(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    model = "captured-home-price-model"
+    run_home = tmp_path / "run-home"
+    _write_model_prices(
+        run_home / ".daydream" / "prices.toml",
+        model=model,
+        input_price=4.0,
+        output_price=5.0,
+    )
+    hostile = _write_model_prices(tmp_path / "ambient.toml", model=model, input_price=40.0, output_price=50.0)
+    monkeypatch.setenv("DAYDREAM_PRICES_FILE", str(hostile))
+    monkeypatch.setenv("HOME", str(tmp_path / "ambient-home"))
+
+    with patch(
+        "daydream.backends._transport.asyncio.create_subprocess_exec",
+        return_value=_codex_price_process(),
+    ):
+        cost = await _codex_cost_for_execution_input(
+            model, {"DAYDREAM_PRICES_FILE": "", "HOME": str(run_home)}
+        )
+
+    assert cost == pytest.approx(9.0)
+
+
+@pytest.mark.asyncio
+async def test_codex_injected_pricing_without_home_uses_builtins(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    custom_model = "ambient-only-price-model"
+    hostile = _write_model_prices(
+        tmp_path / "ambient.toml",
+        model=custom_model,
+        input_price=100.0,
+        output_price=200.0,
+    )
+    monkeypatch.setenv("DAYDREAM_PRICES_FILE", str(hostile))
+    monkeypatch.setenv("HOME", str(tmp_path / "ambient-home"))
+
+    with patch(
+        "daydream.backends._transport.asyncio.create_subprocess_exec",
+        side_effect=[_codex_price_process(), _codex_price_process()],
+    ):
+        custom_cost = await _codex_cost_for_execution_input(custom_model, {"PATH": "/run/bin"})
+        builtin_cost = await _codex_cost_for_execution_input("gpt-5.6-sol", {"PATH": "/run/bin"})
+
+    assert custom_cost is None
+    # One million input tokens crosses the built-in long-context threshold;
+    # this also verifies resolve_prices retains its pricing-policy metadata.
+    assert builtin_cost == pytest.approx(55.0)
+
+
+@pytest.mark.asyncio
+async def test_codex_injected_missing_or_malformed_price_file_falls_back_to_builtins(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    hostile = _write_model_prices(
+        tmp_path / "ambient.toml",
+        model="gpt-5.5",
+        input_price=100.0,
+        output_price=200.0,
+    )
+    malformed = tmp_path / "malformed.toml"
+    malformed.write_text("this is = = not toml", encoding="utf-8")
+    monkeypatch.setenv("DAYDREAM_PRICES_FILE", str(hostile))
+
+    with patch(
+        "daydream.backends._transport.asyncio.create_subprocess_exec",
+        side_effect=[_codex_price_process(), _codex_price_process()],
+    ):
+        missing_cost = await _codex_cost_for_execution_input(
+            "gpt-5.5", {"DAYDREAM_PRICES_FILE": str(tmp_path / "missing.toml")}
+        )
+        malformed_cost = await _codex_cost_for_execution_input(
+            "gpt-5.5", {"DAYDREAM_PRICES_FILE": str(malformed)}
+        )
+
+    assert missing_cost == pytest.approx(35.0)
+    assert malformed_cost == pytest.approx(35.0)
+
+
+@pytest.mark.asyncio
+async def test_codex_without_execution_input_preserves_ambient_price_override(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    model = "ambient-price-model"
+    ambient = _write_model_prices(tmp_path / "ambient.toml", model=model, input_price=6.0, output_price=7.0)
+    monkeypatch.setenv("DAYDREAM_PRICES_FILE", str(ambient))
+
+    backend = CodexBackend(model=model)
+    events = await _run_inline_lines(
+        backend,
+        "price this turn",
+        [
+            '{"type":"thread.started","thread_id":"th_ambient_price"}',
+            '{"type":"turn.completed","usage":{"input_tokens":1000000,"output_tokens":1000000}}',
+        ],
+    )
+
+    costs = [event for event in events if isinstance(event, CostEvent)]
+    assert len(costs) == 1
+    assert costs[0].cost_usd == pytest.approx(13.0)
 
 
 @pytest.mark.asyncio
@@ -2057,6 +2259,115 @@ class TestResolveRealGitDir:
 
 class TestIsolatedChildEnvDarwinPath:
     """Darwin PATH-prepend in _isolated_child_env (issue #1122 M1/M4/M6/M7)."""
+
+    @staticmethod
+    def _install_xcrun(
+        root: Path,
+        *,
+        label: str,
+        exit_code: int = 0,
+    ) -> tuple[dict[str, str], Path, Path]:
+        bin_dir = root / label / "shim-bin"
+        git_dir = root / label / "real-git-bin"
+        bin_dir.mkdir(parents=True)
+        git_dir.mkdir(parents=True)
+        git = git_dir / "git"
+        git.write_text("#!/bin/sh\n", encoding="utf-8")
+        git.chmod(0o755)
+        log = root / f"{label}-probe.jsonl"
+        xcrun = bin_dir / "xcrun"
+        xcrun.write_text(
+            f"#!{sys.executable}\n"
+            "import json, os\n"
+            "with open(os.environ['PROBE_LOG'], 'a', encoding='utf-8') as out:\n"
+            "    out.write(json.dumps(dict(os.environ), sort_keys=True) + '\\n')\n"
+            f"print({str(git)!r})\n"
+            f"raise SystemExit({exit_code})\n",
+            encoding="utf-8",
+        )
+        xcrun.chmod(0o755)
+        environment = {
+            "PATH": str(bin_dir),
+            "HOME": str(root / label / "home"),
+            "DEVELOPER_DIR": str(root / label / "developer"),
+            "PROBE_LOG": str(log),
+        }
+        return environment, git_dir, log
+
+    def test_injected_environments_probe_their_own_paths_despite_ambient_cache(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        from daydream.backends import codex
+
+        ambient, ambient_git_dir, _ = self._install_xcrun(
+            tmp_path, label="ambient"
+        )
+        first, first_git_dir, first_log = self._install_xcrun(
+            tmp_path, label="first"
+        )
+        second, second_git_dir, second_log = self._install_xcrun(
+            tmp_path, label="second"
+        )
+        monkeypatch.setattr(codex.sys, "platform", "darwin")
+        for key, value in ambient.items():
+            monkeypatch.setenv(key, value)
+
+        assert codex._resolve_real_git_dir() == str(ambient_git_dir)
+        real_run = subprocess.run
+        probe_environments: list[dict[str, str] | None] = []
+
+        def recording_run(*args: Any, **kwargs: Any) -> subprocess.CompletedProcess[str]:
+            probe_environments.append(kwargs.get("env"))
+            return real_run(*args, **kwargs)
+
+        monkeypatch.setattr(codex.subprocess, "run", recording_run)
+        first["GIT_DIR"] = "/must/be/stripped"
+        first_child = codex._isolated_child_env(
+            Path("/source"), Path("/first-clone"), base_environment=first
+        )
+        second_child = codex._isolated_child_env(
+            Path("/source"), Path("/second-clone"), base_environment=second
+        )
+
+        assert first_child is not None and second_child is not None
+        assert first_child["PATH"].startswith(f"{first_git_dir}{os.pathsep}")
+        assert second_child["PATH"].startswith(f"{second_git_dir}{os.pathsep}")
+        first_probe = json.loads(first_log.read_text().strip())
+        second_probe = json.loads(second_log.read_text().strip())
+        expected_first = {
+            key: value for key, value in first.items() if key != "GIT_DIR"
+        }
+        assert probe_environments == [expected_first, second]
+        assert expected_first.items() <= first_probe.items()
+        assert second.items() <= second_probe.items()
+        assert "GIT_DIR" not in first_probe
+
+    def test_failed_injected_probe_leaves_path_and_ordinary_cache_unpoisoned(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        from daydream.backends import codex
+
+        failed, _, failed_log = self._install_xcrun(
+            tmp_path, label="failed", exit_code=1
+        )
+        ambient, ambient_git_dir, ambient_log = self._install_xcrun(
+            tmp_path, label="ambient"
+        )
+        monkeypatch.setattr(codex.sys, "platform", "darwin")
+        original_path = failed["PATH"]
+
+        child = codex._isolated_child_env(
+            Path("/source"), Path("/clone"), base_environment=failed
+        )
+
+        assert child is not None
+        assert child["PATH"] == original_path
+        assert failed_log.exists()
+        assert codex._REAL_GIT_RESOLVED is False
+        for key, value in ambient.items():
+            monkeypatch.setenv(key, value)
+        assert codex._resolve_real_git_dir() == str(ambient_git_dir)
+        assert ambient_log.exists()
 
     def test_darwin_prepends_real_git_dir_preserving_rest_of_path(
         self, monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_backend_pi.py
+++ b/tests/test_backend_pi.py
@@ -63,6 +63,66 @@ MakeConfig = Callable[..., "RunConfig"]
 Mute = Callable[..., None]
 
 
+def test_backend_execution_input_is_immutable_parsed_and_returns_fresh_environment(
+    tmp_path: Path,
+) -> None:
+    from daydream.backends import BackendExecutionInput, RetryPolicy
+
+    source = {
+        "HOME": str(tmp_path / "home"),
+        "PATH": "/run/bin",
+        "PI_PROVIDER": "openrouter",
+        "PI_THINKING": "high",
+        "PI_API_KEY": "run-secret",
+        "PI_CODING_AGENT_DIR": str(tmp_path / "pi-agent"),
+        "DAYDREAM_PI_FANOUT_CONCURRENCY": "3",
+        "DAYDREAM_PI_RETRY_ATTEMPTS": "4",
+        "DAYDREAM_PI_RETRY_BASE_DELAY_S": "0.25",
+        "DAYDREAM_PI_RETRY_MAX_DELAY_S": "5",
+        "DAYDREAM_STREAM_IDLE_TIMEOUT_S": "7",
+    }
+
+    execution = BackendExecutionInput.from_environment(source, backend="pi")
+    source["PI_API_KEY"] = "mutated"
+    first = execution.child_environment()
+    first["PI_API_KEY"] = "also-mutated"
+
+    assert execution.retry_policy == RetryPolicy(
+        attempts=4, base_delay_s=0.25, max_delay_s=5.0
+    )
+    assert execution.fanout_concurrency == 3
+    assert execution.pi_provider == "openrouter"
+    assert execution.pi_thinking == "high"
+    assert execution.pi_agent_dir == tmp_path / "pi-agent"
+    assert execution.stream_idle_timeout_s == 7.0
+    assert execution.pi_response_idle_timeout_s == 7.0
+    assert execution.child_environment()["PI_API_KEY"] == "run-secret"
+    assert "run-secret" not in repr(execution)
+
+
+def test_backend_execution_input_uses_backend_specific_defaults(tmp_path: Path) -> None:
+    from daydream.backends import BackendExecutionInput, RetryPolicy
+
+    environment = {"HOME": str(tmp_path), "PATH": "/run/bin"}
+
+    pi = BackendExecutionInput.from_environment(environment, backend="pi")
+    codex = BackendExecutionInput.from_environment(environment, backend="codex")
+    claude = BackendExecutionInput.from_environment(environment, backend="claude")
+
+    assert pi.retry_policy == RetryPolicy(20, 10.0, 120.0)
+    assert pi.fanout_concurrency == 10
+    assert pi.pi_agent_dir == tmp_path / ".pi" / "agent"
+    assert codex.retry_policy == claude.retry_policy == RetryPolicy(20, 2.0, 120.0)
+    assert codex.fanout_concurrency == claude.fanout_concurrency == 8
+
+
+def test_backend_execution_input_rejects_explicit_osprey() -> None:
+    from daydream.backends import BackendExecutionInput
+
+    with pytest.raises(ValueError, match="osprey"):
+        BackendExecutionInput.from_environment({}, backend="osprey")
+
+
 @pytest.mark.asyncio
 async def test_artifact_visibility_protocol_cli_uses_argv_prompt_devnull_and_cwd(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
@@ -133,6 +193,45 @@ async def _run_and_capture_args(
         async for _ in backend.execute(Path("/tmp"), prompt, **kwargs):
             pass
     return list(mock_exec.call_args.args), mock_exec
+
+
+@pytest.mark.asyncio
+async def test_pi_execution_input_controls_native_argv_environment_and_policy(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from daydream.backends import BackendExecutionInput, RetryPolicy
+
+    execution = BackendExecutionInput.from_environment(
+        {
+            "HOME": str(tmp_path / "run-home"),
+            "PATH": "/run/bin",
+            "PI_PROVIDER": "openrouter",
+            "PI_THINKING": "high",
+            "PI_API_KEY": "run-key",
+            "DAYDREAM_PI_FANOUT_CONCURRENCY": "2",
+            "DAYDREAM_PI_RETRY_ATTEMPTS": "1",
+            "DAYDREAM_PI_RETRY_BASE_DELAY_S": "0",
+            "DAYDREAM_PI_RETRY_MAX_DELAY_S": "4",
+        },
+        backend="pi",
+    )
+    monkeypatch.setenv("PI_PROVIDER", "zai")
+    monkeypatch.setenv("PI_THINKING", "low")
+    monkeypatch.setenv("PI_API_KEY", "ambient-key")
+    monkeypatch.setenv("OPENROUTER_API_KEY", "ambient-native-key")
+
+    backend = PiBackend(model="fixture-model", execution_input=execution)
+    args, mock_exec = await _run_and_capture_args(backend)
+    child = mock_exec.call_args.kwargs["env"]
+
+    assert args[args.index("--provider") + 1] == "openrouter"
+    assert args[args.index("--thinking") + 1] == "high"
+    assert child["OPENROUTER_API_KEY"] == "run-key"
+    assert child["PATH"] == "/run/bin"
+    assert "PI_API_KEY" not in child
+    assert "ambient-key" not in repr(child)
+    assert backend.fanout_concurrency == 2
+    assert backend.retry_policy == RetryPolicy(1, 0.0, 4.0)
 
 
 @pytest.mark.asyncio

--- a/tests/test_benchmark_harbor_agent.py
+++ b/tests/test_benchmark_harbor_agent.py
@@ -1,6 +1,7 @@
 """Privacy-safe Daydream Harbor review agent (issue #780) tests."""
 from __future__ import annotations
 
+import asyncio
 import importlib
 import json
 import sys
@@ -257,6 +258,7 @@ def test_entrypoint_build_run_config_is_controlled() -> None:
         trajectory_path="/logs/agent/trajectory.json",
         backend="pi",
         model="deepseek/deepseek-v4-flash-0731",
+        profile_candidate=None,
     )
     assert cfg.output_mode == "review"
     assert cfg.base == "base"
@@ -270,35 +272,29 @@ def test_entrypoint_build_run_config_is_controlled() -> None:
     assert cfg.file_config == DaydreamFileConfig()
 
 
-def test_entrypoint_backend_fail_closed(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_entrypoint_backend_fail_closed() -> None:
     from daydream.benchmark.harbor import entrypoint
 
-    monkeypatch.setenv("DAYDREAM_REVIEW_BACKEND", "codex")
     with pytest.raises(entrypoint.EntrypointError) as exc:
-        entrypoint.require_supported_backend()
+        entrypoint.require_supported_backend({"DAYDREAM_REVIEW_BACKEND": "codex"})
     assert "pi" in str(exc.value)
 
 
-def test_entrypoint_backend_allowlist_pi_and_claude_pass(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_entrypoint_backend_allowlist_pi_and_claude_pass() -> None:
     from daydream.benchmark.harbor import entrypoint
 
     for value in ("pi", "claude", "CLAUDE", " claude "):
-        monkeypatch.setenv("DAYDREAM_REVIEW_BACKEND", value)
-        assert entrypoint.require_supported_backend() == value.strip().lower()
+        assert entrypoint.require_supported_backend({"DAYDREAM_REVIEW_BACKEND": value}) == value.strip().lower()
 
 
-def test_entrypoint_backend_allowlist_rejects_others_and_defaults_pi(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+def test_entrypoint_backend_allowlist_rejects_others_and_defaults_pi() -> None:
     from daydream.benchmark.harbor import entrypoint
 
     for value in ("codex", "opencode"):
-        monkeypatch.setenv("DAYDREAM_REVIEW_BACKEND", value)
         with pytest.raises(entrypoint.EntrypointError) as exc:
-            entrypoint.require_supported_backend()
+            entrypoint.require_supported_backend({"DAYDREAM_REVIEW_BACKEND": value})
         assert "'pi'" in str(exc.value) and "'claude'" in str(exc.value)
-    monkeypatch.delenv("DAYDREAM_REVIEW_BACKEND", raising=False)
-    assert entrypoint.require_supported_backend() == "pi"
+    assert entrypoint.require_supported_backend({}) == "pi"
 
 
 # ---------------------------------------------------------------------------
@@ -774,8 +770,6 @@ def test_end_to_end_findings_and_clean_review(tmp_path: Path, monkeypatch: pytes
     """A real temp git repo/task plus a fake backend drives the production entrypoint
     through the in-process runner and publishes the exact findings and an explicit
     empty review (AC 3 / AC 5 gate)."""
-    import os
-
     from daydream.benchmark.harbor import entrypoint
     from daydream.benchmark.harbor import verifier_core as vc
     from tests.harness.stub_backend import install_stub_backend
@@ -785,17 +779,7 @@ def test_end_to_end_findings_and_clean_review(tmp_path: Path, monkeypatch: pytes
     case_id = "case-abc123def456"
     env = _end_env(repo, tmp_path, case_id)
 
-    saved = {key: os.environ.get(key) for key in env}
-    try:
-        import asyncio
-
-        rc = asyncio.run(entrypoint.main(monkeypatch_env=env))
-    finally:
-        for key, value in saved.items():
-            if value is None:
-                os.environ.pop(key, None)
-            else:
-                os.environ[key] = value
+    rc = asyncio.run(entrypoint.main(env))
     assert rc == 0
     artifact = json.loads((tmp_path / "logs" / "artifacts" / "review.json").read_text())
     parsed = vc.validate_candidate_artifact(artifact)
@@ -853,7 +837,6 @@ def test_local_harbor_task_with_fake_backend(
     import asyncio
     import importlib
     import importlib.util
-    import os
 
     import pytest
 
@@ -950,20 +933,9 @@ def test_local_harbor_task_with_fake_backend(
     for prefix in _BANNED_PREFIXES:
         assert not any(k.startswith(prefix) for k in executed.child)
 
-    # Only the allowlisted child env reaches the executed entrypoint: drop the
-    # host secrets we planted so the in-process runner sees the container env,
-    # then really run the entrypoint against the captured child env.
-    for banned in _BANNED_VARS:
-        os.environ.pop(banned, None)
-    saved = {env_key: os.environ.get(env_key) for env_key in executed.child}
-    try:
-        rc = asyncio.run(entrypoint.main(monkeypatch_env=executed.child))
-    finally:
-        for env_key, value in saved.items():
-            if value is None:
-                os.environ.pop(env_key, None)
-            else:
-                os.environ[env_key] = value
+    # The entrypoint consumes exactly the captured child mapping; no host
+    # credentials need to be removed or restored around this in-process run.
+    rc = asyncio.run(entrypoint.main(executed.child))
     assert rc == 0
 
     # The child env carried the per-case task key through to a genuinely
@@ -1021,7 +993,6 @@ def test_agent_run_accepts_claude_and_invokes_entrypoint(
     in-container claude branch raises EntrypointError and rc != 0.
     """
     import asyncio
-    import os
 
     import pytest
 
@@ -1116,20 +1087,9 @@ def test_agent_run_accepts_claude_and_invokes_entrypoint(
             continue  # exempted for backend="claude"
         assert not any(k.startswith(prefix) for k in executed.child)
 
-    # Only the allowlisted child env reaches the executed entrypoint: drop the
-    # host secrets we planted so the in-process runner sees the container env,
-    # then really run the entrypoint against the captured child env.
-    for banned in _BANNED_VARS:
-        os.environ.pop(banned, None)
-    saved = {env_key: os.environ.get(env_key) for env_key in executed.child}
-    try:
-        rc = asyncio.run(entrypoint.main(monkeypatch_env=executed.child))
-    finally:
-        for env_key, value in saved.items():
-            if value is None:
-                os.environ.pop(env_key, None)
-            else:
-                os.environ[env_key] = value
+    # The entrypoint consumes exactly the captured child mapping; no host
+    # credentials need to be removed or restored around this in-process run.
+    rc = asyncio.run(entrypoint.main(executed.child))
     assert rc == 0
 
     # The child env carried the claude credential through to a genuinely

--- a/tests/test_benchmark_harbor_execution_isolation.py
+++ b/tests/test_benchmark_harbor_execution_isolation.py
@@ -1,0 +1,238 @@
+"""Concurrent Harbor execution through real runners and artifact publication."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import subprocess
+from collections.abc import AsyncIterator
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from daydream import runner
+from daydream.backends import AgentEvent
+from daydream.benchmark.harbor import entrypoint, verifier_core
+from tests.harness.git_helpers import commit, git, init_repo
+from tests.harness.stub_backend import StubBackend
+
+
+def _review_repository(root: Path) -> Path:
+    repo = root / "repo"
+    repo.mkdir(parents=True)
+    (repo / "api.py").write_text("def hello():\n    return 'world'\n")
+    init_repo(repo)
+    git(repo, "add", ".")
+    commit(repo, "base")
+    git(repo, "branch", "base")
+    git(repo, "checkout", "-b", "feature")
+    (repo / "api.py").write_text("def hello():\n    return 'universe'\n")
+    git(repo, "add", ".")
+    commit(repo, "change")
+    return repo
+
+
+async def test_concurrent_harbor_reviews_keep_execution_and_artifacts_private(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repositories = {name: _review_repository(tmp_path / name) for name in ("pi", "claude")}
+    environments: dict[str, dict[str, str]] = {}
+    for name, repo in repositories.items():
+        root = repo.parent
+        profile = root / "profile.toml"
+        profile.write_text(
+            f'schema_version = 1\nname = "{name}-candidate"\n'
+            "[strategies.intent]\n"
+            f'content = "Understand the intent of these changes. PROFILE-{name}."\n'
+            'source = "copied: isolation-test"\n'
+        )
+        environments[name] = {
+            "PATH": os.environ["PATH"],
+            "HOME": str(root / "home"),
+            "LANG": "C.UTF-8",
+            "DAYDREAM_REVIEW_BACKEND": name,
+            "DAYDREAM_REVIEW_MODEL": f"isolation-{name}-model",
+            "DAYDREAM_REVIEW_REPO_DIR": str(repo),
+            "DAYDREAM_REVIEW_ARTIFACT_PATH": str(root / "review.json"),
+            "DAYDREAM_REVIEW_TRAJECTORY_PATH": str(root / "trajectory.json"),
+            "DAYDREAM_REVIEW_CASE_ID": f"case-{name}",
+            "DAYDREAM_REVIEW_PROFILE_CANDIDATE": str(profile),
+            "DAYDREAM_PI_RETRY_ATTEMPTS": "1" if name == "pi" else "2",
+            "DAYDREAM_PI_RETRY_BASE_DELAY_S": "0",
+            "DAYDREAM_PI_RETRY_MAX_DELAY_S": "0",
+            "DAYDREAM_PI_FANOUT_CONCURRENCY": "2",
+            "DAYDREAM_FANOUT_CONCURRENCY": "3",
+            "GH_TOKEN": f"forbidden-{name}-github-token",
+            "GH_HOST": f"forbidden-{name}.example",
+            "DAYDREAM_JUDGE_API_KEY": f"forbidden-{name}-judge-key",
+            "ZAI_API_KEY": f"forbidden-{name}-zai-key",
+            "NOUS_API_KEY": f"forbidden-{name}-nous-key",
+        }
+        if name == "pi":
+            environments[name].update(
+                {
+                    "DAYDREAM_REVIEW_API_KEY": "reviewer-pi-private-key",
+                    "DAYDREAM_REVIEW_BASE_URL": "https://openrouter.ai/api/v1",
+                    "PI_THINKING": "high",
+                    "PI_CODING_AGENT_DIR": str(root / "pi-agent"),
+                }
+            )
+        else:
+            environments[name].update(
+                {
+                    "ANTHROPIC_API_KEY": "reviewer-claude-private-key",
+                    "ANTHROPIC_BASE_URL": "https://claude-review.example/v1",
+                }
+            )
+
+    monkeypatch.setenv("DAYDREAM_APP_ID", "not-an-integer")
+    monkeypatch.setenv("DAYDREAM_APP_PRIVATE_KEY", "parent-private-app-key")
+    monkeypatch.setenv("GH_TOKEN", "parent-github-private-token")
+    monkeypatch.setenv("ANTHROPIC_AUTH_TOKEN", "parent-anthropic-private-token")
+    monkeypatch.setenv("DAYDREAM_PI_RETRY_ATTEMPTS", "0")
+    parent_before = dict(os.environ)
+    caller_before = {name: dict(env) for name, env in environments.items()}
+    entered = {name: asyncio.Event() for name in repositories}
+    release = asyncio.Event()
+    failed_once: set[str] = set()
+    created: dict[str, list[Any]] = {name: [] for name in repositories}
+    prompts: dict[str, list[str]] = {name: [] for name in repositories}
+    github_environments: dict[Path, list[dict[str, str]]] = {}
+    real_subprocess_run = subprocess.run
+
+    def github_subprocess(args: list[str], *pargs: Any, **kwargs: Any) -> Any:
+        if args[0] != "gh":
+            return real_subprocess_run(args, *pargs, **kwargs)
+        assert args[1:3] == ["api", "/user"]
+        environment = kwargs["env"]
+        assert environment is not None
+        github_environments.setdefault(Path(kwargs["cwd"]), []).append(dict(environment))
+        return subprocess.CompletedProcess(args, 0, '{"login":"reviewer"}', "")
+
+    class RetryableError(Exception):
+        retryable = True
+
+    class ReviewBackend(StubBackend):
+        def __init__(self, name: str, model: str, execution: Any) -> None:
+            super().__init__(repositories[name], model=model)
+            self.name = name
+            self.execution = execution
+            self.retry_policy = execution.retry_policy
+            self.fanout_concurrency = execution.fanout_concurrency
+
+        async def execute(
+            self,
+            cwd: Path,
+            prompt: str,
+            *args: Any,
+            **kwargs: Any,
+        ) -> AsyncIterator[AgentEvent]:
+            assert cwd == repositories[self.name]
+            prompts[self.name].append(prompt)
+            entered[self.name].set()
+            await release.wait()
+            if self.name not in failed_once:
+                failed_once.add(self.name)
+                raise RetryableError("retry the owning review once")
+            async for event in super().execute(cwd, prompt, *args, **kwargs):
+                yield event
+
+    def create_backend(
+        name: str,
+        model: str | None = None,
+        *,
+        execution_input: Any = None,
+        **kwargs: Any,
+    ) -> ReviewBackend:
+        assert execution_input is not None, "Harbor lost its explicit backend execution"
+        assert model == f"isolation-{name}-model"
+        backend = ReviewBackend(name, model, execution_input)
+        created[name].append(backend)
+        return backend
+
+    monkeypatch.setattr(subprocess, "run", github_subprocess)
+    monkeypatch.setattr(runner, "create_backend", create_backend)
+    results: dict[str, int] = {}
+
+    async def review(name: str) -> None:
+        results[name] = await entrypoint.main(environments[name])
+
+    async with asyncio.timeout(45):
+        async with asyncio.TaskGroup() as tasks:
+            tasks.create_task(review("pi"))
+            tasks.create_task(review("claude"))
+            await asyncio.gather(*(event.wait() for event in entered.values()))
+            assert dict(os.environ) == parent_before
+            release.set()
+
+    assert results == {"pi": 0, "claude": 0}
+    assert failed_once == {"pi", "claude"}
+    assert environments == caller_before
+    assert dict(os.environ) == parent_before
+    forbidden = (
+        "parent-private-app-key",
+        "parent-github-private-token",
+        "parent-anthropic-private-token",
+        "reviewer-pi-private-key",
+        "reviewer-claude-private-key",
+        "forbidden-pi-github-token",
+        "forbidden-claude-github-token",
+        "forbidden-pi-judge-key",
+        "forbidden-claude-judge-key",
+        "forbidden-pi-zai-key",
+        "forbidden-pi-nous-key",
+        "forbidden-claude-zai-key",
+        "forbidden-claude-nous-key",
+    )
+    for name, repo in repositories.items():
+        assert created[name]
+        assert len({id(backend.execution) for backend in created[name]}) == 1
+        assert any(f"PROFILE-{name}" in prompt for prompt in prompts[name])
+        other = "claude" if name == "pi" else "pi"
+        assert all(f"PROFILE-{other}" not in prompt for prompt in prompts[name])
+        for backend in created[name]:
+            environment = backend.execution.child_environment()
+            assert environment["HOME"] == str(repo.parent / "home")
+            assert backend.fanout_concurrency == (2 if name == "pi" else 3)
+            expected_agent_dir = (
+                repo.parent / "pi-agent" if name == "pi"
+                else repo.parent / "home" / ".pi" / "agent"
+            )
+            assert backend.execution.pi_agent_dir == expected_agent_dir
+            assert backend.retry_policy.attempts == (1 if name == "pi" else 2)
+            assert backend.retry_policy.base_delay_s == backend.retry_policy.max_delay_s == 0
+            if name == "pi":
+                assert backend.execution.pi_provider == "openrouter"
+                assert environment["PI_API_KEY"] == "reviewer-pi-private-key"
+                assert environment["PI_THINKING"] == "high"
+                assert environment["PI_CODING_AGENT_DIR"] == str(repo.parent / "pi-agent")
+                assert backend.execution.pi_thinking == "high"
+                assert "ZAI_API_KEY" not in environment and "NOUS_API_KEY" not in environment
+                assert not any(key.startswith("ANTHROPIC_") for key in environment)
+            else:
+                assert environment["ANTHROPIC_API_KEY"] == "reviewer-claude-private-key"
+                assert environment["ANTHROPIC_BASE_URL"] == "https://claude-review.example/v1"
+                assert "PI_API_KEY" not in environment
+                assert "PI_THINKING" not in environment and "PI_CODING_AGENT_DIR" not in environment
+                assert "ZAI_API_KEY" not in environment and "NOUS_API_KEY" not in environment
+        assert len(github_environments[repo]) == 1
+        for environment in github_environments[repo]:
+            assert environment["HOME"] == str(repo.parent / "home")
+            assert "GH_TOKEN" not in environment and "GH_HOST" not in environment
+            assert not any(key.startswith("DAYDREAM_APP_") for key in environment)
+            assert not any(key in environment for key in (
+                "PI_API_KEY", "ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN",
+                "ZAI_API_KEY", "NOUS_API_KEY",
+            ))
+        artifact_path = repo.parent / "review.json"
+        trajectory_path = repo.parent / "trajectory.json"
+        artifact = json.loads(artifact_path.read_text())
+        assert artifact["case_id"] == f"case-{name}"
+        assert verifier_core.validate_candidate_artifact(artifact)
+        assert trajectory_path.is_file()
+        for path in (artifact_path, trajectory_path):
+            payload = path.read_text()
+            assert all(secret not in payload for secret in forbidden)

--- a/tests/test_benchmark_harbor_profile_delivery.py
+++ b/tests/test_benchmark_harbor_profile_delivery.py
@@ -45,7 +45,9 @@ def test_harbor_resolver_accepts_only_explicit_control_plane_candidate(
     p = tmp_path / "control-plane-candidate.toml"
     p.write_text(_resolver_fixture)
     monkeypatch.setenv("DAYDREAM_REVIEW_PROFILE_CANDIDATE", str(p))
-    resolved = rp.resolve_harbor_profile(env=None)  # env passed explicitly as the trusted control plane
+    resolved = rp.resolve_harbor_profile(
+        env={"DAYDREAM_REVIEW_PROFILE_CANDIDATE": str(p)}
+    )
     assert resolved.profile.name == "candidate"
 
 # Task 11 (R11): controlled Harbor delivery -- entrypoint validation + no
@@ -58,10 +60,10 @@ def test_entrypoint_parses_and_validates_candidate_before_runconfig(
 
     good = tmp_path / "good.toml"
     good.write_text('schema_version = 1\nname = "g"\n[strategies.intent]\ncontent = "C"\nsource = "copied: a"')
-    monkeypatch.setenv("DAYDREAM_REVIEW_PROFILE_CANDIDATE", str(good))
     cfg = entrypoint.build_run_config(
         repo_dir=str(tmp_path), trajectory_path=str(tmp_path / "t.json"),
         backend="pi", model="deepseek/deepseek-v4-flash-0731",
+        profile_candidate=str(good),
     )
     assert cfg.review_profile is not None
     assert cfg.review_profile.name == "g"  # candidate parsed+validated into RunConfig
@@ -75,15 +77,17 @@ def test_entrypoint_invalid_candidate_fails_and_writes_no_review(
 
     bad = tmp_path / "bad.toml"
     bad.write_text('schema_version = 99\nname = "bad"')
-    monkeypatch.setenv("DAYDREAM_REVIEW_PROFILE_CANDIDATE", str(bad))
     artifact = tmp_path / "logs" / "artifacts" / "review.json"
     artifact.parent.mkdir(parents=True)
     # main() is async and RETURNS exit code 1 on EntrypointError (it does not raise).
-    rc = asyncio.run(entrypoint.main(
-        monkeypatch_env={"DAYDREAM_REVIEW_CASE_ID": "case-x",
-                         "DAYDREAM_REVIEW_ARTIFACT_PATH": str(artifact),
-                         "DAYDREAM_REVIEW_REPO_DIR": str(tmp_path)}
-    ))
+    rc = asyncio.run(entrypoint.main({
+        "DAYDREAM_REVIEW_CASE_ID": "case-x",
+        "DAYDREAM_REVIEW_ARTIFACT_PATH": str(artifact),
+        "DAYDREAM_REVIEW_REPO_DIR": str(tmp_path),
+        "DAYDREAM_REVIEW_API_KEY": "sk-or-test",
+        "DAYDREAM_REVIEW_BASE_URL": "https://openrouter.ai/api",
+        "DAYDREAM_REVIEW_PROFILE_CANDIDATE": str(bad),
+    }))
     assert rc == 1  # agent/config error, non-zero exit
     assert not artifact.exists()  # no candidate review artifact written
 
@@ -99,10 +103,10 @@ def test_malicious_target_config_cannot_change_harbor_candidate(
     evil.write_text('review_profile = "/tmp/evil.toml"')
     good = tmp_path / "good.toml"
     good.write_text('schema_version = 1\nname = "g"\n[strategies.intent]\ncontent = "C"\nsource = "copied: a"')
-    monkeypatch.setenv("DAYDREAM_REVIEW_PROFILE_CANDIDATE", str(good))
     cfg = entrypoint.build_run_config(
         repo_dir=str(tmp_path), trajectory_path=str(tmp_path / "t.json"),
         backend="pi", model="deepseek/deepseek-v4-flash-0731",
+        profile_candidate=str(good),
     )
     assert cfg.review_profile is not None
     assert cfg.review_profile.name == "g"  # candidate wins; target config ignored

--- a/tests/test_benchmark_harbor_skill_free.py
+++ b/tests/test_benchmark_harbor_skill_free.py
@@ -16,71 +16,135 @@ import pytest
 from daydream.benchmark.harbor import entrypoint
 
 
-def test_openrouter_reviewer_env_uses_pi_provider(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("ANTHROPIC_API_KEY", "stale-key")
-    monkeypatch.setenv("ANTHROPIC_BASE_URL", "stale-url")
-    monkeypatch.setenv("ANTHROPIC_AUTH_TOKEN", "stale-token")
-    monkeypatch.setenv("OPENROUTER_API_KEY", "stale-openrouter-key")
-    monkeypatch.setenv("PI_API_KEY", "stale-pi-key")
-
-    entrypoint.apply_reviewer_env({
+def test_parse_reviewer_environment_maps_pi_without_mutating_parent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("PI_API_KEY", "ambient-pi-key")
+    parent = {
+        "PATH": "/usr/bin",
+        "DAYDREAM_REVIEW_CASE_ID": "case-parser-pi",
+        "DAYDREAM_REVIEW_REPO_DIR": "/review/repo",
+        "DAYDREAM_REVIEW_ARTIFACT_PATH": "/review/out.json",
+        "DAYDREAM_REVIEW_TRAJECTORY_PATH": "/review/trajectory.json",
+        "DAYDREAM_REVIEW_BASE_REF": "frozen-base",
+        "DAYDREAM_REVIEW_HEAD_REF": "frozen-head",
+        "DAYDREAM_REVIEW_MODEL": "review-model",
+        "DAYDREAM_REVIEW_PROFILE_CANDIDATE": "/review/profile.toml",
         "DAYDREAM_REVIEW_API_KEY": "sk-or-test",
         "DAYDREAM_REVIEW_BASE_URL": "https://openrouter.ai/api",
-    })
+        "ANTHROPIC_API_KEY": "stale-key",
+        "OPENROUTER_API_KEY": "stale-openrouter-key",
+        "PI_API_KEY": "stale-pi-key",
+        "PI_THINKING": "high",
+        "PI_CODING_AGENT_DIR": "/review/pi-agent",
+        "PI_UNRELATED_CONTROL": "must-scrub",
+        "ZAI_API_KEY": "stale-zai-key",
+        "NOUS_API_KEY": "stale-nous-key",
+        "DAYDREAM_JUDGE_MODEL": "judge-model",
+        "GH_TOKEN": "stale-gh-token",
+        "GITHUB_TOKEN": "stale-github-token",
+        "GH_HOST": "github.example",
+        "DAYDREAM_APP_FUTURE_SECRET": "stale-app-secret",
+    }
 
-    assert os.environ["PI_PROVIDER"] == "openrouter"
-    assert os.environ["PI_API_KEY"] == "sk-or-test"
-    assert os.environ["PI_TELEMETRY"] == "0"
-    assert "OPENROUTER_API_KEY" not in os.environ
-    assert not any(key.startswith("ANTHROPIC_") for key in os.environ)
+    parsed = entrypoint.parse_reviewer_environment(parent)
+    child = parsed.execution.backend.child_environment()
+
+    assert child["PI_PROVIDER"] == "openrouter"
+    assert child["PI_API_KEY"] == "sk-or-test"
+    assert child["PI_TELEMETRY"] == "0"
+    assert child["PI_THINKING"] == "high"
+    assert child["PI_CODING_AGENT_DIR"] == "/review/pi-agent"
+    assert parsed.execution.backend.pi_thinking == "high"
+    assert parsed.execution.backend.pi_agent_dir == Path("/review/pi-agent")
+    assert "PI_UNRELATED_CONTROL" not in child
+    assert "OPENROUTER_API_KEY" not in child
+    assert "ZAI_API_KEY" not in child and "NOUS_API_KEY" not in child
+    assert not any(key.startswith("ANTHROPIC_") for key in child)
+    assert not any(key.startswith("DAYDREAM_JUDGE_") for key in child)
+    assert "GH_TOKEN" not in child
+    github_environment = parsed.execution.github.auth.environment_for_request()
+    assert github_environment is not None
+    for forbidden in (
+        "GH_TOKEN", "GITHUB_TOKEN", "GH_HOST", "DAYDREAM_APP_FUTURE_SECRET",
+        "PI_API_KEY", "ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN",
+        "ZAI_API_KEY", "NOUS_API_KEY",
+    ):
+        assert forbidden not in github_environment
+    assert parsed.repo_dir == Path("/review/repo")
+    assert parsed.artifact_path == Path("/review/out.json")
+    assert parsed.trajectory_path == Path("/review/trajectory.json")
+    assert (parsed.case_id, parsed.base_ref, parsed.head_ref) == (
+        "case-parser-pi", "frozen-base", "frozen-head"
+    )
+    assert parsed.model == "review-model"
+    assert parsed.profile_candidate == "/review/profile.toml"
+    assert parent["PI_API_KEY"] == "stale-pi-key"
+    assert parent["PI_THINKING"] == "high"
+    assert parent["PI_CODING_AGENT_DIR"] == "/review/pi-agent"
+    assert parent["ANTHROPIC_API_KEY"] == "stale-key"
+    assert os.environ["PI_API_KEY"] == "ambient-pi-key"
 
 
-def test_reviewer_env_rejects_non_openrouter_endpoint() -> None:
+def test_parse_reviewer_environment_rejects_non_openrouter_endpoint() -> None:
     with pytest.raises(entrypoint.EntrypointError, match="openrouter.ai"):
-        entrypoint.apply_reviewer_env({
+        entrypoint.parse_reviewer_environment({
             "DAYDREAM_REVIEW_API_KEY": "key",
             "DAYDREAM_REVIEW_BASE_URL": "https://example.com/api",
         })
 
 
-def test_claude_reviewer_env_keeps_anthropic_and_no_openrouter_requirement(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.setenv("OPENROUTER_API_KEY", "stale-or")
-    monkeypatch.setenv("PI_API_KEY", "stale-pi")
-    monkeypatch.setenv("DAYDREAM_JUDGE_MODEL", "judge-model")
-
-    entrypoint.apply_reviewer_env({
+def test_parse_reviewer_environment_maps_claude_without_openrouter_requirement() -> None:
+    parent = {
         "DAYDREAM_REVIEW_BACKEND": "claude",
+        "DAYDREAM_REVIEW_CASE_ID": "case-parser-claude",
         "ANTHROPIC_API_KEY": "sk-ant-live",
         "ANTHROPIC_AUTH_TOKEN": "tok-live",
         "ANTHROPIC_BASE_URL": "https://api.anthropic.com",
-    }, backend="claude")
+        "OPENROUTER_API_KEY": "stale-or",
+        "PI_API_KEY": "stale-pi",
+        "PI_THINKING": "must-scrub",
+        "PI_CODING_AGENT_DIR": "/review/must-scrub",
+        "ZAI_API_KEY": "stale-zai-key",
+        "NOUS_API_KEY": "stale-nous-key",
+        "DAYDREAM_JUDGE_MODEL": "judge-model",
+    }
 
-    assert os.environ["ANTHROPIC_API_KEY"] == "sk-ant-live"
-    assert os.environ["ANTHROPIC_AUTH_TOKEN"] == "tok-live"
-    assert os.environ["ANTHROPIC_BASE_URL"] == "https://api.anthropic.com"
-    assert "OPENROUTER_API_KEY" not in os.environ
-    assert "PI_API_KEY" not in os.environ
-    assert not any(k.startswith("DAYDREAM_JUDGE_") for k in os.environ)
+    parsed = entrypoint.parse_reviewer_environment(parent)
+    child = parsed.execution.backend.child_environment()
+
+    assert child["ANTHROPIC_API_KEY"] == "sk-ant-live"
+    assert child["ANTHROPIC_AUTH_TOKEN"] == "tok-live"
+    assert child["ANTHROPIC_BASE_URL"] == "https://api.anthropic.com"
+    assert "OPENROUTER_API_KEY" not in child
+    assert "PI_API_KEY" not in child
+    assert "PI_THINKING" not in child and "PI_CODING_AGENT_DIR" not in child
+    assert "ZAI_API_KEY" not in child and "NOUS_API_KEY" not in child
+    assert not any(key.startswith("DAYDREAM_JUDGE_") for key in child)
+    assert parent["PI_API_KEY"] == "stale-pi"
 
 
-def test_claude_reviewer_env_fails_without_anthropic_key(monkeypatch: pytest.MonkeyPatch) -> None:
-    with pytest.raises(entrypoint.EntrypointError, match="ANTHROPIC"):
-        entrypoint.apply_reviewer_env({
-            "DAYDREAM_REVIEW_BACKEND": "claude",
-            "ANTHROPIC_API_KEY": "",
-        }, backend="claude")
-
-
-def test_claude_reviewer_env_accepts_non_openrouter_base_url_only_for_claude(
-    monkeypatch: pytest.MonkeyPatch,
+@pytest.mark.parametrize("environment", [
+    {"DAYDREAM_REVIEW_BACKEND": "claude", "ANTHROPIC_API_KEY": ""},
+    {"DAYDREAM_REVIEW_BACKEND": "claude", "ANTHROPIC_BASE_URL": "http://api.anthropic.com"},
+])
+def test_parse_reviewer_environment_rejects_invalid_claude_credentials(
+    environment: dict[str, str],
 ) -> None:
-    entrypoint.apply_reviewer_env({
+    with pytest.raises(entrypoint.EntrypointError, match="ANTHROPIC"):
+        entrypoint.parse_reviewer_environment(environment)
+
+
+def test_parse_reviewer_environment_accepts_claude_proxy() -> None:
+    parsed = entrypoint.parse_reviewer_environment({
         "DAYDREAM_REVIEW_BACKEND": "claude",
+        "DAYDREAM_REVIEW_CASE_ID": "case-parser-proxy",
         "ANTHROPIC_API_KEY": "sk-ant",
         "ANTHROPIC_BASE_URL": "https://claude-proxy.internal/v1",
-    }, backend="claude")   # no raise: openrouter.ai requirement is pi-only
+    })
+    assert parsed.execution.backend.child_environment()["ANTHROPIC_BASE_URL"] == (
+        "https://claude-proxy.internal/v1"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -161,6 +225,7 @@ def test_host_preflight_accepts_allowlisted_claude_proxy_without_pi_var(
 
     errs = run_mod._preflight(ws, oracle=True, env={
         "DAYDREAM_REVIEW_BACKEND": "claude",
+        "DAYDREAM_REVIEW_CASE_ID": "case-parser-proxy",
         "ANTHROPIC_API_KEY": "sk-ant",
         "ANTHROPIC_BASE_URL": "https://claude-proxy.internal/v1",
         "DAYDREAM_JUDGE_BASE_URL": "http://127.0.0.1:9",
@@ -183,6 +248,7 @@ def test_host_preflight_blocks_non_allowlisted_claude_proxy(tmp_path: Path) -> N
 
     errs = run_mod._preflight(ws, oracle=True, env={
         "DAYDREAM_REVIEW_BACKEND": "claude",
+        "DAYDREAM_REVIEW_CASE_ID": "case-parser-proxy",
         "ANTHROPIC_API_KEY": "sk-ant",
         "ANTHROPIC_BASE_URL": "https://claude-proxy.internal/v1",
         "DAYDREAM_JUDGE_BASE_URL": "http://127.0.0.1:9",
@@ -229,7 +295,7 @@ def test_entrypoint_skill_free_python_case(tmp_path: Path, monkeypatch: pytest.M
     artifact = tmp_path / "logs" / "artifacts" / "review.json"
     seen: dict[str, Any] = {}
 
-    async def _fake_run(config: Any) -> int:
+    async def _fake_run(config: Any, *, execution: Any) -> int:
         seen["config"] = config
         merged = Path(config.target) / ".daydream" / "deep" / "merged-items.json"
         merged.parent.mkdir(parents=True)
@@ -247,7 +313,7 @@ def test_entrypoint_skill_free_python_case(tmp_path: Path, monkeypatch: pytest.M
 
     monkeypatch.setattr("daydream.runner.run", _fake_run)
 
-    rc = asyncio.run(entrypoint.main(monkeypatch_env={
+    rc = asyncio.run(entrypoint.main({
         "DAYDREAM_REVIEW_CASE_ID": "case-python",
         "DAYDREAM_REVIEW_ARTIFACT_PATH": str(artifact),
         "DAYDREAM_REVIEW_REPO_DIR": str(tmp_path),
@@ -283,7 +349,7 @@ def test_entrypoint_claude_backend_reaches_run_config(
     artifact.parent.mkdir(parents=True)
     seen: dict[str, Any] = {}
 
-    async def _fake_run(config: Any) -> int:
+    async def _fake_run(config: Any, *, execution: Any) -> int:
         seen["backend"] = config.backend
         return 0
 
@@ -293,7 +359,7 @@ def test_entrypoint_claude_backend_reaches_run_config(
     monkeypatch.setattr("daydream.runner.run", _fake_run)
     monkeypatch.setattr(entrypoint, "publish_review", _fake_publish)
 
-    rc = asyncio.run(entrypoint.main(monkeypatch_env={
+    rc = asyncio.run(entrypoint.main({
         "DAYDREAM_REVIEW_CASE_ID": "case-claude",
         "DAYDREAM_REVIEW_ARTIFACT_PATH": str(artifact),
         "DAYDREAM_REVIEW_REPO_DIR": str(tmp_path),
@@ -305,14 +371,13 @@ def test_entrypoint_claude_backend_reaches_run_config(
 
 
 def test_entrypoint_env_has_no_skill_dirs(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    # Inspect the environment while the runner is executing: checking after
-    # main() returns would miss a value that the test-only cleanup restored.
-    monkeypatch.delenv("DAYDREAM_SKILLS_DIR", raising=False)
+    # The map passed to main is the only execution environment; a hostile
+    # skill-dir value must not reach the run-owned backend carrier.
     artifact = tmp_path / "logs" / "artifacts" / "review.json"
     seen: dict[str, Any] = {}
 
-    async def _fake_run(config: Any) -> int:
-        seen["skill_dir"] = os.environ.get("DAYDREAM_SKILLS_DIR")
+    async def _fake_run(config: Any, *, execution: Any) -> int:
+        seen["skill_dir"] = execution.backend.child_environment().get("DAYDREAM_SKILLS_DIR")
         merged = Path(config.target) / ".daydream" / "deep" / "merged-items.json"
         merged.parent.mkdir(parents=True)
         merged.write_text('{"items": []}')
@@ -320,13 +385,14 @@ def test_entrypoint_env_has_no_skill_dirs(tmp_path: Path, monkeypatch: pytest.Mo
 
     monkeypatch.setattr("daydream.runner.run", _fake_run)
 
-    rc = asyncio.run(entrypoint.main(monkeypatch_env={
+    rc = asyncio.run(entrypoint.main({
         "DAYDREAM_REVIEW_CASE_ID": "case-noskill",
         "DAYDREAM_REVIEW_ARTIFACT_PATH": str(artifact),
         "DAYDREAM_REVIEW_REPO_DIR": str(tmp_path),
         "DAYDREAM_REVIEW_BACKEND": "pi",
         "DAYDREAM_REVIEW_API_KEY": "sk-or-test",
         "DAYDREAM_REVIEW_BASE_URL": "https://openrouter.ai/api",
+        "DAYDREAM_SKILLS_DIR": "/host/skills",
     }))
     assert rc == 0
     assert seen["skill_dir"] is None

--- a/tests/test_flow_engine.py
+++ b/tests/test_flow_engine.py
@@ -80,6 +80,43 @@ def test_backend_for_resolves_pi_model_from_workspace(tmp_path: Path) -> None:
     assert ctx.backend_for("review").model == "gpt-5.6-luna"
 
 
+def test_backend_factory_uses_context_workspace_and_cache(tmp_path: Path) -> None:
+    from daydream.backends import Backend
+    from daydream.runner import _resolve_backend
+    from daydream.workspace import AuditWorkspace
+
+    settings = tmp_path / ".pi" / "settings.json"
+    settings.parent.mkdir()
+    settings.write_text('{"defaultModel": "context-model"}')
+    ctx = _ctx(Registry())
+    ctx.config.backend = "pi"
+    ctx.work = WorkContext(
+        repo=tmp_path, source=tmp_path, base_branch="main", base_sha="0" * 40,
+        head_branch="feature", head_sha="1" * 40, is_ephemeral=False, run_id="factory",
+    )
+
+    resolved_phases: list[str] = []
+
+    def factory(
+        config: RunConfig, phase: str,
+        cache: dict[tuple[str, str | None, str | None, Path | None], Backend],
+        cwd: Path, audit: AuditWorkspace | None,
+    ) -> Backend:
+        resolved_phases.append(phase)
+        assert config is ctx.config
+        assert cache is ctx._backend_cache
+        assert cwd == tmp_path
+        assert audit is ctx.audit_workspace
+        return _resolve_backend(config, phase, cache, cwd=cwd, audit_workspace=audit)
+
+    ctx._backend_factory = factory
+    review = ctx.backend_for("review")
+    assert review.model == "context-model"
+    assert ctx.backend_for("review") is review
+    assert len(ctx._backend_cache) == 1
+    assert resolved_phases == ["review", "review"]
+
+
 async def test_order_gating_stop_and_loop() -> None:
     reg = Registry()
     reg.register_phase(FlowStep("a", run=_trace("a")))

--- a/tests/test_integration_workspace.py
+++ b/tests/test_integration_workspace.py
@@ -32,6 +32,7 @@ from daydream.backends import (
     ResultEvent,
     TextEvent,
 )
+from daydream.flows.engine import BackendFactory
 from daydream.github_app import GitHubExecutionInput
 from daydream.run_context import current_run_context
 from daydream.runner import RunConfig
@@ -186,8 +187,10 @@ async def test_branch_only_on_origin_creates_ephemeral_runs_review_cleans_up(
         run_artifacts: Any = None,
         *,
         run_context: Any, github_execution: GitHubExecutionInput,
+        backend_factory: BackendFactory | None,
     ) -> int:
         assert run_context is current_run_context()
+        assert backend_factory is None
         captured["base_branch"] = work.base_branch
         captured["is_ephemeral"] = work.is_ephemeral
         captured["head_sha"] = work.head_sha
@@ -265,8 +268,10 @@ async def test_branch_also_checked_out_locally_warns_uses_origin(
         run_artifacts: Any = None,
         *,
         run_context: Any, github_execution: GitHubExecutionInput,
+        backend_factory: BackendFactory | None,
     ) -> int:
         assert run_context is current_run_context()
+        assert backend_factory is None
         captured["head_sha"] = work.head_sha
         captured["is_ephemeral"] = work.is_ephemeral
         captured["repo"] = work.repo
@@ -328,8 +333,10 @@ async def test_comment_mode_without_open_pr_runs_deep_flow(
         run_artifacts: Any = None,
         *,
         run_context: Any, github_execution: GitHubExecutionInput,
+        backend_factory: BackendFactory | None,
     ) -> int:
         assert run_context is current_run_context()
+        assert backend_factory is None
         captured["is_ephemeral"] = work.is_ephemeral
         captured["head_sha"] = work.head_sha
         captured["output_mode"] = config.output_mode
@@ -396,8 +403,10 @@ async def test_comment_mode_with_open_pr_uses_pr_base(
         run_artifacts: Any = None,
         *,
         run_context: Any, github_execution: GitHubExecutionInput,
+        backend_factory: BackendFactory | None,
     ) -> int:
         assert run_context is current_run_context()
+        assert backend_factory is None
         captured["base_branch"] = work.base_branch
         captured["is_ephemeral"] = work.is_ephemeral
         return 0
@@ -450,8 +459,10 @@ async def test_review_mode_on_base_branch_does_not_error(
         run_artifacts: Any = None,
         *,
         run_context: Any, github_execution: GitHubExecutionInput,
+        backend_factory: BackendFactory | None,
     ) -> int:
         assert run_context is current_run_context()
+        assert backend_factory is None
         routed["base_branch"] = work.base_branch
         routed["head_branch"] = work.head_branch
         return 0

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -36,7 +36,7 @@ from daydream.backends import (
 )
 from daydream.exploration import ExplorationContext
 from daydream.extensions.loader import build_registry
-from daydream.flows.engine import FlowContext
+from daydream.flows.engine import BackendFactory, FlowContext
 from daydream.github_app import GitHubExecutionInput
 from daydream.run_context import RunContext, current_run_context
 from daydream.runner import RunConfig
@@ -989,6 +989,7 @@ async def test_run_dispatches_to_expected_flow(
         async def stub(
             work: Any, config: Any, _run_artifacts: Any = None, *,
             run_context: RunContext, github_execution: GitHubExecutionInput,
+            backend_factory: BackendFactory | None,
         ) -> int:
             assert run_context is current_run_context()
             called.append((name, work, config))
@@ -1025,6 +1026,7 @@ async def test_run_rejects_head_mismatch_before_dispatch(
         async def stub(
             work: Any, config: Any, _run_artifacts: Any = None, *,
             run_context: RunContext, github_execution: GitHubExecutionInput,
+            backend_factory: BackendFactory | None,
         ) -> int:
             assert run_context is current_run_context()
             called.append(name)
@@ -1056,6 +1058,7 @@ async def test_run_allows_matching_approved_head(
         async def stub(
             work: Any, config: Any, _run_artifacts: Any = None, *,
             run_context: RunContext, github_execution: GitHubExecutionInput,
+            backend_factory: BackendFactory | None,
         ) -> int:
             assert run_context is current_run_context()
             called.append(name)
@@ -1093,6 +1096,7 @@ async def test_run_rejects_head_mismatch_on_real_worktree(
         async def stub(
             work: Any, config: Any, _run_artifacts: Any = None, *,
             run_context: RunContext, github_execution: GitHubExecutionInput,
+            backend_factory: BackendFactory | None,
         ) -> int:
             assert run_context is current_run_context()
             called.append(name)
@@ -1129,6 +1133,7 @@ async def test_run_allows_matching_approved_head_on_real_worktree(
         async def stub(
             work: Any, config: Any, _run_artifacts: Any = None, *,
             run_context: RunContext, github_execution: GitHubExecutionInput,
+            backend_factory: BackendFactory | None,
         ) -> int:
             assert run_context is current_run_context()
             called.append(name)
@@ -1267,6 +1272,7 @@ async def test_review_run_does_not_mint_app_identity(
         config: RunConfig,
         _run_artifacts: Any = None,
         *, run_context: RunContext, github_execution: GitHubExecutionInput,
+        backend_factory: BackendFactory | None,
     ) -> int:
         assert run_context is current_run_context()
         assert config.identity == "operator"
@@ -1375,6 +1381,7 @@ async def test_comment_mode_without_open_pr_dispatches_to_deep_flow(
         config: RunConfig,
         _run_artifacts: Any = None,
         *, run_context: RunContext, github_execution: GitHubExecutionInput,
+        backend_factory: BackendFactory | None,
     ) -> int:
         assert run_context is current_run_context()
         seen["output_mode"] = config.output_mode
@@ -1867,6 +1874,7 @@ async def test_run_threads_non_interactive_into_runtime(
     async def stub(
         work: Any, config: Any, _run_artifacts: Any = None, *,
         run_context: RunContext, github_execution: GitHubExecutionInput,
+        backend_factory: BackendFactory | None,
     ) -> int:
         assert current_run_context() is run_context
         received.append(run_context)

--- a/tests/test_runner_execution_factory.py
+++ b/tests/test_runner_execution_factory.py
@@ -1,0 +1,155 @@
+"""Execution factories exercised through real custom and Improve flows."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from daydream import git_ops, runner
+from daydream.artifact_visibility import private_root_locations
+from daydream.backends import AUDIT_ROOT_ISOLATION_V1, BackendExecutionInput
+from daydream.config_file import DaydreamFileConfig
+from daydream.github_app import GitHubExecutionInput
+from tests.conftest import ExtDir
+from tests.harness.backend import ScriptedBackend
+from tests.harness.improve_backend import ImproveStubBackend, improve_artifact
+
+
+@pytest.mark.parametrize(
+    ("flow", "injected"),
+    [("factory-probe", True), ("improve", True), ("factory-probe", False)],
+)
+async def test_runner_factory_reaches_real_flows_and_preserves_ordinary_fallback(
+    flow: str,
+    injected: bool,
+    improve_monorepo_target: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    ext_dir: ExtDir,
+) -> None:
+    repo = improve_monorepo_target
+    login = "execution-owner" if injected else "ambient-owner"
+    ext_dir.write_module(
+        "from daydream.agent import run_agent\n"
+        "from daydream.extensions import FlowStep\n"
+        "from daydream.trajectory import DaydreamPhase\n"
+        "async def probe(ctx):\n"
+        "    phase = 'recon' if ctx.config.flow_name == 'improve' else 'probe'\n"
+        "    first = ctx.backend_for(phase)\n"
+        "    assert first is ctx.backend_for(phase)\n"
+        f"    assert ctx.config.identity == ctx.run_context.github_identity.login == {login!r}\n"
+        f"    assert (ctx._backend_factory is not None) is {injected!r}\n"
+        "    assert '_backend_factory' not in repr(ctx)\n"
+        "    assert 'github_execution' not in repr(ctx)\n"
+        "    if ctx.audit_workspace is not None:\n"
+        "        assert first.audit_root == ctx.audit_workspace.repo\n"
+        "        assert first.audit_root != ctx.work.repo\n"
+        "    else:\n"
+        "        await run_agent(first, ctx.work.repo, 'FACTORY_PROBE', "
+        "phase=DaydreamPhase.REVIEW, run_context=ctx.run_context)\n"
+        "def register(registry):\n"
+        "    registry.register_phase(FlowStep(name='factory-probe', run=probe))\n"
+        "    registry.set_flow('factory-probe', ['factory-probe'])\n"
+        "    registry.insert_before('improve', anchor='recon', step='factory-probe')\n"
+    )
+    source = {
+        "PATH": os.environ["PATH"],
+        "HOME": str(tmp_path / "execution-home"),
+        "ANTHROPIC_API_KEY": "factory-owned-private-key",
+        "DAYDREAM_PI_RETRY_ATTEMPTS": "0",
+    }
+    backend_input = BackendExecutionInput.from_environment(source, backend="claude")
+    github_input = GitHubExecutionInput(
+        git_ops.StaticGitHubAuth(
+            {
+                "PATH": os.environ["PATH"],
+                "HOME": source["HOME"],
+            }
+        )
+    )
+    execution = runner.RunnerExecutionInput(backend_input, github_input) if injected else None
+    created: list[Any] = []
+    github_environments: list[dict[str, str] | None] = []
+    real_subprocess_run = subprocess.run
+
+    def github_subprocess(args: list[str], *pargs: Any, **kwargs: Any) -> Any:
+        if args[0] != "gh":
+            return real_subprocess_run(args, *pargs, **kwargs)
+        assert args[1:3] == ["api", "/user"]
+        github_environments.append(kwargs["env"])
+        return subprocess.CompletedProcess(args, 0, json.dumps({"login": login}), "")
+
+    def create_backend(
+        name: str,
+        model: str | None = None,
+        *,
+        execution_input: Any = None,
+        audit_root: Path | None = None,
+        audit_outward_symlinks: frozenset[Path] = frozenset(),
+        **kwargs: Any,
+    ) -> Any:
+        assert name == "claude"
+        assert model == "factory-model"
+        assert execution_input is (backend_input if injected else None)
+        if flow == "improve":
+            assert audit_root is not None and audit_root != repo
+            backend: Any = ImproveStubBackend(repo, n_findings=0)
+            backend.audit_root = audit_root
+            backend.audit_root_isolation = AUDIT_ROOT_ISOLATION_V1
+            backend.audit_outward_symlinks = audit_outward_symlinks
+        else:
+            assert audit_root is None
+            backend = ScriptedBackend(model=model)
+        backend.model = model
+        if execution_input is not None:
+            backend.retry_policy = execution_input.retry_policy
+        created.append(backend)
+        return backend
+
+    monkeypatch.setattr(subprocess, "run", github_subprocess)
+    monkeypatch.setattr(runner, "create_backend", create_backend)
+    if injected:
+        # An injected GitHub capability must bypass ambient App validation/mint.
+        monkeypatch.setenv("DAYDREAM_APP_ID", "malformed-parent-app-id")
+        monkeypatch.setenv("DAYDREAM_APP_PRIVATE_KEY", "parent-private-key")
+    config = runner.RunConfig(
+        target=str(repo),
+        flow_name=flow,
+        base="main",
+        backend="claude",
+        model="factory-model",
+        archive=False,
+        run_eval=False,
+        non_interactive=True,
+        file_config=DaydreamFileConfig(),
+        trajectory_path=tmp_path / "trajectory.json",
+    )
+    result = await runner.run(
+        config,
+        execution=execution,
+        private_roots=private_root_locations(base=tmp_path / "private"),
+    )
+
+    assert result == 0
+    assert created and any(backend.calls for backend in created)
+    assert len(github_environments) == 1
+    if injected:
+        assert github_environments[0] == github_input.auth.environment_for_request()
+    else:
+        assert github_environments == [None]
+    if flow == "improve":
+        assert improve_artifact(repo, "recon.json").is_file()
+        for backend in created:
+            assert all(call["cwd"] == backend.audit_root for call in backend.calls)
+    else:
+        assert len(created) == 1
+        assert created[0].prompts == ["FACTORY_PROBE"]
+        assert created[0].calls[0]["cwd"] == repo
+    trajectory = (tmp_path / "trajectory.json").read_text()
+    assert "factory-owned-private-key" not in trajectory
+    assert "parent-private-key" not in trajectory


### PR DESCRIPTION
## Summary

- Parse Harbor reviewer inputs without mutating process environment. Concurrent embedded reviews keep their own provider credentials, paths, retry policy, fanout, and idle limits.
- Carry immutable runtime inputs through real deep, Improve, and custom flows to native Pi, Codex, Claude, and GitHub transports. Ordinary CLI callers retain existing environment inheritance.
- Scrub unrelated credentials, keep selected model credentials out of GitHub subprocesses, and keep all execution capabilities outside configuration and artifacts.

## Motivation

Harbor previously cleared and repopulated `os.environ`, while backend construction and retry handling read process globals. Concurrent in-process reviews could therefore replace each other's credentials or settings.

Closes #1022.

## Test Plan

- Real concurrent Pi/Claude Harbor journeys use separate Git repositories, overlap retries, capture native GitHub environments, and verify isolated profiles, candidate publication, trajectories, and unchanged caller/parent environments.
- Runner/factory journeys cover deep, Improve, custom API v6 flows, per-context caches, audit/cwd routing, and ordinary inheritance.
- Native boundaries cover Pi transport, Codex complete environments, independent Darwin toolchain resolution, and run-owned pricing lookup, and a real Claude SDK initialize/hooks/query/result handshake with hostile ambient settings.
- Prescribed integration selection plus new journey suites: 1,090 passed, 4 skipped before review corrections. Final Harbor/Pi follow-up: 193 passed, 1 skipped; native Claude module: 112 passed. Codex and pricing follow-up: 152 passed, 3 skipped, followed by 5 strengthened pricing cases passing.
- Final `make check`: 8,115 passed, 15 skipped; 88.67% coverage. Ruff, mypy across 534 files, root/RL dead-code scans, and Docker actionlint passed. The native-handshake regression covers both normal admission and the SDK-compatible best-effort version timeout while requiring both owning spawn environments and the real main handshake.
- Required local review: `daydream . --precision --non-interactive --backend codex` on signed `dc6ec12bc999366c5a7a8d8f6f678dffb9b4dd59`; session `bc8c181d-ddb4-421f-9ba6-5cb4ae624dca`, exit 0, complete 23/23-file coverage, zero actionable findings. Four final entries were two proposals rejected with recorded contract evidence: deliberately inconsistent backend inputs outside Harbor composition, and changing preserved per-turn pricing-file lookup. Optional diagram generation exceeded its input budget; code-review phases succeeded. Full report, artifacts, and dispositions retained in the private execution ledger.

## Checklist

- [x] Root lint, typing, tests, coverage, root/RL dead-code scans, and Docker workflow lint pass through `make check`.
- [x] Harbor runtime boundary and ordinary inheritance documented.

## Additional Context

The injected Claude path uses a bounded adapter for the pinned SDK 0.2.147 transport and initialization internals because its default path merges ambient environment and reads an ambient timeout. SDK upgrades must preserve the covered handshake/lifecycle behavior.

Supplied home and configuration paths retain normal filesystem lookup behavior; this change does not introduce a separate filesystem credential store.
