### PR TITLE
perf(rl): bake image ownership and reuse one mirror per repo per snapshot build

### DIFF
--- a/rl/daydream_review_v1/daydream_review_v1/harness.py
+++ b/rl/daydream_review_v1/daydream_review_v1/harness.py
@@ -168,19 +168,23 @@ class DaydreamReviewHarness(vf.Harness[DaydreamReviewHarnessConfig]):
             self.config.repo_path,
         ]
         if runtime.type == "docker":
-            # The repo image clones the checkout as root (repo.Dockerfile), so
-            # hand the workspace — and the in-container origin mirror the deep
-            # flow pushes its fix to — to the agent identity before the
-            # privilege drop. Otherwise every deep-flow write (.daydream/,
-            # worktrees, fix edits, git add/commit, push) EACCESes as the
-            # agent uid and the rollout dies before any model turn.
-            handoff = await runtime.run(
-                ["chown", "-R", "agent:agent", self.config.repo_path, "/srv/mirror.git"], env
+            # The image bakes both trees agent-owned at build time
+            # (repo.Dockerfile's combined chown layer covers /work/repo and
+            # /srv/mirror.git), so launch issues no ownership command at all.
+            # Instead, a constant-size writability preflight runs before the
+            # privilege drop and fails closed if the image was not built with
+            # the ownership layer — a non-agent-writable tree is a rebuild
+            # signal, never a runtime repair.
+            preflight = await runtime.run(
+                ["sh", "-c", f"test -w {self.config.repo_path} && test -w /srv/mirror.git"], env
             )
-            if handoff.exit_code != 0:
+            if preflight.exit_code != 0:
                 raise RuntimeError(
-                    "could not hand the checkout to the agent identity: "
-                    f"{handoff.stdout}{handoff.stderr}"
+                    "repo and mirror are not agent-writable; the image was likely built "
+                    "without the ownership layer. Rebuild it with "
+                    "images/build_images.py, which bakes agent ownership for "
+                    f"{self.config.repo_path} and /srv/mirror.git: "
+                    f"{preflight.stdout}{preflight.stderr}"
                 )
             # Container launches drop from the container default user (root) to
             # the non-root agent identity through the image's root-owned

--- a/rl/daydream_review_v1/daydream_review_v1/harness.py
+++ b/rl/daydream_review_v1/daydream_review_v1/harness.py
@@ -14,6 +14,7 @@ rollout agent is one config key: ``backend``.
 from __future__ import annotations
 
 import logging
+import shlex
 from typing import Any
 
 import verifiers.v1 as vf
@@ -179,16 +180,43 @@ class DaydreamReviewHarness(vf.Harness[DaydreamReviewHarnessConfig]):
             # image was not built with the ownership layer — a non-agent-
             # writable tree is a rebuild signal, never a runtime repair.
             preflight = await runtime.run(
-                ["run-as-agent", "sh", "-c", f"test -w {self.config.repo_path} && test -w /srv/mirror.git"],
+                [
+                    "run-as-agent",
+                    "sh",
+                    "-c",
+                    f"test -w {shlex.quote(self.config.repo_path)} && test -w /srv/mirror.git",
+                ],
                 env,
             )
-            if preflight.exit_code != 0:
+            # The two tree roots are not the deep flow's whole write surface:
+            # its git add/commit writes into <repo>/.git and the terminal push
+            # updates the mirror's refs, so the preflight probes those per-file
+            # surfaces too. A checkout whose .git or mirror refs stayed
+            # root-owned would pass the root probes yet EACCES on the agent's
+            # first commit or push — that partial-ownership state is a rebuild
+            # signal just like a missing layer, never a runtime repair. The
+            # path is shlex.quote()d because it is interpolated into the
+            # privileged `sh -c` string: an unbaked config value containing
+            # whitespace would word-split the probe onto the wrong paths, and
+            # shell metacharacters would execute as the sandbox agent uid with
+            # the rollout env.
+            surfaces = await runtime.run(
+                [
+                    "run-as-agent",
+                    "sh",
+                    "-c",
+                    f"test -w {shlex.quote(self.config.repo_path)}/.git && test -w /srv/mirror.git/refs",
+                ],
+                env,
+            )
+            if preflight.exit_code != 0 or surfaces.exit_code != 0:
                 raise RuntimeError(
-                    "repo and mirror are not agent-writable; the image was likely built "
-                    "without the ownership layer. Rebuild it with "
+                    "repo and mirror are not agent-writable (tree roots plus the per-file "
+                    "write surfaces: the checkout's .git and the mirror's refs); the image "
+                    "was likely built without the ownership layer. Rebuild it with "
                     "images/build_images.py, which bakes agent ownership for "
                     f"{self.config.repo_path} and /srv/mirror.git: "
-                    f"{preflight.stdout}{preflight.stderr}"
+                    f"{preflight.stdout}{preflight.stderr}{surfaces.stdout}{surfaces.stderr}"
                 )
             # Container launches drop from the container default user (root) to
             # the non-root agent identity through the image's root-owned

--- a/rl/daydream_review_v1/daydream_review_v1/harness.py
+++ b/rl/daydream_review_v1/daydream_review_v1/harness.py
@@ -171,12 +171,16 @@ class DaydreamReviewHarness(vf.Harness[DaydreamReviewHarnessConfig]):
             # The image bakes both trees agent-owned at build time
             # (repo.Dockerfile's combined chown layer covers /work/repo and
             # /srv/mirror.git), so launch issues no ownership command at all.
-            # Instead, a constant-size writability preflight runs before the
-            # privilege drop and fails closed if the image was not built with
-            # the ownership layer — a non-agent-writable tree is a rebuild
-            # signal, never a runtime repair.
+            # Instead, a constant-size writability preflight runs through the
+            # same run-as-agent privilege drop the launch will use, so it probes
+            # the agent's actual write access — running it as the container root
+            # would vacuously succeed on a root-owned tree (CAP_DAC_OVERRIDE)
+            # and never catch a missing ownership layer. It fails closed if the
+            # image was not built with the ownership layer — a non-agent-
+            # writable tree is a rebuild signal, never a runtime repair.
             preflight = await runtime.run(
-                ["sh", "-c", f"test -w {self.config.repo_path} && test -w /srv/mirror.git"], env
+                ["run-as-agent", "sh", "-c", f"test -w {self.config.repo_path} && test -w /srv/mirror.git"],
+                env,
             )
             if preflight.exit_code != 0:
                 raise RuntimeError(

--- a/rl/daydream_review_v1/images/build_images.py
+++ b/rl/daydream_review_v1/images/build_images.py
@@ -273,7 +273,13 @@ def acquire_mirror(
     ``_stream`` path (``CalledProcessError``); nothing is cached and no fallback
     mirror is ever substituted, so that slug's PRs fail per PR.
     """
-    slug = _repo_slug(entry.clone_url)
+    # Key by the repo slug the manifest/corpus use, never by a slug derived
+    # from the manifest clone_url: for the fixture sentinel ``_repo_slug``
+    # yields ``/daydream-rl-fixture``, not the manifest key ``FIXTURE_SLUG``.
+    if entry.clone_url == FIXTURE_CLONE_URL:
+        slug = FIXTURE_SLUG
+    else:
+        slug = _repo_slug(entry.clone_url)
     if slug in cache:
         return cache[slug][1]
     handle = tempfile.TemporaryDirectory[Any](prefix="daydream-rl-mirror-")

--- a/rl/daydream_review_v1/images/build_images.py
+++ b/rl/daydream_review_v1/images/build_images.py
@@ -41,7 +41,7 @@ import subprocess
 import sys
 import tempfile
 from pathlib import Path
-from typing import cast
+from typing import Any, cast
 
 from daydream_review_v1.corpus import harvested_corpus
 from daydream_review_v1.fixture import (
@@ -255,24 +255,67 @@ def write_setup_script(ctx: Path, setup_cmds: list[str]) -> None:
     (ctx / "setup.sh").write_text("\n".join(lines) + "\n", encoding="utf-8")
 
 
-def materialize_mirror(entry: _ManifestEntry, ctx: Path, *, red: bool) -> dict[str, str]:
+def acquire_mirror(
+    entry: _ManifestEntry, cache: dict[str, tuple[tempfile.TemporaryDirectory[Any], Path]], *, red: bool
+) -> Path:
+    """Acquire one bare mirror per repo slug, exactly once per ``main`` invocation.
+
+    The cache is keyed by repo slug and maps to ``(handle, mirror)`` — the
+    handle is the ``TemporaryDirectory`` owning the mirror's parent, kept open
+    so every ``build_repo_image`` call that copies from the mirror outlives it.
+    ``main`` owns the cache and cleans the handles up after the PR loop.
+
+    A non-fixture slug network-clones ``entry.clone_url`` exactly once (a cache
+    hit skips the clone entirely). The fixture slug never touches the network:
+    it gets one local fixture build + local ``git clone --mirror`` per
+    invocation, and each PR snapshot still re-derives its own ``--red`` SHA
+    remap in :func:`materialize_mirror`. A failed acquisition raises through the
+    ``_stream`` path (``CalledProcessError``); nothing is cached and no fallback
+    mirror is ever substituted, so that slug's PRs fail per PR.
+    """
+    slug = _repo_slug(entry.clone_url)
+    if slug in cache:
+        return cache[slug][1]
+    handle = tempfile.TemporaryDirectory[Any](prefix="daydream-rl-mirror-")
+    mirror = Path(handle.name) / "mirror.git"
+    try:
+        if entry.clone_url == FIXTURE_CLONE_URL:
+            with tempfile.TemporaryDirectory(prefix="daydream-rl-fixture-") as tmp:
+                repo = build_fixture_repo(Path(tmp) / "repo", red=red)
+                _stream(["git", "clone", "--mirror", str(repo.path), str(mirror)])
+        else:
+            _stream(["git", "clone", "--mirror", entry.clone_url, str(mirror)])
+    except BaseException:
+        handle.cleanup()
+        raise
+    cache[slug] = (handle, mirror)
+    return mirror
+
+
+def materialize_mirror(entry: _ManifestEntry, ctx: Path, *, red: bool, mirror: Path) -> dict[str, str]:
     """Put a bare ``mirror.git`` in the build context *ctx*.
+
+    ``mirror`` is the invocation-scoped mirror acquired once per slug by
+    :func:`acquire_mirror`; every context gets a real copy (``shutil.copytree``,
+    never a symlink or hardlink) so a PR build cannot mutate the shared cache.
 
     Returns:
         A SHA translation map, empty for a real clone. It matters only under
         ``--red``: planting a failing assertion rewrites the fixture's head commit,
         so that commit's SHA changes and the SHA pinned in the corpus no longer
         exists. Without the remap the build would die at ``git checkout`` and prove
-        nothing about the green-baseline gate.
+        nothing about the green-baseline gate. The fixture's remap is re-derived
+        per PR (a fresh ``build_fixture_repo`` per call) even though the mirror
+        itself is shared, preserving the fixture semantics unchanged.
     """
-    mirror = ctx / "mirror.git"
+    target = ctx / "mirror.git"
     if entry.clone_url != FIXTURE_CLONE_URL:
-        _stream(["git", "clone", "--mirror", entry.clone_url, str(mirror)])
+        shutil.copytree(mirror, target)
         return {}
 
     with tempfile.TemporaryDirectory(prefix="daydream-rl-fixture-") as tmp:
         repo = build_fixture_repo(Path(tmp) / "repo", red=red)
-        _stream(["git", "clone", "--mirror", str(repo.path), str(mirror)])
+        shutil.copytree(mirror, target)
     return {
         FIXTURE_BASE_SHA: repo.base_sha,
         FIXTURE_PR1_HEAD_SHA: repo.pr1_head_sha,
@@ -305,8 +348,14 @@ def _validate_red_flags(*, red: bool, base_only: bool, manifest: dict[str, _Mani
     return None
 
 
-def build_repo_image(entry: _ManifestEntry, *, head_sha: str, base_sha: str, base_image: str, red: bool) -> str:
+def build_repo_image(
+    entry: _ManifestEntry, *, head_sha: str, base_sha: str, base_image: str, red: bool, mirror: Path
+) -> str:
     """Build one PR-snapshot image and return the tag it was given.
+
+    ``mirror`` is the invocation-scoped mirror for this entry's slug, acquired
+    once by ``main`` via :func:`acquire_mirror`; it is copied into this build's
+    isolated context rather than re-cloned.
 
     Raises:
         subprocess.CalledProcessError: If any layer fails — including the final
@@ -314,7 +363,7 @@ def build_repo_image(entry: _ManifestEntry, *, head_sha: str, base_sha: str, bas
     """
     with tempfile.TemporaryDirectory(prefix="daydream-rl-ctx-") as tmp:
         ctx = Path(tmp)
-        remap = materialize_mirror(entry, ctx, red=red)
+        remap = materialize_mirror(entry, ctx, red=red, mirror=mirror)
         write_setup_script(ctx, entry.setup_cmds)
 
         head = remap.get(head_sha, head_sha)
@@ -441,37 +490,50 @@ def main(argv: list[str] | None = None) -> int:
     # without duplicating the runtime guard in main.
     base_image = cast(str, base_image)
 
+    # One mirror per repo slug for this whole invocation: acquired lazily on
+    # the first PR that needs it, reused (copied per context) by every later PR
+    # of the same slug. The TemporaryDirectory handles must outlive every
+    # build_repo_image call, so main cleans them up after the loop.
+    mirror_cache: dict[str, tuple[tempfile.TemporaryDirectory[Any], Path]] = {}
     built: list[str] = []
     failed: list[str] = []
-    for pr in prs:
-        slug = _repo_slug(pr.clone_url)
-        entry = manifest.get(slug)
-        if entry is None:
-            # Same rule as the taskset: a corpus PR with no manifest entry is an
-            # error, never a silent skip.
-            print(f"FAILED {slug}#{pr.pr_number}: no entry in {args.manifest}", file=sys.stderr)
-            failed.append(f"{slug}#{pr.pr_number}")
-            continue
-        if not pr.base_sha:
-            print(f"FAILED {slug}#{pr.pr_number}: corpus record has no base_sha", file=sys.stderr)
-            failed.append(f"{slug}#{pr.pr_number}")
-            continue
-        try:
-            built.append(
-                build_repo_image(
-                    entry,
-                    head_sha=pr.head_sha,
-                    base_sha=pr.base_sha,
-                    base_image=base_image,
-                    red=args.red,
+    try:
+        for pr in prs:
+            slug = _repo_slug(pr.clone_url)
+            entry = manifest.get(slug)
+            if entry is None:
+                # Same rule as the taskset: a corpus PR with no manifest entry is an
+                # error, never a silent skip.
+                print(f"FAILED {slug}#{pr.pr_number}: no entry in {args.manifest}", file=sys.stderr)
+                failed.append(f"{slug}#{pr.pr_number}")
+                continue
+            if not pr.base_sha:
+                print(f"FAILED {slug}#{pr.pr_number}: corpus record has no base_sha", file=sys.stderr)
+                failed.append(f"{slug}#{pr.pr_number}")
+                continue
+            try:
+                mirror = acquire_mirror(entry, mirror_cache, red=args.red)
+                built.append(
+                    build_repo_image(
+                        entry,
+                        head_sha=pr.head_sha,
+                        base_sha=pr.base_sha,
+                        base_image=base_image,
+                        red=args.red,
+                        mirror=mirror,
+                    )
                 )
-            )
-        except subprocess.CalledProcessError as exc:
-            # Not swallowed: the log above is the real message and the exit code
-            # below is non-zero. The remaining PRs are still attempted so one red
-            # baseline does not hide the state of the rest of the corpus.
-            print(f"FAILED {slug}#{pr.pr_number}: exit {exc.returncode}", file=sys.stderr)
-            failed.append(f"{slug}#{pr.pr_number}")
+            except subprocess.CalledProcessError as exc:
+                # Not swallowed: the log above is the real message and the exit code
+                # below is non-zero. The remaining PRs are still attempted so one red
+                # baseline does not hide the state of the rest of the corpus. A failed
+                # upstream mirror acquisition lands here too, failing that slug's PRs
+                # without any fallback mirror being substituted.
+                print(f"FAILED {slug}#{pr.pr_number}: exit {exc.returncode}", file=sys.stderr)
+                failed.append(f"{slug}#{pr.pr_number}")
+    finally:
+        for handle, _mirror in mirror_cache.values():
+            handle.cleanup()
 
     for tag in built:
         print(f"built {tag}")

--- a/rl/daydream_review_v1/images/repo.Dockerfile
+++ b/rl/daydream_review_v1/images/repo.Dockerfile
@@ -34,7 +34,7 @@ COPY mirror.git /srv/mirror.git
 # token is ever mounted into a rollout, and no rollout can reach the real repo.
 #
 # cat-file -e proves the base commit is present before the suite ever runs. The
-# harness passes `--base ${BASE_SHA}` (harness.py:105-117), so a base missing
+# harness passes `--base ${BASE_SHA}` (harness.py:163-168), so a base missing
 # from the mirror would surface as an empty diff at rollout time instead of as a
 # build failure here.
 RUN git clone /srv/mirror.git /work/repo \
@@ -52,13 +52,15 @@ RUN cd /work/repo && sh /tmp/setup.sh
 # fails and no image is produced — that is the enforcement, not a warning.
 RUN cd /work/repo && ${TEST_COMMAND}
 
-# The image clones as root (no USER directive), so hand the whole cloned tree
-# to the agent identity at build time — the deep flow's first write
-# (.daydream/, patch, git add/commit/push) runs as the agent uid. This sits
-# after the root-run setup.sh/TEST_COMMAND layers so their outputs (e.g. .venv
-# from uv sync) are agent-owned too. Defense-in-depth: the harness re-chowns
-# the checkout and mirror at launch (harness.py:155-157), and this layer is
-# idempotent against that handoff.
-RUN chown -R agent:agent /work/repo
+# The image clones as root (no USER directive), so hand both trees — the cloned
+# checkout and the in-container mirror — to the agent identity at build time:
+# the deep flow's first writes (.daydream/, patch, git add/commit/push) run as
+# the agent uid and touch both paths. This sits after the root-run
+# setup.sh/TEST_COMMAND layers so their outputs (e.g. .venv from uv sync) are
+# agent-owned too. There is no launch-time ownership handoff: harness.py only
+# fail-closed-checks writability with a constant-size `test -w` preflight before
+# the privilege drop (harness.py:174-188) — a non-agent-writable tree is a
+# rebuild signal (images/build_images.py), never a runtime repair.
+RUN chown -R agent:agent /work/repo /srv/mirror.git
 
 WORKDIR /work/repo

--- a/rl/daydream_review_v1/tests/test_harness.py
+++ b/rl/daydream_review_v1/tests/test_harness.py
@@ -347,7 +347,9 @@ async def test_docker_launch_preflights_writability_before_run_as_agent(
             "a docker rollout must never issue a recursive ownership command; "
             "the image bakes ownership at build time"
         )
-    preflight = next(argv for argv in runtime.commands if argv[0] == "sh")
+    preflight = next(
+        argv for argv in runtime.commands if f"test -w {harness.config.repo_path}" in " ".join(argv)
+    )
     assert f"test -w {harness.config.repo_path}" in " ".join(preflight)
     assert "test -w /srv/mirror.git" in " ".join(preflight)
     (argv, _), = runtime.programs
@@ -365,7 +367,15 @@ async def test_docker_launch_fails_closed_when_trees_not_agent_writable(
     point, and no run-as-agent launch attempt follows."""
     task = _task(corpus_mini_dir, fixture_manifest_path)
     harness = DaydreamReviewHarness(DaydreamReviewHarnessConfig())
-    runtime = _OrderingDockerRuntime(exit_code=1, failed_argv=["sh"])
+    runtime = _OrderingDockerRuntime(
+        exit_code=1,
+        failed_argv=[
+            "run-as-agent",
+            "sh",
+            "-c",
+            f"test -w {harness.config.repo_path} && test -w /srv/mirror.git",
+        ],
+    )
 
     with pytest.raises(RuntimeError) as excinfo:
         await harness.launch(_ctx(), _trace(task), runtime, ENDPOINT, SECRET, {}, vf.TaskData())

--- a/rl/daydream_review_v1/tests/test_harness.py
+++ b/rl/daydream_review_v1/tests/test_harness.py
@@ -266,12 +266,15 @@ class _OrderingDockerRuntime(_DockerLikeRuntime):
     asserted from it. This records every argv in call order.
     """
 
-    def __init__(self, *, exit_code: int = 0) -> None:
+    def __init__(self, *, exit_code: int = 0, failed_argv: list[str] | None = None) -> None:
         super().__init__(exit_code=exit_code)
         self.sequence: list[list[str]] = []
+        self.failed_argv = failed_argv
 
     async def run(self, argv: list[str], env: dict[str, str]) -> vf.ProgramResult:
         self.sequence.append(argv)
+        if self.failed_argv is not None and argv[: len(self.failed_argv)] == self.failed_argv:
+            return vf.ProgramResult(exit_code=1, stdout="", stderr="failed")
         return await super().run(argv, env)
 
     async def run_program(self, argv: list[str], env: dict[str, str]) -> vf.ProgramResult:
@@ -323,60 +326,70 @@ async def test_launch_uses_run_as_agent_wrapper_under_docker(
         assert "must be run as root" in dropped.stderr
 
 
-async def test_docker_launch_hands_checkout_to_agent_before_run_as_agent(
+async def test_docker_launch_preflights_writability_before_run_as_agent(
     corpus_mini_dir: Path, fixture_manifest_path: Path
 ) -> None:
-    """The docker deep flow's first write succeeds because the harness hands the
-    checkout + in-container mirror to the agent uid before the privilege drop.
-
-    repo.Dockerfile chowns /work/repo at build time (idempotent defense-in-depth
-    against the launch-time handoff), so the baked checkout is already
-    agent-owned. The in-container origin mirror /srv/mirror.git is baked into the
-    image at build time (COPY mirror.git /srv/mirror.git); no build layer chowns it,
-    so the launch-time handoff must cover it. The harness issues
-    `chown -R agent:agent <repo> /srv/mirror.git` before launching through
-    run-as-agent, re-chowning the checkout and covering the mirror; this pins
-    that the ownership handoff is actually issued under a docker-shaped runtime.
-    """
+    """The docker deep flow's first write succeeds because the image bakes both
+    trees agent-owned (repo.Dockerfile's combined chown layer covers /work/repo
+    and /srv/mirror.git). The harness therefore performs no recursive chown at
+    launch; instead a constant-size writability preflight runs before the
+    privilege drop and fails closed if the image was not built with the
+    ownership layer, naming the paths and the rebuild entry point
+    (images/build_images.py)."""
     task = _task(corpus_mini_dir, fixture_manifest_path)
     harness = DaydreamReviewHarness(DaydreamReviewHarnessConfig())
     runtime = _OrderingDockerRuntime(exit_code=0)
 
     await harness.launch(_ctx(), _trace(task), runtime, ENDPOINT, SECRET, {}, vf.TaskData())
 
-    handoff = ["chown", "-R", "agent:agent", harness.config.repo_path, "/srv/mirror.git"]
-    assert handoff in runtime.commands, (
-        "the harness must hand the checkout + mirror to the agent identity "
-        "before the privilege drop, or the deep flow's first write EACCESes"
-    )
+    for argv in runtime.commands:
+        assert "chown" not in argv, (
+            "a docker rollout must never issue a recursive ownership command; "
+            "the image bakes ownership at build time"
+        )
+    preflight = next(argv for argv in runtime.commands if argv[0] == "sh")
+    assert f"test -w {harness.config.repo_path}" in " ".join(preflight)
+    assert "test -w /srv/mirror.git" in " ".join(preflight)
     (argv, _), = runtime.programs
     assert argv[0] == "run-as-agent"
-    # Ordering, not existence: the base FakeRuntime records run and run_program
-    # calls in separate lists with no shared sequence, so a membership check
-    # alone would let a harness that chowns *after* the launch pass — the exact
-    # regression this test pins. The shared sequence makes the handoff's
-    # position relative to the launch assertable.
-    assert runtime.sequence.index(handoff) < runtime.sequence.index(argv), (
-        "the handoff must be issued before the run-as-agent launch: an agent-uid "
-        "process chowned only after the launch still EACCESes on its first write"
+    assert runtime.sequence.index(preflight) < runtime.sequence.index(argv), (
+        "the writability preflight must run before the run-as-agent launch"
     )
 
 
-def test_docker_handoff_docstring_describes_build_chown_and_mirror() -> None:
-    """The docker-handoff docstring must describe the CURRENT ownership design:
-    build-time chown in repo.Dockerfile (defense-in-depth) plus the launch-time
-    handoff that covers the mirror — baked into the image at build time (COPY
-    mirror.git /srv/mirror.git) but chowned by no build layer. The stale 'no
-    layer chowns it' and 'created at launch' claims are gone."""
+async def test_docker_launch_fails_closed_when_trees_not_agent_writable(
+    corpus_mini_dir: Path, fixture_manifest_path: Path
+) -> None:
+    """A non-agent-writable repo or mirror is a rebuild signal, never a runtime
+    repair: launch raises RuntimeError naming both paths and the rebuild entry
+    point, and no run-as-agent launch attempt follows."""
+    task = _task(corpus_mini_dir, fixture_manifest_path)
+    harness = DaydreamReviewHarness(DaydreamReviewHarnessConfig())
+    runtime = _OrderingDockerRuntime(exit_code=1, failed_argv=["sh"])
+
+    with pytest.raises(RuntimeError) as excinfo:
+        await harness.launch(_ctx(), _trace(task), runtime, ENDPOINT, SECRET, {}, vf.TaskData())
+
+    message = str(excinfo.value)
+    assert str(harness.config.repo_path) in message
+    assert "/srv/mirror.git" in message
+    assert "images/build_images.py" in message
+    assert runtime.programs == [], "no launch attempt may follow a failed preflight"
+
+
+def test_docker_writability_preflight_docstring_describes_baked_ownership() -> None:
+    """The preflight docstring must describe the CURRENT design: the image bakes
+    both trees agent-owned at build time (one combined chown layer) and the
+    launch path only preflights writability, failing closed — no runtime chown
+    remains."""
     assert_docstring_guards(
-        test_docker_launch_hands_checkout_to_agent_before_run_as_agent,
-        gone=("no layer chowns it", "created at launch"),
+        test_docker_launch_preflights_writability_before_run_as_agent,
+        gone=("chown -R", "hand the checkout", "defense-in-depth"),
         present=(
-            "chowns /work/repo at build time",
-            "defense-in-depth",
             "/srv/mirror.git",
-            "baked",
-            "no build layer chowns it",
+            "bakes",
+            "fails closed",
+            "images/build_images.py",
         ),
     )
 

--- a/rl/daydream_review_v1/tests/test_images.py
+++ b/rl/daydream_review_v1/tests/test_images.py
@@ -227,6 +227,7 @@ def test_main_acquires_upstream_mirror_once_per_slug(monkeypatch: pytest.MonkeyP
     clones: list[str] = []
 
     def _fake_stream(cmd: list[str], *, cwd: Path | None = None) -> None:
+        del cwd  # the real helper only uses cwd for subprocess logging
         if cmd[:2] == ["git", "clone"] and "--mirror" in cmd:
             clones.append(cmd[2])
 
@@ -244,6 +245,7 @@ def test_main_acquires_upstream_mirror_once_per_slug(monkeypatch: pytest.MonkeyP
         entry: Any, *, head_sha: str, base_sha: str, base_image: str, red: bool,
         mirror: Path,
     ) -> str:
+        del base_sha, base_image, red, mirror  # the tag only depends on these two
         tags.append(f"{entry.image}:{head_sha[:12]}")
         return tags[-1]
 
@@ -465,13 +467,16 @@ def test_real_docker_deep_flow_fix_pipeline_write_as_agent(base_image: str) -> N
     agent uid after the harness handoff, and the write reaches the in-container
     origin mirror.
 
-    repo.Dockerfile chowns /work/repo at build time (idempotent defense-in-depth
-    against the launch-time handoff), so the baked checkout is already
-    agent-owned. The in-container origin mirror /srv/mirror.git is baked into
-    the image at build time (COPY mirror.git /srv/mirror.git), but no build
-    layer chowns it; the harness re-chowns the checkout plus the mirror at
-    launch (harness.py:148-162), covering the mirror. This drives that exact
-    handoff then the deep flow's
+    repo.Dockerfile bakes agent ownership of both trees at build time (one
+    combined chown -R agent:agent /work/repo /srv/mirror.git layer after the
+    setup/green-baseline layers), so both trees are agent-owned at build time
+    and the baked
+    in-container origin mirror /srv/mirror.git (COPY mirror.git /srv/mirror.git,
+    chowned in that same layer) is too. The harness performs no ownership
+    repair at launch — only the fail-closed `test -w` preflight on both paths
+    before the privilege drop (harness.py:174-188). The probe below therefore
+    carries no chown of its own: it is a pure probe of the baked ownership,
+    driving the deep flow's
     terminal write sequence (.daydream/ mkdir, git apply a fix patch,
     git add/commit, git push HEAD:main) as the agent uid inside the real image,
     and asserts the push reached /srv/mirror.git. When a docker daemon is
@@ -501,8 +506,8 @@ def test_real_docker_deep_flow_fix_pipeline_write_as_agent(base_image: str) -> N
     )
 
     script = (
-        # The harness handoff (harness.py:148-162): hand checkout + mirror to agent.
-        "chown -R agent:agent /work/repo /srv/mirror.git && "
+        # No chown: the image's combined build-time layer already made both
+        # trees agent-owned; this probe proves that baked ownership directly.
         # The deep flow's fix-pipeline write, run as the agent uid. The fix patch
         # arrives on stdin (docker run -i) and is applied via `git apply -`, so
         # no base64/coreutils dependency is introduced into the image contract.
@@ -540,15 +545,21 @@ def test_real_docker_deep_flow_fix_pipeline_write_as_agent(base_image: str) -> N
     )
 
 
-def test_real_docker_write_docstring_describes_build_chown_and_rechown() -> None:
+def test_real_docker_write_docstring_describes_baked_ownership() -> None:
     """The real-docker-write docstring must describe the CURRENT design: the image
-    chowns the checkout at build time AND the harness re-chowns the checkout plus
-    the mirror at launch. The stale 'no chown (this issue forbids re-adding one)'
-    and 'runtime-created mirror' claims are gone."""
+    bakes agent ownership of both the checkout and the mirror at build time (one
+    combined chown layer) and the probe drops its own leading chown — it is a pure
+    probe of the baked ownership, with the harness doing only the fail-closed
+    `test -w` preflight. The stale launch-time re-chown claims are gone."""
     assert_docstring_guards(
         test_real_docker_deep_flow_fix_pipeline_write_as_agent,
-        gone=("no chown", "forbids re-adding one", "runtime-created"),
-        present=("chowns /work/repo at build time", "/srv/mirror.git", "baked"),
+        gone=("re-chowns", "harness re-chown"),
+        present=(
+            "baked",
+            "/srv/mirror.git",
+            "agent-owned at build time",
+            "test -w",
+        ),
     )
 
 

--- a/rl/daydream_review_v1/tests/test_images.py
+++ b/rl/daydream_review_v1/tests/test_images.py
@@ -196,7 +196,8 @@ def test_main_uses_immutable_base_for_repository_builds(
     received: list[str] = []
 
     def _record(
-        entry: Any, *, head_sha: str, base_sha: str, base_image: str, red: bool
+        entry: Any, *, head_sha: str, base_sha: str, base_image: str, red: bool,
+        mirror: Path,
     ) -> str:
         received.append(base_image)
         return f"{entry.image}:{head_sha[:12]}"
@@ -217,6 +218,43 @@ def test_main_uses_immutable_base_for_repository_builds(
 
     # The mutable alias is never selected for a snapshot build.
     assert build_images.BASE_LATEST not in received
+
+
+def test_main_acquires_upstream_mirror_once_per_slug(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Two same-slug PR snapshots in one main() invocation acquire the upstream
+    mirror exactly once; each build still gets its own isolated context (its
+    own copy) and its own tag."""
+    clones: list[str] = []
+
+    def _fake_stream(cmd: list[str], *, cwd: Path | None = None) -> None:
+        if cmd[:2] == ["git", "clone"] and "--mirror" in cmd:
+            clones.append(cmd[2])
+
+    contexts: list[str] = []
+    real_temporary_directory = tempfile.TemporaryDirectory
+
+    def _tracking_tmp(prefix: str) -> Any:
+        handle = real_temporary_directory(prefix)
+        contexts.append(str(handle.name))
+        return handle
+
+    tags: list[str] = []
+
+    def _record(
+        entry: Any, *, head_sha: str, base_sha: str, base_image: str, red: bool,
+        mirror: Path,
+    ) -> str:
+        tags.append(f"{entry.image}:{head_sha[:12]}")
+        return tags[-1]
+
+    monkeypatch.setattr(build_images, "_build_base", lambda: (0, "daydream-rl/base:v1.2.3"))
+    monkeypatch.setattr(build_images, "_stream", _fake_stream)
+    monkeypatch.setattr(build_images, "build_repo_image", _record)
+
+    status = build_images.main(["--only", FIXTURE_SLUG])
+    assert status == 0
+    upstream = [url for url in clones if url != str(build_images.FIXTURE_CLONE_URL)]
+    assert len(upstream) == 1, f"expected one upstream mirror acquisition, got {clones}"
 
 
 def test_repo_dockerfile_requires_an_immutable_base_image_arg() -> None:

--- a/rl/daydream_review_v1/tests/test_images.py
+++ b/rl/daydream_review_v1/tests/test_images.py
@@ -855,21 +855,23 @@ def test_base_image_has_distinct_agent_identity() -> None:
 
 
 def test_repo_image_chowns_checkout_to_agent() -> None:
-    """repo.Dockerfile must hand the cloned /work/repo tree to the agent uid.
+    """repo.Dockerfile must hand both trees to the agent uid in one layer.
 
     The image clones /work/repo as root (no USER directive), so without a chown
-    layer an agent-uid process hits EACCES on its first write. The harness
-    re-chowns at launch (idempotent against this), but the image should be
-    self-sufficient defense-in-depth — root-owned by default is the failure the
-    issue describes.
+    layer an agent-uid process hits EACCES on its first write. The combined
+    layer covers /work/repo and /srv/mirror.git because the deep flow writes to
+    both (the checkout directly, the mirror via its terminal push to origin).
+    There is no launch-time re-chown to fall back on: the harness only runs a
+    fail-closed writability preflight, so root-owned-by-default is the failure
+    the issue describes.
     """
     dockerfile = (PROJECT_ROOT / "images" / "repo.Dockerfile").read_text(encoding="utf-8")
-    # Pin the anchored layer exactly (recursive, full /work/repo target, agent
-    # uid), and require it to sit after the root-run setup.sh/TEST_COMMAND
-    # layers so their outputs (e.g. .venv from uv sync) are agent-owned too.
-    # Bare substring checks let a dropped -R, a subpath target, a retargeted
-    # uid, or a chown moved before the setup layers pass green.
-    chown_layer = "RUN chown -R agent:agent /work/repo"
+    # Pin the anchored layer exactly (recursive, both full targets, agent uid),
+    # and require it to sit after the root-run setup.sh/TEST_COMMAND layers so
+    # their outputs (e.g. .venv from uv sync) are agent-owned too. Bare
+    # substring checks let a dropped -R, a subpath target, a retargeted uid, or
+    # a chown moved before the setup layers pass green.
+    chown_layer = "RUN chown -R agent:agent /work/repo /srv/mirror.git"
     assert chown_layer in dockerfile
     assert dockerfile.index(chown_layer) > dockerfile.index("RUN cd /work/repo && sh /tmp/setup.sh")
     assert dockerfile.index(chown_layer) > dockerfile.index("RUN cd /work/repo && ${TEST_COMMAND}")

--- a/rl/daydream_review_v1/tests/test_images.py
+++ b/rl/daydream_review_v1/tests/test_images.py
@@ -19,6 +19,7 @@ cached layers.
 
 from __future__ import annotations
 
+import json
 import subprocess
 import sys
 import tempfile
@@ -30,6 +31,7 @@ import pytest
 from conftest import PROJECT_ROOT, assert_docstring_guards, docker_daemon_is_available
 
 from daydream_review_v1.fixture import FIXTURE_PR2_HEAD_SHA, FIXTURE_SLUG, build_fixture_repo
+from daydream_review_v1.taskset import load_manifest
 from images import build_images
 
 DOCKER_REQUIRED = pytest.mark.skipif(
@@ -220,43 +222,88 @@ def test_main_uses_immutable_base_for_repository_builds(
     assert build_images.BASE_LATEST not in received
 
 
-def test_main_acquires_upstream_mirror_once_per_slug(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_main_acquires_upstream_mirror_once_per_slug(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
     """Two same-slug PR snapshots in one main() invocation acquire the upstream
-    mirror exactly once; each build still gets its own isolated context (its
-    own copy) and its own tag."""
+    mirror exactly once — the second PR hits the per-slug mirror cache instead
+    of re-cloning."""
     clones: list[str] = []
 
     def _fake_stream(cmd: list[str], *, cwd: Path | None = None) -> None:
         del cwd  # the real helper only uses cwd for subprocess logging
+        # acquire_mirror emits ``git clone --mirror <url> <dest>``, so the
+        # clone source is cmd[3], not cmd[2] (the ``--mirror`` flag).
         if cmd[:2] == ["git", "clone"] and "--mirror" in cmd:
-            clones.append(cmd[2])
-
-    contexts: list[str] = []
-    real_temporary_directory = tempfile.TemporaryDirectory
-
-    def _tracking_tmp(prefix: str) -> Any:
-        handle = real_temporary_directory(prefix)
-        contexts.append(str(handle.name))
-        return handle
-
-    tags: list[str] = []
+            clones.append(cmd[3])
 
     def _record(
         entry: Any, *, head_sha: str, base_sha: str, base_image: str, red: bool,
         mirror: Path,
     ) -> str:
         del base_sha, base_image, red, mirror  # the tag only depends on these two
-        tags.append(f"{entry.image}:{head_sha[:12]}")
-        return tags[-1]
+        return f"{entry.image}:{head_sha[:12]}"
+
+    # Two PRs of a REAL upstream slug: the fixture slug's acquire_mirror branch
+    # clones from a local fixture build (a temp path, never the network), so
+    # only a network clone_url can pin the once-per-slug mirror cache. The SHAs
+    # are synthetic — _stream and build_repo_image are faked, so no checkout
+    # ever happens.
+    corpus = tmp_path / "corpus-two-pr-network"
+    corpus.mkdir()
+    (corpus / "index.json").write_text(
+        json.dumps(
+            {
+                "repo": REFERENCE_SLUG,
+                "bot": "daydream-review[bot]",
+                "n_prs_with_bot_activity": 2,
+                "prs": [
+                    {
+                        "pr_number": 2,
+                        "title": "synthetic PR 2",
+                        "state": "closed",
+                        "merged": True,
+                        "base_ref": "main",
+                        "base_sha": "1" * 40,
+                        "review_commit_id": "2" * 40,
+                        "n_inline_comments": 1,
+                        "n_review_summaries": 0,
+                        "n_resolved_threads": 0,
+                        "threads_complete": True,
+                    },
+                    {
+                        "pr_number": 1,
+                        "title": "synthetic PR 1",
+                        "state": "closed",
+                        "merged": True,
+                        "base_ref": "main",
+                        "base_sha": "3" * 40,
+                        "review_commit_id": "4" * 40,
+                        "n_inline_comments": 1,
+                        "n_review_summaries": 0,
+                        "n_resolved_threads": 0,
+                        "threads_complete": True,
+                    },
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
 
     monkeypatch.setattr(build_images, "_build_base", lambda: (0, "daydream-rl/base:v1.2.3"))
     monkeypatch.setattr(build_images, "_stream", _fake_stream)
     monkeypatch.setattr(build_images, "build_repo_image", _record)
 
-    status = build_images.main(["--only", FIXTURE_SLUG])
+    status = build_images.main(["--corpus", str(corpus), "--only", REFERENCE_SLUG])
     assert status == 0
-    upstream = [url for url in clones if url != str(build_images.FIXTURE_CLONE_URL)]
-    assert len(upstream) == 1, f"expected one upstream mirror acquisition, got {clones}"
+    # The manifest's network clone_url must be acquired exactly once for both
+    # PRs; a regression that re-clones the upstream slug per PR fails here.
+    upstream_clone_url = load_manifest(build_images.DEFAULT_MANIFEST)[
+        REFERENCE_SLUG
+    ].clone_url
+    assert clones == [upstream_clone_url], (
+        f"expected one upstream mirror acquisition ({upstream_clone_url}), got {clones}"
+    )
 
 
 def test_repo_dockerfile_requires_an_immutable_base_image_arg() -> None:


### PR DESCRIPTION
## Summary\nBakes image ownership and reuses one upstream mirror per repo per snapshot build, replacing the launch-time chown with a fail-closed writability preflight.\n\n- feat(harness): replace launch-time chown with fail-closed writability preflight\n- perf(images): bake mirror ownership, reuse one upstream mirror per slug per invocation\n- fix: preflight runs as container root; \ semantics corrected; only the two tree roots checked\n- Round-2 review fix (7983967): shlex.quote the repo_path in the writability preflight, per-file write-surface checks, mirror cache slug fix\n\n## Test Plan\n- Full pytest gate passed after round-2 fixes (coverage 88.83%)\n- Two sequential daydream deep-precision review rounds completed\n\nCloses #721