### PR TITLE
refactor(artifacts): require explicit session routing

### DIFF
--- a/daydream/artifact_visibility.py
+++ b/daydream/artifact_visibility.py
@@ -40,7 +40,13 @@ if TYPE_CHECKING:
 _SCHEMA_VERSION = 1
 _DAYDREAM = ".daydream"
 _REVIEW_OUTPUT = ".review-output.md"
-_LEGACY_ANCHORS = frozenset(("runs", "deep", "exploration", "partial-fixes", "diff.patch", "hunk-index.json"))
+_LEGACY_DIRECTORY_ANCHORS = frozenset(
+    ("runs", "deep", "exploration", "partial-fixes", "improve")
+)
+_LEGACY_FILE_ANCHORS = frozenset(
+    ("diff.patch", "hunk-index.json", "recommended.patch")
+)
+_LEGACY_ANCHORS = _LEGACY_DIRECTORY_ANCHORS | _LEGACY_FILE_ANCHORS
 _OPERATIONAL_NAMES = frozenset(("worktrees", "audit"))
 
 
@@ -353,6 +359,59 @@ def private_root_locations(*, base: Path | None = None) -> PrivateRootLocations:
 
 def _absolute_lexical(path: Path) -> Path:
     return Path(os.path.abspath(os.fspath(path)))
+
+
+def _projection_path(path: Path) -> Path:
+    """Admit one absolute lexical path without resolving absent components."""
+    if (
+        not isinstance(path, Path)
+        or not path.is_absolute()
+        or "\0" in os.fspath(path)
+        or _absolute_lexical(path) != path
+    ):
+        raise ArtifactVisibilityError("artifact projection path is unsafe")
+    return path
+
+
+def _validate_projection_ancestry(
+    path: Path,
+    *,
+    expected_kind: Literal["file", "directory", "either"],
+) -> None:
+    """Validate existing projection components without requiring the leaf."""
+    for index, component in enumerate((path, *path.parents)):
+        try:
+            metadata = component.lstat()
+        except FileNotFoundError:
+            continue
+        except OSError as exc:
+            raise ArtifactVisibilityError(
+                "artifact projection path could not be inspected"
+            ) from exc
+        if stat.S_ISLNK(metadata.st_mode):
+            raise ArtifactVisibilityError(
+                "artifact projection ancestry contains a symlink"
+            )
+        if index == 0:
+            valid_leaf = (
+                expected_kind == "directory"
+                and stat.S_ISDIR(metadata.st_mode)
+                or expected_kind == "file"
+                and stat.S_ISREG(metadata.st_mode)
+                or expected_kind == "either"
+                and (
+                    stat.S_ISDIR(metadata.st_mode)
+                    or stat.S_ISREG(metadata.st_mode)
+                )
+            )
+            if not valid_leaf:
+                raise ArtifactVisibilityError(
+                    "artifact projection has the wrong filesystem type"
+                )
+        elif not stat.S_ISDIR(metadata.st_mode):
+            raise ArtifactVisibilityError(
+                "artifact projection ancestry is not a directory"
+            )
 
 
 def _declared_directory_metadata(path: Path, *, label: str) -> tuple[Path, os.stat_result]:
@@ -2556,7 +2615,24 @@ def _validate_owner(path: Path, expected: dict[str, object]) -> None:
         raise ArtifactVisibilityError("artifact owner metadata does not match the source")
 
 
-def _validate_legacy_public(source: Path) -> None:
+def _validated_canonical_entries(
+    state_root: Path,
+) -> tuple[ArtifactManifestEntry, ...] | None:
+    """Return an attested prior public tree, if this workspace has one."""
+    canonical = state_root / "canonical"
+    if not canonical.exists() and not canonical.is_symlink():
+        return None
+    entries = _parse_manifest(state_root / "canonical-manifest.json")
+    if _manifest(canonical) != entries:
+        raise ArtifactVisibilityError("canonical artifact recovery copy is corrupt")
+    return entries
+
+
+def _validate_legacy_public(
+    source: Path,
+    *,
+    canonical_entries: tuple[ArtifactManifestEntry, ...] | None,
+) -> tuple[ArtifactManifestEntry, ...]:
     daydream = source / _DAYDREAM
     if daydream.exists() or daydream.is_symlink():
         try:
@@ -2588,13 +2664,76 @@ def _validate_legacy_public(source: Path) -> None:
             if occupied:
                 raise ArtifactVisibilityError("legacy operational workspace blocks artifact detach")
             anchor_children.discard(name)
-        if anchor_children and not anchor_children.intersection(_LEGACY_ANCHORS):
-            raise ArtifactVisibilityError("legacy .daydream tree has no recognized artifact anchor")
+        for name in sorted(anchor_children & _LEGACY_ANCHORS):
+            anchor = daydream / name
+            try:
+                anchor_metadata = anchor.lstat()
+            except OSError as exc:
+                raise ArtifactVisibilityError(
+                    "legacy artifact anchor could not be inspected"
+                ) from exc
+            expected_directory = name in _LEGACY_DIRECTORY_ANCHORS
+            if stat.S_ISLNK(anchor_metadata.st_mode) or (
+                expected_directory != stat.S_ISDIR(anchor_metadata.st_mode)
+                or not (
+                    stat.S_ISDIR(anchor_metadata.st_mode)
+                    or stat.S_ISREG(anchor_metadata.st_mode)
+                )
+            ):
+                raise ArtifactVisibilityError(
+                    "legacy artifact anchor has the wrong filesystem type"
+                )
     review = source / _REVIEW_OUTPUT
     if review.exists() or review.is_symlink():
         metadata = review.lstat()
         if stat.S_ISLNK(metadata.st_mode) or not stat.S_ISREG(metadata.st_mode):
             raise ArtifactVisibilityError("artifact roots accept only regular files and directories")
+    public_entries = _manifest(source, (_DAYDREAM, _REVIEW_OUTPUT))
+    daydream_entry = _entry_at(public_entries, _DAYDREAM)
+    if daydream_entry is not None and daydream_entry.kind != "directory":
+        raise ArtifactVisibilityError("artifact roots accept only regular files and directories")
+    review_entry = _entry_at(public_entries, _REVIEW_OUTPUT)
+    if review_entry is not None and review_entry.kind != "file":
+        raise ArtifactVisibilityError("artifact roots accept only regular files and directories")
+    daydream_prefix = f"{_DAYDREAM}/"
+    manifested_children = {
+        entry.path.removeprefix(daydream_prefix): entry
+        for entry in public_entries
+        if entry.path.startswith(daydream_prefix)
+        and "/" not in entry.path.removeprefix(daydream_prefix)
+    }
+    for name in sorted(manifested_children.keys() & _OPERATIONAL_NAMES):
+        relative = f"{_DAYDREAM}/{name}"
+        if manifested_children[name].kind != "directory" or any(
+            entry.path.startswith(f"{relative}/") for entry in public_entries
+        ):
+            raise ArtifactVisibilityError("legacy operational workspace blocks artifact detach")
+    anchor_children = manifested_children.keys() - _OPERATIONAL_NAMES
+    for name in sorted(anchor_children & _LEGACY_ANCHORS):
+        expected_kind = "directory" if name in _LEGACY_DIRECTORY_ANCHORS else "file"
+        if manifested_children[name].kind != expected_kind:
+            raise ArtifactVisibilityError(
+                "legacy artifact anchor has the wrong filesystem type"
+            )
+    nonstatic_children = anchor_children - _LEGACY_ANCHORS
+    for name in sorted(nonstatic_children):
+        relative = f"{_DAYDREAM}/{name}"
+        prefix = f"{relative}/"
+        actual = tuple(
+            entry
+            for entry in public_entries
+            if entry.path == relative or entry.path.startswith(prefix)
+        )
+        expected = tuple(
+            entry
+            for entry in canonical_entries or ()
+            if entry.path == relative or entry.path.startswith(prefix)
+        )
+        if not expected or actual != expected:
+            raise ArtifactVisibilityError(
+                "legacy .daydream tree contains an unregistered artifact anchor"
+            )
+    return public_entries
 
 
 def _manifest_is_subset(
@@ -3466,6 +3605,102 @@ class ArtifactSession:
             live_root=self.layout.live_root,
         )
 
+    @staticmethod
+    def _projection_kind(route: RoutedDestination) -> Literal["file", "directory"]:
+        return (
+            "directory"
+            if route.label in (OutputLabel.PUBLIC_DAYDREAM, OutputLabel.DUMP_DIRECTORY)
+            else "file"
+        )
+
+    def _projection_routes(self) -> tuple[RoutedDestination, ...]:
+        trajectory = self._trajectory_route
+        paired = () if trajectory is None else (trajectory.full, trajectory.partial)
+        return (*paired, *self._destinations)
+
+    def durable_path_for(self, path: Path, *, repo: Path) -> Path:
+        """Project one registered live write path to its durable destination."""
+        self._route_repo(repo)
+        declared = _projection_path(path)
+
+        # Exact explicit routes precede the public .daydream subtree. A custom
+        # trajectory may deliberately publish somewhere inside that subtree
+        # while writing at the session's canonical trajectory path.
+        for route in self._projection_routes():
+            if route.label is OutputLabel.PUBLIC_DAYDREAM or route.write_path is None:
+                continue
+            if declared == route.write_path:
+                kind = self._projection_kind(route)
+                _validate_projection_ancestry(declared, expected_kind=kind)
+                _validate_projection_ancestry(route.requested, expected_kind=kind)
+                return route.requested
+
+        for route in self._destinations:
+            if route.label is not OutputLabel.PUBLIC_DAYDREAM:
+                continue
+            live_root = route.write_path
+            if live_root is None:
+                raise ArtifactVisibilityError(
+                    "registered artifact destination has no writable path"
+                )
+            if declared == live_root or live_root in declared.parents:
+                relative = declared.relative_to(live_root)
+                durable = route.requested / relative
+                leaf_kind: Literal["directory", "either"] = (
+                    "directory" if not relative.parts else "either"
+                )
+                _validate_projection_ancestry(
+                    declared, expected_kind=leaf_kind
+                )
+                _validate_projection_ancestry(durable, expected_kind=leaf_kind)
+                return durable
+
+        raise ArtifactVisibilityError(
+            "path is not owned by a registered artifact destination"
+        )
+
+    def live_path_for(self, path: Path, *, repo: Path) -> Path:
+        """Project one registered durable destination to its live write path."""
+        self._route_repo(repo)
+        declared = _projection_path(path)
+
+        for route in self._projection_routes():
+            if route.label is OutputLabel.PUBLIC_DAYDREAM:
+                continue
+            if declared == route.requested:
+                kind = self._projection_kind(route)
+                _validate_projection_ancestry(declared, expected_kind=kind)
+                if route.write_path is None:
+                    raise ArtifactVisibilityError(
+                        "registered artifact destination has no writable path"
+                    )
+                _validate_projection_ancestry(route.write_path, expected_kind=kind)
+                return route.write_path
+
+        for route in self._destinations:
+            if route.label is not OutputLabel.PUBLIC_DAYDREAM:
+                continue
+            live_root = route.write_path
+            if live_root is None:
+                raise ArtifactVisibilityError(
+                    "registered artifact destination has no writable path"
+                )
+            if declared == route.requested or route.requested in declared.parents:
+                relative = declared.relative_to(route.requested)
+                live = live_root / relative
+                leaf_kind: Literal["directory", "either"] = (
+                    "directory" if not relative.parts else "either"
+                )
+                _validate_projection_ancestry(
+                    declared, expected_kind=leaf_kind
+                )
+                _validate_projection_ancestry(live, expected_kind=leaf_kind)
+                return live
+
+        raise ArtifactVisibilityError(
+            "path is not owned by a registered artifact destination"
+        )
+
     def _require_active(self) -> None:
         if self._state is not _SessionState.ACTIVE:
             raise ArtifactVisibilityError("artifact session is frozen and no longer writable")
@@ -4234,27 +4469,31 @@ class ArtifactSession:
         os.close(self._repo_fd)
 
 
-def artifact_dir_for(repo: Path, *, session: ArtifactSession | None = None, allow_standalone: bool = True) -> Path:
-    """Routed ``.daydream`` path for *repo* (one explicit-or-bound session).
+def artifact_dir_for(
+    repo: Path,
+    *,
+    session: ArtifactSession | None = None,
+    allow_standalone: bool = False,
+) -> Path:
+    """Routed ``.daydream`` path for *repo*.
 
-    Resolution order (#1162): an explicitly passed ``session`` wins and is
-    routed with the usual fail-closed repo identity checks; otherwise the
-    bound channel (``_SESSION``, the documented extension contract) is used;
-    otherwise the legacy ``repo/.daydream`` path is returned only when
-    ``allow_standalone`` is set — intentional standalone phase calls keep
-    working (docs/extensions.md), while strict callers can pass
-    ``allow_standalone=False`` to fail closed instead of silently writing the
-    public tree when no session is bound.
+    Production callers pass an explicit session. Intentional standalone and
+    legacy extension callers must affirmatively allow compatibility routing;
+    only that path may consult the bound session before falling back to the
+    public ``repo/.daydream`` location.
     """
-    resolved = session if session is not None else _SESSION.get()
-    if resolved is None:
-        if not allow_standalone:
-            raise ArtifactVisibilityError(
-                "no artifact session is bound and standalone artifact routing is not allowed"
-            )
-        return repo / _DAYDREAM
-    resolved._route_repo(repo)
-    return resolved.daydream_dir
+    if session is not None:
+        session._route_repo(repo)
+        return session.daydream_dir
+    if not allow_standalone:
+        raise ArtifactVisibilityError(
+            "an explicit artifact session is required for strict artifact routing"
+        )
+    bound = _SESSION.get()
+    if bound is not None:
+        bound._route_repo(repo)
+        return bound.daydream_dir
+    return repo / _DAYDREAM
 
 
 def artifact_session_active() -> bool:
@@ -4266,18 +4505,21 @@ def review_output_path_for(
     repo: Path,
     *,
     session: ArtifactSession | None = None,
-    allow_standalone: bool = True,
+    allow_standalone: bool = False,
 ) -> Path:
     """Routed ``.review-output.md`` path for *repo* (see :func:`artifact_dir_for`)."""
-    resolved = session if session is not None else _SESSION.get()
-    if resolved is None:
-        if not allow_standalone:
-            raise ArtifactVisibilityError(
-                "no artifact session is bound and standalone artifact routing is not allowed"
-            )
-        return repo / _REVIEW_OUTPUT
-    resolved._route_repo(repo)
-    return resolved.review_output
+    if session is not None:
+        session._route_repo(repo)
+        return session.review_output
+    if not allow_standalone:
+        raise ArtifactVisibilityError(
+            "an explicit artifact session is required for strict artifact routing"
+        )
+    bound = _SESSION.get()
+    if bound is not None:
+        bound._route_repo(repo)
+        return bound.review_output
+    return repo / _REVIEW_OUTPUT
 
 
 def assert_model_cwd_clean(cwd: Path) -> None:
@@ -4400,7 +4642,11 @@ def _open_layout(work: WorkContext, session_id: str, owner: PrivateWorkspaceOwne
         transaction: Path | None = None
         try:
             _recover_transactions(state_root, source)
-            _validate_legacy_public(source)
+            validated_canonical_entries = _validated_canonical_entries(state_root)
+            validated_public_entries = _validate_legacy_public(
+                source,
+                canonical_entries=validated_canonical_entries,
+            )
             runs = state_root / "runs"
             transactions = state_root / "transactions"
             _create_private_directory(runs)
@@ -4411,6 +4657,8 @@ def _open_layout(work: WorkContext, session_id: str, owner: PrivateWorkspaceOwne
             run_root.mkdir(mode=0o700)
 
             public_entries = _manifest(source, (_DAYDREAM, _REVIEW_OUTPUT))
+            if public_entries != validated_public_entries:
+                raise ArtifactVisibilityError("public artifacts changed during session open")
             transaction_id = f"detach-{session_id}-{secrets.token_hex(8)}"
             transaction = transactions / transaction_id
             transaction.mkdir(mode=0o700)
@@ -4436,6 +4684,8 @@ def _open_layout(work: WorkContext, session_id: str, owner: PrivateWorkspaceOwne
             canonical_present = canonical.exists()
             if canonical_present:
                 canonical_entries = _parse_manifest(canonical_manifest)
+                if _manifest(canonical) != canonical_entries:
+                    raise ArtifactVisibilityError("canonical artifact recovery copy is corrupt")
                 if public_entries != canonical_entries:
                     _rebaseline_canonical_from_public(
                         state_root, source, public_entries, transaction=transaction

--- a/daydream/deep/artifacts.py
+++ b/daydream/deep/artifacts.py
@@ -1,7 +1,8 @@
 """Deep-review artifact path helpers + predecessor-check guard.
 
-All deep-mode artifacts live under `target / ".daydream" / "deep"` per D-41.
-The final merged report writes to `target / REVIEW_OUTPUT_FILE` per D-24/D-42.
+Deep artifacts use the explicit session's private `.daydream/deep` route.
+Intentional standalone callers opt into `target / ".daydream" / "deep"`.
+The session publishes the merged report to `target / REVIEW_OUTPUT_FILE`.
 
 The check_deep_artifacts() helper mirrors check_review_file_exists()
 (daydream/phases.py:611-629) -- same exception type, same actionable message format.
@@ -12,7 +13,7 @@ from __future__ import annotations
 import hashlib
 from pathlib import Path
 
-from daydream.artifact_visibility import artifact_dir_for
+from daydream.artifact_visibility import ArtifactSession, artifact_dir_for
 
 # Stage prerequisites -- single source of truth.
 # Value is a list of file names (relative to deep_dir) that must exist before the
@@ -33,9 +34,11 @@ _EARLIER_STAGE: dict[str, str] = {
 }
 
 
-def deep_dir(target: Path) -> Path:
+def deep_dir(
+    target: Path, *, session: ArtifactSession | None = None, allow_standalone: bool = False,
+) -> Path:
     """Return the `.daydream/deep/` directory for `target`, creating it if absent."""
-    d = artifact_dir_for(target) / "deep"
+    d = artifact_dir_for(target, session=session, allow_standalone=allow_standalone) / "deep"
     d.mkdir(parents=True, exist_ok=True)
     return d
 

--- a/daydream/deep/orchestrator.py
+++ b/daydream/deep/orchestrator.py
@@ -27,7 +27,12 @@ import anyio
 from rich.markup import escape as escape_markup
 
 from daydream.agent import console, run_agent
-from daydream.artifact_visibility import artifact_dir_for, review_output_path_for
+from daydream.artifact_visibility import (
+    ArtifactVisibilityError,
+    artifact_dir_for,
+    artifact_session_active,
+    review_output_path_for,
+)
 from daydream.backends import effective_fanout_concurrency
 from daydream.config import (
     DEFAULT_DEEP_SHARD_ENABLED,
@@ -1060,7 +1065,11 @@ async def _step_exploration(ctx: FlowContext) -> None:
 
     config = ctx.config
     target_dir = ctx.work.repo
-    daydream_dir = artifact_dir_for(target_dir)
+    daydream_dir = artifact_dir_for(
+        target_dir,
+        session=ctx.artifacts,
+        allow_standalone=ctx.allow_standalone_artifacts,
+    )
     # Issue #644 — the pre-scan must be grounded in the FULL diff, never the
     # bounded in-memory ``ctx.data["diff"]``: ``detect_affected_files`` seeds a
     # specialist per affected file, so a dropped-block file would otherwise get
@@ -1349,6 +1358,8 @@ async def _per_stack_body(ctx: FlowContext, *, include_alternatives: bool) -> No
                 # sharding; #740 updates the evidence gate and bounds).
                 write_coverage_receipts=True,
                 run_context=ctx.run_context,
+                artifact_session=ctx.artifacts,
+                allow_standalone=ctx.allow_standalone_artifacts,
             )
         # Persist so a later `--start-at merge` resume can still surface
         # uncovered stacks (the in-memory failure map otherwise dies here).
@@ -2138,6 +2149,8 @@ async def _step_arbiter(ctx: FlowContext) -> None:
                     intent_authoritative=ctx.data.get("intent_authoritative", False),
                     strategy=ctx.strategy("arbitration"),
                     run_context=ctx.run_context,
+                    artifact_session=ctx.artifacts,
+                    allow_standalone=ctx.allow_standalone_artifacts,
                 )
                 # Identity gate: only resume when merge runs on the very same
                 # backend instance. A per-phase override that resolves a
@@ -2200,6 +2213,8 @@ async def _step_arbiter(ctx: FlowContext) -> None:
                         exploration_dir=ctx.data["exploration_dir"],
                         strategy=ctx.strategy("suppression"),
                         run_context=ctx.run_context,
+                        artifact_session=ctx.artifacts,
+                        allow_standalone=ctx.allow_standalone_artifacts,
                     )
                 adjudicated, adjudicated_sources = _apply_adjudication_verdicts(
                     adjudicated, adjudicated_sources, suppression_targets, sup_verdicts,
@@ -2432,6 +2447,8 @@ async def _step_cross_stack_merge(ctx: FlowContext) -> Stop | None:
                 continuation=ctx.data.get("arbiter_continuation"),
                 strategy=ctx.strategy("merge"),
                 run_context=ctx.run_context,
+                artifact_session=ctx.artifacts,
+                allow_standalone=ctx.allow_standalone_artifacts,
             )
         except CrossStackMergeError as exc:
             phase.finish(LifecycleStatus.FAILED, LifecycleReasonCode.DOMAIN_FAILURE)
@@ -2492,6 +2509,8 @@ def _salvage_merge_failure(ctx: FlowContext, exc: CrossStackMergeError) -> None:
         records,
         ctx.data["structural_records_path"],
         failed_stacks=ctx.data.get("failed_stacks") or None,
+        artifact_session=ctx.artifacts,
+        allow_standalone=ctx.allow_standalone_artifacts,
     )
 
     # Record the failure for resume. Never drop existing per-stack entries.
@@ -2524,6 +2543,8 @@ async def _step_single_stack_merge(ctx: FlowContext) -> None:
             ctx.data["records"],
             ctx.data["structural_records_path"],
             failed_stacks=failed_stacks or None,
+            artifact_session=ctx.artifacts,
+            allow_standalone=ctx.allow_standalone_artifacts,
         )
 
 
@@ -2533,7 +2554,11 @@ async def _step_load_items(ctx: FlowContext) -> Stop | None:
     dd = ctx.data["dd"]
 
     print_stage_progress(console, 5, 5, _PIPELINE_STAGE_NAMES[4])
-    merged_report = review_output_path_for(target_dir)
+    merged_report = review_output_path_for(
+        target_dir,
+        session=ctx.artifacts,
+        allow_standalone=ctx.allow_standalone_artifacts,
+    )
 
     # merged-items.json is the canonical source of truth; review-output.md is
     # render-only. The missing-input guard keys on the JSON so a --start-at fix
@@ -2716,6 +2741,8 @@ async def _step_supervise(ctx: FlowContext) -> None:
                 exploration_dir=ctx.data["exploration_dir"],
                 strategy=ctx.strategy("supervision"),
                 run_context=ctx.run_context,
+                artifact_session=ctx.artifacts,
+                allow_standalone=ctx.allow_standalone_artifacts,
             )
     kept, held, events = apply_findings_verdicts(items, verdicts)
     items_file.write_text(json.dumps({"items": kept, "held": held}, indent=2))
@@ -3246,7 +3273,15 @@ async def _run_diagram_step(
     from daydream.services import enumerate_services
 
     changed_files = sorted(str(path) for path in ctx.data["changed_files"])
-    hunk_ranges = head_side_ranges_by_file(load_hunk_index(artifact_dir_for(target_dir)))
+    hunk_ranges = head_side_ranges_by_file(
+        load_hunk_index(
+            artifact_dir_for(
+                target_dir,
+                session=ctx.artifacts,
+                allow_standalone=ctx.allow_standalone_artifacts,
+            )
+        )
+    )
     file_config = _file_config_or_empty(ctx.config)
     eligibility = decide_eligibility(
         repo_root=target_dir,
@@ -3473,7 +3508,11 @@ async def _step_fix_gate(ctx: FlowContext) -> Stop | None:
         fix_failures_path(dd),
         fix_leftover_untracked_path(dd),
         stabilization_failed_path(dd),
-        artifact_dir_for(ctx.work.repo) / "recommended.patch",
+        artifact_dir_for(
+            ctx.work.repo,
+            session=ctx.artifacts,
+            allow_standalone=ctx.allow_standalone_artifacts,
+        ) / "recommended.patch",
     )
     try:
         for stale in stale_paths:
@@ -4436,7 +4475,13 @@ async def _step_fix_authorized(ctx: FlowContext, state: FixCycleState) -> Stop |
     }
     if quality_enabled:
         quality_before, quality_unavailable = await _capture_quality_before(
-            artifact_dir_for(ctx.work.repo), ctx.work.repo, reviewed_python
+            artifact_dir_for(
+                ctx.work.repo,
+                session=ctx.artifacts,
+                allow_standalone=ctx.allow_standalone_artifacts,
+            ),
+            ctx.work.repo,
+            reviewed_python,
         )
     else:
         quality_before, quality_unavailable = None, None
@@ -4566,7 +4611,11 @@ async def _step_fix_authorized(ctx: FlowContext, state: FixCycleState) -> Stop |
             verbosity_absolute_threshold=_quality_gate_threshold(
                 config, "quality_gate_verbosity_absolute", DEFAULT_QUALITY_GATE_VERBOSITY_ABSOLUTE
             ),
-            daydream_dir=artifact_dir_for(ctx.work.repo),
+            daydream_dir=artifact_dir_for(
+                ctx.work.repo,
+                session=ctx.artifacts,
+                allow_standalone=ctx.allow_standalone_artifacts,
+            ),
             code_workspace=ctx.work.repo,
             dd=ctx.data["dd"],
             candidates={path for path in snapshot.paths if path.endswith(".py")}
@@ -4923,7 +4972,11 @@ async def finalize_retained_tree_after_test(
             )
 
         try:
-            patch_path = artifact_dir_for(ctx.work.repo) / "recommended.patch"
+            patch_path = artifact_dir_for(
+                ctx.work.repo,
+                session=ctx.artifacts,
+                allow_standalone=ctx.allow_standalone_artifacts,
+            ) / "recommended.patch"
             patch_path.parent.mkdir(parents=True, exist_ok=True)
             patch_path.write_bytes(snapshot.recommended_patch)
             atomic_write_json(
@@ -4969,6 +5022,8 @@ async def _step_test(ctx: FlowContext) -> Stop | None:
                 capture_tree_key=lambda: _capture_full_delta_key(ctx.work, state),
                 footprint=state.footprint,
                 run_context=ctx.run_context,
+                artifact_session=ctx.artifacts,
+                allow_standalone=ctx.allow_standalone_artifacts,
             )
             if not isinstance(result, TestAndHealResult):
                 raise TypeError("phase_test_and_heal returned an invalid evidence result")
@@ -5371,7 +5426,11 @@ async def _perform_cleanup(ctx: FlowContext) -> None:
 
     if not enabled:
         return
-    review_output_path = review_output_path_for(target_dir)
+    review_output_path = review_output_path_for(
+        target_dir,
+        session=ctx.artifacts,
+        allow_standalone=ctx.allow_standalone_artifacts,
+    )
     if review_output_path.exists():
         review_output_path.unlink()
         print_success(console, f"Cleaned up {REVIEW_OUTPUT_FILE}")
@@ -5572,6 +5631,7 @@ async def run_deep(
     run_context: RunContext | None = None,
     github_execution: GitHubExecutionInput | None = None,
     backend_factory: BackendFactory | None = None,
+    allow_standalone: bool = False,
 ) -> int:
     """Execute the deep-review pipeline (D-07) across every PR-process mode.
 
@@ -5592,11 +5652,18 @@ async def run_deep(
         work: Resolved working environment for the run.
         run_artifacts: The composition root's artifact session and its
             pre-registered output routes, or ``None`` for a standalone caller.
+        allow_standalone: Intentional direct callers without ``run_artifacts``
+            must pass ``True`` and have no active artifact session.
+            Runner-managed calls always keep this false.
 
     Returns:
         Exit code (0 on success, 1 on failure).
     """
     run_context = resolve_run_context(run_context)
+    if run_artifacts is None and not allow_standalone:
+        raise ArtifactVisibilityError("standalone deep flow requires allow_standalone=True")
+    if run_artifacts is None and artifact_session_active():
+        raise ArtifactVisibilityError("standalone deep flow cannot run inside an active artifact session")
     execution = github_execution or GitHubExecutionInput()
     return await _run_review_spine(
         config,
@@ -5606,6 +5673,7 @@ async def run_deep(
         run_context=run_context,
         github_execution=execution,
         backend_factory=backend_factory,
+        allow_standalone=allow_standalone,
     )
 
 
@@ -5675,8 +5743,10 @@ async def _run_review_spine(
     run_context: RunContext | None = None,
     github_execution: GitHubExecutionInput,
     backend_factory: BackendFactory | None = None,
+    allow_standalone: bool = False,
 ) -> int:
     """Review-spine preamble for the deep pipeline (the former ``run_deep`` body)."""
+    artifact_session = None if run_artifacts is None else run_artifacts.session
     run_context = resolve_run_context(run_context)
     # Late imports to avoid circular dependency with runner.
     from daydream import git_ops
@@ -5717,7 +5787,11 @@ async def _run_review_spine(
         print_warning(console, f"No diff found -- nothing to {subject}")
         return 0
 
-    daydream_dir = artifact_dir_for(target_dir)
+    daydream_dir = artifact_dir_for(
+        target_dir,
+        session=artifact_session,
+        allow_standalone=allow_standalone,
+    )
     daydream_dir.mkdir(exist_ok=True)
     diff_path = daydream_dir / "diff.patch"
     diff_path.write_text(diff)
@@ -5728,7 +5802,11 @@ async def _run_review_spine(
     # Diff is immutable from here on; compute the tiering verdict once and reuse
     # it at both the exploration step's gate and the alternatives step's gate.
     tier = select_tier(count_changed_files(diff))
-    dd = deep_dir(target_dir)
+    dd = deep_dir(
+        target_dir,
+        session=artifact_session,
+        allow_standalone=allow_standalone,
+    )
     current_diff_sha = diff_key(diff)
     # Issue #1113: a diagram-only run must NEVER clear ``.daydream/deep/``. It
     # produces none of the artifacts ``diff-key`` attests, and wiping the
@@ -5747,6 +5825,7 @@ async def _run_review_spine(
     async with _open_recorder(
         config=config, target_dir=target_dir, work=work, flow_kind=_flow_kind_for_mode(mode),
         run_artifacts=run_artifacts,
+        allow_standalone=allow_standalone,
     ):
         # Composition-root re-entry: resolution already happened in
         # ``_run_loop_deep`` before this recorder existed; this no-op resolve
@@ -5956,6 +6035,7 @@ async def _run_review_spine(
                 "failed_stacks": {},
             },
             _backend_cache=backend_cache,
+            allow_standalone_artifacts=allow_standalone,
         )
 
         # Nothing is torn down after the flow. .daydream/exploration/ is a

--- a/daydream/flows/engine.py
+++ b/daydream/flows/engine.py
@@ -66,6 +66,9 @@ class FlowContext:
         _backend_factory: Runner-bound transport factory. It receives this
             context's configuration, cache, workspace, and audit boundary;
             omission keeps ordinary backend resolution.
+        allow_standalone_artifacts: Explicit opt-in for direct flow callers
+            without a runner-owned artifact session. Runner-created contexts
+            keep this false and pass ``artifacts`` to generated-path helpers.
     """
 
     config: RunConfig
@@ -76,6 +79,7 @@ class FlowContext:
     audit_workspace: AuditWorkspace | None = None
     private_workspace_owner: PrivateWorkspaceOwner | None = None
     artifacts: ArtifactSession | None = None
+    allow_standalone_artifacts: bool = field(default=False, kw_only=True)
     run_context: RunContext | None = field(default=None, kw_only=True)
     github_execution: GitHubExecutionInput = field(
         default_factory=GitHubExecutionInput, repr=False, compare=False, kw_only=True,

--- a/daydream/improve/artifacts.py
+++ b/daydream/improve/artifacts.py
@@ -4,12 +4,14 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from daydream.artifact_visibility import artifact_dir_for
+from daydream.artifact_visibility import ArtifactSession, artifact_dir_for
 
 
-def improve_dir(target: Path) -> Path:
+def improve_dir(
+    target: Path, *, session: ArtifactSession | None = None, allow_standalone: bool = False,
+) -> Path:
     """Return the target's ``.daydream/improve`` directory, creating it."""
-    directory = artifact_dir_for(target) / "improve"
+    directory = artifact_dir_for(target, session=session, allow_standalone=allow_standalone) / "improve"
     directory.mkdir(parents=True, exist_ok=True)
     return directory
 

--- a/daydream/phases.py
+++ b/daydream/phases.py
@@ -27,7 +27,13 @@ from daydream.agent import (
     resolve_gate,
     run_agent,
 )
-from daydream.artifact_visibility import artifact_dir_for, artifact_session_active, review_output_path_for
+from daydream.artifact_visibility import (
+    ArtifactSession,
+    ArtifactVisibilityError,
+    artifact_dir_for,
+    artifact_session_active,
+    review_output_path_for,
+)
 from daydream.backends import (
     Backend,
     ContinuationToken,
@@ -667,7 +673,11 @@ def _changed_files(repo: Path) -> list[Path]:
 
 
 def _resolve_handoff_paths(
-    recorder: TrajectoryRecorder | None, work: WorkContext,
+    recorder: TrajectoryRecorder | None,
+    work: WorkContext,
+    *,
+    artifact_session: ArtifactSession | None = None,
+    allow_standalone: bool = False,
 ) -> tuple[Path, Path | None, Path | None, Path | None, Path | None, Path | None]:
     """Return ``(handoff_path, trajectory_path, trajectories_dir, diff_path, manifest_path, deep_dir)``.
 
@@ -681,12 +691,12 @@ def _resolve_handoff_paths(
     * Session-managed runs: projected trajectory subtree under
       ``<source>/.daydream/runs/<session_id>/`` (written by the recorder
       and published by the host shortly after this function runs).
-    * Ephemeral runs with archiving enabled: archive subtree under
-      ``<archive_root>/runs/<session_id>/`` (populated by the on_write
-      callback after ``__aexit__``).
-    * Ephemeral runs with archiving disabled: live paths, even though
-      the worktree will be removed — best-effort, with no persistent
-      copy of the artifacts available.
+    * Intentional standalone ephemeral runs with archiving enabled: archive
+      subtree under ``<archive_root>/runs/<session_id>/`` (populated by the
+      on_write callback after ``__aexit__``).
+    * Intentional standalone ephemeral runs with archiving disabled: live
+      paths, even though the worktree will be removed — best-effort, with no
+      persistent copy of the artifacts available.
 
     When *recorder* is ``None``, ``handoff_path`` falls back to
     ``<source>/.daydream/handoff-<ts>.md`` (no session id available) and
@@ -696,17 +706,47 @@ def _resolve_handoff_paths(
     the trajectory has not been flushed yet and the archive bundle has
     not been copied. The caller treats them as forward references.
     """
+    if artifact_session is None:
+        if not allow_standalone:
+            # Strict callers must supply the session even if a standalone
+            # archive would otherwise make a durable reference available.
+            artifact_dir_for(
+                work.repo,
+                session=None,
+                allow_standalone=False,
+            )
+        if artifact_session_active():
+            raise ArtifactVisibilityError(
+                "an explicit artifact session is required for handoff routing"
+            )
+
     if recorder is None:
         ts = datetime.now().strftime("%Y%m%dT%H%M%S")  # noqa: DTZ005 - filename only
-        handoff_path = work.source / ".daydream" / f"handoff-{ts}.md"
+        unbound_target = work.source if work.is_ephemeral else work.repo
+        live_handoff = artifact_dir_for(
+            work.repo if artifact_session is not None else unbound_target,
+            session=artifact_session,
+            allow_standalone=allow_standalone,
+        ) / f"handoff-{ts}.md"
+        handoff_path = (
+            artifact_session.durable_path_for(live_handoff, repo=work.repo)
+            if artifact_session is not None
+            else live_handoff
+        )
         return handoff_path, None, None, None, None, None
 
-    active = artifact_session_active()
-    if active:
-        public_daydream_dir = work.source / ".daydream"
-        artifact_root = public_daydream_dir / "runs" / recorder.session_id
-        diff_path = public_daydream_dir / "diff.patch"
-        deep_dir = public_daydream_dir / "deep"
+    if artifact_session is not None:
+        live_daydream_dir = artifact_dir_for(
+            work.repo,
+            session=artifact_session,
+            allow_standalone=False,
+        )
+        live_artifact_root = live_daydream_dir / "runs" / recorder.session_id
+        artifact_root = artifact_session.durable_path_for(live_artifact_root, repo=work.repo)
+        diff_path = artifact_session.durable_path_for(
+            live_daydream_dir / "diff.patch", repo=work.repo,
+        )
+        deep_dir = artifact_session.durable_path_for(live_daydream_dir / "deep", repo=work.repo)
     elif work.is_ephemeral and recorder.on_write is not None:
         # The ephemeral worktree (and everything under it) will be
         # removed after the recorder exits; the archive callback copies
@@ -719,22 +759,18 @@ def _resolve_handoff_paths(
         diff_path = artifact_root / "diff.patch"
         deep_dir = artifact_root / "deep"
     else:
-        daydream_dir = artifact_dir_for(recorder.target_dir)
+        daydream_dir = artifact_dir_for(
+            recorder.target_dir,
+            session=artifact_session,
+            allow_standalone=allow_standalone,
+        )
         artifact_root = daydream_dir / "runs" / recorder.session_id
         diff_path = daydream_dir / "diff.patch"
         deep_dir = daydream_dir / "deep"
 
     trajectory_path = artifact_root / "trajectory.json"
-    if active:
-        # Project the recorder's exact private relative placement back into the
-        # public compatibility tree. A validated external explicit destination
-        # receives live writes instead, and needs no projection.
-        try:
-            live_relative = recorder.path.relative_to(artifact_dir_for(work.repo))
-        except ValueError:
-            trajectory_path = recorder.path
-        else:
-            trajectory_path = work.source / ".daydream" / live_relative
+    if artifact_session is not None:
+        trajectory_path = artifact_session.durable_path_for(recorder.path, repo=work.repo)
 
     return (
         artifact_root / "handoff.md",
@@ -747,13 +783,28 @@ def _resolve_handoff_paths(
 
 
 def _handoff_write_path(
-    handoff_reference: Path, recorder: TrajectoryRecorder | None, work: WorkContext
+    handoff_reference: Path,
+    recorder: TrajectoryRecorder | None,
+    work: WorkContext,
+    *,
+    artifact_session: ArtifactSession | None = None,
+    allow_standalone: bool = False,
 ) -> Path:
     """Return the private active-session destination for a public handoff ref."""
-    if not artifact_session_active():
+    if artifact_session is None:
+        if not allow_standalone:
+            # Keep strict routing failure consistent with the public accessors.
+            artifact_dir_for(
+                work.repo,
+                session=artifact_session,
+                allow_standalone=False,
+            )
+        if artifact_session_active():
+            raise ArtifactVisibilityError(
+                "an explicit artifact session is required for handoff routing"
+            )
         return handoff_reference
-    live = artifact_dir_for(work.repo)
-    return live / handoff_reference.name if recorder is None else live / "runs" / recorder.session_id / "handoff.md"
+    return artifact_session.live_path_for(handoff_reference, repo=work.repo)
 
 
 def _write_handoff(path: Path, body: str) -> bool:
@@ -870,21 +921,14 @@ def _build_minimal_handoff(
     return "\n".join(parts)
 
 
-def _replace_known_handoff_paths(text: str, mappings: list[tuple[Path, Path]]) -> str:
-    """Replace only exact, validated live paths with their durable identities."""
-    pairs = sorted(((str(a), str(b)) for a, b in mappings), key=lambda p: len(p[0]), reverse=True)
-    for live, durable in pairs:
-        pattern = rf"(?<![A-Za-z0-9_./-]){re.escape(live)}" + r"(?=$|[\s`'\"\[\](){}<>:,;])"
-        text = re.sub(pattern, lambda _match: durable, text)
-    return text
-
-
 @bind_resolved_run_context
 async def _run_failure_summarizer(
     backend: Backend,
     work: WorkContext,
     test_output: str,
     *,
+    artifact_session: ArtifactSession | None = None,
+    allow_standalone: bool = False,
     run_context: RunContext | None = None,
 ) -> tuple[str, Path, bool]:
     """Run the read-only failure-summarizer and write ``handoff.md``.
@@ -910,7 +954,12 @@ async def _run_failure_summarizer(
         diff_path,
         manifest_path,
         deep_dir,
-    ) = _resolve_handoff_paths(recorder, work)
+    ) = _resolve_handoff_paths(
+        recorder,
+        work,
+        artifact_session=artifact_session,
+        allow_standalone=allow_standalone,
+    )
 
     # Drop a ``.partial`` snapshot of the trajectory before invoking the
     # summarizer. The recorder's ``_write()`` only fires in ``__aexit__``
@@ -936,25 +985,34 @@ async def _run_failure_summarizer(
         return None if path is None else path.with_suffix(path.suffix + ".partial")
 
     has_trajectory = recorder is not None
-    active_session = artifact_session_active()
+    active_session = artifact_session is not None
     changed_live = _changed_files(work.repo)
     durable_input_paths = _labelled(
         _partial_of(trajectory_path), diff_path, manifest_path, deep_dir
     )
-    transient_prefixes: list[Path] = []
+    private_runtime_paths: tuple[Path, ...] = ()
     if active_session:
+        assert artifact_session is not None
         changed_for_model = [path.relative_to(work.repo) for path in changed_live]
         durable_changed = [work.source / name for name in changed_for_model]
-        live_daydream = artifact_dir_for(work.repo)
+        private_runtime_paths = (
+            artifact_session.layout.artifact_runtime_root,
+            artifact_session.layout.operational_workspaces_root,
+        ) + ((work.repo,) if work.repo != work.source else ())
+
+        def _live(path: Path | None) -> Path | None:
+            return (
+                None
+                if path is None
+                else artifact_session.live_path_for(path, repo=work.repo)
+            )
+
         possible_inputs = _labelled(
-            _partial_of(None if recorder is None else recorder.path),
-            live_daydream / "diff.patch",
-            None if recorder is None else live_daydream / "runs" / recorder.session_id / "manifest.json",
-            live_daydream / "deep",
+            None if recorder is None else _partial_of(recorder.path),
+            _live(diff_path),
+            _live(manifest_path),
+            _live(deep_dir),
         )
-        transient_prefixes = [live_daydream]
-        if work.repo != work.source:
-            transient_prefixes.append(work.repo)
     else:
         changed_for_model = durable_changed = changed_live
         possible_inputs = durable_input_paths
@@ -963,13 +1021,6 @@ async def _run_failure_summarizer(
         for label, path in possible_inputs.items()
         if path is not None and path.is_file()
     }
-    known_path_mappings = [
-        (path, durable)
-        for label, path in readable_inputs.items()
-        if (durable := durable_input_paths[label]) is not None
-    ]
-    if active_session and work.repo != work.source:
-        known_path_mappings.extend(zip(changed_live, durable_changed, strict=True))
 
     prompt = _build_failure_summarizer_prompt(
         test_output=test_output,
@@ -1005,11 +1056,10 @@ async def _run_failure_summarizer(
             if isinstance(body, str) and body.strip():
                 if not active_session:
                     return body
-                normalized = _replace_known_handoff_paths(body, known_path_mappings)
-                if not any(str(prefix) in normalized for prefix in transient_prefixes):
-                    return normalized
+                if not any(str(path) in body for path in private_runtime_paths):
+                    return body
                 _logger.warning(
-                    "failure-summarizer output contained an unknown transient path; "
+                    "failure-summarizer output contained a private runtime path; "
                     "using the deterministic handoff"
                 )
         return None
@@ -1024,10 +1074,11 @@ async def _run_failure_summarizer(
 
     if body is None:
         fallback_output = test_output
-        if active_session:
-            fallback_output = _replace_known_handoff_paths(fallback_output, known_path_mappings)
-            for prefix in sorted({str(p) for p in transient_prefixes}, key=len, reverse=True):
-                fallback_output = fallback_output.replace(prefix, "[TRANSIENT_PATH]")
+        if active_session and any(
+            str(path) in fallback_output
+            for path in private_runtime_paths
+        ):
+            fallback_output = "Test output omitted because it contained a private runtime path."
         body = _build_minimal_handoff(
             test_output=fallback_output,
             trajectory_path=trajectory_path,
@@ -1039,7 +1090,16 @@ async def _run_failure_summarizer(
             has_trajectory=has_trajectory,
         )
 
-    written = _write_handoff(_handoff_write_path(handoff_path, recorder, work), body)
+    written = _write_handoff(
+        _handoff_write_path(
+            handoff_path,
+            recorder,
+            work,
+            artifact_session=artifact_session,
+            allow_standalone=allow_standalone,
+        ),
+        body,
+    )
     return body, handoff_path, written
 
 
@@ -2009,13 +2069,22 @@ def _git_branch(cwd: Path) -> str:
     return name or ""
 
 
-def check_review_file_exists(target_dir: Path) -> None:
+def check_review_file_exists(
+    target_dir: Path,
+    *,
+    artifact_session: ArtifactSession | None = None,
+    allow_standalone: bool = False,
+) -> None:
     """Check that the review output file exists.
 
     Raises:
         FileNotFoundError: If the review output file doesn't exist.
     """
-    review_output_path = review_output_path_for(target_dir)
+    review_output_path = review_output_path_for(
+        target_dir,
+        session=artifact_session,
+        allow_standalone=allow_standalone,
+    )
     if not review_output_path.exists():
         msg = f"""No review file found.
 
@@ -2035,6 +2104,8 @@ async def phase_parse_feedback(
     output_schema: dict[str, Any] | None = None,
     include_verdicts: Literal[False] = False,
     strategy: str | None = None,
+    artifact_session: ArtifactSession | None = None,
+    allow_standalone: bool = False,
     run_context: RunContext | None = None,
 ) -> list[dict[str, Any]]: ...
 
@@ -2048,6 +2119,8 @@ async def phase_parse_feedback(
     output_schema: dict[str, Any] | None = None,
     include_verdicts: Literal[True],
     strategy: str | None = None,
+    artifact_session: ArtifactSession | None = None,
+    allow_standalone: bool = False,
     run_context: RunContext | None = None,
 ) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]: ...
 
@@ -2061,6 +2134,8 @@ async def phase_parse_feedback(
     output_schema: dict[str, Any] | None = None,
     include_verdicts: bool = False,
     strategy: str | None = None,
+    artifact_session: ArtifactSession | None = None,
+    allow_standalone: bool = False,
     run_context: RunContext | None = None,
 ) -> list[dict[str, Any]] | tuple[list[dict[str, Any]], list[dict[str, Any]]]:
     """Phase 2: Parse feedback from review output and return validated items.
@@ -2138,7 +2213,11 @@ async def phase_parse_feedback(
     verdicts_empty = ', "verdicts": []' if include_verdicts else ""
 
     # Use absolute path to prevent model hallucination of paths from training data
-    review_output_path = input_path if input_path is not None else review_output_path_for(work.repo)
+    review_output_path = input_path if input_path is not None else review_output_path_for(
+        work.repo,
+        session=artifact_session,
+        allow_standalone=allow_standalone,
+    )
     if strategy is None:
         strategy = _rp.build_default_profile().strategies["parse"].content
     prompt = build_parse_prompt(
@@ -3362,6 +3441,8 @@ async def _emit_failure_handoff(
     output: str,
     *,
     offer_clipboard: bool,
+    artifact_session: ArtifactSession | None = None,
+    allow_standalone: bool = False,
     run_context: RunContext | None = None,
 ) -> None:
     """Run the failure summarizer, display the handoff body, and optionally
@@ -3377,7 +3458,12 @@ async def _emit_failure_handoff(
     """
     run_context = resolve_run_context(run_context)
     body, handoff_path, handoff_written = await _run_failure_summarizer(
-        backend, work, output, run_context=run_context,
+        backend,
+        work,
+        output,
+        artifact_session=artifact_session,
+        allow_standalone=allow_standalone,
+        run_context=run_context,
     )
     if handoff_written:
         preview_lines = body.splitlines()
@@ -3436,6 +3522,8 @@ def _reject_test_healing_generated_file_edits(
     pre_untracked: set[str],
     pre_untracked_contents: dict[str, bytes] | None = None,
     snapshot_captured: bool = True,
+    artifact_session: ArtifactSession | None = None,
+    allow_standalone: bool = False,
 ) -> list[str] | None:
     """Restore generated files, returning ``None`` if any restoration fails."""
     if not snapshot_captured:
@@ -3444,7 +3532,11 @@ def _reject_test_healing_generated_file_edits(
         return []
 
     ref = snapshot or "HEAD"
-    recovery_dir = artifact_dir_for(repo) / "partial-fixes"
+    recovery_dir = artifact_dir_for(
+        repo,
+        session=artifact_session,
+        allow_standalone=allow_standalone,
+    ) / "partial-fixes"
 
     try:
         changed = git_ops.changed_files_against(
@@ -3518,7 +3610,11 @@ def _reject_test_healing_generated_file_edits(
             restoration_failed = True
 
     if direct_violations:
-        artifact = artifact_dir_for(repo) / "deep" / "generated-file-violations.json"
+        artifact = artifact_dir_for(
+            repo,
+            session=artifact_session,
+            allow_standalone=allow_standalone,
+        ) / "deep" / "generated-file-violations.json"
         try:
             artifact.parent.mkdir(parents=True, exist_ok=True)
             artifact.write_text(
@@ -3727,6 +3823,8 @@ async def phase_test_and_heal(
     session_id: str | None = None,
     capture_tree_key: Callable[[], str] | None = None,
     footprint: AuthorizedFixFootprint | None = None,
+    artifact_session: ArtifactSession | None = None,
+    allow_standalone: bool = False,
     run_context: RunContext | None = None,
 ) -> TestAndHealResult:
     """Phase 4: Run tests and prompt user on failure for action.
@@ -3805,6 +3903,8 @@ async def phase_test_and_heal(
             snapshot_captured=snapshot_captured,
             pre_untracked=pre_untracked,
             pre_untracked_contents=pre_untracked_contents,
+            artifact_session=artifact_session,
+            allow_standalone=allow_standalone,
         )
         return guard_result is not None
 
@@ -3867,7 +3967,13 @@ async def phase_test_and_heal(
                 console, "Tests failed", "Aborting heal loop (no further auto-retries)",
             )
             await _emit_failure_handoff(
-                backend, work, output, offer_clipboard=False, run_context=run_context,
+                backend,
+                work,
+                output,
+                offer_clipboard=False,
+                artifact_session=artifact_session,
+                allow_standalone=allow_standalone,
+                run_context=run_context,
             )
             return TestAndHealResult(False, retries_used, False, False, tuple(attempts))
         if decision is True:
@@ -3985,7 +4091,13 @@ async def phase_test_and_heal(
         elif choice == "4":
             print_error(console, "Aborted", "User requested abort")
             await _emit_failure_handoff(
-                backend, work, output, offer_clipboard=True, run_context=run_context,
+                backend,
+                work,
+                output,
+                offer_clipboard=True,
+                artifact_session=artifact_session,
+                allow_standalone=allow_standalone,
+                run_context=run_context,
             )
             return TestAndHealResult(False, retries_used, False, False, tuple(attempts))
 
@@ -4841,6 +4953,8 @@ async def phase_per_stack_reviews(
     include_alternatives: bool = True,
     write_coverage_receipts: bool = False,
     strategies: dict[str, str] | None = None,
+    artifact_session: ArtifactSession | None = None,
+    allow_standalone: bool = False,
     run_context: RunContext | None = None,
 ) -> tuple[dict[str, Path], dict[str, str]]:
     """Run one review agent per detected stack concurrently (D-17).
@@ -4893,7 +5007,11 @@ async def phase_per_stack_reviews(
     from daydream.deep.prompts import _diff_blocks_for_files
     from daydream.deep.records import stamp_record_uids
 
-    deep_dir_path = _deep_dir(work.repo)
+    deep_dir_path = _deep_dir(
+        work.repo,
+        session=artifact_session,
+        allow_standalone=allow_standalone,
+    )
     recorder = get_current_recorder()
     if strategies is None:
         strategies = {
@@ -5216,6 +5334,8 @@ async def phase_supervise_review(
     alternatives_path: Path,
     exploration_dir: Path | None = None,
     strategy: str | None = None,
+    artifact_session: ArtifactSession | None = None,
+    allow_standalone: bool = False,
     run_context: RunContext | None = None,
 ) -> dict[int, dict[str, Any]]:
     """Adjudicate canonical merged findings in one batched LLM call."""
@@ -5226,7 +5346,11 @@ async def phase_supervise_review(
     print_dim(console, f"Model: {backend.model}")
     print_info(console, f"Supervising {len(items)} merged finding(s)")
 
-    dd = deep_dir(work.repo)
+    dd = deep_dir(
+        work.repo,
+        session=artifact_session,
+        allow_standalone=allow_standalone,
+    )
     input_path = dd / "supervise-input.json"
     # Deliberately a verbatim dump of the canonical items, host-only fields and
     # all (``lens``, ``location_note``, ``severity_before_demotion``,
@@ -5355,6 +5479,8 @@ async def phase_arbiter_review(
     exploration_dir: Path | None = None,
     intent_authoritative: bool = False,
     strategy: str | None = None,
+    artifact_session: ArtifactSession | None = None,
+    allow_standalone: bool = False,
     run_context: RunContext | None = None,
 ) -> tuple[dict[int, dict[str, Any]], ContinuationToken | None]:
     """Re-review high-severity / contested per-stack findings with the arbiter (#168).
@@ -5402,7 +5528,11 @@ async def phase_arbiter_review(
     print_dim(console, f"Model: {backend.model}")
     print_info(console, f"Arbitrating {len(selected_records)} high-severity/contested finding(s)")
 
-    dd = deep_dir(work.repo)
+    dd = deep_dir(
+        work.repo,
+        session=artifact_session,
+        allow_standalone=allow_standalone,
+    )
     input_path = arbiter_input_path(dd)
     arbiter_input = _index_records(selected_records, "arb_id")
     input_path.write_text(json.dumps(arbiter_input, indent=2))
@@ -5482,6 +5612,8 @@ async def phase_suppression_review(
     alternatives_path: Path,
     exploration_dir: Path | None = None,
     strategy: str | None = None,
+    artifact_session: ArtifactSession | None = None,
+    allow_standalone: bool = False,
     run_context: RunContext | None = None,
 ) -> dict[int, dict[str, Any]]:
     """Skeptical precision-mode second opinion over borderline findings (#232).
@@ -5519,7 +5651,11 @@ async def phase_suppression_review(
     print_dim(console, f"Model: {backend.model}")
     print_info(console, f"Suppression-reviewing {len(selected_records)} borderline finding(s)")
 
-    dd = deep_dir(work.repo)
+    dd = deep_dir(
+        work.repo,
+        session=artifact_session,
+        allow_standalone=allow_standalone,
+    )
     input_path = suppression_input_path(dd)
     suppression_input = _index_records(selected_records, "sup_id")
     input_path.write_text(json.dumps(suppression_input, indent=2))
@@ -5953,6 +6089,8 @@ def _write_single_stack_merged_items(
     structural_records_path: Path | None,
     *,
     failed_stacks: dict[str, str] | None = None,
+    artifact_session: ArtifactSession | None = None,
+    allow_standalone: bool = False,
 ) -> None:
     """Write the canonical ``merged-items.json`` for a tiny-diff run (issue #172).
 
@@ -5987,7 +6125,11 @@ def _write_single_stack_merged_items(
     from daydream.deep.artifacts import merged_items_path, merged_report_path
     from daydream.deep.records import RECORD_SOURCE_UIDS_KEY, record_uid, union_source_uids
 
-    canonical_path = review_output_path_for(repo)
+    canonical_path = review_output_path_for(
+        repo,
+        session=artifact_session,
+        allow_standalone=allow_standalone,
+    )
     report_path = merged_report_path(deep_dir_path)
     items_path = merged_items_path(deep_dir_path)
 
@@ -6175,6 +6317,8 @@ async def phase_cross_stack_merge(
     intent_authoritative: bool = False,
     continuation: ContinuationToken | None = None,
     strategy: str | None = None,
+    artifact_session: ArtifactSession | None = None,
+    allow_standalone: bool = False,
     run_context: RunContext | None = None,
 ) -> Path:
     """Run the cross-stack merge agent and return the merged-report path (D-23..D-27).
@@ -6233,8 +6377,16 @@ async def phase_cross_stack_merge(
     from daydream.deep.artifacts import deep_dir, merged_items_path, merged_report_path
     from daydream.deep.records import stack_name_from_records_source
 
-    dd = deep_dir(work.repo)
-    canonical_path = review_output_path_for(work.repo)
+    dd = deep_dir(
+        work.repo,
+        session=artifact_session,
+        allow_standalone=allow_standalone,
+    )
+    canonical_path = review_output_path_for(
+        work.repo,
+        session=artifact_session,
+        allow_standalone=allow_standalone,
+    )
     report_path = merged_report_path(dd)
     items_path = merged_items_path(dd)
 

--- a/daydream/runner.py
+++ b/daydream/runner.py
@@ -48,6 +48,7 @@ from daydream.artifact_visibility import (
     RoutedDestination,
     TrajectoryOutputRoute,
     artifact_dir_for,
+    artifact_session_active,
     open_artifact_session,
     private_root_locations,
     resolve_private_workspace_owner,
@@ -503,6 +504,7 @@ def _open_recorder(
     work: WorkContext | None,
     flow_kind: DaydreamRunFlow,
     run_artifacts: _RunArtifacts | None = None,
+    allow_standalone: bool = False,
 ) -> TrajectoryRecorder:
     """Construct the run's ``TrajectoryRecorder`` bound to the run's artifacts.
 
@@ -513,10 +515,15 @@ def _open_recorder(
     constructing ``TrajectoryRecorder`` directly, so the snapshot retention that
     feeds strict archive finalization can never be silently dropped. Session id
     and trajectory path are resolved here identically for all flows.
-    ``run_artifacts`` is ``None`` only for a standalone direct caller, which
-    retains no snapshot and therefore archives nothing.
+    A standalone direct caller passes ``allow_standalone=True`` with no
+    ``run_artifacts`` or active artifact session; it retains no snapshot and
+    therefore archives nothing.
     """
     if run_artifacts is None:
+        if not allow_standalone:
+            raise ArtifactVisibilityError("standalone recorder requires allow_standalone=True")
+        if artifact_session_active():
+            raise ArtifactVisibilityError("standalone recorder cannot run inside an active artifact session")
         session_id = str(uuid.uuid4())
         trajectory_path = config.trajectory_path or default_trajectory_path(target_dir, session_id)
     else:
@@ -1653,7 +1660,7 @@ async def _run_improve(
         )
         return 1
 
-    directory = improve_dir(target_dir)
+    directory = improve_dir(target_dir, session=run_artifacts.session, allow_standalone=False)
     tier = EFFORT_TIERS[config.improve_effort]
 
     async with _open_recorder(
@@ -1662,6 +1669,7 @@ async def _run_improve(
         work=work,
         flow_kind=DaydreamRunFlow.IMPROVE,
         run_artifacts=run_artifacts,
+        allow_standalone=False,
     ):
         _resolve_review_profile(config)
         # The standalone snapshot gives improve independent Git storage. The
@@ -1687,6 +1695,7 @@ async def _run_improve(
                 artifacts=run_artifacts.session,
                 run_context=run_context, github_execution=github_execution,
                 _backend_factory=backend_factory,
+                allow_standalone_artifacts=False,
             )
             ctx.data["audit_repo"] = audit.repo
             ctx.data["improve_dir"] = directory
@@ -1751,7 +1760,7 @@ async def _run_custom_flow(
         print_dim(console, "No diff found — custom flow will run without a diff seed.")
         diff = ""
 
-    daydream_dir = artifact_dir_for(target_dir)
+    daydream_dir = artifact_dir_for(target_dir, session=run_artifacts.session, allow_standalone=False)
     daydream_dir.mkdir(exist_ok=True)
     diff_path = daydream_dir / "diff.patch"
     diff_path.write_text(diff)
@@ -1762,6 +1771,7 @@ async def _run_custom_flow(
     async with _open_recorder(
         config=config, target_dir=target_dir, work=work, flow_kind=DaydreamRunFlow.CUSTOM,
         run_artifacts=run_artifacts,
+        allow_standalone=False,
     ):
         _resolve_review_profile(config)
         ctx = FlowContext(
@@ -1773,6 +1783,7 @@ async def _run_custom_flow(
             artifacts=run_artifacts.session,
             run_context=run_context, github_execution=github_execution,
             _backend_factory=backend_factory,
+            allow_standalone_artifacts=False,
         )
         ctx.data["post_to_pr"] = False  # custom flows do not post to PR by default
         ctx.data["diff"] = diff
@@ -1808,4 +1819,5 @@ async def _run_loop_deep(
     return await run_deep(
         config, work, run_artifacts=run_artifacts, run_context=run_context, github_execution=github_execution,
         backend_factory=backend_factory,
+        allow_standalone=False,
     )

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -563,12 +563,13 @@ Working contracts for extension steps:
   their full contents.
 - Private storage is cwd-rooted discovery isolation, not an OS sandbox; no
   transport grants access to an entire runtime directory.
-- Intentional standalone phase calls without an active artifact session keep
-  the legacy paths and provide no isolation guarantee. Production runner and
+- Intentional standalone phase calls pass `allow_standalone=True` to keep
+  the legacy paths without an active artifact session. Production runner and
   custom-flow calls bind a session and cannot opt out of the model-cwd check.
 
-This is additive: it does not bump `EXTENSION_API_VERSION`, rename stable keys,
-or alter verifier routing headings.
+API v6 retains `ctx.artifacts`, the stable data keys, and verifier routing
+headings. Extensions using implicit artifact lookup must update their calls
+as shown below.
 
 A complete example — write a private note, prepare it as a sanctioned input,
 and dispatch one read-only agent turn:
@@ -584,7 +585,10 @@ from daydream.trajectory import DaydreamPhase
 DAYDREAM_EXT_API = 6
 
 async def explain_note(ctx: FlowContext) -> None:
-    note = artifact_dir_for(ctx.work.repo) / "extension-note.txt"
+    assert ctx.artifacts is not None
+    note = artifact_dir_for(
+        ctx.work.repo, session=ctx.artifacts, allow_standalone=False,
+    ) / "runs" / ctx.artifacts.layout.session_id / "extension-note.txt"
     note.parent.mkdir(parents=True, exist_ok=True)
     note.write_text("Review this repository's error-handling conventions.", encoding="utf-8")
     backend = ctx.backend_for("review")
@@ -606,15 +610,42 @@ def register(registry: Registry) -> None:
     registry.set_flow("explain-note", ["explain-note"])
 ```
 
-Inside the runner, `artifact_dir_for(ctx.work.repo)` routes to the active
-session's private directory while the session is live, so the note is
+Inside the runner, pass `session=ctx.artifacts, allow_standalone=False` to
+`artifact_dir_for(ctx.work.repo, ...)`. It routes to the owning session's
+private directory while the session is live, so the note is
 invisible to the model's cwd and to git during the run. At finalization the
 whole `.daydream/` subtree is published back into the checkout (the same
 contract as `review_output_path_for`: private while the session is active,
 published under the checkout's untracked `.daydream/` at finalization).
-`review_output_path_for(ctx.work.repo)` routes the review-output file the same
-way: private while the session is active, published as `.review-output.md` at
-finalization.
+`review_output_path_for(ctx.work.repo, session=ctx.artifacts,
+allow_standalone=False)` routes the review-output file the same way: private
+while the session is active, published as `.review-output.md` at finalization.
+
+Both accessors require an explicit session by default, even when a session is
+bound to the current task. Intentional standalone callers pass
+`allow_standalone=True`; this compatibility mode may use a bound session or,
+without one, the repository's public artifact path. Direct `run_deep` callers
+without runner-owned artifacts also opt in with `allow_standalone=True`, and
+must have no active artifact session. The recorder factory has the same
+restriction. Active flows must pass their owning artifacts to these entry
+points and to handoff helpers so writable and durable paths share one owner.
+Direct flow contexts carry that choice in `allow_standalone_artifacts`; its
+default is false. Pass `artifact_session=ctx.artifacts` and
+`allow_standalone=ctx.allow_standalone_artifacts` to built-in phases that use
+generated paths. Keep these runtime choices outside `ctx.data`.
+
+For durable handoff references, use
+`ctx.artifacts.durable_path_for(live_path, repo=ctx.work.repo)`; use
+`ctx.artifacts.live_path_for(public_path, repo=ctx.work.repo)` for the writable destination.
+These methods validate the owning session, repository, registered route, and
+path ancestry. They reject unrelated paths and destinations without a live
+write route, including finalization-only artifact dumps.
+
+Place extension artifacts under the current `runs/<session_id>/` directory.
+Legacy adoption accepts only registered top-level artifact names; an unknown
+sibling is rejected even when the tree also contains a recognized directory.
+Previously published custom paths can reopen when their complete subtree
+matches the validated canonical recovery copy.
 
 ### Interaction and output policy
 

--- a/tests/test_arbiter_prose_extraction.py
+++ b/tests/test_arbiter_prose_extraction.py
@@ -126,6 +126,7 @@ async def test_arbiter_extracts_findings_from_prose_wrapped_message(
         diff_path=diff_path,
         intent_path=intent_path,
         alternatives_path=alternatives_path,
+        allow_standalone=True,
     )
     assert set(verdicts) == {1, 2}
     assert verdicts[1]["keep"] is True
@@ -149,6 +150,7 @@ async def test_arbiter_still_raises_on_genuinely_unparseable_output(
             diff_path=diff_path,
             intent_path=intent_path,
             alternatives_path=alternatives_path,
+            allow_standalone=True,
         )
 
 
@@ -249,6 +251,7 @@ async def test_arbiter_captures_structured_output_in_log_mode(
         intent_path=intent_path,
         alternatives_path=alternatives_path,
         run_context=RunContext(InteractionPolicy(log_mode=True)),
+        allow_standalone=True,
     )
     assert set(verdicts) == {1, 2}
     assert verdicts[1]["keep"] is True

--- a/tests/test_artifact_routing.py
+++ b/tests/test_artifact_routing.py
@@ -1,0 +1,197 @@
+"""Real-runner regressions for explicit artifact ownership and durable handoffs."""
+
+from __future__ import annotations
+
+import json
+import shlex
+import sys
+from collections.abc import Callable
+from dataclasses import replace
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from daydream import runner
+from daydream.agent import run_agent
+from daydream.artifact_visibility import (
+    ArtifactVisibilityError,
+    open_artifact_session,
+    private_root_locations,
+    resolve_private_workspace_owner,
+)
+from daydream.backends import ResultEvent, TextEvent
+from daydream.deep.orchestrator import run_deep
+from daydream.runner import RunConfig
+from daydream.trajectory import DaydreamPhase, DaydreamRunFlow
+from daydream.workspace import WorkContext
+from tests.harness.backend import ScriptedBackend
+from tests.harness.git_helpers import bare_remote, git
+
+
+async def test_recorder_public_output_requires_standalone_opt_in(
+    tmp_path: Path, make_config: Callable[..., RunConfig],
+) -> None:
+    config = make_config(tmp_path)
+    with pytest.raises(ArtifactVisibilityError, match="allow_standalone=True"):
+        runner._open_recorder(
+            config=config, target_dir=tmp_path, work=None, flow_kind=DaydreamRunFlow.CUSTOM,
+        )
+    assert not (tmp_path / ".daydream").exists()
+
+    recorder = runner._open_recorder(
+        config=config, target_dir=tmp_path, work=None, flow_kind=DaydreamRunFlow.CUSTOM,
+        allow_standalone=True,
+    )
+    async with recorder:
+        await run_agent(
+            ScriptedBackend(
+                events=[TextEvent(text="Standalone result"), ResultEvent(structured_output=None, continuation=None)],
+            ),
+            tmp_path,
+            "Record one standalone turn.",
+            phase=DaydreamPhase.REVIEW,
+        )
+    assert recorder.path.is_file()
+    assert json.loads(recorder.path.read_text())["session_id"] == recorder.session_id
+
+
+@pytest.mark.parametrize("entrypoint", ["deep", "recorder"])
+async def test_standalone_entry_rejects_borrowing_a_bound_artifact_session(
+    tiny_diff_target: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    make_config: Callable[..., RunConfig],
+    make_work: Callable[..., WorkContext],
+    entrypoint: str,
+) -> None:
+    repo = tiny_diff_target
+    work = make_work(
+        repo, base_sha=git(repo, "rev-parse", "main"),
+        head_sha=git(repo, "rev-parse", "HEAD"), head_branch="feature",
+    )
+    prior = repo / ".daydream" / "deep" / "prior.txt"
+    prior.parent.mkdir(parents=True)
+    prior.write_bytes(b"prior session evidence\n")
+    owner = resolve_private_workspace_owner(
+        repo, locations=private_root_locations(base=(tmp_path / "private").resolve()),
+    )
+    backend = ScriptedBackend(events=[ResultEvent(structured_output=None, continuation=None)])
+    monkeypatch.setattr(runner, "create_backend", lambda *_args, **_kwargs: backend)
+    config = make_config(repo, start_at="fix")
+
+    async with open_artifact_session(work, session_id=f"bound-{entrypoint}", owner=owner) as session:
+        live = session.daydream_dir
+        before = sorted(path.relative_to(live) for path in live.rglob("*"))
+        with pytest.raises(ArtifactVisibilityError, match="standalone.*active artifact session"):
+            if entrypoint == "deep":
+                await run_deep(config, work, allow_standalone=True)
+            else:
+                runner._open_recorder(
+                    config=config, target_dir=repo, work=work,
+                    flow_kind=DaydreamRunFlow.CUSTOM, allow_standalone=True,
+                )
+        assert not (repo / ".daydream").exists()
+        assert (live / "deep" / "prior.txt").read_bytes() == b"prior session evidence\n"
+        assert sorted(path.relative_to(live) for path in live.rglob("*")) == before
+        assert backend.call_count == 0
+
+    assert prior.read_bytes() == b"prior session evidence\n"
+
+
+@pytest.mark.parametrize(
+    "relative_destination", ["operator evidence/trajectory.json", ".daydream/custom trajectory.json"],
+)
+async def test_ephemeral_failure_handoff_retains_explicit_trajectory_without_archive(
+    tiny_diff_target: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    ext_dir: Any,
+    make_config: Callable[..., RunConfig],
+    relative_destination: str,
+) -> None:
+    repo = tiny_diff_target
+    origin = bare_remote(tmp_path / "origin.git")
+    git(repo, "remote", "add", "origin", str(origin))
+    git(repo, "push", "-u", "origin", "main")
+    git(repo, "push", "-u", "origin", "feature")
+    explicit = repo / relative_destination
+    private_base = (tmp_path / "private artifact roots").resolve()
+    head_before = git(repo, "rev-parse", "HEAD")
+    ext_dir.write_module(
+        "from daydream import git_ops\n"
+        "from daydream.extensions import FlowStep, Stop\n"
+        "from daydream.fix_footprint import AuthorizedFixFootprint\n"
+        "from daydream.phases import phase_test_and_heal\n"
+        "async def _handoff(ctx):\n"
+        "    assert ctx.artifacts is not None\n"
+        "    def capture_tree():\n"
+        "        return git_ops.tree_key(git_ops.snapshot_worktree_delta(\n"
+        "            ctx.work.repo, 'HEAD', preexisting_untracked={},\n"
+        "        ))\n"
+        "    result = await phase_test_and_heal(\n"
+        "        ctx.backend_for('test'), ctx.work, config=ctx.config,\n"
+        "        session_id=ctx.artifacts.layout.session_id,\n"
+        "        capture_tree_key=capture_tree,\n"
+        "        footprint=AuthorizedFixFootprint.build(ctx.work.repo, set(), []),\n"
+        "        run_context=ctx.run_context,\n"
+        "        artifact_session=ctx.artifacts, allow_standalone=False,\n"
+        "    )\n"
+        "    return Stop(0 if result.passed else 1)\n"
+        "def register(registry):\n"
+        "    registry.register_phase(FlowStep(name='artifact-handoff', run=_handoff))\n"
+        "    registry.set_flow('artifact-handoff', ['artifact-handoff'])\n"
+    )
+    # An empty, valid response exercises the deterministic host handoff.
+    backend = ScriptedBackend(
+        events=[ResultEvent(structured_output={"handoff_prompt": ""}, continuation=None)],
+    )
+    monkeypatch.setattr(runner, "create_backend", lambda *_args, **_kwargs: backend)
+    config = make_config(
+        repo,
+        flow_name="artifact-handoff",
+        force_worktree=True,
+        trajectory_path=explicit,
+        archive=False,
+        run_eval=False,
+        test_command=shlex.join(
+            [sys.executable, "-c", "import sys; print('1 failed, 0 passed'); sys.exit(1)"]
+        ),
+    )
+
+    result = await runner.run(config, private_roots=private_root_locations(base=private_base))
+
+    assert result == 1
+    assert explicit.is_file()
+    trajectory = json.loads(explicit.read_text())
+    handoffs = list(repo.glob(".daydream/runs/*/handoff.md"))
+    assert len(handoffs) == 1
+    assert handoffs[0].parent.name == trajectory["session_id"]
+    body = handoffs[0].read_text()
+    assert str(explicit) in body
+    assert str(repo / ".daydream" / "diff.patch") in body
+    assert str(private_base) not in body
+    assert "1 failed, 0 passed" in body
+    assert backend.call_count == 1
+    assert backend.read_only_calls == [True]
+    model_cwd = backend.calls[0]["cwd"]
+    assert model_cwd != repo
+    assert str(model_cwd) not in body
+    assert not model_cwd.exists()
+    assert git(repo, "rev-parse", "HEAD") == head_before
+
+    # A later real run must accept the prior session's published destinations
+    # and preserve their bytes when writing its own default trajectory.
+    published = explicit.read_bytes()
+    second_config = replace(
+        config,
+        trajectory_path=None,
+        test_command=shlex.join([sys.executable, "-c", "print('1 passed')"]),
+    )
+    assert await runner.run(
+        second_config, private_roots=private_root_locations(base=private_base),
+    ) == 0
+    assert explicit.read_bytes() == published
+    assert handoffs[0].read_text() == body
+    assert backend.call_count == 1
+    assert git(repo, "rev-parse", "HEAD") == head_before

--- a/tests/test_artifact_visibility.py
+++ b/tests/test_artifact_visibility.py
@@ -565,7 +565,7 @@ def _external_fifo_observation_child(fifo: Path, entered: Path, completed: Path)
 def _seed_public_artifacts(source: Path) -> tuple[_Entry, ...]:
     deep = source / ".daydream" / "deep"
     runs = source / ".daydream" / "runs"
-    empty = source / ".daydream" / "empty-directory"
+    empty = deep / "empty-directory"
     deep.mkdir(parents=True)
     runs.mkdir()
     empty.mkdir()
@@ -666,6 +666,30 @@ def _freeze_run(session: Any, session_id: str, *, payload: bytes | None = None) 
 
 def _publish(session: Any, frozen: Any, disposition: Any = None) -> None:
     session.finalize_frozen(frozen, disposition=_COMPLETE if disposition is None else disposition)
+
+
+async def _publish_custom_public_trajectory(
+    source: Path,
+    *,
+    session_id: str,
+    status: str = "complete",
+) -> tuple[Path, Path, bytes]:
+    requested = source / ".daydream" / "custom" / "root.json"
+    selected = requested if status == "complete" else requested.with_suffix(".json.partial")
+    payload = _payload(session_id)
+    async with open_artifact_session(_work(source), session_id=session_id) as session:
+        session.register_destination(source / ".daydream", label=OutputLabel.PUBLIC_DAYDREAM)
+        assert not session.daydream_dir.exists()
+        route = session.register_trajectory_output(requested)
+        selected_route = route.full if status == "complete" else route.partial
+        assert selected_route.write_path is not None
+        document = TrajectoryDocumentSnapshot(session_id, selected_route.write_path, payload)
+        session.write_trajectory_document(route, document, cast(Any, status))
+        assert not (source / ".daydream").exists()
+        frozen = session.freeze(_snapshot(session_id, (document,), status=status))
+        state_root = session.layout.state_root
+        _publish(session, frozen)
+    return state_root, selected, payload
 
 
 @contextmanager
@@ -799,11 +823,13 @@ def test_recovery_spike_survives_real_process_death_at_each_journal_transition(
     assert _manifest(source) == expected
     assert _manifest(state / "canonical") == expected
     assert (source / ".daydream" / "runs" / "opaque.bin").read_bytes() == b"\x00\xff\xfe\x80payload\n"
-    assert (source / ".daydream" / "empty-directory").is_dir()
-    assert not any((source / ".daydream" / "empty-directory").iterdir())
+    assert (source / ".daydream" / "deep" / "empty-directory").is_dir()
+    assert not any((source / ".daydream" / "deep" / "empty-directory").iterdir())
     assert stat.S_IMODE((source / ".daydream" / "deep" / "prior.md").stat().st_mode) == 0o640
     assert stat.S_IMODE((source / ".daydream" / "runs" / "opaque.bin").stat().st_mode) == 0o600
-    assert stat.S_IMODE((source / ".daydream" / "empty-directory").stat().st_mode) == 0o711
+    assert stat.S_IMODE(
+        (source / ".daydream" / "deep" / "empty-directory").stat().st_mode
+    ) == 0o711
     assert stat.S_IMODE((source / ".review-output.md").stat().st_mode) == 0o644
     assert _load_json(state / "owner.json") == {
         "schema_version": 1,
@@ -979,19 +1005,19 @@ async def test_artifact_session_detaches_routes_and_restores_public_bytes(
     expected = _seed_public_artifacts(source)
     work = _work(source)
 
-    assert artifact_dir_for(work.repo) == source / ".daydream"
-    assert review_output_path_for(work.repo) == source / ".review-output.md"
+    assert artifact_dir_for(work.repo, allow_standalone=True) == source / ".daydream"
+    assert review_output_path_for(work.repo, allow_standalone=True) == source / ".review-output.md"
     async with open_artifact_session(work, session_id="session-one") as session:
         assert session.layout.state_root.parent == artifact_runtime_root
         assert not (source / ".daydream").exists()
         assert not (source / ".review-output.md").exists()
         assert _manifest(session.layout.live_root) == expected
-        assert artifact_dir_for(work.repo) == session.daydream_dir
-        assert review_output_path_for(work.repo) == session.review_output
-        assert artifact_dir_for(work.repo).is_relative_to(session.layout.state_root)
+        assert artifact_dir_for(work.repo, session=session) == session.daydream_dir
+        assert review_output_path_for(work.repo, session=session) == session.review_output
+        assert artifact_dir_for(work.repo, session=session).is_relative_to(session.layout.state_root)
 
     assert _manifest(source) == expected
-    assert artifact_dir_for(work.repo) == source / ".daydream"
+    assert artifact_dir_for(work.repo, allow_standalone=True) == source / ".daydream"
 
 
 async def test_artifact_session_preserves_resume_mtimes_across_publication_and_reopen(source: Path) -> None:
@@ -1067,23 +1093,23 @@ async def test_bound_routing_propagates_to_tasks_and_rejects_wrong_or_aliased_re
     async with open_artifact_session(work, session_id="routing") as session:
         assert artifact_session_active() is True
         async def child() -> None:
-            observed.append(artifact_dir_for(work.repo))
+            observed.append(artifact_dir_for(work.repo, allow_standalone=True))
 
         async with anyio.create_task_group() as group:
             group.start_soon(child)
         assert observed == [session.daydream_dir]
         with bind_artifact_session(session):
-            assert artifact_dir_for(work.repo) == session.daydream_dir
-        assert artifact_dir_for(work.repo) == session.daydream_dir
+            assert artifact_dir_for(work.repo, allow_standalone=True) == session.daydream_dir
+        assert artifact_dir_for(work.repo, allow_standalone=True) == session.daydream_dir
         with pytest.raises(ArtifactVisibilityError, match="active artifact session"):
-            artifact_dir_for(tmp_path / "wrong-repo")
+            artifact_dir_for(tmp_path / "wrong-repo", allow_standalone=True)
         with pytest.raises(ArtifactVisibilityError, match="active artifact session"):
-            artifact_dir_for(alias)
+            artifact_dir_for(alias, allow_standalone=True)
         assert not (source / ".daydream").exists()
         assert not (source / ".review-output.md").exists()
 
     assert artifact_session_active() is False
-    assert artifact_dir_for(work.repo) == source / ".daydream"
+    assert artifact_dir_for(work.repo, allow_standalone=True) == source / ".daydream"
 
 
 @pytest.mark.parametrize("exit_kind", ["error", "cancel"])
@@ -1100,7 +1126,7 @@ async def test_artifact_session_resets_binding_after_error_or_cancellation(sourc
                 scope.cancel()
                 await anyio.sleep(0)
 
-    assert artifact_dir_for(work.repo) == source / ".daydream"
+    assert artifact_dir_for(work.repo, allow_standalone=True) == source / ".daydream"
 
 
 async def test_artifact_session_open_and_recovery_run_off_async_owner_thread(
@@ -1125,12 +1151,12 @@ async def test_artifact_session_open_and_recovery_run_off_async_owner_thread(
     monkeypatch.setattr(artifact_visibility, "_open_layout", observed_open)
     monkeypatch.setattr(artifact_visibility.ArtifactSession, "_restore_prior", observed_restore)
 
-    async with open_artifact_session(_work(source), session_id="threaded-lifecycle"):
-        assert artifact_dir_for(source) != source / ".daydream"
+    async with open_artifact_session(_work(source), session_id="threaded-lifecycle") as session:
+        assert artifact_dir_for(source, session=session) != source / ".daydream"
 
     assert open_threads and all(thread != owner_thread for thread in open_threads)
     assert restore_threads and all(thread != owner_thread for thread in restore_threads)
-    assert artifact_dir_for(source) == source / ".daydream"
+    assert artifact_dir_for(source, allow_standalone=True) == source / ".daydream"
 
 
 @pytest.mark.parametrize("tracked", [".daydream/tracked.txt", ".review-output.md"])
@@ -1148,19 +1174,116 @@ async def test_artifact_session_rejects_tracked_public_collision_untouched(sourc
     assert target.read_bytes() == b"tracked collision"
 
 
-async def test_artifact_session_rejects_unknown_legacy_tree_but_preserves_extensions(source: Path) -> None:
+async def test_artifact_session_rejects_unknown_legacy_tree(source: Path) -> None:
     unknown = source / ".daydream" / "extension-only" / "opaque.bin"
     unknown.parent.mkdir(parents=True)
     unknown.write_bytes(b"extension")
-    with pytest.raises(ArtifactVisibilityError, match="recognized artifact anchor"):
+    with pytest.raises(ArtifactVisibilityError, match="unregistered artifact anchor"):
         async with open_artifact_session(_work(source), session_id="unknown"):
             pass
     assert unknown.read_bytes() == b"extension"
 
-    (source / ".daydream" / "runs").mkdir()
-    async with open_artifact_session(_work(source), session_id="anchored") as session:
-        assert (session.daydream_dir / "extension-only" / "opaque.bin").read_bytes() == b"extension"
+
+async def test_artifact_session_rejects_recognized_legacy_anchor_with_unknown_sibling(source: Path) -> None:
+    daydream = source / ".daydream"
+    (daydream / "runs").mkdir(parents=True)
+    unknown = daydream / "extension-only" / "opaque.bin"
+    unknown.parent.mkdir()
+    unknown.write_bytes(b"extension")
+
+    with pytest.raises(ArtifactVisibilityError, match="unregistered artifact anchor"):
+        async with open_artifact_session(_work(source), session_id="mixed-anchors"):
+            pass
+
+    assert (daydream / "runs").is_dir()
     assert unknown.read_bytes() == b"extension"
+
+
+@pytest.mark.parametrize(
+    ("anchor", "kind"),
+    [pytest.param("improve", "directory", id="improve"), pytest.param("recommended.patch", "file", id="patch")],
+)
+async def test_artifact_session_accepts_registered_legacy_anchor_format(
+    source: Path, anchor: str, kind: str,
+) -> None:
+    target = source / ".daydream" / anchor
+    target.parent.mkdir()
+    if kind == "directory":
+        target.mkdir()
+    else:
+        target.write_bytes(b"diff bytes\n")
+
+    async with open_artifact_session(_work(source), session_id=f"legacy-{anchor}") as session:
+        private = session.daydream_dir / anchor
+        assert private.is_dir() if kind == "directory" else private.read_bytes() == b"diff bytes\n"
+
+    assert target.is_dir() if kind == "directory" else target.read_bytes() == b"diff bytes\n"
+
+
+@pytest.mark.parametrize(
+    ("anchor", "make_wrong_type"),
+    [
+        pytest.param("improve", lambda path: path.write_bytes(b"not a directory"), id="improve-file"),
+        pytest.param("recommended.patch", lambda path: path.mkdir(), id="patch-directory"),
+    ],
+)
+async def test_artifact_session_rejects_registered_legacy_anchor_with_wrong_type(
+    source: Path, anchor: str, make_wrong_type: Callable[[Path], object],
+) -> None:
+    target = source / ".daydream" / anchor
+    target.parent.mkdir()
+    make_wrong_type(target)
+
+    with pytest.raises(ArtifactVisibilityError, match="legacy artifact anchor has the wrong filesystem type"):
+        async with open_artifact_session(_work(source), session_id=f"wrong-{anchor}"):
+            pass
+
+    assert target.exists()
+
+
+@pytest.mark.parametrize(
+    ("mutation", "message"),
+    [
+        pytest.param("unknown-sibling", "unregistered artifact anchor", id="unknown-sibling"),
+        pytest.param("static-kind", "legacy artifact anchor has the wrong filesystem type", id="static-kind"),
+    ],
+)
+async def test_legacy_validation_classifies_the_exact_manifested_tree(
+    source: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    mutation: str,
+    message: str,
+) -> None:
+    daydream = source / ".daydream"
+    anchor = daydream / ("runs" if mutation == "unknown-sibling" else "improve")
+    anchor.mkdir(parents=True)
+    original_manifest = artifact_visibility._manifest
+    mutated = False
+
+    def mutate_before_manifest(
+        root: Path,
+        names: Any = None,
+        *,
+        digest: bool = True,
+    ) -> Any:
+        nonlocal mutated
+        if root == source and names == (".daydream", ".review-output.md") and not mutated:
+            mutated = True
+            if mutation == "unknown-sibling":
+                unknown = daydream / "inserted" / "opaque.bin"
+                unknown.parent.mkdir()
+                unknown.write_bytes(b"inserted after classification")
+            else:
+                anchor.rmdir()
+                anchor.write_bytes(b"wrong kind after classification")
+        return original_manifest(root, names, digest=digest)
+
+    monkeypatch.setattr(artifact_visibility, "_manifest", mutate_before_manifest)
+    with pytest.raises(ArtifactVisibilityError, match=message):
+        async with open_artifact_session(_work(source), session_id=f"manifest-race-{mutation}"):
+            pass
+
+    assert mutated is True
 
 
 async def test_artifact_session_rebaselines_public_deletion_at_open(
@@ -1244,7 +1367,7 @@ async def test_artifact_session_rebaselines_stray_public_addition(
     async with open_artifact_session(_work(source), session_id="baseline") as session:
         state_root = session.layout.state_root
 
-    stray = source / ".daydream" / "operator-notes.txt"
+    stray = source / ".daydream" / "deep" / "operator-notes.txt"
     stray.write_bytes(b"stray external bytes\n")
 
     async with open_artifact_session(_work(source), session_id="after-stray") as session:
@@ -1252,7 +1375,7 @@ async def test_artifact_session_rebaselines_stray_public_addition(
         assert _manifest_identity(_pv_manifest(state_root / "canonical")) == _manifest_identity(entries)
         stray_entry = next(entry for entry in entries if entry.path.endswith("operator-notes.txt"))
         assert stray_entry.kind == "file"
-        assert (session.daydream_dir / "operator-notes.txt").read_bytes() == (
+        assert (session.daydream_dir / "deep" / "operator-notes.txt").read_bytes() == (
             b"stray external bytes\n"
         )
     # On close the adopted baseline (with the stray file) is restored publicly.
@@ -1260,7 +1383,9 @@ async def test_artifact_session_rebaselines_stray_public_addition(
     assert _manifest_identity(_pv_manifest(source, (".daydream", ".review-output.md"))) == (
         _manifest_identity(restored)
     )
-    assert (source / ".daydream" / "operator-notes.txt").read_bytes() == b"stray external bytes\n"
+    assert (source / ".daydream" / "deep" / "operator-notes.txt").read_bytes() == (
+        b"stray external bytes\n"
+    )
 
 
 async def test_artifact_session_open_still_fails_closed_on_nonregular_public_node(
@@ -1278,7 +1403,7 @@ async def test_artifact_session_open_still_fails_closed_on_nonregular_public_nod
     shutil.rmtree(source / ".daydream" / "runs")
     (source / ".daydream" / "runs").symlink_to(outside, target_is_directory=True)
 
-    with pytest.raises(ArtifactVisibilityError, match="regular files and directories"):
+    with pytest.raises(ArtifactVisibilityError, match="wrong filesystem type"):
         async with open_artifact_session(_work(source), session_id="unsafe"):
             pass
     assert (outside / "canary").read_bytes() == b"outside"
@@ -1364,7 +1489,10 @@ async def test_artifact_session_rejects_nonregular_public_nodes_without_followin
             listener.bind(".daydream/runs/node")
 
     try:
-        with pytest.raises(ArtifactVisibilityError, match="regular files and directories"):
+        with pytest.raises(
+            ArtifactVisibilityError,
+            match="regular files and directories|wrong filesystem type",
+        ):
             async with open_artifact_session(_work(source), session_id=node_kind):
                 pass
         assert (outside / "canary").read_bytes() == b"outside"
@@ -1503,7 +1631,7 @@ async def test_artifact_session_freezes_snapshot_bytes_not_document_path_and_pub
         assert (frozen.root / ".daydream" / "runs" / session_id / "trajectory.json").read_bytes() == payload
         assert stale.read_bytes() == b"wrong bytes"
         with pytest.raises(ArtifactVisibilityError, match="frozen"):
-            artifact_dir_for(work.repo)
+            artifact_dir_for(work.repo, session=session)
         _publish(session, frozen)
 
     assert (source / ".daydream" / "runs" / session_id / "trajectory.json").read_bytes() == payload
@@ -1766,7 +1894,7 @@ async def test_bound_routing_rejects_same_spelling_repository_replacements(tmp_p
         try:
             for resolver in (artifact_dir_for, review_output_path_for):
                 with pytest.raises(ArtifactVisibilityError, match="active artifact session"):
-                    resolver(source)
+                    resolver(source, session=session)
         finally:
             source.unlink()
             moved.rename(source)
@@ -1777,7 +1905,7 @@ async def test_bound_routing_rejects_same_spelling_repository_replacements(tmp_p
         try:
             for resolver in (artifact_dir_for, review_output_path_for):
                 with pytest.raises(ArtifactVisibilityError, match="active artifact session"):
-                    resolver(source)
+                    resolver(source, session=session)
         finally:
             source.rename(tmp_path / "unrelated-repository")
             moved.rename(source)
@@ -1788,7 +1916,7 @@ async def test_bound_routing_rejects_same_spelling_repository_replacements(tmp_p
         try:
             for resolver in (artifact_dir_for, review_output_path_for):
                 with pytest.raises(ArtifactVisibilityError, match="active artifact session"):
-                    resolver(source)
+                    resolver(source, session=session)
         finally:
             container.unlink()
             moved_container.rename(container)
@@ -2147,13 +2275,13 @@ async def test_nested_artifact_sessions_restore_exact_context_token(tmp_path: Pa
     second_work = _work(second)
 
     async with open_artifact_session(first_work, session_id="first") as first_session:
-        assert artifact_dir_for(first) == first_session.daydream_dir
+        assert artifact_dir_for(first, allow_standalone=True) == first_session.daydream_dir
         async with open_artifact_session(second_work, session_id="second") as second_session:
-            assert artifact_dir_for(second) == second_session.daydream_dir
+            assert artifact_dir_for(second, allow_standalone=True) == second_session.daydream_dir
             with pytest.raises(ArtifactVisibilityError, match="active artifact session"):
-                artifact_dir_for(first)
-        assert artifact_dir_for(first) == first_session.daydream_dir
-    assert artifact_dir_for(first) == first / ".daydream"
+                artifact_dir_for(first, allow_standalone=True)
+        assert artifact_dir_for(first, allow_standalone=True) == first_session.daydream_dir
+    assert artifact_dir_for(first, allow_standalone=True) == first / ".daydream"
 
 
 async def test_artifact_session_rejects_forged_snapshot_object(tmp_path: Path, source: Path) -> None:
@@ -2212,7 +2340,7 @@ async def test_public_subtree_trajectory_uses_whole_daydream_transaction(
     status: str,
 ) -> None:
     _seed_public_artifacts(source)
-    custom_relative = Path("custom outputs") / "nested root.json"
+    custom_relative = Path("deep") / "custom outputs" / "nested root.json"
     requested = source / ".daydream" / custom_relative
     requested.parent.mkdir()
     requested.write_bytes(b"prior full")
@@ -2538,21 +2666,97 @@ async def test_public_subtree_trajectory_checks_private_root_itself(
     assert artifact_visibility._manifest(outside) == outside_before
 
 
-async def test_public_subtree_trajectory_allows_missing_private_root(source: Path) -> None:
-    session_id = "fresh-custom-root"
-    requested = source / ".daydream" / "custom" / "root.json"
-    payload = _payload(session_id)
-    async with open_artifact_session(_work(source), session_id=session_id) as session:
-        session.register_destination(source / ".daydream", label=OutputLabel.PUBLIC_DAYDREAM)
-        assert not session.daydream_dir.exists()
-        route = session.register_trajectory_output(requested)
-        assert route.full.write_path is not None
-        document = TrajectoryDocumentSnapshot(session_id, route.full.write_path, payload)
-        session.write_trajectory_document(route, document, "complete")
-        assert not (source / ".daydream").exists()
-        frozen = session.freeze(_snapshot(session_id, (document,)))
-        _publish(session, frozen)
-    assert requested.read_bytes() == payload
+@pytest.mark.parametrize("status", ["complete", "partial"])
+async def test_public_subtree_trajectory_reopens_from_prior_canonical(
+    source: Path,
+    status: str,
+) -> None:
+    session_id = f"fresh-custom-root-{status}"
+    _state_root, selected, payload = await _publish_custom_public_trajectory(
+        source,
+        session_id=session_id,
+        status=status,
+    )
+    assert selected.read_bytes() == payload
+
+    async with open_artifact_session(_work(source), session_id=f"reopen-{status}") as session:
+        assert (session.daydream_dir / "custom" / selected.name).read_bytes() == payload
+
+    assert selected.read_bytes() == payload
+
+
+@pytest.mark.parametrize("mutation", ["content", "addition", "kind"])
+async def test_prior_session_owned_nonstatic_subtree_rejects_public_mutation(
+    source: Path,
+    mutation: str,
+) -> None:
+    _state_root, selected, payload = await _publish_custom_public_trajectory(
+        source,
+        session_id=f"custom-mutation-{mutation}",
+    )
+    if mutation == "content":
+        selected.write_bytes(b"changed public bytes")
+    elif mutation == "addition":
+        (selected.parent / "unowned.json").write_bytes(b"new public bytes")
+    else:
+        selected.unlink()
+        selected.mkdir()
+
+    with pytest.raises(ArtifactVisibilityError, match="unregistered artifact anchor"):
+        async with open_artifact_session(_work(source), session_id=f"reject-{mutation}"):
+            pass
+
+    if mutation == "content":
+        assert selected.read_bytes() == b"changed public bytes"
+    elif mutation == "addition":
+        assert selected.read_bytes() == payload
+        assert (selected.parent / "unowned.json").read_bytes() == b"new public bytes"
+    else:
+        assert selected.is_dir()
+
+
+async def test_prior_session_owned_nonstatic_subtree_rejects_new_unknown_sibling(source: Path) -> None:
+    _state_root, selected, payload = await _publish_custom_public_trajectory(
+        source,
+        session_id="custom-with-new-sibling",
+    )
+    sibling = source / ".daydream" / "not-session-owned" / "opaque.bin"
+    sibling.parent.mkdir()
+    sibling.write_bytes(b"unowned bytes")
+
+    with pytest.raises(ArtifactVisibilityError, match="unregistered artifact anchor"):
+        async with open_artifact_session(_work(source), session_id="reject-new-sibling"):
+            pass
+
+    assert selected.read_bytes() == payload
+    assert sibling.read_bytes() == b"unowned bytes"
+
+
+@pytest.mark.parametrize("corruption", ["canonical-bytes", "canonical-manifest"])
+async def test_nonstatic_subtree_authorization_rejects_corrupt_canonical_proof(
+    source: Path,
+    corruption: str,
+) -> None:
+    state_root, selected, payload = await _publish_custom_public_trajectory(
+        source,
+        session_id=f"custom-corrupt-{corruption}",
+    )
+    relative = selected.relative_to(source)
+    if corruption == "canonical-bytes":
+        (state_root / "canonical" / relative).write_bytes(b"corrupt recovery bytes")
+    else:
+        manifest_path = state_root / "canonical-manifest.json"
+        manifest = _load_json(manifest_path)
+        entries = cast(list[dict[str, object]], manifest["entries"])
+        entry = next(item for item in entries if item["path"] == relative.as_posix())
+        entry["sha256"] = "0" * 64
+        _atomic_json(manifest_path, manifest)
+
+    with pytest.raises(ArtifactVisibilityError, match="canonical artifact recovery copy is corrupt"):
+        async with open_artifact_session(_work(source), session_id=f"reject-{corruption}"):
+            pass
+
+    assert selected.read_bytes() == payload
 
 
 @pytest.mark.parametrize(
@@ -3339,49 +3543,118 @@ async def test_transfer_intents_are_durable_before_first_move(
 async def test_routed_path_accessors_resolve_explicit_session_over_fallbacks(
     tmp_path: Path,
 ) -> None:
-    """Single-channel routing matrix for artifact_dir_for/review_output_path_for (#1162).
-
-    Pins the #1162 seam: an explicit ``session`` wins, the bound channel
-    (``_SESSION``) is honored for extension steps, the documented standalone
-    legacy path remains the no-session compatibility story, and strict
-    callers can fail closed with ``allow_standalone=False``.
-    """
+    """Strict calls require a session; compatibility requires affirmative opt-in."""
     source = tmp_path / "source"
     _init_repo(source)
     work = _work(source)
 
-    # No session bound: documented legacy standalone path, unchanged.
-    assert artifact_dir_for(work.repo) == source / ".daydream"
-    assert review_output_path_for(work.repo) == source / ".review-output.md"
+    with pytest.raises(ArtifactVisibilityError, match="explicit artifact session"):
+        artifact_dir_for(work.repo)
+    with pytest.raises(ArtifactVisibilityError, match="explicit artifact session"):
+        review_output_path_for(work.repo)
+    assert artifact_dir_for(work.repo, allow_standalone=True) == source / ".daydream"
+    assert review_output_path_for(work.repo, allow_standalone=True) == source / ".review-output.md"
 
     async with open_artifact_session(work, session_id="routing-seam") as session:
-        # Explicit session wins even though the ContextVar is also bound.
         assert artifact_dir_for(work.repo, session=session) == session.daydream_dir
-        assert (
-            review_output_path_for(work.repo, session=session)
-            == session.review_output
+        assert review_output_path_for(work.repo, session=session) == session.review_output
+        with pytest.raises(ArtifactVisibilityError, match="explicit artifact session"):
+            artifact_dir_for(work.repo)
+        with pytest.raises(ArtifactVisibilityError, match="explicit artifact session"):
+            review_output_path_for(work.repo)
+        assert artifact_dir_for(work.repo, allow_standalone=True) == session.daydream_dir
+        assert review_output_path_for(work.repo, allow_standalone=True) == session.review_output
+
+    with pytest.raises(ArtifactVisibilityError, match="explicit artifact session"):
+        artifact_dir_for(work.repo)
+
+
+async def test_artifact_session_projects_registered_live_and_durable_paths(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "source"
+    _init_repo(source)
+    work = _work(source)
+
+    async with open_artifact_session(work, session_id="projections") as session:
+        session.register_destination(source / ".daydream", label=OutputLabel.PUBLIC_DAYDREAM)
+        session.register_destination(source / ".review-output.md", label=OutputLabel.PUBLIC_REVIEW_OUTPUT)
+        findings = session.register_destination(source / "findings.json", label=OutputLabel.FINDINGS_OUTPUT)
+        trajectory = session.register_trajectory_output(
+            source / ".daydream" / "custom" / "trajectory.json"
         )
-        # Bound channel (the documented extension contract) still routes.
-        assert artifact_dir_for(work.repo) == session.daydream_dir
-        assert review_output_path_for(work.repo) == session.review_output
 
-    # Session closed: bound channel is empty again, standalone path resumes.
-    assert artifact_dir_for(work.repo) == source / ".daydream"
-
-    # Explicit fail-closed seam for strict callers (e.g. a future composition
-    # root that must never silently write the public tree).
-    with pytest.raises(ArtifactVisibilityError, match="standalone artifact routing"):
-        artifact_dir_for(work.repo, allow_standalone=False)
-    with pytest.raises(ArtifactVisibilityError, match="standalone artifact routing"):
-        review_output_path_for(work.repo, allow_standalone=False)
-
-    # A bound session satisfies allow_standalone=False (it is a real session).
-    async with open_artifact_session(work, session_id="routing-strict") as session:
-        assert artifact_dir_for(work.repo, allow_standalone=False) == session.daydream_dir
-        assert (
-            review_output_path_for(work.repo, allow_standalone=False)
-            == session.review_output
+        public_deep = source / ".daydream" / "deep" / "summary.md"
+        live_deep = session.daydream_dir / "deep" / "summary.md"
+        assert session.durable_path_for(live_deep, repo=work.repo) == public_deep
+        assert session.live_path_for(public_deep, repo=work.repo) == live_deep
+        assert session.durable_path_for(session.review_output, repo=work.repo) == (
+            source / ".review-output.md"
         )
+        assert session.live_path_for(source / ".review-output.md", repo=work.repo) == (
+            session.review_output
+        )
+
+        assert findings.write_path is not None
+        assert session.durable_path_for(findings.write_path, repo=work.repo) == findings.requested
+        assert session.live_path_for(findings.requested, repo=work.repo) == findings.write_path
+
+        for route in (trajectory.full, trajectory.partial):
+            assert route.write_path is not None
+            # The exact trajectory route must win over the broader registered
+            # public .daydream subtree in both directions.
+            assert session.durable_path_for(route.write_path, repo=work.repo) == route.requested
+            assert session.live_path_for(route.requested, repo=work.repo) == route.write_path
+
+
+async def test_artifact_session_projection_rejects_unowned_or_unsafe_paths(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "source"
+    other = tmp_path / "other"
+    _init_repo(source)
+    _init_repo(other)
+    work = _work(source)
+
+    async with open_artifact_session(work, session_id="prior") as prior:
+        prior.register_destination(source / ".daydream", label=OutputLabel.PUBLIC_DAYDREAM)
+        prior_live = prior.daydream_dir / "deep" / "prior.md"
+
+    async with open_artifact_session(work, session_id="current") as session:
+        session.register_destination(source / ".daydream", label=OutputLabel.PUBLIC_DAYDREAM)
+        findings = session.register_destination(source / "findings.json", label=OutputLabel.FINDINGS_OUTPUT)
+        dump = session.register_destination(tmp_path / "dump", label=OutputLabel.DUMP_DIRECTORY)
+
+        with pytest.raises(ArtifactVisibilityError, match="requested repo"):
+            session.durable_path_for(session.daydream_dir / "deep" / "current.md", repo=other)
+        with pytest.raises(ArtifactVisibilityError, match="registered artifact destination"):
+            session.durable_path_for(prior_live, repo=work.repo)
+        with pytest.raises(ArtifactVisibilityError, match="registered artifact destination"):
+            session.live_path_for(source / "unregistered.json", repo=work.repo)
+        with pytest.raises(ArtifactVisibilityError, match="writable path"):
+            session.live_path_for(dump.requested, repo=work.repo)
+
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        session.daydream_dir.mkdir()
+        linked = session.daydream_dir / "linked"
+        linked.symlink_to(outside, target_is_directory=True)
+        try:
+            with pytest.raises(ArtifactVisibilityError, match="symlink"):
+                session.durable_path_for(linked / "escape.md", repo=work.repo)
+        finally:
+            linked.unlink()
+
+        assert findings.write_path is not None
+        findings.write_path.mkdir(parents=True)
+        try:
+            with pytest.raises(ArtifactVisibilityError, match="wrong filesystem type"):
+                session.durable_path_for(findings.write_path, repo=work.repo)
+        finally:
+            findings.write_path.rmdir()
+
+    with pytest.raises(ArtifactVisibilityError, match="frozen and no longer writable"):
+        session.live_path_for(source / ".daydream", repo=work.repo)
 
 
 def _main() -> None:

--- a/tests/test_artifact_visibility_integration.py
+++ b/tests/test_artifact_visibility_integration.py
@@ -126,7 +126,7 @@ def _seed_visibility_canaries(repo: Path, private_base: Path) -> None:
     prior = repo / ".daydream" / "runs" / "prior-public-run"
     prior.mkdir(parents=True)
     (prior / "trajectory.json").write_text(json.dumps({"reasoning": PRIOR_REASONING_CANARY}), encoding="utf-8")
-    legacy = repo / ".daydream" / "resume" / "legacy cache.json"
+    legacy = repo / ".daydream" / "exploration" / "legacy cache.json"
     legacy.parent.mkdir(parents=True)
     legacy.write_text(RESUME_CACHE_CANARY, encoding="utf-8")
     _seed_private_canaries(private_base)

--- a/tests/test_cli_main_integration.py
+++ b/tests/test_cli_main_integration.py
@@ -478,7 +478,7 @@ def _seed_visibility_canaries(repo: Path, private_base: Path) -> None:
     prior = repo / ".daydream" / "runs" / "prior-public-run"
     prior.mkdir(parents=True)
     (prior / "trajectory.json").write_text(json.dumps({"reasoning": PRIOR_REASONING_CANARY}))
-    legacy = repo / ".daydream" / "resume" / "legacy cache.json"
+    legacy = repo / ".daydream" / "exploration" / "legacy cache.json"
     legacy.parent.mkdir(parents=True)
     legacy.write_text(RESUME_CACHE_CANARY, encoding="utf-8")
 

--- a/tests/test_deep_artifacts.py
+++ b/tests/test_deep_artifacts.py
@@ -12,9 +12,9 @@ def test_deep_dir_uses_active_artifact_route(
     from daydream.deep import artifacts
 
     routed = tmp_path / "private" / ".daydream"
-    monkeypatch.setattr(artifacts, "artifact_dir_for", lambda _target: routed)
+    monkeypatch.setattr(artifacts, "artifact_dir_for", lambda _target, **_kwargs: routed)
 
-    assert artifacts.deep_dir(tmp_path / "model-cwd") == routed / "deep"
+    assert artifacts.deep_dir(tmp_path / "model-cwd", allow_standalone=True) == routed / "deep"
     assert (routed / "deep").is_dir()
 
 
@@ -233,7 +233,7 @@ def test_diagram_artifact_paths_live_in_the_deep_dir(tmp_path: Path) -> None:
     other deep artifacts, under the same deep dir the run already owns."""
     from daydream.deep.artifacts import deep_dir, diagram_markdown_path, diagram_path
 
-    dd = deep_dir(tmp_path)
+    dd = deep_dir(tmp_path, allow_standalone=True)
     assert diagram_path(dd) == dd / "diagram.json"
     assert diagram_markdown_path(dd) == dd / "diagram.md"
     assert diagram_path(dd).parent == diagram_markdown_path(dd).parent == dd

--- a/tests/test_deep_fanout.py
+++ b/tests/test_deep_fanout.py
@@ -109,6 +109,7 @@ async def test_phase_per_stack_reviews_dispatch_interval_success(
             diff_path=diff,
             intent_path=intent,
             alternatives_path=alts,
+            allow_standalone=True,
         )
 
     assert set(results) == {"python", "react", "generic"}
@@ -134,6 +135,7 @@ async def test_fan_out_invokes_each_stack(tmp_path: Path, make_work: Callable[..
         diff_path=diff,
         intent_path=intent,
         alternatives_path=alts,
+        allow_standalone=True,
     )
 
     assert set(results.keys()) == {"python", "react", "generic"}
@@ -154,7 +156,7 @@ async def test_fan_out_invokes_each_stack(tmp_path: Path, make_work: Callable[..
     from daydream.deep.artifacts import deep_dir as _deep_dir
     from daydream.deep.artifacts import per_stack_records_path
 
-    deep_dir_path = _deep_dir(tmp_path)
+    deep_dir_path = _deep_dir(tmp_path, allow_standalone=True)
     declared: dict[str, list[Any]] = {"issues": [], "verdicts": []}
     for name in results:
         records = per_stack_records_path(deep_dir_path, name)
@@ -215,6 +217,7 @@ async def test_phase_per_stack_reviews_uses_structural_prompt_for_structure_stac
         diff_path=diff,
         intent_path=intent,
         alternatives_path=alts,
+        allow_standalone=True,
     )
 
     assert len(structural_calls) == 1
@@ -263,6 +266,7 @@ async def test_phase_per_stack_reviews_partial_dispatch_continues_after_one_fail
             diff_path=diff,
             intent_path=intent,
             alternatives_path=alts,
+            allow_standalone=True,
         )
 
     assert "python" in results
@@ -317,6 +321,7 @@ async def test_per_stack_prompts_are_skill_free(
         diff_path=diff,
         intent_path=intent,
         alternatives_path=alts,
+        allow_standalone=True,
     )
 
     assert failures == {}
@@ -365,6 +370,7 @@ async def test_fanout_default_concurrency(
         diff_path=diff,
         intent_path=intent,
         alternatives_path=alts,
+        allow_standalone=True,
     )
 
     assert 4 in captured
@@ -395,6 +401,7 @@ async def test_fanout_low_concurrency(
         diff_path=diff,
         intent_path=intent,
         alternatives_path=alts,
+        allow_standalone=True,
     )
 
     assert captured == [2]

--- a/tests/test_deep_merge.py
+++ b/tests/test_deep_merge.py
@@ -106,6 +106,7 @@ async def test_phase_cross_stack_merge_returns_output_path(
         intent_path=tmp_path / "i.md",
         alternatives_path=tmp_path / "a.json",
         dedup_candidates_path=tmp_path / "d.json",
+        allow_standalone=True,
     )
     assert result == tmp_path / REVIEW_OUTPUT_FILE
 
@@ -120,6 +121,7 @@ async def test_phase_cross_stack_merge_no_agents_kwarg(tmp_path: Path, make_work
         intent_path=tmp_path / "i.md",
         alternatives_path=tmp_path / "a.json",
         dedup_candidates_path=tmp_path / "d.json",
+        allow_standalone=True,
     )
     assert all(c["agents"] is None for c in backend.calls)
 

--- a/tests/test_deep_merge_recovery.py
+++ b/tests/test_deep_merge_recovery.py
@@ -167,7 +167,7 @@ async def test_merge_salvage_applies_dedup_prefilter(
     }
     stub.merge_emit_str = "no item list"
     assert await _run_deep(multi_stack_target) != 0  # merge salvaged -> Stop(1)
-    dd = deep_dir(multi_stack_target)
+    dd = deep_dir(multi_stack_target, allow_standalone=True)
     items = json.loads(merged_items_path(dd).read_text())
     # The dead ``partial: true`` root flag (unread by any consumer) is not
     # written; recoverability comes from the ``__merge__`` failure record +
@@ -214,6 +214,7 @@ def _merge_args(tmp_path: Path) -> dict[str, Any]:
         "intent_path": inputs["intent"],
         "alternatives_path": inputs["alts"],
         "dedup_candidates_path": inputs["dedup"],
+        "allow_standalone": True,
     }
 
 
@@ -276,7 +277,7 @@ async def test_merge_accepts_bare_list_result(tmp_path: Path, make_work: Callabl
         make_work(tmp_path),
         **args,
     )
-    items = json.loads(merged_items_path(deep_dir(tmp_path)).read_text())
+    items = json.loads(merged_items_path(deep_dir(tmp_path, allow_standalone=True)).read_text())
     assert [i["file"] for i in items["items"]] == ["api.py"]
     assert items.get("partial") is not True
 
@@ -322,7 +323,7 @@ async def test_merge_accepts_bare_list_end_to_end(multi_stack_target: Path, monk
         _merge_item(2, "cli/main.py", "medium", desc="unused arg"),
     ]
     assert await _run_deep(multi_stack_target) == 0
-    items = json.loads(merged_items_path(deep_dir(multi_stack_target)).read_text())
+    items = json.loads(merged_items_path(deep_dir(multi_stack_target, allow_standalone=True)).read_text())
     # Structural findings are appended after the merge independent of this branch,
     # so scope the assertion to the per-stack merge items (R7(i)): the bare-list
     # result is normalized + merged rather than rejected or silently lost.
@@ -358,7 +359,7 @@ async def test_merge_str_response_is_salvaged_not_fatal(
     stub.parse_severity = "high"
     stub.merge_emit_str = merge_str
     assert await _run_deep(multi_stack_target) != 0  # controlled Stop(1), not a crash
-    dd = deep_dir(multi_stack_target)
+    dd = deep_dir(multi_stack_target, allow_standalone=True)
     items = json.loads(merged_items_path(dd).read_text())
     # The ``partial: true`` root flag is dead metadata (no consumer reads it -
     # issue #361 follow-up); the salvage is recoverable via the ``__merge__``
@@ -426,7 +427,7 @@ async def test_merge_failure_relaunch_picks_up_salvage(
     # Read the expectation off the salvaged artifact rather than hard-coding one
     # stub description: which findings survive the salvage is decided by the
     # D-27 pre-filter and the evidence gate, not by this test.
-    salvaged = json.loads(merged_items_path(deep_dir(multi_stack_target)).read_text())["items"]
+    salvaged = json.loads(merged_items_path(deep_dir(multi_stack_target, allow_standalone=True)).read_text())["items"]
     assert salvaged, "salvage wrote no items to consume"
     fix_calls = [
         c["prompt"]
@@ -519,7 +520,7 @@ async def test_merge_salvage_keeps_a_side_when_three_stacks_share_id_and_file(
     }
     stub.merge_emit_str = "no item list"
     assert await _run_deep(multi_stack_target) != 0  # merge salvaged -> Stop(1)
-    dd = deep_dir(multi_stack_target)
+    dd = deep_dir(multi_stack_target, allow_standalone=True)
     items = json.loads(merged_items_path(dd).read_text())["items"]
     per_stack = [i for i in items if i.get("lens") == "per-stack"]
     # The regression: on the old ``(id, file)`` key this list is EMPTY -- every
@@ -657,7 +658,7 @@ async def test_merge_salvage_partial_items_carry_source_uids(
 
     assert await _run_deep(multi_stack_target) != 0  # merge salvaged -> Stop(1)
 
-    dd = deep_dir(multi_stack_target)
+    dd = deep_dir(multi_stack_target, allow_standalone=True)
     items = json.loads(merged_items_path(dd).read_text())["items"]
     provenance = {str(i["description"]): i["source_uids"] for i in items}
     assert provenance == {

--- a/tests/test_deep_orchestrator.py
+++ b/tests/test_deep_orchestrator.py
@@ -4459,7 +4459,7 @@ async def test_structural_language_twin_is_arbitrated_and_reported_once(
 
     assert await _run_deep(multi_stack_target) == 0
 
-    dd = deep_dir(multi_stack_target)
+    dd = deep_dir(multi_stack_target, allow_standalone=True)
 
     # (1) The arbiter saw the twin -- both sides, and nothing else. The other two
     # stacks are medium and uncontested, so they stay below the default
@@ -4515,7 +4515,7 @@ async def test_whole_file_structural_twin_is_arbitrated_and_reported_once(
 
     assert await _run_deep(multi_stack_target) == 0
 
-    dd = deep_dir(multi_stack_target)
+    dd = deep_dir(multi_stack_target, allow_standalone=True)
 
     arbiter_input = json.loads(arbiter_input_path(dd).read_text())
     assert sorted((e["file"], e["line"]) for e in arbiter_input) == [
@@ -4585,7 +4585,7 @@ async def test_precision_mode_suppression_never_sees_structural_records(
 
     assert await _run_deep(multi_stack_target, precision_mode=True) == 0
 
-    items = json.loads(merged_items_path(deep_dir(multi_stack_target)).read_text())["items"]
+    items = json.loads(merged_items_path(deep_dir(multi_stack_target, allow_standalone=True)).read_text())["items"]
     descriptions = [i["description"] for i in items]
     # The borderline LANGUAGE finding is suppressed (that is the pass working).
     assert not any("Borderline python nit" in d for d in descriptions), descriptions
@@ -4616,7 +4616,7 @@ async def test_distinct_structural_finding_survives_the_fold(
 
     assert await _run_deep(multi_stack_target) == 0
 
-    dd = deep_dir(multi_stack_target)
+    dd = deep_dir(multi_stack_target, allow_standalone=True)
     items = json.loads(merged_items_path(dd).read_text())["items"]
     api_items = sorted(
         i["description"] for i in items if i["file"] == "api.py"
@@ -6723,13 +6723,13 @@ async def test_environmental_failure_aborts_heal_loop(
         pytest.param("default", "clean", id="default-clean"),
         pytest.param("custom-public", "clean", id="custom-public-clean"),
         pytest.param("external", "clean", id="external-clean"),
-        pytest.param("default", "known-leaf", id="default-known-leaf-normalized"),
+        pytest.param("default", "known-leaf", id="default-known-leaf-private-fallback"),
         pytest.param(
             "custom-public",
             "known-leaf",
-            id="custom-public-known-leaf-normalized",
+            id="custom-public-known-leaf-private-fallback",
         ),
-        pytest.param("external", "known-leaf", id="external-known-leaf-normalized"),
+        pytest.param("external", "known-leaf", id="external-known-leaf-preserved"),
         pytest.param("default", "unknown-private", id="unknown-private-fallback"),
     ],
 )
@@ -6858,13 +6858,19 @@ async def test_ephemeral_failure_handoff_projects_public_refs_without_private_pa
     if response_kind == "clean":
         assert body == observation["model_body"]
     elif response_kind == "known-leaf":
-        assert body == observation["model_body"].replace(private_partial, str(expected_partial))
+        if trajectory_mode == "external":
+            assert body == observation["model_body"]
+        else:
+            assert "HANDOFF_STRUCTURED_SUCCESS" not in body
+            assert "Tests did not report success" in body
+            assert "1 failed" in body
+            assert private_partial not in body
         assert expected_partial.is_file()
         assert expected_partial.read_bytes() == private_partial_payloads[0]
     else:
         assert "HANDOFF_STRUCTURED_SUCCESS" not in body
         assert "Tests did not report success" in body
-        assert "[TRANSIENT_PATH]/.daydream/unreported.log" in body
+        assert ".daydream/unreported.log" not in body
     if trajectory_mode != "external":
         assert private_partial not in body
     assert observation["cwd"] not in body
@@ -7556,7 +7562,7 @@ async def test_host_only_merge_resume_publishes_and_archives_system_root(
         "    from daydream.artifact_visibility import artifact_dir_for\n"
         "    from daydream.trajectory import DaydreamPhase, phase_scope\n"
         "    async with phase_scope(DaydreamPhase.MERGE, stage='host-only-fixture'):\n"
-        "        deep = artifact_dir_for(ctx.work.repo) / 'deep'\n"
+        "        deep = artifact_dir_for(ctx.work.repo, session=ctx.artifacts, allow_standalone=False) / 'deep'\n"
         "        deep.mkdir(parents=True, exist_ok=True)\n"
         f"        (deep / 'merged-items.json').write_bytes({expected_items!r})\n"
         "\n"
@@ -10488,7 +10494,7 @@ async def test_every_merged_item_carries_source_uids_on_a_multi_stack_run(
 
     assert await _run_deep(multi_stack_target) == 0
 
-    deep = deep_dir(multi_stack_target)
+    deep = deep_dir(multi_stack_target, allow_standalone=True)
     items = _merged_items(deep)
     pool = _run_uid_pool(deep)
     assert pool == {"generic:1", "python:1", "react:1", "structure:1"}, pool
@@ -10561,7 +10567,7 @@ async def test_hallucinated_merge_source_uid_is_dropped_and_reported(
 
     assert await _run_deep(multi_stack_target, start_at="merge") == 0
 
-    deep = deep_dir(multi_stack_target)
+    deep = deep_dir(multi_stack_target, allow_standalone=True)
     by_description = _source_uids_by_description(deep)
     # The real uid survives; the invention beside it is gone.
     assert by_description["Partly attributed finding"] == ["python:1"]
@@ -10614,7 +10620,7 @@ async def test_unattributable_merge_source_uids_degrade_to_empty_list(
 
     assert await _run_deep(multi_stack_target, start_at="merge") == 0
 
-    deep = deep_dir(multi_stack_target)
+    deep = deep_dir(multi_stack_target, allow_standalone=True)
     by_description = _source_uids_by_description(deep)
     for description in (
         "Explicit null provenance",
@@ -10664,7 +10670,7 @@ async def test_single_stack_bypass_attributes_items_to_their_own_records(
     assert [c for c in stub.calls if "cross-stack merge agent" in c["prompt"].lower()] == [], (
         "the single-stack bypass must not invoke the merge agent"
     )
-    deep = deep_dir(tiny_diff_target)
+    deep = deep_dir(tiny_diff_target, allow_standalone=True)
     assert _run_uid_pool(deep) == {"generic:1", "structure:1"}
     by_description = _source_uids_by_description(deep)
     assert by_description["Sample issue"] == ["generic:1"]
@@ -10713,7 +10719,7 @@ async def test_structural_fold_survivor_inherits_both_provenances(
 
     assert await _run_deep(multi_stack_target, start_at="merge") == 0
 
-    deep = deep_dir(multi_stack_target)
+    deep = deep_dir(multi_stack_target, allow_standalone=True)
     twins = [item for item in _merged_items(deep) if item["description"] == _TWIN_DESCRIPTION]
     assert len(twins) == 1, f"the structural twin did not fold: {twins}"
     # The base item survived (it is the evidenced side) and now stands for both
@@ -10771,7 +10777,7 @@ async def test_structural_fold_provenance_when_structural_side_survives(
 
     assert await _run_deep(multi_stack_target, start_at="merge") == 0
 
-    deep = deep_dir(multi_stack_target)
+    deep = deep_dir(multi_stack_target, allow_standalone=True)
     twins = [item for item in _merged_items(deep) if item["description"] == _TWIN_DESCRIPTION]
     assert len(twins) == 1, f"the corroborated defect did not ship exactly once: {twins}"
     # The STRUCTURAL side survived this time, so its own provenance leads.
@@ -10820,7 +10826,7 @@ async def test_dropped_speculative_sidecar_records_item_provenance(
 
     assert await _run_deep(multi_stack_target, start_at="merge") == 0
 
-    deep = deep_dir(multi_stack_target)
+    deep = deep_dir(multi_stack_target, allow_standalone=True)
     by_description = _source_uids_by_description(deep)
     assert "Speculative unfounded finding" not in by_description, by_description
     assert by_description["Grounded finding"] == ["python:1"]
@@ -10929,7 +10935,7 @@ async def test_every_shipped_item_carries_a_unique_item_uid_on_a_multi_stack_run
 
     assert await _run_deep(multi_stack_target) == 0
 
-    deep = deep_dir(multi_stack_target)
+    deep = deep_dir(multi_stack_target, allow_standalone=True)
     items = _merged_items(deep)
     assert len(items) > 1, f"fixture must ship several items or uniqueness proves nothing: {items}"
 
@@ -10979,7 +10985,7 @@ async def test_shipped_item_carries_id_item_uid_and_provenance_independently(
 
     assert await _run_deep(multi_stack_target) == 0
 
-    deep = deep_dir(multi_stack_target)
+    deep = deep_dir(multi_stack_target, allow_standalone=True)
     items = _merged_items(deep)
     # The display ordinal is dense and 1-based over the SHIPPED list -- the
     # evidence gate deletes items after the merge agent numbered them, so this
@@ -11030,7 +11036,7 @@ async def test_item_uid_is_never_reported_as_record_provenance(
 
     assert await _run_deep(multi_stack_target) == 0
 
-    deep = deep_dir(multi_stack_target)
+    deep = deep_dir(multi_stack_target, allow_standalone=True)
     pool = _run_uid_pool(deep)
     for item in _merged_items(deep):
         provenance = item["source_uids"]
@@ -11185,6 +11191,7 @@ def _direct_fix_context(
             run_id="session-current",
         ),
         registry=Registry(),
+        allow_standalone_artifacts=True,
         data={
             "dd": dd,
             "items_file": items_file,

--- a/tests/test_improve_flow.py
+++ b/tests/test_improve_flow.py
@@ -77,9 +77,9 @@ def test_improve_dir_uses_active_artifact_route(
     from daydream.improve import artifacts
 
     routed = tmp_path / "private" / ".daydream"
-    monkeypatch.setattr(artifacts, "artifact_dir_for", lambda _target: routed)
+    monkeypatch.setattr(artifacts, "artifact_dir_for", lambda _target, **_kwargs: routed)
 
-    assert artifacts.improve_dir(tmp_path / "model-cwd") == routed / "improve"
+    assert artifacts.improve_dir(tmp_path / "model-cwd", allow_standalone=True) == routed / "improve"
     assert (routed / "improve").is_dir()
 
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -15,6 +15,7 @@ import pytest
 from rich.console import Console
 
 from daydream import git_ops
+from daydream.artifact_visibility import ArtifactSession
 from daydream.backends import (
     AgentEvent,
     CostEvent,
@@ -1839,7 +1840,15 @@ async def test_run_populates_exploration_context(
 
     captured: dict[str, Any] = {}
 
-    async def fake_per_stack_reviews(backend: Any, work: Any, stacks: Any, **kwargs: dict[str, Any]) -> tuple[Any, ...]:
+    async def fake_per_stack_reviews(
+        backend: Any,
+        work: Any,
+        stacks: Any,
+        *,
+        artifact_session: ArtifactSession | None = None,
+        allow_standalone: bool = False,
+        **kwargs: Any,
+    ) -> tuple[Any, ...]:
         captured["exploration_dir"] = kwargs.get("exploration_dir")
         # Issue #745: reviewers write PER_STACK_RECORD_SCHEMA records files that
         # the loader requires; the fake must do the same or the run stops.
@@ -1847,7 +1856,9 @@ async def test_run_populates_exploration_context(
 
         from daydream.deep.artifacts import deep_dir, per_stack_records_path
 
-        dd = deep_dir(work.repo)
+        dd = deep_dir(
+            work.repo, session=artifact_session, allow_standalone=allow_standalone
+        )
         dd.mkdir(parents=True, exist_ok=True)
         for s in stacks:
             per_stack_records_path(dd, s.stack_name).write_text(
@@ -1921,7 +1932,9 @@ async def test_exploration_enriched_output_both_flows(tmp_path: Path, make_work:
     # Normal flow: phase_parse_feedback returns list of validated issues
     (tmp_path / ".review-output.md").write_text("# Review\n")
     normal_backend = _issue_backend({"issues": [enriched_normal_issue]})
-    normal_issues = await phase_parse_feedback(normal_backend, work)
+    normal_issues = await phase_parse_feedback(
+        normal_backend, work, allow_standalone=True
+    )
 
     # TTT flow: phase_alternative_review returns list of issues
     diff_path = tmp_path / "diff.txt"

--- a/tests/test_log_mode.py
+++ b/tests/test_log_mode.py
@@ -366,6 +366,7 @@ async def test_log_mode_failure_handoff_redacts_credential_body(
     with bind_run_context(RunContext(InteractionPolicy(log_mode=True))):
         await _emit_failure_handoff(
             backend, work, "failing test output", offer_clipboard=False,
+            allow_standalone=True,
         )
         captured = capsys.readouterr()
         out = captured.out + captured.err

--- a/tests/test_observability_integration.py
+++ b/tests/test_observability_integration.py
@@ -46,7 +46,10 @@ async def trace_probe(ctx):
         phase=DaydreamPhase.REVIEW,
         output_schema={"type": "object", "properties": {"answer": {"type": "string"}}, "required": ["answer"]},
     )
-    (artifact_dir_for(ctx.work.repo) / "observability-result.json").write_text(json.dumps(output))
+    result_path = artifact_dir_for(
+        ctx.work.repo, session=ctx.artifacts, allow_standalone=False
+    ) / "observability-result.json"
+    result_path.write_text(json.dumps(output))
 
 def register(r):
     r.register_phase(FlowStep(name="trace-probe", run=trace_probe))

--- a/tests/test_phase_parse_input_path.py
+++ b/tests/test_phase_parse_input_path.py
@@ -61,7 +61,7 @@ async def test_input_path_default_uses_review_output_file(
     """D-40 regression: default call (no kwarg) reads work.repo / REVIEW_OUTPUT_FILE."""
     backend = _SpyBackend()
     (tmp_path / REVIEW_OUTPUT_FILE).write_text("# Issues\n1. [a.py:1] x\n")
-    await phase_parse_feedback(cast(Backend, backend), make_work(tmp_path))
+    await phase_parse_feedback(cast(Backend, backend), make_work(tmp_path), allow_standalone=True)
     assert str(tmp_path / REVIEW_OUTPUT_FILE) in backend.last_prompt
 
 
@@ -71,7 +71,9 @@ async def test_input_path_override_used_when_provided(tmp_path: Path, make_work:
     custom = tmp_path / ".daydream" / "deep" / "stack-python-review.md"
     custom.parent.mkdir(parents=True, exist_ok=True)
     custom.write_text("# Issues\n1. [api.py:1] x\n")
-    await phase_parse_feedback(cast(Backend, backend), make_work(tmp_path), input_path=custom)
+    await phase_parse_feedback(
+        cast(Backend, backend), make_work(tmp_path), input_path=custom, allow_standalone=True
+    )
     assert str(custom) in backend.last_prompt
     # Default path is NOT in the prompt when override is used
     assert str(tmp_path / REVIEW_OUTPUT_FILE) not in backend.last_prompt

--- a/tests/test_phases.py
+++ b/tests/test_phases.py
@@ -243,6 +243,7 @@ def test_test_healing_guard_reverts_existing_generated_file_and_keeps_new_migrat
 
     violations = _reject_test_healing_generated_file_edits(
         tmp_path, snapshot=snapshot, snapshot_captured=True, pre_untracked=set(),
+        allow_standalone=True,
     )
 
     assert violations == ["migrations/0001_init.sql"]
@@ -273,6 +274,7 @@ def test_test_healing_guard_uses_snapshot_bytes_to_detect_marker_generated_file(
 
     violations = _reject_test_healing_generated_file_edits(
         tmp_path, snapshot=snapshot, snapshot_captured=True, pre_untracked=set(),
+        allow_standalone=True,
     )
 
     assert violations == ["client.py"]
@@ -297,6 +299,7 @@ def test_test_healing_guard_skips_restoration_when_snapshot_capture_failed(
 
     violations = _reject_test_healing_generated_file_edits(
         tmp_path, snapshot=None, snapshot_captured=False, pre_untracked=set(),
+        allow_standalone=True,
     )
 
     assert violations == []
@@ -327,6 +330,7 @@ def test_test_healing_guard_uses_unique_recovery_patch_names(
 
     _reject_test_healing_generated_file_edits(
         tmp_path, snapshot=snapshot, snapshot_captured=True, pre_untracked=set(),
+        allow_standalone=True,
     )
 
     patches = list((tmp_path / ".daydream" / "partial-fixes").glob("*.patch"))
@@ -359,6 +363,7 @@ def test_test_healing_guard_skips_restoration_when_change_discovery_fails(
 
     violations = _reject_test_healing_generated_file_edits(
         tmp_path, snapshot=snapshot, snapshot_captured=True, pre_untracked=set(),
+        allow_standalone=True,
     )
 
     assert violations == []
@@ -391,6 +396,7 @@ def test_test_healing_guard_reports_restoration_failure(
 
     violations = _reject_test_healing_generated_file_edits(
         tmp_path, snapshot=snapshot, snapshot_captured=True, pre_untracked=set(),
+        allow_standalone=True,
     )
 
     assert violations is None
@@ -425,6 +431,7 @@ def test_test_healing_guard_restores_preexisting_untracked_generated_bytes(
         snapshot_captured=True,
         pre_untracked=pre_untracked,
         pre_untracked_contents=pre_untracked_contents,
+        allow_standalone=True,
     )
 
     assert violations == ["migrations/0000_local_draft.sql"]
@@ -458,6 +465,7 @@ def test_test_healing_guard_preserves_untouched_preexisting_untracked_bytes(
         snapshot_captured=True,
         pre_untracked=pre_untracked,
         pre_untracked_contents=pre_untracked_contents,
+        allow_standalone=True,
     )
 
     assert violations == []
@@ -1081,6 +1089,7 @@ async def test_phase_test_and_heal_honors_wall_budget_override(
             test_command="true",
             file_config=DaydreamFileConfig(test_command="true", test_command_wall_s=1234.0),
         ),
+        allow_standalone=True,
     )
     assert success is True
     assert retries == 0
@@ -1092,6 +1101,7 @@ async def test_phase_test_and_heal_honors_wall_budget_override(
         config=SimpleNamespace(
             test_command="true", file_config=DaydreamFileConfig(test_command="true"),
         ),
+        allow_standalone=True,
     )
     assert captured[-1]["wall_budget_s"] == TEST_WALL_BUDGET_S
 
@@ -1124,7 +1134,12 @@ async def test_phase_test_and_heal_fix_uses_fresh_context(
         {"id": 2, "description": "Missing import", "file": "src/utils.py", "line": 1},
     ]
 
-    success, retries, _ = await phase_test_and_heal(backend, make_work(tmp_path), feedback_items=feedback_items)
+    success, retries, _ = await phase_test_and_heal(
+        backend,
+        make_work(tmp_path),
+        feedback_items=feedback_items,
+        allow_standalone=True,
+    )
 
     assert success is True
     assert retries == 1
@@ -1158,7 +1173,7 @@ async def test_phase_test_and_heal_aborts_when_generated_restore_fails(
         lambda *args, **kwargs: None,
     )
 
-    result = await phase_test_and_heal(backend, make_work(tmp_path))
+    result = await phase_test_and_heal(backend, make_work(tmp_path), allow_standalone=True)
 
     assert (result.passed, result.retries, result.proceed) == (False, 1, False)
     assert backend.call_count == 2
@@ -1200,6 +1215,7 @@ async def test_phase_test_and_heal_fix_prompt_absolute_path_and_no_turn_cap(
 
     success, retries, _ = await phase_test_and_heal(
         backend, make_work(tmp_path), feedback_items=feedback_items,
+        allow_standalone=True,
     )
 
     assert success is True
@@ -1228,8 +1244,27 @@ async def test_phase_parse_feedback_empty_response_returns_empty_list(
     (tmp_path / REVIEW_OUTPUT_FILE).write_text("## Verdict\n\nReady: Yes\n")
 
     # Default script = a bare ResultEvent: a schema miss with no structured output, no text.
-    result = await phase_parse_feedback(ScriptedBackend(), make_work(tmp_path))
+    result = await phase_parse_feedback(
+        ScriptedBackend(), make_work(tmp_path), allow_standalone=True
+    )
     assert result == []
+
+
+@pytest.mark.asyncio
+async def test_phase_parse_feedback_requires_explicit_session_or_standalone_opt_in(
+    tmp_path: Path,
+    make_work: Callable[..., WorkContext],
+    silence_console: Callable[..., None],
+) -> None:
+    """Direct callers must affirmatively select legacy public-path routing."""
+    from daydream.artifact_visibility import ArtifactVisibilityError
+    from daydream.phases import phase_parse_feedback
+
+    silence_console("daydream.phases")
+    (tmp_path / REVIEW_OUTPUT_FILE).write_text("# Review\n", encoding="utf-8")
+
+    with pytest.raises(ArtifactVisibilityError, match="explicit artifact session"):
+        await phase_parse_feedback(ScriptedBackend(), make_work(tmp_path))
 
 
 @pytest.mark.asyncio
@@ -1257,7 +1292,7 @@ async def test_phase_parse_feedback_json_fallback(
         _RESULT,
     ])
 
-    result = await phase_parse_feedback(backend, make_work(tmp_path))
+    result = await phase_parse_feedback(backend, make_work(tmp_path), allow_standalone=True)
     assert len(result) == 1
     assert result[0]["file"] == "foo.py"
 
@@ -1306,7 +1341,7 @@ async def test_phase_parse_feedback_default_path_drops_speculative(
         ]
     }))
 
-    result = await phase_parse_feedback(backend, make_work(tmp_path))
+    result = await phase_parse_feedback(backend, make_work(tmp_path), allow_standalone=True)
     assert [i["description"] for i in result] == ["grounded"], (
         f"speculative finding leaked past the shallow-path gate: {result}"
     )
@@ -1518,7 +1553,7 @@ async def test_bound_phase_fix_transports_only_named_private_inputs(
     backend = _inline_or_exact_backend(repo, inline=inline)
 
     async with _private_session(tmp_path, work, f"phase-fix-{inline}"):
-        deep = artifact_dir_for(repo) / "deep"
+        deep = artifact_dir_for(repo, allow_standalone=True) / "deep"
         intent = deep / "intent.md"
         affected = deep / "exploration" / "affected_files.md"
         affected.parent.mkdir(parents=True)
@@ -2177,6 +2212,7 @@ async def test_phase_per_stack_reviews_threads_exploration_dir_to_structural_rev
         intent_path=intent,
         alternatives_path=alts,
         exploration_dir=exploration_dir,
+        allow_standalone=True,
     )
 
     assert failures == {}
@@ -3468,6 +3504,7 @@ async def test_approved_investigator_command_runs_once_host_side(
 
     passed, retries, proceed = await phase_test_and_heal(
         backend, make_work(tmp_path), feedback_items=None,
+        allow_standalone=True,
     )
 
     assert passed is True
@@ -3520,6 +3557,7 @@ async def test_approved_investigator_backtick_only_command_is_skipped_not_crash(
 
     passed, retries, proceed = await phase_test_and_heal(
         backend, make_work(tmp_path), feedback_items=None,
+        allow_standalone=True,
     )
 
     assert passed is True
@@ -3557,6 +3595,7 @@ async def test_phase_test_and_heal_spawn_error_routes_through_failure_gate(
     passed, retries, proceed = await phase_test_and_heal(
         _HealBackend(script=[]), make_work(tmp_path),
         feedback_items=None, config=config,
+        allow_standalone=True,
     )
 
     assert passed is False
@@ -3591,7 +3630,7 @@ async def test_phase_test_and_heal_option1_verdict_correct_uses_original_prompt(
         "daydream.run_context._prompt_user", lambda *a, **kw: next(choices, "3"),
     )
 
-    success, retries, _ = await phase_test_and_heal(backend, make_work(tmp_path))
+    success, retries, _ = await phase_test_and_heal(backend, make_work(tmp_path), allow_standalone=True)
 
     assert success is True
     assert retries == 1
@@ -3640,7 +3679,7 @@ async def test_phase_test_and_heal_option1_verdict_replace_user_confirms(
 
     monkeypatch.setattr("daydream.phases.run_test_command", fake_run)
 
-    success, retries, _ = await phase_test_and_heal(backend, make_work(tmp_path))
+    success, retries, _ = await phase_test_and_heal(backend, make_work(tmp_path), allow_standalone=True)
 
     assert success is True
     assert retries == 0
@@ -3682,7 +3721,7 @@ async def test_phase_test_and_heal_prompts_require_foreground_run_and_summary_li
         _fake_passed_run,
     )
 
-    success, _, _ = await phase_test_and_heal(backend, make_work(tmp_path))
+    success, _, _ = await phase_test_and_heal(backend, make_work(tmp_path), allow_standalone=True)
 
     assert success is True
     generic_prompt, investigator_prompt = backend.prompts[0], backend.prompts[1]
@@ -3718,7 +3757,7 @@ async def test_phase_test_and_heal_option1_verdict_replace_user_declines(
     # Select the investigator, then decline its replacement command.
     monkeypatch.setattr("daydream.run_context._prompt_user", lambda *a, **kw: "1" if "Choice" in a[1] else "n")
 
-    success, retries, _ = await phase_test_and_heal(backend, make_work(tmp_path))
+    success, retries, _ = await phase_test_and_heal(backend, make_work(tmp_path), allow_standalone=True)
 
     assert success is True
     assert retries == 1
@@ -3756,7 +3795,7 @@ async def test_phase_test_and_heal_option1_investigator_failure_falls_back(
         "daydream.run_context._prompt_user", lambda *a, **kw: next(choices, "3"),
     )
 
-    success, retries, _ = await phase_test_and_heal(backend, make_work(tmp_path))
+    success, retries, _ = await phase_test_and_heal(backend, make_work(tmp_path), allow_standalone=True)
 
     assert success is True
     assert retries == 1
@@ -3810,7 +3849,7 @@ async def test_summarizer_invoked_read_only_normal_calls_mutating(
     backend = _HealBackend(script=[_FAIL_TURN, _handoff_turn("# H")])
     monkeypatch.setattr("daydream.run_context._prompt_user", lambda *a, **k: "4")
 
-    await phase_test_and_heal(backend, make_work(tmp_path))
+    await phase_test_and_heal(backend, make_work(tmp_path), allow_standalone=True)
 
     # First call = the failing test run (mutating allowed); second = summarizer (read-only).
     assert backend.read_only_calls == [False, True]
@@ -3872,7 +3911,7 @@ async def test_phase_test_and_heal_option4_writes_handoff_to_live_path(
         "daydream.run_context._prompt_user", lambda *a, **kw: next(choices, "3"),
     )
 
-    success, retries, _ = await phase_test_and_heal(backend, make_work(tmp_path))
+    success, retries, _ = await phase_test_and_heal(backend, make_work(tmp_path), allow_standalone=True)
 
     assert success is False
     assert retries == 0
@@ -3910,7 +3949,7 @@ async def test_phase_test_and_heal_option4_clipboard_offer_fires_on_confirm(
     # Abort at the menu, then approve copying the handoff.
     monkeypatch.setattr("daydream.run_context._prompt_user", lambda *a, **kw: "4" if "Choice" in a[1] else "y")
 
-    success, _, _ = await phase_test_and_heal(backend, make_work(tmp_path))
+    success, _, _ = await phase_test_and_heal(backend, make_work(tmp_path), allow_standalone=True)
 
     assert success is False
     assert copied == ["BODY"]
@@ -3959,7 +3998,7 @@ async def test_phase_test_and_heal_option4_no_clipboard_skip_message(
         _handoff_turn("BODY"),
     ])
 
-    await phase_test_and_heal(backend, make_work(tmp_path))
+    await phase_test_and_heal(backend, make_work(tmp_path), allow_standalone=True)
 
     assert any("clipboard unavailable" in m for m in infos)
     # Only the menu "Choice" prompt fires — no clipboard confirmation prompt.
@@ -3991,7 +4030,7 @@ async def test_phase_test_and_heal_option4_no_recorder_writes_fallback_handoff(
         "daydream.run_context._prompt_user", lambda *a, **kw: next(choices, "3"),
     )
 
-    success, _, _ = await phase_test_and_heal(backend, make_work(tmp_path))
+    success, _, _ = await phase_test_and_heal(backend, make_work(tmp_path), allow_standalone=True)
     assert success is False
 
     fallback_dir = tmp_path / ".daydream"
@@ -4029,7 +4068,7 @@ async def test_phase_test_and_heal_option4_summarizer_failure_writes_minimal(
         "daydream.run_context._prompt_user", lambda *a, **kw: next(choices, "3"),
     )
 
-    success, _, _ = await phase_test_and_heal(backend, make_work(tmp_path))
+    success, _, _ = await phase_test_and_heal(backend, make_work(tmp_path), allow_standalone=True)
     assert success is False
 
     handoff = tmp_path / ".daydream" / "runs" / "test-session-id" / "handoff.md"
@@ -4065,7 +4104,7 @@ async def test_phase_test_and_heal_option4_summarizer_garbage_writes_minimal(
         "daydream.run_context._prompt_user", lambda *a, **kw: next(choices, "3"),
     )
 
-    success, _, _ = await phase_test_and_heal(backend, make_work(tmp_path))
+    success, _, _ = await phase_test_and_heal(backend, make_work(tmp_path), allow_standalone=True)
     assert success is False
 
     handoff = tmp_path / ".daydream" / "runs" / "test-session-id" / "handoff.md"
@@ -4090,7 +4129,7 @@ async def test_option4_handoff_has_facts_and_hypotheses_on_disk(
     backend = _HealBackend(script=[_FAIL_TURN, _handoff_turn("# H\nbody")])
     monkeypatch.setattr("daydream.run_context._prompt_user", lambda *a, **k: "4")
 
-    await phase_test_and_heal(backend, make_work(tmp_path))
+    await phase_test_and_heal(backend, make_work(tmp_path), allow_standalone=True)
 
     # The code we own is the prompt sent to the summarizer (agent output mocked).
     summarizer_prompt = backend.prompts[-1]
@@ -4122,7 +4161,7 @@ async def test_option4_fallback_puts_unknown_cause_in_hypotheses(
     backend = _HealBackend(script=[_FAIL_TURN, (RuntimeError("scripted summarizer failure"),)])
     monkeypatch.setattr("daydream.run_context._prompt_user", lambda *a, **k: "4")
 
-    await phase_test_and_heal(backend, make_work(tmp_path))
+    await phase_test_and_heal(backend, make_work(tmp_path), allow_standalone=True)
 
     body = (tmp_path / ".daydream" / "runs" / "test-session-id" / "handoff.md").read_text(
         encoding="utf-8",
@@ -4138,6 +4177,68 @@ async def test_option4_fallback_puts_unknown_cause_in_hypotheses(
 
 
 # _resolve_handoff_paths — ephemeral worktree + archive routing
+
+
+@pytest.mark.asyncio
+async def test_recorderless_standalone_ephemeral_handoff_survives_worktree_cleanup(
+    tmp_path: Path,
+) -> None:
+    """A standalone handoff without a recorder still belongs to the source checkout."""
+    from daydream.phases import _run_failure_summarizer
+
+    source = tmp_path / "source"
+    init_repo(source)
+    (source / "tracked.py").write_text("value = 1\n", encoding="utf-8")
+    git(source, "add", "tracked.py")
+    head = git_commit(source, "base")
+    worktree = tmp_path / "ephemeral-worktree"
+    git(source, "worktree", "add", "--detach", str(worktree), head)
+    work = WorkContext(
+        repo=worktree,
+        source=source,
+        base_branch="main",
+        base_sha=head,
+        head_branch=None,
+        head_sha=head,
+        is_ephemeral=True,
+        run_id="20260101000000-deadbeef",
+    )
+    backend = ScriptedBackend(events=_handoff_turn("DURABLE_HANDOFF_BODY"))
+
+    try:
+        body, handoff_path, written = await _run_failure_summarizer(
+            backend,
+            work,
+            "1 failed, 0 passed",
+            allow_standalone=True,
+        )
+        git(source, "worktree", "remove", "--force", str(worktree))
+
+        assert written is True
+        assert handoff_path.parent == source / ".daydream"
+        assert handoff_path.read_text(encoding="utf-8") == "DURABLE_HANDOFF_BODY"
+        assert body == "DURABLE_HANDOFF_BODY"
+        assert str(worktree) not in body
+    finally:
+        if worktree.exists():
+            git(source, "worktree", "remove", "--force", str(worktree))
+
+
+@pytest.mark.asyncio
+async def test_recorderless_handoff_rejects_a_bound_session_without_explicit_ownership(
+    tmp_path: Path,
+    make_work: Callable[..., WorkContext],
+) -> None:
+    """Compatibility routing cannot borrow a private session for a durable handoff."""
+    from daydream.artifact_visibility import ArtifactVisibilityError
+    from daydream.phases import _resolve_handoff_paths
+
+    repo = tmp_path / "repo"
+    init_repo(repo)
+    work = make_work(repo)
+    async with _private_session(tmp_path, work, "missing-handoff-session"):
+        with pytest.raises(ArtifactVisibilityError, match="explicit artifact session"):
+            _resolve_handoff_paths(None, work, allow_standalone=True)
 
 
 def _make_ephemeral_workcontext(source: Path, repo: Path) -> Any:
@@ -4189,6 +4290,7 @@ def test_resolve_handoff_paths_ephemeral_archive_routes_to_archive_bundle(
 
     handoff, trajectory, traj_dir, diff, manifest, deep = _resolve_handoff_paths(
         cast(TrajectoryRecorder, _Recorder()), work,
+        allow_standalone=True,
     )
 
     archive_run_dir = archive_root / "runs" / "sess-xyz"
@@ -4224,6 +4326,7 @@ def test_resolve_handoff_paths_inplace_uses_live_target_dir(tmp_path: Path) -> N
 
     handoff, trajectory, traj_dir, diff, manifest, deep = _resolve_handoff_paths(
         cast(TrajectoryRecorder, _Recorder()), work,
+        allow_standalone=True,
     )
 
     live_run_dir = tmp_path / ".daydream" / "runs" / "sess-abc"
@@ -4265,6 +4368,7 @@ def test_resolve_handoff_paths_returns_paths_even_when_files_missing(tmp_path: P
 
     _, trajectory, traj_dir, _, manifest, deep = _resolve_handoff_paths(
         cast(TrajectoryRecorder, _Recorder()), work,
+        allow_standalone=True,
     )
 
     # None of these files exist on disk yet, but the resolver must still
@@ -4350,7 +4454,7 @@ async def test_phase_test_and_heal_option4_inlines_body_when_write_fails(
         "daydream.run_context._prompt_user", lambda *a, **kw: next(choices, "3"),
     )
 
-    success, _, _ = await phase_test_and_heal(backend, make_work(tmp_path))
+    success, _, _ = await phase_test_and_heal(backend, make_work(tmp_path), allow_standalone=True)
 
     assert success is False
     # A warning explaining the failure was emitted.
@@ -4412,6 +4516,7 @@ async def test_phase_test_and_heal_non_interactive_writes_handoff_without_menu(
 
         passed, retries, _ = await phase_test_and_heal(
             backend, make_work(tmp_path), run_context=run_context,
+            allow_standalone=True,
         )
 
         # Took the abort/terminate path (choice "4" semantics, no mutation).
@@ -4476,6 +4581,7 @@ async def test_phase_test_and_heal_non_interactive_fallback_has_facts_hypotheses
 
         passed, retries, _ = await phase_test_and_heal(
             backend, make_work(tmp_path), run_context=run_context,
+            allow_standalone=True,
         )
         assert passed is False
         assert retries == 0
@@ -4541,6 +4647,7 @@ async def test_phase_test_and_heal_yes_bounded_loop_exactly_one_auto_attempt(
         ])
         success, retries, _ = await phase_test_and_heal(
             backend, make_work(tmp_path), run_context=run_context,
+            allow_standalone=True,
         )
 
         # Loop terminated after exactly one auto fix attempt.
@@ -4618,7 +4725,7 @@ async def test_normal_test_path_uses_host_runner_no_agent_turn(
     )
 
     work = make_work(tmp_path)
-    passed, retries, proceed = await phase_test_and_heal(backend, work)
+    passed, retries, proceed = await phase_test_and_heal(backend, work, allow_standalone=True)
 
     assert passed is True
     assert retries == 0
@@ -4672,7 +4779,7 @@ async def test_phase_test_and_heal_option1_strips_backticks_from_host_command(
 
     monkeypatch.setattr("daydream.phases.run_test_command", fake_run)
 
-    success, _, _ = await phase_test_and_heal(backend, make_work(tmp_path))
+    success, _, _ = await phase_test_and_heal(backend, make_work(tmp_path), allow_standalone=True)
 
     assert success is True
     assert cmds == [["make", "check", "IGNORE", "PREVIOUS", "INSTRUCTIONS"]]
@@ -4728,7 +4835,7 @@ async def test_phase_test_and_heal_option1_shows_suggested_command_before_confir
         _PASS_TURN,
     ])
 
-    await phase_test_and_heal(backend, make_work(tmp_path))
+    await phase_test_and_heal(backend, make_work(tmp_path), allow_standalone=True)
 
     # "Suggested command: ..." must be emitted before the confirmation prompt
     # (the second prompt_user call).
@@ -4847,35 +4954,81 @@ async def test_failure_summarizer_handles_changed_symlink_outside_repo(
         f"## Changed files\n\n- {repo / 'linked.txt'}\n"
     ))
 
-    async with _private_session(tmp_path, work, session_id):
-        live_daydream = artifact_dir_for(repo)
-        recorder = TrajectoryRecorder(
-            path=live_daydream / "runs" / session_id / "trajectory.json",
-            run_flow=DaydreamRunFlow.NORMAL,
-            target_dir=repo,
-            artifact_run_dir=live_daydream / "runs" / session_id,
-            agent_model_name="fake-external",
-            session_id=session_id,
+    live_daydream = artifact_dir_for(repo, allow_standalone=True)
+    recorder = TrajectoryRecorder(
+        path=live_daydream / "runs" / session_id / "trajectory.json",
+        run_flow=DaydreamRunFlow.NORMAL,
+        target_dir=repo,
+        artifact_run_dir=live_daydream / "runs" / session_id,
+        agent_model_name="fake-external",
+        session_id=session_id,
+    )
+    async with recorder:
+        body, handoff_path, written = await _run_failure_summarizer(
+            backend,
+            work,
+            "1 failed",
+            allow_standalone=True,
         )
-        async with recorder:
+        saved = live_daydream / "runs" / session_id / "handoff.md"
+        assert saved.read_text(encoding="utf-8") == body
+
+    assert written is True
+    assert handoff_path == repo / ".daydream" / "runs" / session_id / "handoff.md"
+    assert backend.call_count == 1
+    assert backend.calls[0]["cwd"] == repo
+    assert backend.calls[0]["read_only"] is True
+    assert f"- {repo / 'linked.txt'}" in backend.last_prompt
+    assert "HANDOFF_SYMLINK_SUCCESS" in body
+    assert str(outside_one) not in body
+    assert str(outside_two) not in body
+    assert str(live_daydream) not in body
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("private_leaf", ["control.json", "sibling-run/log.txt"])
+async def test_failure_summarizer_falls_back_for_non_live_private_runtime_paths(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+    make_work: Callable[..., WorkContext],
+    private_leaf: str,
+) -> None:
+    """A model cannot echo private control or sibling-workspace identities."""
+    from daydream.artifact_visibility import OutputLabel
+    from daydream.phases import _run_failure_summarizer
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    init_repo(repo)
+    work = make_work(repo)
+    async with _private_session(tmp_path, work, "handoff-private-roots") as session:
+        session.register_destination(
+            session.layout.public_daydream_dir,
+            label=OutputLabel.PUBLIC_DAYDREAM,
+        )
+        private_root = (
+            session.layout.artifact_runtime_root
+            if private_leaf == "control.json"
+            else session.layout.operational_workspaces_root
+        )
+        leaked = private_root / private_leaf
+        backend = ScriptedBackend(events=_handoff_turn(f"# Handoff\n\n{leaked}\n"))
+
+        with caplog.at_level("WARNING", logger="daydream.phases"):
             body, handoff_path, written = await _run_failure_summarizer(
                 backend,
                 work,
                 "1 failed",
+                artifact_session=session,
             )
-            saved = live_daydream / "runs" / session_id / "handoff.md"
-            assert saved.read_text(encoding="utf-8") == body
 
-        assert written is True
-        assert handoff_path == repo / ".daydream" / "runs" / session_id / "handoff.md"
-        assert backend.call_count == 1
-        assert backend.calls[0]["cwd"] == repo
-        assert backend.calls[0]["read_only"] is True
-        assert "- linked.txt" in backend.last_prompt
-        assert "HANDOFF_SYMLINK_SUCCESS" in body
-        assert str(outside_one) not in body
-        assert str(outside_two) not in body
-        assert str(live_daydream) not in body
+    assert written is True
+    assert handoff_path.parent == repo / ".daydream"
+    assert handoff_path.name.startswith("handoff-")
+    assert str(leaked) not in body
+    assert "structured handoff" in body
+    assert "private runtime path" not in body
+    assert "output contained a private runtime path" in caplog.text
 
 
 def test_failure_summarizer_empty_governed_set_keeps_public_paths_future_only(
@@ -4945,7 +5098,7 @@ async def test_option4_calls_write_partial_before_summarizer(
         "daydream.run_context._prompt_user", lambda *a, **kw: next(choices, "3"),
     )
 
-    success, _, _ = await phase_test_and_heal(backend, make_work(tmp_path))
+    success, _, _ = await phase_test_and_heal(backend, make_work(tmp_path), allow_standalone=True)
 
     assert success is False
     # The first backend call runs the failing test; write_partial must occur
@@ -5077,6 +5230,8 @@ async def test_phase_prints_model_line_after_hero(
     kwargs = setup(tmp_path)
     backend = ScriptedBackend(events=events, model=model)
 
+    if phase_name in {"phase_parse_feedback", "phase_cross_stack_merge"}:
+        kwargs["allow_standalone"] = True
     await getattr(phases, phase_name)(backend, make_work(tmp_path), **kwargs)
 
     assert any(title == expected_hero for title, _ in heroes)
@@ -5134,9 +5289,10 @@ async def test_merge_writes_canonical_json_and_renders_markdown(
         alternatives_path=tmp_path / "a.json",
         dedup_candidates_path=tmp_path / "d.json",
         structural_records_path=struct_path,
+        allow_standalone=True,
     )
 
-    items = json.loads(merged_items_path(deep_dir(work.repo)).read_text())["items"]
+    items = json.loads(merged_items_path(deep_dir(work.repo, allow_standalone=True)).read_text())["items"]
     assert any(i["lens"] == "structural" for i in items)  # structural survives into canonical
     assert any(i["lens"] == "per-stack" for i in items)  # agent items kept too
     assert len({i["id"] for i in items}) == len(items)  # ids unique after normalize
@@ -5174,7 +5330,7 @@ async def test_merge_sanctioned_inputs_use_real_transport_specific_budget(
         repo, inline=inline, events=_structured_turn(_MERGE_ITEMS)
     )
     async with _private_session(tmp_path, work, f"phase-merge-{inline}"):
-        deep = artifact_dir_for(repo) / "deep"
+        deep = artifact_dir_for(repo, allow_standalone=True) / "deep"
         deep.mkdir(parents=True)
         intent = _write_sized(deep / "intent.md", "intent", 6_361)
         alternatives = _write_sized(deep / "alternatives.json", "[]", 6_234)
@@ -5197,6 +5353,7 @@ async def test_merge_sanctioned_inputs_use_real_transport_specific_budget(
             dedup_candidates_path=dedup,
             structural_records_path=structural,
             exploration_dir=exploration,
+            allow_standalone=True,
         )
         if inline:
             with pytest.raises(SanctionedInputUnavailable, match="byte budget"):
@@ -5257,7 +5414,7 @@ async def test_phase_understand_intent_inline_exploration_budget_degrades(
     owner = resolve_private_workspace_owner(repo, locations=locations)
 
     async with open_artifact_session(work, session_id="intent-inline-oversize", owner=owner):
-        exploration = artifact_dir_for(repo) / "exploration"
+        exploration = artifact_dir_for(repo, allow_standalone=True) / "exploration"
         exploration.mkdir(parents=True)
         big_summary = "s" * (SANCTIONED_INLINE_INPUT_AGGREGATE_MAX_BYTES + 1)
         (exploration / "summary.md").write_text(big_summary, encoding="utf-8")
@@ -5324,7 +5481,7 @@ async def test_phase_understand_intent_inline_pair_over_budget_drops_tail(
     owner = resolve_private_workspace_owner(repo, locations=locations)
 
     async with open_artifact_session(work, session_id="intent-inline-pair", owner=owner):
-        exploration = artifact_dir_for(repo) / "exploration"
+        exploration = artifact_dir_for(repo, allow_standalone=True) / "exploration"
         exploration.mkdir(parents=True)
         half = SANCTIONED_INLINE_INPUT_AGGREGATE_MAX_BYTES // 2
         summary = "s" * half
@@ -5401,7 +5558,7 @@ async def test_phase_understand_intent_non_clone_inline_correction_omits_diff_pa
     monkeypatch.setattr("daydream.run_context._prompt_user", lambda *a, **kw: next(responses))
 
     async with open_artifact_session(work, session_id="intent-inline-correction", owner=owner):
-        exploration = artifact_dir_for(repo) / "exploration"
+        exploration = artifact_dir_for(repo, allow_standalone=True) / "exploration"
         exploration.mkdir(parents=True)
         (exploration / "summary.md").write_text("summary works\n", encoding="utf-8")
         (exploration / "affected_files.md").write_text("affected-a\n", encoding="utf-8")
@@ -5467,6 +5624,7 @@ async def test_cross_stack_merge_agent_phase_label(
             intent_path=tmp_path / "i.md",
             alternatives_path=tmp_path / "a.json",
             dedup_candidates_path=tmp_path / "d.json",
+            allow_standalone=True,
         )
 
     root = read_trajectory(recorder.path)
@@ -5493,6 +5651,7 @@ async def test_merge_raises_on_empty_agent_output(
             intent_path=tmp_path / "i.md",
             alternatives_path=tmp_path / "a.json",
             dedup_candidates_path=tmp_path / "d.json",
+            allow_standalone=True,
         )
 
 
@@ -5514,7 +5673,7 @@ async def test_verifier_excludes_structural_lens(
     silence_console("daydream.phases")
 
     work = make_work(tmp_path)
-    dd = deep_dir(work.repo)
+    dd = deep_dir(work.repo, allow_standalone=True)
     dd.mkdir(parents=True, exist_ok=True)
 
     structural_id = 1
@@ -5599,7 +5758,7 @@ async def test_verifier_prompt_carries_gate_zero_protocol(
     silence_console("daydream.phases")
 
     work = make_work(tmp_path)
-    dd = deep_dir(work.repo)
+    dd = deep_dir(work.repo, allow_standalone=True)
     dd.mkdir(parents=True, exist_ok=True)
 
     items = {
@@ -5913,6 +6072,7 @@ async def test_phase_test_and_heal_records_each_agent_attempt_and_heal_scope(
         session_id="session-2",
         capture_tree_key=lambda: next(keys),
         footprint=footprint,
+        allow_standalone=True,
     )
 
     assert result.passed is True
@@ -6519,7 +6679,7 @@ def test_merge_validates_finding_locations_before_write(tmp_path: Path) -> None:
             "evidence": "e",
         }
     ]
-    _write_single_stack_merged_items(tmp_path, dd, records, None)
+    _write_single_stack_merged_items(tmp_path, dd, records, None, allow_standalone=True)
     from daydream.deep.artifacts import merged_items_path
 
     items = json.loads(merged_items_path(dd).read_text())["items"]
@@ -6552,7 +6712,7 @@ def test_merge_demotion_preserves_original_severity_and_marks_distrust(tmp_path:
             "evidence": "e",
         }
     ]
-    _write_single_stack_merged_items(tmp_path, dd, records, None)
+    _write_single_stack_merged_items(tmp_path, dd, records, None, allow_standalone=True)
     from daydream.deep.artifacts import merged_items_path
 
     items = json.loads(merged_items_path(dd).read_text())["items"]

--- a/tests/test_phases_render.py
+++ b/tests/test_phases_render.py
@@ -64,7 +64,7 @@ async def test_parse_feedback_renders_issue_table(
     }
     backend = MockBackend([ResultEvent(structured_output=payload, continuation=None)])
 
-    items = await phase_parse_feedback(backend, make_work(tmp_path))
+    items = await phase_parse_feedback(backend, make_work(tmp_path), allow_standalone=True)
 
     out = rec.export_text()
     assert items == payload["issues"]
@@ -111,6 +111,7 @@ async def test_merge_prints_item_count(
         per_stack_records_paths=[],
         intent_path=intent,
         alternatives_path=alts,
+        allow_standalone=True,
         dedup_candidates_path=dedup,
     )
 
@@ -159,6 +160,7 @@ async def test_arbiter_prints_kept_dropped(
         diff_path=diff,
         intent_path=intent,
         alternatives_path=alts,
+        allow_standalone=True,
     )
 
     out = rec.export_text()
@@ -235,6 +237,7 @@ async def test_per_stack_failures_summarized_once(
         diff_path=diff,
         intent_path=intent,
         alternatives_path=alts,
+        allow_standalone=True,
     )
 
     out = rec.export_text()

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -2298,6 +2298,7 @@ def test_open_recorder_resolves_backend_identity(tmp_path: Path) -> None:
     target_dir.mkdir()
     config = RunConfig(target=str(target_dir), backend="codex", fix_backend="pi", run_eval=False)
     recorder = _open_recorder(
+        allow_standalone=True,
         config=config, target_dir=target_dir, work=None, flow_kind=DaydreamRunFlow.NORMAL,
     )
     assert recorder.backend_name == "codex"
@@ -2324,6 +2325,7 @@ def test_open_recorder_resolves_backend_via_per_stack_review(tmp_path: Path) -> 
         file_config=DaydreamFileConfig(phases={"per_stack_review": {"backend": "pi"}}),
     )
     recorder = _open_recorder(
+        allow_standalone=True,
         config=config, target_dir=target_dir, work=None, flow_kind=DaydreamRunFlow.NORMAL,
     )
     assert recorder.backend_name == "pi"
@@ -2340,6 +2342,7 @@ def test_open_recorder_improve_omits_fix_test_backend(tmp_path: Path) -> None:
     target_dir.mkdir()
     config = RunConfig(target=str(target_dir), backend="codex", run_eval=False)
     recorder = _open_recorder(
+        allow_standalone=True,
         config=config, target_dir=target_dir, work=None, flow_kind=DaydreamRunFlow.IMPROVE,
     )
     assert recorder.backend_name == "codex"
@@ -2359,6 +2362,7 @@ def test_open_recorder_review_only_omits_fix_test_backend(tmp_path: Path) -> Non
     target_dir.mkdir()
     config = RunConfig(target=str(target_dir), backend="codex", run_eval=False)
     recorder = _open_recorder(
+        allow_standalone=True,
         config=config, target_dir=target_dir, work=None, flow_kind=DaydreamRunFlow.TTT,
     )
     assert recorder.backend_name == "codex"
@@ -2380,6 +2384,7 @@ def test_open_recorder_custom_omits_fix_test_backend(tmp_path: Path) -> None:
     target_dir.mkdir()
     config = RunConfig(target=str(target_dir), backend="codex", fix_backend="pi", run_eval=False)
     recorder = _open_recorder(
+        allow_standalone=True,
         config=config, target_dir=target_dir, work=None, flow_kind=DaydreamRunFlow.CUSTOM,
     )
     assert recorder.backend_name == "codex"
@@ -2400,6 +2405,7 @@ def test_open_recorder_diagram_omits_fix_test_backend(tmp_path: Path) -> None:
     target_dir.mkdir()
     config = RunConfig(target=str(target_dir), backend="codex", fix_backend="pi", run_eval=False)
     recorder = _open_recorder(
+        allow_standalone=True,
         config=config, target_dir=target_dir, work=None, flow_kind=DaydreamRunFlow.DIAGRAM,
     )
     assert recorder.backend_name == "codex"
@@ -2423,6 +2429,7 @@ def test_open_recorder_diagram_resolves_backend_via_the_diagram_phase(tmp_path: 
         file_config=DaydreamFileConfig(phases={"diagram": {"backend": "pi"}}),
     )
     recorder = _open_recorder(
+        allow_standalone=True,
         config=config, target_dir=target_dir, work=None, flow_kind=DaydreamRunFlow.DIAGRAM,
     )
     assert recorder.backend_name == "pi"
@@ -2450,6 +2457,7 @@ def test_open_recorder_improve_resolves_backend_via_recon(tmp_path: Path) -> Non
         file_config=DaydreamFileConfig(phases={"recon": {"backend": "pi"}}),
     )
     recorder = _open_recorder(
+        allow_standalone=True,
         config=config, target_dir=target_dir, work=None, flow_kind=DaydreamRunFlow.IMPROVE,
     )
     assert recorder.backend_name == "pi"
@@ -2465,6 +2473,7 @@ def test_open_recorder_pr_flow_resolves_fix_omits_test(tmp_path: Path) -> None:
     target_dir.mkdir()
     config = RunConfig(target=str(target_dir), review_backend="codex", run_eval=False)
     recorder = _open_recorder(
+        allow_standalone=True,
         config=config, target_dir=target_dir, work=None, flow_kind=DaydreamRunFlow.PR,
     )
     assert recorder.backend_name == "codex"
@@ -2479,6 +2488,7 @@ def test_open_recorder_backend_falls_back_to_claude(tmp_path: Path) -> None:
     target_dir.mkdir()
     config = RunConfig(target=str(target_dir), run_eval=False)
     recorder = _open_recorder(
+        allow_standalone=True,
         config=config, target_dir=target_dir, work=None, flow_kind=DaydreamRunFlow.NORMAL,
     )
     assert recorder.backend_name == "claude"


### PR DESCRIPTION
## Summary

- Route runner, deep, Improve, and generated-path phase helpers through their explicit artifact session. Direct standalone callers now opt in with `allow_standalone=True`; API v6 retains `ctx.artifacts` and its existing data mapping.
- Use validated session projections for failure handoffs, preserving requested trajectory destinations after ephemeral worktree cleanup and falling back safely when model text contains private runtime paths.
- Reject unowned legacy siblings while allowing unchanged artifacts from prior sessions to reopen with exact canonical ownership proof. Validate membership and types against the captured manifest to close directory-scan races.

## Motivation

Closes #1165. Production paths still relied on an ambient session, and handoff path reconstruction lost explicit trajectory destinations. Strict legacy adoption also needs to distinguish new unowned files from custom outputs already published by a prior session. The existing capture, freeze, recovery, and publication validation boundaries remain in place.

## Test Plan

- Storage and recovery suite: 180 passed, 1 skipped, including canonical corruption and deterministic insertion/type-change races.
- Real runner handoff/reopen and observability journeys: 25 passed. Native CLI artifact visibility module: 14 passed. Existing handoff cases retain complete/partial output byte checks.
- Final `make check`: 8,144 passed, 15 skipped, 88.67% coverage; Ruff, 536-file mypy, root/RL dead-code scans, and Docker workflow lint passed.
- Phase suite: 218 passed, 2 skipped. Real standalone cleanup regression passes; nested standalone entry-point tests prove rejection before artifact writes or backend dispatch.
- Exact local `daydream . --precision --non-interactive --backend codex`: exit 0 on signed commit `68277387`, with all 26 changed files read and zero actionable findings after adjudication. Three proposals were rejected with contract/code/test evidence: existing between-run cleanup semantics, consistent supplied-path guidance, and the explicitly retained API v6. Optional diagram generation exceeded its input byte budget; code-review phases succeeded.

## Checklist

- [x] Root checks, standalone RL dead-code scan, coverage, and Docker workflow lint passed locally with `make check`. Standalone `rl-check` is also required in CI.
- [x] Extension documentation updated for strict routing, standalone opt-in, and durable path projection.

## Additional Context

Based on current main, including dependency update #1160. The issue contract records the canonical ownership reconciliation and its two-run reproduction. No storage schema or extension API version changes.
