### PR TITLE
refactor(archive): serialize captured run identity

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,6 +86,7 @@ deep FlowSteps -> phases.py -> agent.py -> Backend.execute()
 |------|----------------|
 | `cli.py` | Args, signals, process lifecycle, subcommand dispatch |
 | `runner.py` | Flow preambles (workspace, diff, recorder), backend resolution, registry, dispatch |
+| `run_snapshot.py` | Immutable manifest identity and archive aggregate; runner captures policy before recorder entry |
 | `flows/` | `FlowContext` + `run_flow()` engine: ordering, `enabled` gates, `Stop`/`BreakLoop`, loop groups |
 | `extensions/` | `Registry` (phases+flows, prompts, stack rules), `daydream_ext` loader |
 | `deep/orchestrator.py` | Public deep/diagram entry points, flow assembly, mode gates, diff/stack preamble, and success-only cleanup dispatch |

--- a/daydream/archive/__init__.py
+++ b/daydream/archive/__init__.py
@@ -19,19 +19,15 @@ from __future__ import annotations
 import json
 import os
 import shutil
+from collections.abc import Mapping
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable
 
 from daydream.archive.git_context import capture_git_context
 from daydream.archive.index import upsert_run
-from daydream.archive.manifest import (
-    ArchiveRecorderProvenance,
-    _flow_fix_test_steps,
-    _flow_phase_steps,
-    _runtime_flow_name,
-    build_manifest_from_snapshot,
-)
+from daydream.archive.manifest import build_manifest_from_snapshot
 from daydream.config import REVIEW_OUTPUT_FILE
+from daydream.run_snapshot import ArchiveRunSnapshot
 from daydream.trajectory import DaydreamRunFlow
 
 if TYPE_CHECKING:
@@ -57,43 +53,6 @@ def _warn(message: str) -> None:
     from daydream.ui import create_console, print_warning
 
     print_warning(create_console(), message)
-
-
-def _flow_runs_merge(flow: DaydreamRunFlow, flow_name: str | None) -> bool:
-    """Whether the executed flow runs the deep cross-stack/single-stack merge.
-
-    The deep pipeline's merge step runs for normal and review flows. Improve-only,
-    diagram-only (issue #1113) and the legacy PR compatibility label do not run
-    the merge spine. Diagram-only must answer False explicitly: it reuses the
-    deep preamble and deliberately keeps a prior deep run's
-    ``.daydream/deep/`` artifacts on disk (D21), so a True here would make it
-    adopt that run's ``merged-items.json`` as its own pipeline state.
-    Custom flows are classified from their registered pipeline (a fork
-    composing the built-in deep merge step is detected as it runs), mirroring
-    ``_flow_fix_test_steps`` in ``archive.manifest``.
-    """
-    if flow is DaydreamRunFlow.PR:
-        return False
-    if flow is DaydreamRunFlow.IMPROVE:
-        return False
-    if flow is DaydreamRunFlow.DIAGRAM:
-        return False
-    if flow is DaydreamRunFlow.CUSTOM:
-        from daydream.archive.manifest import _flow_phase_steps, _runtime_flow_name
-
-        steps = _flow_phase_steps(_runtime_flow_name(flow, flow_name))
-        return any("merge" in step for step in steps)
-    return True
-
-
-def _flow_push_remote_steps(
-    flow: DaydreamRunFlow, flow_name: str | None
-) -> tuple[bool, bool]:
-    """Return exact commit/push and remote-CI capabilities for this run."""
-    if flow in {DaydreamRunFlow.TTT, DaydreamRunFlow.PR}:
-        return False, False
-    steps = _flow_phase_steps(_runtime_flow_name(flow, flow_name))
-    return ("commit" in steps, "remote-ci" in steps)
 
 
 def get_archive_dir() -> Path:
@@ -124,11 +83,10 @@ def _validate_frozen_artifacts(artifacts: ArtifactTreeSnapshot) -> None:
 
 def _copy_snapshot_bundle(
     *,
+    run: ArchiveRunSnapshot,
     artifacts: ArtifactTreeSnapshot,
     artifact_provenance: ArtifactEvidenceProvenance,
     run_dir: Path,
-    recorder_provenance: ArchiveRecorderProvenance,
-    write_snapshot: RunWriteSnapshot,
 ) -> None:
     """Assemble an archive only from frozen tree and immutable document bytes.
 
@@ -137,7 +95,12 @@ def _copy_snapshot_bundle(
     """
     from daydream.artifact_visibility import OutputLabel
 
-    _project_documents(write_snapshot, run_dir, session_id=recorder_provenance.session_id)
+    recorder_provenance = run.recorder_provenance
+    _project_documents(
+        run.trajectories,
+        run_dir,
+        session_id=recorder_provenance.session_id,
+    )
     findings_routes = [
         route for route in artifacts.destinations if route.label is OutputLabel.FINDINGS_OUTPUT
     ]
@@ -161,10 +124,8 @@ def _copy_snapshot_bundle(
 def _manifest_state(
     *,
     target_dir: Path,
-    recorder_provenance: ArchiveRecorderProvenance,
-    config: RunConfig,
-    status: str,
-    frozen_extra: dict[str, Any],
+    run: ArchiveRunSnapshot,
+    frozen_extra: Mapping[str, Any],
 ) -> dict[str, Any]:
     """Derive the status, fix, and pipeline manifest fields for one run tree.
 
@@ -175,15 +136,15 @@ def _manifest_state(
     """
     from daydream.archive.pipeline import derive_phase_states, derive_pipeline_status
 
+    recorder_provenance = run.recorder_provenance
+    phases = run.identity.phases
     session_id = recorder_provenance.session_id
-    runs_fix, runs_test = _flow_fix_test_steps(recorder_provenance.run_flow, config.flow_name)
-    runs_merge = (
-        _flow_runs_merge(recorder_provenance.run_flow, config.flow_name)
-        and getattr(config, "start_at", None) != "fix"
-    )
-    runs_push, runs_remote_ci = _flow_push_remote_steps(
-        recorder_provenance.run_flow, config.flow_name
-    )
+    status = run.trajectories.status
+    runs_merge = phases.merge
+    runs_fix = phases.fix
+    runs_test = phases.test
+    runs_push = phases.push
+    runs_remote_ci = phases.remote_ci
     # A deep fix run that hit per-group failures left partial/reverted edits in
     # the tree; the run is NOT "complete".
     fix_failures = _read_fix_failures(target_dir) if runs_fix else None
@@ -234,16 +195,17 @@ def _discard_or_note(path: Path, exc: BaseException, stage: str, *, recreate: bo
 
 def finalize_archive_run(
     *,
-    recorder_provenance: ArchiveRecorderProvenance,
+    run: ArchiveRunSnapshot,
     artifacts: ArtifactTreeSnapshot,
     artifact_provenance: ArtifactEvidenceProvenance,
     config: RunConfig,
-    write_snapshot: RunWriteSnapshot,
     work: WorkContext | None,
     upload: bool = True,
     dump_path: Path | None = None,
 ) -> None:
     """Strictly archive one immutable run or raise a closed typed error."""
+    recorder_provenance = run.recorder_provenance
+    write_snapshot = run.trajectories
     session_id = recorder_provenance.session_id
     if (
         session_id != artifacts.session_id
@@ -275,11 +237,10 @@ def finalize_archive_run(
         assembly_dir.mkdir()
         assembly_created = True
         _copy_snapshot_bundle(
+            run=run,
             artifacts=artifacts,
             artifact_provenance=artifact_provenance,
             run_dir=assembly_dir,
-            recorder_provenance=recorder_provenance,
-            write_snapshot=write_snapshot,
         )
         target_dir = artifacts.root
         git_ctx = capture_git_context(work.repo if work is not None else target_dir)
@@ -312,20 +273,15 @@ def finalize_archive_run(
         frozen_root = frozen.get("main")
         frozen_extra = frozen_root.get("extra") if isinstance(frozen_root, dict) else None
         manifest = build_manifest_from_snapshot(
-            recorder_provenance=recorder_provenance,
-            write_snapshot=write_snapshot,
-            config=config,
+            run=run,
             git_ctx=git_ctx,
             archive_path=run_dir,
             evaluation=evaluation,
             source_path=str(work.source) if work is not None else None,
-            cwd=str(work.repo) if work is not None else None,
             provenance=capture_executable_provenance(),
             **_manifest_state(
                 target_dir=target_dir,
-                recorder_provenance=recorder_provenance,
-                config=config,
-                status=write_snapshot.status,
+                run=run,
                 frozen_extra=frozen_extra if isinstance(frozen_extra, dict) else {},
             ),
         )

--- a/daydream/archive/manifest.py
+++ b/daydream/archive/manifest.py
@@ -1,8 +1,8 @@
 """Run archive manifest builder.
 
-Assembles a ``manifest.json`` from the recorder, run config, git context,
-and optional evaluation results. The manifest is the single source of
-truth for what's in an archive bundle.
+Assembles a ``manifest.json`` from an immutable public run snapshot, git
+context, and optional evaluation results. The manifest is the single source
+of truth for what's in an archive bundle.
 
 Provenance namespaces: ``git.*`` and ``code_context.*`` record provenance
 of the repository under review (target ``base_sha``/``head_sha``); the
@@ -25,32 +25,25 @@ Exports:
 from __future__ import annotations
 
 import json
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any
 
 from daydream.archive.git_context import GitContext
-from daydream.config import DEFAULT_PI_MODEL
-from daydream.extensions import UnresolvedExtensionError, get_registry
+from daydream.run_snapshot import (
+    ArchiveRecorderProvenance as ArchiveRecorderProvenance,
+)
+from daydream.run_snapshot import ArchiveRunSnapshot
 from daydream.trajectory import DaydreamRunFlow
 
 if TYPE_CHECKING:
     from pathlib import Path
 
-    from daydream.runner import RunConfig
+    from daydream.archive.provenance import ExecutableProvenance
     from daydream.trajectory import RunWriteSnapshot
 
 MANIFEST_SCHEMA_VERSION = "1.0"
-
-
-@dataclass(frozen=True)
-class ArchiveRecorderProvenance:
-    """Immutable recorder identity recovered from one frozen root document."""
-
-    session_id: str
-    run_flow: DaydreamRunFlow
-    pr_number: int | None
-    pr_repo: str | None
 
 
 def archive_recorder_provenance_from_snapshot(
@@ -94,79 +87,6 @@ def archive_recorder_provenance_from_snapshot(
         pr_number=pr_number,
         pr_repo=pr_repo,
     )
-
-
-def _runtime_flow_name(flow: DaydreamRunFlow, flow_name: str | None) -> str | None:
-    """Return the registered flow name ``run_flow`` resolved for this label.
-
-    The deep family (NORMAL/DEEP/TTT/PR — four mode labels of the single
-    registered ``deep`` flow, #330) always resolves to ``"deep"`` regardless
-    of ``config.flow_name``; ``IMPROVE`` resolves ``"improve"``; ``CUSTOM`` is
-    the literal ``--flow`` name; ``DIAGRAM`` (issue #1113) resolves the
-    two-step ``diagram`` flow. Builtins are seeded before the session's
-    registry loads, so a fork registering a built-in name is resolved exactly
-    as it runs (issue #648).
-    """
-    if flow is DaydreamRunFlow.IMPROVE:
-        return "improve"
-    if flow is DaydreamRunFlow.DIAGRAM:
-        return "diagram"
-    if flow is DaydreamRunFlow.CUSTOM:
-        return flow_name
-    return "deep"
-
-
-def _flow_phase_steps(flow_name: str | None) -> set[str]:
-    """Return the set of phase steps in the registered flow's pipeline.
-
-    Introspects the per-run registry (builtins are seeded before extension
-    load) — the same source ``run_flow`` resolves — so a fork flow composing
-    the built-in ``fix``/``test`` phases is detected exactly as it runs them.
-    An unknown/absent flow yields an empty set: we record no backend rather
-    than invent one for phases that never ran (#648).
-    """
-    if not flow_name:
-        return set()
-    try:
-        entries = get_registry().flow(flow_name)
-    except UnresolvedExtensionError:
-        return set()
-    step_names: set[str] = set()
-    for entry in entries:
-        if isinstance(entry, str):
-            step_names.add(entry)
-        else:
-            step_names.update(entry.steps)
-    return step_names
-
-
-def _flow_fix_test_steps(flow: DaydreamRunFlow, flow_name: str | None) -> tuple[bool, bool]:
-    """Return ``(runs_fix, runs_test)`` for the pipeline ``run_flow`` executes.
-
-    Issue #648 gates the manifest's fix/test backend labels on the step
-    pipeline ``run_flow`` actually executes, resolved from the per-run registry
-    for every label — not just ``CUSTOM`` — because ``Registry.set_flow`` has no
-    built-in-name guard: a fork overriding ``deep`` or ``improve`` runs its own
-    pipeline while the label would suggest the built-in. Two labels are fixed
-    by runtime mode, not the registry:
-
-    - Review/comment (``TTT``) stops after ``post-review`` and never runs the
-      fix cycle, so it records neither backend.
-    - The legacy PR compatibility mode runs its fix phase but never the test
-      step, so it records a fix backend only.
-
-    ``NORMAL``/``DEEP``/``IMPROVE``/``DIAGRAM``/``CUSTOM`` are classified by the
-    registered pipeline (``NORMAL``/``DEEP`` → the ``deep`` flow; ``IMPROVE`` →
-    ``improve``; ``DIAGRAM`` → the ``diagram`` flow, whose two steps run neither
-    fix nor test; ``CUSTOM`` → the literal ``--flow`` name).
-    """
-    if flow is DaydreamRunFlow.TTT:
-        return False, False
-    if flow is DaydreamRunFlow.PR:
-        # Feedback runs the fix phase (fix-items) but never the test phase.
-        return True, False
-    steps = _flow_phase_steps(_runtime_flow_name(flow, flow_name))
-    return ("fix" in steps, "test" in steps)
 
 
 def _omit_falsy(**fields: Any) -> dict[str, Any]:
@@ -492,63 +412,24 @@ class Manifest:
 
 def build_manifest_from_snapshot(
     *,
-    recorder_provenance: ArchiveRecorderProvenance,
-    write_snapshot: RunWriteSnapshot,
-    config: RunConfig,
+    run: ArchiveRunSnapshot,
     git_ctx: GitContext,
     status: str,
     archive_path: Path,
-    evaluation: dict[str, Any] | None = None,
+    evaluation: Mapping[str, Any] | None = None,
     source_path: str | None = None,
-    cwd: str | None = None,
-    fix_failures: dict[str, str] | None = None,
-    fix_leftover_untracked: list[str] | None = None,
-    fix_quality_gate: dict[str, Any] | None = None,
+    fix_failures: Mapping[str, str] | None = None,
+    fix_leftover_untracked: Sequence[str] | None = None,
+    fix_quality_gate: Mapping[str, Any] | None = None,
     recommended_capture: str | None = None,
     pipeline_status: str = "unknown",
-    phase_states: dict[str, Any] | None = None,
-    provenance: Any | None = None,
+    phase_states: Mapping[str, Any] | None = None,
+    provenance: ExecutableProvenance | None = None,
 ) -> Manifest:
-    """Construct a Manifest from run context.
-
-    Args:
-        recorder_provenance: Immutable identity for the archived run.
-        write_snapshot: Frozen trajectory bytes the run totals and timings come
-            from.
-        config: The RunConfig for this run.
-        git_ctx: Captured git metadata.
-        status: Run status (``complete``, ``partial``, ``failed``).
-        archive_path: Absolute path to the archive directory for this run.
-        evaluation: Optional ``analyze_session()`` result dict.
-        source_path: Absolute path to the source repository at archive time.
-        cwd: The repository directory daydream operated on (``work.repo``), used
-            to mirror PiBackend's cwd-configured default model resolution.
-        fix_failures: Map of dropped fix file-group -> reason, or ``None`` when
-            every fix applied. Ignored when the resolved flow has no fix phase.
-        fix_leftover_untracked: Sorted list of untracked paths left behind by a
-            failed fix pass, or ``None``. Ignored when the resolved flow has no
-            fix phase.
-        fix_quality_gate: The fix-phase anti-degradation quality-gate verdict
-            (issue #315), or ``None`` when the artifact is absent. Ignored when
-            the resolved flow has no fix phase.
-        recommended_capture: Which tree produced the archived ``recommended.patch``
-            (``"pre_test"`` = fix-phase fallback, ``"post_test"`` = post-heal
-            re-capture), or ``None`` on legacy runs. On fix-bearing flows an
-            absent sidecar defaults ``recommended_patch_capture`` to ``"pre_test"``;
-            flows with no fix phase leave it
-            ``None`` since they never produce a fix-phase fallback capture.
-        pipeline_status: Pipeline-outcome aggregate (succeeded/failed/partial/
-            cancelled/unknown) derived from per-phase terminal states; distinct
-            from ``status``/``archive_status`` (archive finalization).
-        phase_states: Per-phase terminal states (``merge``/``fix``/``test``/
-            ``push``/``remote_ci``), each ``{"ran": bool, "status": str}``
-            plus optional bounded details, or ``None`` for legacy runs.
-        provenance: The ``ExecutableProvenance`` of the Daydream executable that
-            produced this run, or ``None`` (never merged into ``git.*``).
-
-    Returns:
-        A fully populated Manifest.
-    """
+    """Construct a manifest from captured identity and frozen trajectory bytes."""
+    recorder_provenance = run.recorder_provenance
+    write_snapshot = run.trajectories
+    identity = run.identity
     if recorder_provenance.session_id != write_snapshot.root_trajectory_id:
         raise ValueError("archive provenance does not match frozen snapshot")
     from daydream.trajectory import compute_timing_summary, snapshot_trajectories
@@ -565,107 +446,44 @@ def build_manifest_from_snapshot(
         "any_cost_seen": final_metrics.get("total_cost_usd") is not None,
     }
     timing_summary = compute_timing_summary(write_snapshot)
-
-    # Deferred import breaks the module-level cycle: archive.manifest → runner → (lazy) archive.
-    from daydream.runner import (  # noqa: PLC0415 - deferred import avoids cycle
-        _DEEP_FLOW_ALIASES,
-        _default_backend_name,
-        _resolved_backend_name,
-        _resolved_model,
-        _resolved_review_backend_name,
-    )
-
-    # ``backend`` records the phase-agnostic general default (config.backend →
-    # file-config global → "claude"), never a per-phase override.
-    # ``review_backend`` is an override marker, NOT an effective value: it is
-    # stamped only when a review-specific override exists, and it can differ
-    # from the backend review actually ran on (a CLI ``--backend`` masks a
-    # file-config review override). Sibling fields ``fix_backend``/
-    # ``test_backend`` are effective per-phase values; ``review_backend`` is
-    # not.
-
-    # Per-stack reviewers (issue #646) execute on the "per_stack_review" phase key —
-    # NOT the "review" tier — so archives record that tier's resolved backend and
-    # model from its own key. The per-stack-reviews step runs in every deep-flow
-    # mode (loop, shallow, review, comment); shallow is NOT excluded — a collapsed
-    # single stack is still reviewed through phase_per_stack_reviews. Only improve/custom
-    # flows (which never invoke the deep orchestrator) have no per-stack fan-out, so
-    # those runs leave both fields None (and to_dict() omits them). The deep-flow
-    # alias set is runner._DEEP_FLOW_ALIASES — the same list _dispatch_selected_flow
-    # routes — so the gate cannot drift from the actual flow routing.
-    # A diagram-only run (issue #1113) reuses the deep preamble but its flow is
-    # exploration -> diagram -> post-diagram, so it has no per-stack fan-out.
-    # start_at defaults to "review" on the real RunConfig; getattr keeps the
-    # gate robust to lighter config fakes that omit the field.
-    _start_at = getattr(config, "start_at", "review")
-    per_stack_reviews_ran = (
-        (config.flow_name is None or config.flow_name in _DEEP_FLOW_ALIASES)
-        and _start_at not in ("merge", "fix")
-        and recorder_provenance.run_flow is not DaydreamRunFlow.DIAGRAM
-    )
-    per_stack_review_backend: str | None = None
-    per_stack_review_model: str | None = None
-    if per_stack_reviews_ran:
-        per_stack_review_backend = _resolved_backend_name(config, "per_stack_review")
-        per_stack_review_model = _resolved_model(config, "per_stack_review")
-        if per_stack_review_model is None and per_stack_review_backend == "pi":
-            # Pi's default is a backend fallback (resolved by PiBackend from cwd)
-            # that intentionally never appears in PHASE_DEFAULT_MODELS, so
-            # _resolved_model returns None here even though the per-stack reviewers
-            # ran on a concrete model. Mirror PiBackend's own precedence — a
-            # cwd-configured default first, then DEFAULT_PI_MODEL — so the archived
-            # identity matches what actually ran (#646 finding 1).
-            from pathlib import Path
-
-            from daydream.backends.pi import _configured_pi_model
-            per_stack_review_model = (
-                _configured_pi_model(Path(cwd)) if cwd else None
-            ) or DEFAULT_PI_MODEL
-
-    # Gate fix/test backend labels on whether this flow's step pipeline actually
-    # includes those phases (issue #648): improve never reaches the fix/test
-    # STEPS, TTT (review/comment) gates them off at runtime (_fix_cycle_enabled
-    # is loop/shallow only), and custom flows are classified from their registered pipeline
-    # (every ``--flow`` run is stamped CUSTOM regardless of step composition), so
-    # a fork composing the built-in fix/test steps records backends like the deep
-    # family. Registry-resolved for every label so fork overrides of built-in
-    # ``deep``/``improve`` are classified by the pipeline actually executed.
-    runs_fix, runs_test = _flow_fix_test_steps(
-        recorder_provenance.run_flow,
-        config.flow_name,
-    )
+    runs_fix = identity.phases.fix
+    profile = identity.profile
 
     m = Manifest(
         session_id=recorder_provenance.session_id,
         archived_at=datetime.now(timezone.utc).isoformat(),
         status=status,
         run_flow=recorder_provenance.run_flow.value,
-        skill=config.stack,
-        model=None,
-        backend=_default_backend_name(config),
-        review_backend=_resolved_review_backend_name(config),
-        fix_backend=_resolved_backend_name(config, "fix") if runs_fix else None,
-        test_backend=_resolved_backend_name(config, "test") if runs_test else None,
-        per_stack_review_backend=per_stack_review_backend,
-        per_stack_review_model=per_stack_review_model,
+        skill=identity.skill,
+        model=identity.model,
+        backend=identity.backend,
+        review_backend=identity.review_backend,
+        fix_backend=identity.fix_backend,
+        test_backend=identity.test_backend,
+        per_stack_review_backend=identity.per_stack_review_backend,
+        per_stack_review_model=identity.per_stack_review_model,
         archive_status=status,
         pipeline_status=pipeline_status,
-        phase_states=phase_states,
+        phase_states=dict(phase_states) if phase_states is not None else None,
         daydream=provenance,
-        review_only=config.output_mode == "review",
-        deep=not config.shallow,
-        fix_failures=(fix_failures or None) if runs_fix else None,
-        fix_leftover_untracked=(fix_leftover_untracked or None) if runs_fix else None,
-        fix_quality_gate=(fix_quality_gate or None) if runs_fix else None,
+        review_only=identity.review_only,
+        deep=identity.deep,
+        fix_failures=(dict(fix_failures) or None) if runs_fix and fix_failures is not None else None,
+        fix_leftover_untracked=(
+            (list(fix_leftover_untracked) or None) if runs_fix and fix_leftover_untracked is not None else None
+        ),
+        fix_quality_gate=(
+            (dict(fix_quality_gate) or None) if runs_fix and fix_quality_gate is not None else None
+        ),
         recommended_patch_capture=(
             recommended_capture
             if recommended_capture
-            else (
-                "pre_test"
-                if runs_fix and recorder_provenance.run_flow is not DaydreamRunFlow.PR
-                else None
-            )
+            else ("pre_test" if runs_fix and recorder_provenance.run_flow is not DaydreamRunFlow.PR else None)
         ),
+        profile_schema_version=profile.schema_version if profile is not None else None,
+        profile_name=profile.name if profile is not None else None,
+        profile_source_kind=profile.source_kind if profile is not None else None,
+        profile_digest=profile.digest if profile is not None else None,
         source_path=source_path,
         remote_url=git_ctx.remote_url,
         repo_slug=git_ctx.repo_slug,
@@ -682,17 +500,6 @@ def build_manifest_from_snapshot(
         total_cached_tokens=totals["cached"] or None,
         archive_path=str(archive_path),
     )
-
-    # Review-profile provenance (issue #885, R12): the resolved profile lives
-    # on ``config.review_profile`` (set once by the runner composition root);
-    # archive it so results attribute to the exact policy tested. A direct
-    # caller that skipped resolution leaves the fields None (omitted).
-    resolved_profile = getattr(config, "review_profile", None)
-    if resolved_profile is not None:
-        m.profile_schema_version = resolved_profile.profile.schema_version
-        m.profile_name = resolved_profile.profile.name
-        m.profile_source_kind = resolved_profile.source_kind
-        m.profile_digest = resolved_profile.digest
 
     # Lifecycle timing comes from the immutable write snapshot. A snapshot the
     # reducer cannot span (no lifecycle stamps, or a cutoff it cannot match)

--- a/daydream/run_snapshot.py
+++ b/daydream/run_snapshot.py
@@ -1,0 +1,80 @@
+"""Public immutable identity and trajectory inputs for run archiving."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from daydream.trajectory import DaydreamRunFlow
+
+if TYPE_CHECKING:
+    from daydream.trajectory import RunWriteSnapshot
+
+
+@dataclass(frozen=True)
+class ArchiveRecorderProvenance:
+    """Immutable recorder identity recovered from one frozen root document."""
+
+    session_id: str
+    run_flow: DaydreamRunFlow
+    pr_number: int | None
+    pr_repo: str | None
+
+
+@dataclass(frozen=True)
+class RunPhaseCapabilities:
+    """Phases the resolved run can execute."""
+
+    per_stack_review: bool
+    merge: bool
+    fix: bool
+    test: bool
+    push: bool
+    remote_ci: bool
+
+
+@dataclass(frozen=True)
+class RunProfileIdentity:
+    """Resolved review-profile identity."""
+
+    schema_version: int
+    name: str
+    source_kind: str
+    digest: str
+
+
+@dataclass(frozen=True)
+class ManifestRunIdentity:
+    """Effective non-recorder identity serialized in a run manifest."""
+
+    flow_name: str | None
+    skill: str | None
+    model: str | None
+    backend: str
+    review_backend: str | None
+    fix_backend: str | None
+    test_backend: str | None
+    per_stack_review_backend: str | None
+    per_stack_review_model: str | None
+    review_only: bool
+    deep: bool
+    profile: RunProfileIdentity | None
+    phases: RunPhaseCapabilities
+
+
+@dataclass(frozen=True)
+class ArchiveRunSnapshot:
+    """Joined immutable inputs for one archive finalization."""
+
+    recorder_provenance: ArchiveRecorderProvenance
+    identity: ManifestRunIdentity
+    trajectories: RunWriteSnapshot
+
+
+__all__ = [
+    "ArchiveRecorderProvenance",
+    "ArchiveRunSnapshot",
+    "ManifestRunIdentity",
+    "RunPhaseCapabilities",
+    "RunProfileIdentity",
+]

--- a/daydream/runner.py
+++ b/daydream/runner.py
@@ -60,11 +60,19 @@ from daydream.backends import (
     BackendExecutionInput,
     create_backend,
 )
-from daydream.config import EFFORT_TIERS, PHASE_DEFAULT_EFFORT, PHASE_DEFAULT_MODELS, REVIEW_OUTPUT_FILE
+from daydream.config import (
+    DEFAULT_PI_MODEL,
+    EFFORT_TIERS,
+    PHASE_DEFAULT_EFFORT,
+    PHASE_DEFAULT_MODELS,
+    REVIEW_OUTPUT_FILE,
+)
 from daydream.config_file import DaydreamFileConfig
 from daydream.exploration import ExplorationContext
 from daydream.extensions import (
     ExtensionError,
+    Registry,
+    UnresolvedExtensionError,
     build_registry,
     get_registry,
     set_registry,
@@ -86,6 +94,7 @@ from daydream.phases import (
 )
 from daydream.review_profile import ResolvedProfile, resolve_from_runconfig
 from daydream.run_context import InteractionPolicy, RunContext, bind_run_context
+from daydream.run_snapshot import ArchiveRunSnapshot, ManifestRunIdentity, RunPhaseCapabilities, RunProfileIdentity
 from daydream.trajectory import (
     DaydreamRunFlow,
     RunWriteSnapshot,
@@ -428,6 +437,7 @@ class _RunWriteCapture:
     partial: RunWriteSnapshot | None = None
     final: RunWriteSnapshot | None = None
     validation_error: _RunSnapshotCaptureError | None = None
+    manifest_identity: ManifestRunIdentity | None = None
 
     def retain(self, recorder: TrajectoryRecorder, snapshot: RunWriteSnapshot) -> None:
         try:
@@ -483,6 +493,7 @@ class _RunArtifacts:
     trajectory: TrajectoryOutputRoute
     capture: _RunWriteCapture
     dump: RoutedDestination | None
+    execution_input: BackendExecutionInput | None = field(default=None, kw_only=True, repr=False, compare=False)
 
     def write_trajectory_document(
         self, document: TrajectoryDocumentSnapshot, status: Literal["complete", "partial"]
@@ -541,10 +552,15 @@ def _open_recorder(
         if run_artifacts.trajectory.full.write_path is None:
             raise ArtifactVisibilityError("trajectory route has no writable destination")
         trajectory_path = run_artifacts.trajectory.full.write_path
-    # Backend identity is resolved in exactly one place,
-    # ``_recorder_backend_names`` — see its docstring for the authoritative
-    # per-flow phase mapping. Keep the mapping prose there so it cannot drift
-    # between call sites (runner, archive manifest).
+        if run_artifacts.capture.manifest_identity is not None:
+            raise ArtifactVisibilityError("manifest run identity was already captured")
+        _resolve_review_profile(config)
+        run_artifacts.capture.manifest_identity = capture_manifest_run_identity(
+            config, flow_kind, get_registry(), work.repo,
+            execution_input=run_artifacts.execution_input,
+        )
+    # Trajectory labels retain their representative per-flow phase mapping;
+    # manifest identity separately records the general default and capabilities.
     names = _recorder_backend_names(config, flow_kind)
     recorder = TrajectoryRecorder(
         path=trajectory_path,
@@ -665,19 +681,16 @@ class RecorderBackendNames(NamedTuple):
 def _recorder_backend_names(
     config: RunConfig, flow_kind: DaydreamRunFlow
 ) -> RecorderBackendNames:
-    """Resolve the backend identities for the run's trajectory and manifest.
+    """Resolve the representative backend identities for the run's trajectory.
 
-    Single authoritative source for the per-flow backend mapping, shared by
-    :func:`_open_recorder` and ``archive.manifest.build_manifest_from_snapshot`` so the
-    trajectory and manifest never diverge on which backend produced the run.
     The representative backend resolves through the phase that actually governs
     the flow: deep-flow runs (DEEP/NORMAL/TTT) fan out on ``per_stack_review``;
     improve runs on its advisory phases with ``recon`` first; DIAGRAM runs on
-    ``diagram``, the only agent phase its two-step flow executes (issue #1113);
+    ``diagram``, the only agent phase its flow executes (issue #1113);
     other flows fall back to ``review``. Per-phase fix/test are recorded only
     for flows that statically run those phases: improve/TTT/DIAGRAM never run
     fix/test; PR runs fix but never test; CUSTOM composition is fork-defined and
-    unknowable at recorder-open time, so labeling it unconditionally would
+    independent of this static trajectory mapping, so labeling it unconditionally would
     mislabel review-only forks. A flow that skips a phase yields an empty name
     (the key is omitted on serialization) rather than a misleading label.
     """
@@ -767,6 +780,99 @@ def _resolved_model(config: RunConfig, phase: str) -> str | None:
         or file_config.phase_model(phase)
         or file_config.model
         or PHASE_DEFAULT_MODELS.get(backend_name, {}).get(phase)
+    )
+
+
+def capture_manifest_run_identity(
+    config: RunConfig, flow_kind: DaydreamRunFlow, registry: Registry, cwd: Path,
+    *, execution_input: BackendExecutionInput | None = None,
+) -> ManifestRunIdentity:
+    """Freeze manifest identity from resolved runner policy before model execution.
+
+    The registry is the run's resolved registry, including built-in overrides.
+    Mode and resume exceptions preserve the historical archive capabilities;
+    these labels do not evaluate each step's runtime predicate. Backend/model
+    precedence stays owned by the same helpers used to construct backends.
+    """
+    runtime_flow_name: str | None
+    if flow_kind is DaydreamRunFlow.IMPROVE:
+        runtime_flow_name = "improve"
+    elif flow_kind is DaydreamRunFlow.DIAGRAM:
+        runtime_flow_name = "diagram"
+    elif flow_kind is DaydreamRunFlow.CUSTOM:
+        runtime_flow_name = config.flow_name
+    else:
+        runtime_flow_name = "deep"
+    step_names: set[str] = set()
+    if runtime_flow_name:
+        try:
+            entries = registry.flow(runtime_flow_name)
+        except UnresolvedExtensionError:
+            entries = []
+        for entry in entries:
+            if isinstance(entry, str):
+                step_names.add(entry)
+            else:
+                step_names.update(entry.steps)
+
+    if flow_kind is DaydreamRunFlow.TTT:
+        runs_fix, runs_test = False, False
+    elif flow_kind is DaydreamRunFlow.PR:
+        runs_fix, runs_test = True, False
+    else:
+        runs_fix, runs_test = "fix" in step_names, "test" in step_names
+    if flow_kind in (DaydreamRunFlow.PR, DaydreamRunFlow.IMPROVE, DaydreamRunFlow.DIAGRAM):
+        runs_merge = False
+    elif flow_kind is DaydreamRunFlow.CUSTOM:
+        runs_merge = any("merge" in step for step in step_names)
+    else:
+        runs_merge = True
+    runs_per_stack_review = (
+        (config.flow_name is None or config.flow_name in _DEEP_FLOW_ALIASES)
+        and config.start_at not in ("merge", "fix")
+        and flow_kind is not DaydreamRunFlow.DIAGRAM
+    )
+    phases = RunPhaseCapabilities(
+        per_stack_review=runs_per_stack_review,
+        merge=runs_merge and config.start_at != "fix",
+        fix=runs_fix,
+        test=runs_test,
+        push=flow_kind not in (DaydreamRunFlow.TTT, DaydreamRunFlow.PR) and "commit" in step_names,
+        remote_ci=flow_kind not in (DaydreamRunFlow.TTT, DaydreamRunFlow.PR) and "remote-ci" in step_names,
+    )
+    per_stack_backend: str | None = None
+    per_stack_model: str | None = None
+    if phases.per_stack_review:
+        per_stack_backend = _resolved_backend_name(config, "per_stack_review")
+        per_stack_model = _resolved_model(config, "per_stack_review")
+        if per_stack_model is None and per_stack_backend == "pi":
+            from daydream.backends.pi import _configured_pi_model
+
+            configured_model = (
+                _configured_pi_model(cwd) if execution_input is None
+                else _configured_pi_model(cwd, agent_dir=execution_input.pi_agent_dir)
+            )
+            per_stack_model = configured_model or DEFAULT_PI_MODEL
+    profile = config.review_profile
+    return ManifestRunIdentity(
+        flow_name=config.flow_name,
+        skill=config.stack,
+        model=None,
+        backend=_default_backend_name(config),
+        review_backend=_resolved_review_backend_name(config),
+        fix_backend=_resolved_backend_name(config, "fix") if phases.fix else None,
+        test_backend=_resolved_backend_name(config, "test") if phases.test else None,
+        per_stack_review_backend=per_stack_backend,
+        per_stack_review_model=per_stack_model,
+        review_only=config.output_mode == "review",
+        deep=not config.shallow,
+        profile=None if profile is None else RunProfileIdentity(
+            schema_version=profile.profile.schema_version,
+            name=profile.name,
+            source_kind=profile.source_kind,
+            digest=profile.digest,
+        ),
+        phases=phases,
     )
 
 
@@ -1083,6 +1189,7 @@ async def run(
         return await _run_with_context(
             config, private_roots=private_roots, run_context=run_context,
             backend_factory=backend_factory,
+            backend_execution=None if execution is None else execution.backend,
             github_execution=None if execution is None else execution.github,
         )
 
@@ -1091,6 +1198,7 @@ async def _run_with_context(
     config: RunConfig, *, private_roots: PrivateRootLocations | None,
     run_context: RunContext,
     backend_factory: BackendFactory | None = None,
+    backend_execution: BackendExecutionInput | None = None,
     github_execution: github_app.GitHubExecutionInput | None = None,
 ) -> int:
     """Execute with the runner's immutable policy bound before any output."""
@@ -1179,6 +1287,7 @@ async def _run_with_context(
                 config, target_dir, skip_tests=skip_tests, private_owner=private_owner,
                 run_context=run_context, github_execution=session.execution,
                 backend_factory=backend_factory,
+                backend_execution=backend_execution,
             )
             observed.finish(result)
             return result
@@ -1205,6 +1314,9 @@ def _finalize_run_artifacts(
 
     if run_artifacts.capture.run_flow is None:
         raise ArtifactVisibilityError("run flow provenance was not retained")
+    identity = run_artifacts.capture.manifest_identity
+    if identity is None:
+        raise ArtifactVisibilityError("manifest run identity was not captured")
     snapshot = run_artifacts.session.freeze(selected)
     recorder_provenance = archive_recorder_provenance_from_snapshot(
         write_snapshot=selected, run_flow=run_artifacts.capture.run_flow
@@ -1217,9 +1329,9 @@ def _finalize_run_artifacts(
     archive_error: Exception | None = None
     try:
         finalize_archive_run(
-            recorder_provenance=recorder_provenance, artifacts=snapshot,
+            run=ArchiveRunSnapshot(recorder_provenance, identity, selected), artifacts=snapshot,
             artifact_provenance=run_artifacts.session.provenance, config=config,
-            write_snapshot=selected, work=work, upload=successful, dump_path=dump_path,
+            work=work, upload=successful, dump_path=dump_path,
         )
     except ArchiveFinalizationError as exc:
         archive_error = exc
@@ -1247,6 +1359,7 @@ async def _run_workspace(
     private_owner: PrivateWorkspaceOwner, run_context: RunContext,
     github_execution: github_app.GitHubExecutionInput,
     backend_factory: BackendFactory | None = None,
+    backend_execution: BackendExecutionInput | None = None,
 ) -> int:
     """Keep workspace errors inside the run span so returned failures are recorded."""
     # ``open_workspace`` runs ``assert_is_worktree`` and surfaces
@@ -1275,7 +1388,10 @@ async def _run_workspace(
                 findings = _route(config.findings_out, OutputLabel.FINDINGS_OUTPUT)
                 dump = _route(config.dump_artifacts, OutputLabel.DUMP_DIRECTORY)
                 capture = _RunWriteCapture(session_id=session_id)
-                run_artifacts = _RunArtifacts(artifacts, private_owner, trajectory, capture, dump)
+                run_artifacts = _RunArtifacts(
+                    artifacts, private_owner, trajectory, capture, dump,
+                    execution_input=backend_execution,
+                )
                 dispatch_config = (
                     config if findings is None else replace(config, findings_out=str(findings.write_path))
                 )

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -6,8 +6,8 @@ Covers git_context, manifest, index, and the strict ``finalize_archive_run`` flo
 import json
 import sqlite3
 import subprocess
-from collections.abc import Callable
-from dataclasses import dataclass
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import Any, cast
 
@@ -46,7 +46,6 @@ from daydream.artifact_visibility import (
     RoutedDestination,
     _manifest,
 )
-from daydream.config_file import DaydreamFileConfig
 from daydream.remote_ci import (
     CIObservation,
     PRCIBinding,
@@ -55,6 +54,12 @@ from daydream.remote_ci import (
     RequiredContext,
     RequiredPolicy,
     write_remote_ci_verdict,
+)
+from daydream.run_snapshot import (
+    ArchiveRunSnapshot,
+    ManifestRunIdentity,
+    RunPhaseCapabilities,
+    RunProfileIdentity,
 )
 from daydream.runner import RunConfig
 from daydream.trajectory import (
@@ -175,6 +180,7 @@ def _strict_archive(
     config: Any,
     write_snapshot: RunWriteSnapshot,
     run_flow: DaydreamRunFlow = DaydreamRunFlow.NORMAL,
+    identity: ManifestRunIdentity | None = None,
     destinations: tuple[RoutedDestination, ...] = (),
     work: Any = None,
     upload: bool = False,
@@ -189,9 +195,7 @@ def _strict_archive(
     from daydream.archive import finalize_archive_run
 
     finalize_archive_run(
-        recorder_provenance=archive_recorder_provenance_from_snapshot(
-            write_snapshot=write_snapshot, run_flow=run_flow,
-        ),
+        run=_archive_snapshot(write_snapshot, run_flow=run_flow, identity=identity),
         artifacts=ArtifactTreeSnapshot(
             session_id=session_id,
             workspace_key="workspace",
@@ -207,33 +211,84 @@ def _strict_archive(
             # to one resolve unchanged inside the other.
             live_root=target,
         ),
-        config=cast(RunConfig, config),
-        write_snapshot=write_snapshot,
+        config=config,
         work=work,
         upload=upload,
         dump_path=dump_path,
     )
 
 
-@dataclass
-class _MockConfig:
-    stack: str | None = "python"
-    backend: str | None = None
-    model: str | None = None
-    review_backend: str | None = None
-    fix_backend: str | None = None
-    test_backend: str | None = None
-    output_mode: str = "loop"
-    shallow: bool = False
-    bot: str | None = None
-    flow_name: str | None = None
-    loop: bool = False
-    archive: bool = True
-    run_eval: bool = False
-    dump_artifacts: str | None = None
-    trajectory_hub_repo: str | None = None
-    file_config: DaydreamFileConfig | None = None
-    findings_out: str | None = None
+def _manifest_identity(**overrides: Any) -> ManifestRunIdentity:
+    """Build the public, already-resolved identity supplied by the runner."""
+    identity = ManifestRunIdentity(
+        flow_name=None,
+        skill="python",
+        model=None,
+        backend="claude",
+        review_backend=None,
+        fix_backend="claude",
+        test_backend="claude",
+        per_stack_review_backend="claude",
+        per_stack_review_model="sonnet",
+        review_only=False,
+        deep=True,
+        profile=None,
+        phases=RunPhaseCapabilities(
+            per_stack_review=True,
+            merge=True,
+            fix=True,
+            test=True,
+            push=True,
+            remote_ci=True,
+        ),
+    )
+    return replace(identity, **overrides)
+
+
+def _manifest_write_snapshot(
+    *,
+    session_id: str = "abcd1234-0000-0000-0000-000000000000",
+    final_metrics: Mapping[str, Any] | None = None,
+    extra: Mapping[str, Any] | None = None,
+) -> RunWriteSnapshot:
+    """Build explicit immutable root bytes for manifest-reducer tests."""
+    snapshot_extra = dict(extra or {})
+    payload = {
+        "session_id": session_id,
+        "trajectory_id": session_id,
+        "steps": [],
+        "final_metrics": dict(_DEFAULT_FINAL_METRICS if final_metrics is None else final_metrics),
+        "extra": snapshot_extra,
+    }
+    return RunWriteSnapshot(
+        status="complete",
+        cutoff_at=str(snapshot_extra.get("run_ended_at", "2026-01-01T00:00:01Z")),
+        root_trajectory_id=session_id,
+        documents=(
+            TrajectoryDocumentSnapshot(
+                trajectory_id=session_id,
+                path=Path("/frozen/trajectory.json"),
+                json_bytes=json.dumps(payload).encode(),
+            ),
+        ),
+    )
+
+
+def _archive_snapshot(
+    trajectories: RunWriteSnapshot,
+    *,
+    run_flow: DaydreamRunFlow = DaydreamRunFlow.NORMAL,
+    identity: ManifestRunIdentity | None = None,
+) -> ArchiveRunSnapshot:
+    """Join frozen trajectory provenance with the runner's public identity."""
+    return ArchiveRunSnapshot(
+        recorder_provenance=archive_recorder_provenance_from_snapshot(
+            write_snapshot=trajectories,
+            run_flow=run_flow,
+        ),
+        identity=identity or _manifest_identity(),
+        trajectories=trajectories,
+    )
 
 
 def _run_git_init_with_credential_origin(repo: Path, origin_url: str) -> None:
@@ -326,20 +381,19 @@ def _build(
     tmp_path: Path,
     *,
     git_ctx: GitContext | None = None,
-    recorder: _MockRecorder | None = None,
-    config: Any | None = None,
+    write_snapshot: RunWriteSnapshot | None = None,
+    run_flow: DaydreamRunFlow = DaydreamRunFlow.NORMAL,
+    identity: ManifestRunIdentity | None = None,
     **kw: Any,
 ) -> Manifest:
-    """Build a manifest from one frozen snapshot of the mock recorder/config pair."""
-    active_recorder = recorder or _MockRecorder()
-    write_snapshot = kw.pop("write_snapshot", None) or _write_snapshot(active_recorder)
+    """Build a manifest from immutable public archive inputs."""
+    snapshot = write_snapshot or _manifest_write_snapshot()
     return build_manifest_from_snapshot(
-        recorder_provenance=archive_recorder_provenance_from_snapshot(
-            write_snapshot=write_snapshot,
-            run_flow=active_recorder.run_flow,
+        run=_archive_snapshot(
+            snapshot,
+            run_flow=run_flow,
+            identity=identity,
         ),
-        write_snapshot=write_snapshot,
-        config=cast(RunConfig, _MockConfig() if config is None else config),
         git_ctx=git_ctx if git_ctx is not None else GitContext(),
         status="complete",
         archive_path=tmp_path,
@@ -359,7 +413,7 @@ def test_build_manifest_basic(tmp_path: Path) -> None:
         ),
     )
 
-    assert m.session_id == _MockRecorder().session_id
+    assert m.session_id == "abcd1234-0000-0000-0000-000000000000"
     assert m.run_flow == "normal"
     assert m.skill == "python"
     # Per-phase models replaced config.model; the manifest stamps model as None.
@@ -374,61 +428,57 @@ def test_build_manifest_basic(tmp_path: Path) -> None:
     assert m.head_sha == "a" * 40
 
 
-@pytest.mark.parametrize(
-    "flow",
-    list(DaydreamRunFlow),
-    ids=[f.value for f in DaydreamRunFlow],
-)
-def test_build_manifest_fix_test_backend_gated_per_flow(
-    tmp_path: Path, flow: DaydreamRunFlow,
-) -> None:
-    """Issue #648: backend labels track the executed step pipeline.
+def test_build_manifest_serializes_resolved_profile_identity(tmp_path: Path) -> None:
+    """Resolved profile provenance is preserved in the manifest projection."""
+    profile = RunProfileIdentity(
+        schema_version=7,
+        name="focused",
+        source_kind="explicit",
+        digest="e2e-profile-digest",
+    )
 
-    Driven over every ``DaydreamRunFlow`` member: the deep family's
-    fix-bearing mode labels (NORMAL for shallow, DEEP for loop) resolve
-    fix/test backends exactly as today, while TTT (review/comment) gates the
-    fix/test STEPS off at runtime (``_fix_cycle_enabled`` is loop/shallow
-    only) and drops both labels. PR (feedback) runs its own ``fix-items``
-    phase (``_step_fix_items``, ``backend_for("fix")``) but never the ``test``
-    step, so it keeps a fix backend and drops only test. IMPROVE's built-in
-    pipeline defines no fix/test phase, so it drops both. CUSTOM is classified
-    by its registered pipeline; with no fork flow configured here it cannot
-    prove a fix/test phase, so it drops both. DIAGRAM (issue #1113) runs
-    exploration -> diagram -> post-diagram and no fix/test phase, so it drops
-    both as well.
-    """
-    recorder = _MockRecorder(run_flow=flow)
-    config = _MockConfig(fix_backend="codex", test_backend="codex")
-    m = _build(tmp_path, recorder=recorder, config=config)
-    run = m.to_dict()["run"]
-    if flow is DaydreamRunFlow.PR:
-        # Feedback runs fix-items but never the test step.
-        assert m.fix_backend == "codex"
-        assert m.test_backend is None
-        assert run["fix_backend"] == "codex"
-        assert "test_backend" not in run
-    elif flow in (
-        DaydreamRunFlow.IMPROVE,
-        DaydreamRunFlow.TTT,
-        DaydreamRunFlow.CUSTOM,
-        DaydreamRunFlow.DIAGRAM,
-    ):
-        assert m.fix_backend is None
-        assert m.test_backend is None
-        assert "fix_backend" not in run
-        assert "test_backend" not in run
-    else:
-        assert m.fix_backend == "codex"
-        assert m.test_backend == "codex"
-        assert run["fix_backend"] == "codex"
-        assert run["test_backend"] == "codex"
+    manifest = _build(
+        tmp_path,
+        identity=_manifest_identity(profile=profile),
+    ).to_dict()
+
+    assert {
+        key: manifest[key]
+        for key in (
+            "profile_schema_version",
+            "profile_name",
+            "profile_source_kind",
+            "profile_digest",
+        )
+    } == {
+        "profile_schema_version": 7,
+        "profile_name": "focused",
+        "profile_source_kind": "explicit",
+        "profile_digest": "e2e-profile-digest",
+    }
+
+
+def test_build_manifest_omits_unresolved_profile_identity(tmp_path: Path) -> None:
+    """A direct legacy caller with no resolved profile keeps all four keys absent."""
+    manifest = _build(tmp_path).to_dict()
+
+    assert {
+        "profile_schema_version",
+        "profile_name",
+        "profile_source_kind",
+        "profile_digest",
+    }.isdisjoint(manifest)
+
+
 
 
 def test_build_manifest_omits_fix_metadata_for_diagram_flow(tmp_path: Path) -> None:
-    recorder = _MockRecorder(run_flow=DaydreamRunFlow.DIAGRAM)
     m = _build(
         tmp_path,
-        recorder=recorder,
+        run_flow=DaydreamRunFlow.DIAGRAM,
+        identity=_manifest_identity(
+            phases=replace(_manifest_identity().phases, fix=False, test=False)
+        ),
         fix_failures={"src/old.py": "reverted"},
         fix_leftover_untracked=["src/leftover.py"],
         fix_quality_gate={"enabled": True, "rounds": []},
@@ -439,70 +489,8 @@ def test_build_manifest_omits_fix_metadata_for_diagram_flow(tmp_path: Path) -> N
     assert m.fix_quality_gate is None
 
 
-def test_build_manifest_classifies_custom_flow_by_registered_pipeline(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Every ``--flow`` run is stamped CUSTOM regardless of step composition, so
-    a fork flow is classified from its registered pipeline, not its label: one
-    composing the built-in fix/test steps records backends, one without them
-    records none.
-    """
-    from daydream.extensions import build_registry
-
-    registry = build_registry()
-    registry.set_flow("fix-cycle-fork", ["exploration", "intent", "fix", "test", "commit"])
-    registry.set_flow("review-only-fork", ["exploration", "intent"])
-    monkeypatch.setattr("daydream.archive.manifest.get_registry", lambda: registry)
-
-    for flow_name, fix_backend, test_backend in (
-        ("fix-cycle-fork", "codex", "codex"),
-        ("review-only-fork", None, None),
-    ):
-        recorder = _MockRecorder(run_flow=DaydreamRunFlow.CUSTOM)
-        config = _MockConfig(
-            fix_backend="codex", test_backend="codex", flow_name=flow_name,
-        )
-        m = _build(tmp_path, recorder=recorder, config=config)
-        assert m.fix_backend == fix_backend
-        assert m.test_backend == test_backend
-        run = m.to_dict()["run"]
-        assert ("fix_backend" in run) == (fix_backend is not None)
-        assert ("test_backend" in run) == (test_backend is not None)
 
 
-def test_build_manifest_classifies_fork_override_of_builtin_flow(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Issue #648: fork overrides of built-in flow names are classified by
-    the registry pipeline actually executed by ``run_flow``, not by the label.
-
-    ``Registry.set_flow`` has no built-in-name guard, so a fork overriding
-    ``deep`` (dropping fix/test) or ``improve`` (adding fix/test) runs its own
-    pipeline while the recorder label still suggests the built-in. The manifest
-    must follow the registry in both directions.
-    """
-    from daydream.extensions import build_registry
-
-    registry = build_registry()
-    # Override built-ins after seeding, exactly as an extension would.
-    registry.set_flow("deep", ["exploration", "intent"])
-    registry.set_flow("improve", ["exploration", "fix", "test"])
-    monkeypatch.setattr("daydream.archive.manifest.get_registry", lambda: registry)
-
-    for flow, flow_name, fix_backend, test_backend in (
-        (DaydreamRunFlow.DEEP, None, None, None),
-        (DaydreamRunFlow.NORMAL, None, None, None),
-        (DaydreamRunFlow.IMPROVE, None, "codex", "codex"),
-    ):
-        recorder = _MockRecorder(run_flow=flow)
-        config = _MockConfig(
-            fix_backend="codex", test_backend="codex", flow_name=flow_name,
-        )
-        m = _build(tmp_path, recorder=recorder, config=config)
-        assert m.fix_backend == fix_backend
-        assert m.test_backend == test_backend
 
 
 def test_fix_cycle_classification_covers_every_run_flow() -> None:
@@ -625,91 +613,12 @@ async def test_custom_flow_archive_real_path_omits_fix_test_backend(
     _assert_archive_omits_fix_test_backend(archive_dir, "custom")
 
 
-@pytest.mark.parametrize(
-    ("flow_name", "shallow"),
-    [
-        pytest.param(None, False, id="default-deep-loop"),
-        pytest.param(None, True, id="shallow-single-stack"),
-        pytest.param("deep", False, id="flow-deep"),
-        pytest.param("shallow", False, id="flow-shallow"),
-        pytest.param("review", False, id="flow-review"),
-    ],
-)
-def test_build_manifest_per_stack_review_tier(
-    tmp_path: Path, flow_name: str | None, shallow: bool
-) -> None:
-    """Issue #646: every deep-flow mode that executes per-stack reviews records the
-    per-stack tier resolved from its own key — including shallow, whose collapsed
-    single stack is still reviewed by ``phase_per_stack_reviews`` on the
-    ``per_stack_review`` tier."""
-    fc = DaydreamFileConfig(
-        model=None, backend=None,
-        phases={"per_stack_review": {"backend": "codex", "model": "gpt-psr"}},
-    )
-    config = RunConfig(
-        target=str(tmp_path), backend=None, model=None,
-        file_config=fc, shallow=shallow, flow_name=flow_name,
-        review_backend="claude",
-    )
-    m = _build(tmp_path, config=config)
-    run = m.to_dict()["run"]
-    assert m.per_stack_review_backend == "codex"  # per-stack tier resolved from its own key
-    assert m.per_stack_review_model == "gpt-psr"
-    # Post-#647, review_backend is an override marker (_resolved_review_backend_name),
-    # so it stays the explicit review override "claude" — distinct from the
-    # per-stack tier resolved from its own key. The per-stack model is the
-    # load-bearing part of the identity.
-    assert m.review_backend == "claude"
-    assert run["per_stack_review_backend"] == "codex"
-    assert run["per_stack_review_model"] == "gpt-psr"
-    assert run["review_backend"] == "claude"
 
 
-def test_build_manifest_per_stack_review_gate_tracks_runner_aliases(
-    tmp_path: Path,
-) -> None:
-    """Issue #646 finding 3: the per-stack gate derives from the same alias list
-    ``runner._dispatch_selected_flow`` routes (no third inline copy), so adding
-    or renaming a deep-flow alias surfaces here instead of silently misstating
-    "who reviewed" in archived runs."""
-    from daydream.runner import _DEEP_FLOW_ALIASES
-
-    assert _DEEP_FLOW_ALIASES  # non-empty; every alias must record the identity
-    for flow_name in _DEEP_FLOW_ALIASES:
-        m = _build(
-            tmp_path,
-            config=RunConfig(target=str(tmp_path), backend=None, model=None, flow_name=flow_name),
-        )
-        assert m.per_stack_review_backend is not None
-        assert m.per_stack_review_model is not None
-        assert "per_stack_review_backend" in m.to_dict()["run"]
 
 
-def test_build_manifest_omits_per_stack_review_without_spine(tmp_path: Path) -> None:
-    """Issue #646: improve/custom flows record no per-stack review identity."""
-    for config in (
-        RunConfig(target=str(tmp_path), backend=None, model=None, flow_name="improve"),
-        RunConfig(target=str(tmp_path), backend=None, model=None, flow_name="custom-flow"),
-    ):
-        m = _build(tmp_path, config=config)
-        run = m.to_dict()["run"]
-        assert m.per_stack_review_backend is None
-        assert m.per_stack_review_model is None
-        assert "per_stack_review_backend" not in run
-        assert "per_stack_review_model" not in run
 
 
-def test_build_manifest_pi_deep_records_backend_default_model(tmp_path: Path) -> None:
-    """Issue #646: a Pi deep run with no explicit model override records Pi's
-    backend default. Pi's default intentionally lives outside PHASE_DEFAULT_MODELS
-    (it is a backend fallback), so _resolved_model alone leaves the load-bearing
-    model NULL; the manifest surfaces the backend default instead."""
-    from daydream.config import DEFAULT_PI_MODEL
-
-    m = _build(tmp_path, config=RunConfig(target=str(tmp_path), backend="pi", model=None))
-    assert m.per_stack_review_backend == "pi"
-    assert m.per_stack_review_model == DEFAULT_PI_MODEL
-    assert m.to_dict()["run"]["per_stack_review_model"] == DEFAULT_PI_MODEL
 
 
 def test_manifest_to_dict_structure(tmp_path: Path) -> None:
@@ -717,7 +626,7 @@ def test_manifest_to_dict_structure(tmp_path: Path) -> None:
 
     d = m.to_dict()
     assert d["schema_version"] == "1.0"
-    assert d["session_id"] == _MockRecorder().session_id
+    assert d["session_id"] == "abcd1234-0000-0000-0000-000000000000"
     assert "run" in d and d["run"]["flow"] == "normal"
     assert "git" in d
     assert "pr" in d
@@ -802,13 +711,13 @@ def test_build_manifest_without_evaluation(tmp_path: Path) -> None:
 
 def test_build_manifest_wall_clock_without_evaluation(tmp_path: Path) -> None:
     """The snapshot's own run span fills wall-clock even when --eval did not run."""
-    recorder = _MockRecorder()
     m = _build(
         tmp_path,
-        recorder=recorder,
-        write_snapshot=_write_snapshot(
-            recorder,
-            lifecycle=("2026-01-01T00:00:00Z", "2026-01-01T00:00:12.300000Z"),
+        write_snapshot=_manifest_write_snapshot(
+            extra={
+                "run_started_at": "2026-01-01T00:00:00Z",
+                "run_ended_at": "2026-01-01T00:00:12.300000Z",
+            },
         ),
     )
 
@@ -819,10 +728,10 @@ def test_build_manifest_wall_clock_without_evaluation(tmp_path: Path) -> None:
 def test_build_manifest_snapshot_timing_overrides_conflicting_evaluation(
     tmp_path: Path,
 ) -> None:
-    recorder = _MockRecorder(session_id="snapshot-session")
+    session_id = "snapshot-session"
     payload = {
-        "session_id": recorder.session_id,
-        "trajectory_id": recorder.session_id,
+        "session_id": session_id,
+        "trajectory_id": session_id,
         "steps": [],
         "final_metrics": {"total_prompt_tokens": 7, "total_steps": 0},
         "extra": {
@@ -833,14 +742,14 @@ def test_build_manifest_snapshot_timing_overrides_conflicting_evaluation(
                     "phase": "review",
                     "event": "phase_start",
                     "timestamp": "2026-01-01T00:00:02Z",
-                    "session_id": recorder.session_id,
+                    "session_id": session_id,
                     "scope_id": "review",
                 },
                 {
                     "phase": "review",
                     "event": "phase_end",
                     "timestamp": "2026-01-01T00:00:08Z",
-                    "session_id": recorder.session_id,
+                    "session_id": session_id,
                     "scope_id": "review",
                     "status": "succeeded",
                 },
@@ -850,11 +759,11 @@ def test_build_manifest_snapshot_timing_overrides_conflicting_evaluation(
     snapshot = RunWriteSnapshot(
         status="complete",
         cutoff_at="2026-01-01T00:00:10Z",
-        root_trajectory_id=recorder.session_id,
+        root_trajectory_id=session_id,
         documents=(
             TrajectoryDocumentSnapshot(
-                recorder.session_id,
-                recorder.path,
+                session_id,
+                Path("/frozen/snapshot-session.json"),
                 json.dumps(payload).encode(),
             ),
         ),
@@ -862,7 +771,6 @@ def test_build_manifest_snapshot_timing_overrides_conflicting_evaluation(
 
     manifest = _build(
         tmp_path,
-        recorder=recorder,
         write_snapshot=snapshot,
         evaluation={"timing": {"total_wall_clock_seconds": 42.5}},
     )
@@ -1446,8 +1354,7 @@ def test_feedback_run_leaves_recommended_patch_capture_none() -> None:
     absent sidecar must leave ``recommended_patch_capture`` ``None`` rather
     than defaulting to ``"pre_test"`` (feedback's ``_step_fix_items`` never
     writes ``recommended.patch``)."""
-    recorder = _MockRecorder(run_flow=DaydreamRunFlow.PR)
-    m = _build(tmp_path=Path("/tmp"), recorder=recorder)
+    m = _build(tmp_path=Path("/tmp"), run_flow=DaydreamRunFlow.PR)
     assert m.recommended_patch_capture is None
     assert "recommended_patch_capture" not in m.to_dict()
 
@@ -1519,6 +1426,7 @@ def _assemble_bundle(
 
     snapshot = write_snapshot if write_snapshot is not None else _write_snapshot(recorder)
     _copy_snapshot_bundle(
+        run=_archive_snapshot(snapshot, run_flow=recorder.run_flow),
         artifacts=ArtifactTreeSnapshot(
             session_id=recorder.session_id,
             workspace_key="workspace",
@@ -1533,10 +1441,6 @@ def _assemble_bundle(
             live_root=target,
         ),
         run_dir=run_dir,
-        recorder_provenance=archive_recorder_provenance_from_snapshot(
-            write_snapshot=snapshot, run_flow=recorder.run_flow,
-        ),
-        write_snapshot=snapshot,
     )
 
 
@@ -1720,7 +1624,7 @@ def test_dump_artifacts_refuses_credential_bearing_bundle(
     session_id = "abcd1234-0000-0000-0000-000000000000"
     dest = tmp_path / "dump"
     dest.mkdir()
-    config = _MockConfig(archive=True, dump_artifacts=str(dest))
+    config = RunConfig(target=str(tmp_path), archive=True, dump_artifacts=str(dest))
 
     target, _, recorder = _setup_bundle(tmp_path, session_id)
     # Inject a credential into the serialized trajectory the bundle will carry.
@@ -1754,7 +1658,7 @@ def test_dump_artifacts_copies_clean_bundle(
     session_id = "abcd1234-0000-0000-0000-000000000000"
     dest = tmp_path / "dump"
     dest.mkdir()
-    config = _MockConfig(archive=True, dump_artifacts=str(dest))
+    config = RunConfig(target=str(tmp_path), archive=True, dump_artifacts=str(dest))
     target, _, recorder = _setup_bundle(tmp_path, session_id)
 
     _strict_archive(
@@ -1773,7 +1677,7 @@ def test_dump_artifacts_copies_clean_bundle(
 
 def test_finalize_archive_run_round_trip(tmp_path: Path, archive_dir: Path) -> None:
     session_id = "abcd1234-0000-0000-0000-000000000000"
-    config = _MockConfig(archive=True)
+    config = RunConfig(target=str(tmp_path), archive=True)
 
     target, _, recorder = _setup_bundle(tmp_path, session_id)
 
@@ -2609,63 +2513,14 @@ def test_legacy_z_valid_at_rows_are_left_untouched(tmp_path: Path) -> None:
     assert [r["valid_at"] for r in hist] == ["2026-01-01T00:00:00Z"]
 
 
-def test_manifest_backend_is_general_default_not_review_override(
-    tmp_path: Path,
-) -> None:
-    """#647: backend records the general default even when review differs."""
-    m = _build(tmp_path, config=_MockConfig(backend="claude", review_backend="codex"))
-    assert m.backend == "claude"
-    assert m.review_backend == "codex"
 
 
-def test_manifest_review_backend_none_when_no_override(tmp_path: Path) -> None:
-    """#647: only a general backend -> review_backend stays None."""
-    m = _build(tmp_path, config=_MockConfig(backend="codex"))
-    assert m.backend == "codex"
-    assert m.review_backend is None
 
 
-def test_manifest_backend_falls_back_to_file_config_global(tmp_path: Path) -> None:
-    """#647: no CLI backend -> backend resolves from the file-config global."""
-    m = _build(
-        tmp_path,
-        config=_MockConfig(backend=None, file_config=DaydreamFileConfig(backend="file-backend")),
-    )
-    assert m.backend == "file-backend"
-    assert m.review_backend is None
 
 
-def test_manifest_review_backend_from_file_config_phase(tmp_path: Path) -> None:
-    """#647: a file-config review-phase override stamps review_backend only."""
-    m = _build(
-        tmp_path,
-        config=_MockConfig(
-            backend="claude",
-            file_config=DaydreamFileConfig(phases={"review": {"backend": "codex"}}),
-        ),
-    )
-    assert m.backend == "claude"
-    assert m.review_backend == "codex"
 
 
-def test_archive_records_general_backend_and_override(tmp_path: Path, archive_dir: Path) -> None:
-    """#647: the archive persists the general backend + nullable review override."""
-    session_id = "abcd1234-0000-0000-0000-000000000000"
-    config = _MockConfig(archive=True, backend="claude", review_backend="codex")
-    target, _, recorder = _setup_bundle(tmp_path, session_id)
-    _strict_archive(
-        target=target,
-        session_id=session_id,
-        config=config,
-        write_snapshot=_write_snapshot(recorder),
-    )
-    manifest_data = json.loads((archive_dir / "runs" / session_id / "manifest.json").read_text())
-    assert manifest_data["run"]["backend"] == "claude"
-    assert manifest_data["run"]["review_backend"] == "codex"
-    rows = query_runs(archive_dir)
-    assert len(rows) == 1
-    assert rows[0]["backend"] == "claude"
-    assert rows[0]["review_backend"] == "codex"
 
 
 async def test_build_manifest_totals_include_fork_trajectories(tmp_path: Path) -> None:
@@ -2701,11 +2556,7 @@ async def test_build_manifest_totals_include_fork_trajectories(tmp_path: Path) -
 
     write_snapshot = snapshots[-1]
     m = build_manifest_from_snapshot(
-        recorder_provenance=archive_recorder_provenance_from_snapshot(
-            write_snapshot=write_snapshot, run_flow=recorder.run_flow,
-        ),
-        write_snapshot=write_snapshot,
-        config=cast(RunConfig, _MockConfig()),
+        run=_archive_snapshot(write_snapshot, run_flow=recorder.run_flow),
         git_ctx=GitContext(),
         status="complete",
         archive_path=tmp_path,
@@ -2717,62 +2568,10 @@ async def test_build_manifest_totals_include_fork_trajectories(tmp_path: Path) -
     assert m.total_cost_usd == pytest.approx(0.25)
 
 
-def test_build_manifest_pi_records_cwd_configured_default_model(tmp_path: Path) -> None:
-    """Issue #646 finding 1: a Pi deep run with no explicit override records the
-    model PiBackend actually resolved — the cwd-configured default from
-    ``<repo>/.pi/settings.json``, not DEFAULT_PI_MODEL — so the archived
-    'who reviewed' identity matches what ran."""
-    from daydream.backends.pi import _configured_pi_model
-    from daydream.config import DEFAULT_PI_MODEL
-
-    # Configure a Pi default in the repo cwd (the same seam PiBackend reads).
-    pi_dir = tmp_path / ".pi"
-    pi_dir.mkdir()
-    (pi_dir / "settings.json").write_text(
-        json.dumps({"defaultModel": "gpt-psr-configured"}), encoding="utf-8"
-    )
-    assert _configured_pi_model(tmp_path) == "gpt-psr-configured"
-
-    m = _build(
-        tmp_path,
-        config=RunConfig(target=str(tmp_path), backend="pi", model=None),
-        cwd=str(tmp_path),
-    )
-    assert m.per_stack_review_backend == "pi"
-    assert m.per_stack_review_model == "gpt-psr-configured"
-    assert m.per_stack_review_model != DEFAULT_PI_MODEL
-    assert m.to_dict()["run"]["per_stack_review_model"] == "gpt-psr-configured"
 
 
-def test_build_manifest_pi_falls_back_to_default_when_no_cwd_config(
-    tmp_path: Path,
-) -> None:
-    """Issue #646 finding 1: with no cwd-configured Pi default (and no cwd passed),
-    the manifest records DEFAULT_PI_MODEL as before — the fallback path is intact."""
-    from daydream.config import DEFAULT_PI_MODEL
-
-    m = _build(tmp_path, config=RunConfig(target=str(tmp_path), backend="pi", model=None))
-    assert m.per_stack_review_backend == "pi"
-    assert m.per_stack_review_model == DEFAULT_PI_MODEL
 
 
-def test_build_manifest_omits_per_stack_review_on_merge_fix_resume(
-    tmp_path: Path,
-) -> None:
-    """Issue #646 finding 2: a --start-at merge/fix resume skips
-    phase_per_stack_reviews (orchestrator.py:1132), so the manifest must not
-    attribute the resume config's per-stack tier to the prior run's artifacts."""
-    for start_at in ("merge", "fix"):
-        config = RunConfig(
-            target=str(tmp_path), backend=None, model=None,
-            flow_name="deep", start_at=start_at,
-        )
-        m = _build(tmp_path, config=config)
-        run = m.to_dict()["run"]
-        assert m.per_stack_review_backend is None, f"start_at={start_at}"
-        assert m.per_stack_review_model is None, f"start_at={start_at}"
-        assert "per_stack_review_backend" not in run, f"start_at={start_at}"
-        assert "per_stack_review_model" not in run, f"start_at={start_at}"
 
 
 def test_manifest_splits_status_from_pipeline() -> None:
@@ -4049,59 +3848,6 @@ def test_current_archive_survives_invalid_utf8_fix_failures(
     assert [row["session_id"] for row in query_runs(archive_dir)] == [session_id]
 
 
-@pytest.mark.parametrize(
-    ("flow", "expected_pipeline"),
-    [
-        (DaydreamRunFlow.TTT, "succeeded"),
-        (DaydreamRunFlow.PR, "partial"),
-    ],
-)
-def test_nonpublishing_runtime_flows_ignore_matching_push_and_remote_artifacts(
-    tmp_path: Path,
-    archive_dir: Path,
-    make_config: MakeConfig,
-    flow: DaydreamRunFlow,
-    expected_pipeline: str,
-) -> None:
-    from daydream.archive import _flow_push_remote_steps
-
-    assert _flow_push_remote_steps(flow, None) == (False, False)
-    target = _frozen_target(tmp_path)
-    recorder = _MockRecorder(session_id="nonpublishing-session", run_flow=flow)
-    config = make_config(
-        target,
-        archive=True,
-        pr_repo="example/project",
-        pr_number=42,
-    )
-    _write_deep(target, "merged-items.json", {"items": []})
-    _write_push_verdict(target, session_id=recorder.session_id)
-    _write_remote_verdict(target, session_id=recorder.session_id)
-
-    _strict_archive(
-        target=target,
-        session_id=recorder.session_id,
-        run_flow=flow,
-        config=config,
-        write_snapshot=_write_snapshot(
-            recorder,
-            phase_events=(
-                _merge_events(recorder.session_id, "succeeded")
-                if flow is DaydreamRunFlow.TTT
-                else []
-            ),
-        ),
-    )
-
-    manifest = json.loads(
-        (archive_dir / "runs" / recorder.session_id / "manifest.json").read_text()
-    )
-    assert manifest["phase_states"]["push"] == {"ran": False, "status": "absent"}
-    assert manifest["phase_states"]["remote_ci"] == {
-        "ran": False,
-        "status": "absent",
-    }
-    assert manifest["pipeline_status"] == expected_pipeline
 
 
 def test_start_at_fix_archive_does_not_require_or_inherit_merge(
@@ -4128,6 +3874,9 @@ def test_start_at_fix_archive_does_not_require_or_inherit_merge(
         session_id=session_id,
         config=make_config(target, archive=True, start_at="fix"),
         write_snapshot=_write_snapshot(recorder, phase_events=[fix_start]),
+        identity=_manifest_identity(
+            phases=replace(_manifest_identity().phases, merge=False)
+        ),
     )
 
     manifest = json.loads(
@@ -4691,6 +4440,20 @@ def test_diagram_flow_does_not_inherit_a_prior_deep_run_pipeline_state(
         run_flow=DaydreamRunFlow.DIAGRAM,
         config=make_config(target, archive=True),
         write_snapshot=_write_snapshot(recorder),
+        identity=_manifest_identity(
+            fix_backend=None,
+            test_backend=None,
+            per_stack_review_backend=None,
+            per_stack_review_model=None,
+            phases=RunPhaseCapabilities(
+                per_stack_review=False,
+                merge=False,
+                fix=False,
+                test=False,
+                push=False,
+                remote_ci=False,
+            ),
+        ),
     )
 
     manifest_path = archive_dir / "runs" / recorder.session_id / "manifest.json"
@@ -4734,6 +4497,20 @@ def test_diagram_flow_does_not_evaluate_stale_review_artifacts(
         run_flow=DaydreamRunFlow.DIAGRAM,
         config=make_config(target, archive=True, run_eval=True),
         write_snapshot=_write_snapshot(recorder),
+        identity=_manifest_identity(
+            fix_backend=None,
+            test_backend=None,
+            per_stack_review_backend=None,
+            per_stack_review_model=None,
+            phases=RunPhaseCapabilities(
+                per_stack_review=False,
+                merge=False,
+                fix=False,
+                test=False,
+                push=False,
+                remote_ci=False,
+            ),
+        ),
     )
 
     run_dir = archive_dir / "runs" / recorder.session_id
@@ -4751,35 +4528,41 @@ def test_snapshot_manifest_pr_metadata_is_immutable_after_live_inputs_mutate(
         build_manifest_from_snapshot,
     )
 
-    recorder = _MockRecorder(pr_number=7, pr_repo="Owner/Repo")
-    snapshot = _write_snapshot(recorder)
+    session_id = "frozen-pr-session"
+    snapshot = _manifest_write_snapshot(
+        session_id=session_id,
+        extra={"pr_number": 7, "pr_repo": "Owner/Repo"},
+    )
     payload = json.loads(snapshot.documents[0].json_bytes)
     payload["extra"] = {"pr_number": 7, "pr_repo": "Owner/Repo"}
     document = TrajectoryDocumentSnapshot(
-        trajectory_id=recorder.session_id,
+        trajectory_id=session_id,
         path=snapshot.documents[0].path,
         json_bytes=json.dumps(payload).encode(),
     )
     snapshot = RunWriteSnapshot(
         status="complete",
         cutoff_at=snapshot.cutoff_at,
-        root_trajectory_id=recorder.session_id,
+        root_trajectory_id=session_id,
         documents=(document,),
     )
     provenance = archive_recorder_provenance_from_snapshot(
         write_snapshot=snapshot,
         run_flow=DaydreamRunFlow.NORMAL,
     )
-    recorder.pr_number = 99
-    recorder.pr_repo = "mutated/repo"
-    config = _MockConfig()
-    config.pr_number = 100  # type: ignore[attr-defined]
-    config.pr_repo = "also/mutated"  # type: ignore[attr-defined]
+    live_recorder = _MockRecorder(pr_number=7, pr_repo="Owner/Repo")
+    live_config = RunConfig(target=str(tmp_path), pr_number=7, pr_repo="Owner/Repo")
+    live_recorder.pr_number = 99
+    live_recorder.pr_repo = "mutated/repo"
+    live_config.pr_number = 100
+    live_config.pr_repo = "also/mutated"
 
     manifest = build_manifest_from_snapshot(
-        recorder_provenance=provenance,
-        write_snapshot=snapshot,
-        config=cast(Any, config),
+        run=ArchiveRunSnapshot(
+            recorder_provenance=provenance,
+            identity=_manifest_identity(),
+            trajectories=snapshot,
+        ),
         git_ctx=GitContext(),
         status="complete",
         archive_path=tmp_path,
@@ -4788,6 +4571,7 @@ def test_snapshot_manifest_pr_metadata_is_immutable_after_live_inputs_mutate(
     assert manifest.session_id == snapshot.root_trajectory_id
     assert manifest.pr_number == 7
     assert manifest.pr_repo == "Owner/Repo"
+    assert manifest.to_dict()["pr"] == {"number": 7, "repo": "Owner/Repo"}
 
 
 @pytest.mark.parametrize(
@@ -4868,7 +4652,6 @@ def test_strict_archive_evaluation_failure_is_typed_and_never_reports_success(
 ) -> None:
     """The host finalizer cannot infer success from the legacy fail-open wrapper."""
     from daydream.archive import ArchiveFinalizationError, finalize_archive_run
-    from daydream.archive.manifest import ArchiveRecorderProvenance
     from daydream.artifact_visibility import (
         ArtifactEvidenceProvenance,
         ArtifactTreeSnapshot,
@@ -4920,16 +4703,10 @@ def test_strict_archive_evaluation_failure_is_typed_and_never_reports_success(
 
     with pytest.raises(ArchiveFinalizationError, match="evaluation"):
         finalize_archive_run(
-            recorder_provenance=ArchiveRecorderProvenance(
-                session_id=session_id,
-                run_flow=DaydreamRunFlow.NORMAL,
-                pr_number=None,
-                pr_repo=None,
-            ),
+            run=_archive_snapshot(write_snapshot),
             artifacts=artifacts,
             artifact_provenance=artifact_provenance,
-            config=cast(Any, _MockConfig(run_eval=True)),
-            write_snapshot=write_snapshot,
+            config=RunConfig(target=str(tmp_path), run_eval=True),
             work=None,
             upload=False,
         )
@@ -4944,7 +4721,6 @@ def test_strict_archive_rejects_frozen_receipt_changed_by_evaluator(
 ) -> None:
     """A code-running consumer cannot make archive bytes and manifest disagree."""
     from daydream.archive import ArchiveFinalizationError, finalize_archive_run
-    from daydream.archive.manifest import ArchiveRecorderProvenance
     from daydream.artifact_visibility import (
         ArtifactEvidenceProvenance,
         ArtifactTreeSnapshot,
@@ -5007,12 +4783,7 @@ def test_strict_archive_rejects_frozen_receipt_changed_by_evaluator(
     )
 
     arguments: dict[str, Any] = dict(
-        recorder_provenance=ArchiveRecorderProvenance(
-            session_id,
-            DaydreamRunFlow.NORMAL,
-            None,
-            None,
-        ),
+        run=_archive_snapshot(snapshot),
         artifacts=artifacts,
         artifact_provenance=ArtifactEvidenceProvenance(
             "workspace",
@@ -5020,8 +4791,7 @@ def test_strict_archive_rejects_frozen_receipt_changed_by_evaluator(
             public_source,
             tmp_path / "live",
         ),
-        config=cast(Any, _MockConfig(run_eval=True)),
-        write_snapshot=snapshot,
+        config=RunConfig(target=str(tmp_path), run_eval=True),
         work=None,
         upload=False,
     )
@@ -5056,7 +4826,6 @@ def test_strict_archive_upload_refusal_removes_incomplete_local_success(
     discard a completed review without containing anything extra.
     """
     from daydream.archive import finalize_archive_run
-    from daydream.archive.manifest import ArchiveRecorderProvenance
     from daydream.artifact_visibility import (
         ArtifactEvidenceProvenance,
         ArtifactTreeSnapshot,
@@ -5093,15 +4862,12 @@ def test_strict_archive_upload_refusal_removes_incomplete_local_success(
     monkeypatch.setattr("daydream.archive.hub.upload_run_bundle", _refuse)
 
     finalize_archive_run(
-        recorder_provenance=ArchiveRecorderProvenance(
-            session_id, DaydreamRunFlow.NORMAL, None, None
-        ),
+        run=_archive_snapshot(snapshot),
         artifacts=ArtifactTreeSnapshot(session_id, "workspace", frozen, _manifest(frozen), ()),
         artifact_provenance=ArtifactEvidenceProvenance(
             "workspace", session_id, tmp_path / "source", tmp_path / "live"
         ),
-        config=cast(Any, _MockConfig(run_eval=False, archive=True)),
-        write_snapshot=snapshot,
+        config=RunConfig(target=str(tmp_path), run_eval=False, archive=True),
         work=None,
         upload=True,
     )
@@ -5119,7 +4885,6 @@ def test_strict_archive_upload_refuses_frozen_tree_mutated_before_publication(
 ) -> None:
     """A frozen tree mutated after finalization starts is caught before the external upload."""
     from daydream.archive import ArchiveFinalizationError, finalize_archive_run
-    from daydream.archive.manifest import ArchiveRecorderProvenance
     from daydream.artifact_visibility import (
         ArtifactEvidenceProvenance,
         ArtifactTreeSnapshot,
@@ -5162,15 +4927,12 @@ def test_strict_archive_upload_refuses_frozen_tree_mutated_before_publication(
 
     with pytest.raises(ArchiveFinalizationError, match="frozen artifact tree changed"):
         finalize_archive_run(
-            recorder_provenance=ArchiveRecorderProvenance(
-                session_id, DaydreamRunFlow.NORMAL, None, None
-            ),
+            run=_archive_snapshot(snapshot),
             artifacts=artifacts,
             artifact_provenance=ArtifactEvidenceProvenance(
                 "workspace", session_id, tmp_path / "source", tmp_path / "live"
             ),
-            config=cast(Any, _MockConfig(run_eval=False, archive=True)),
-            write_snapshot=snapshot,
+            config=RunConfig(target=str(tmp_path), run_eval=False, archive=True),
             work=None,
             upload=True,
         )
@@ -5185,7 +4947,6 @@ def test_strict_archive_dump_scan_refusal_leaves_late_stage_empty(
 ) -> None:
     """A refused secret scan publishes neither an archive nor dump bytes."""
     from daydream.archive import ArchiveFinalizationError, finalize_archive_run
-    from daydream.archive.manifest import ArchiveRecorderProvenance
     from daydream.artifact_visibility import (
         ArtifactEvidenceProvenance,
         ArtifactTreeSnapshot,
@@ -5234,20 +4995,16 @@ def test_strict_archive_dump_scan_refusal_leaves_late_stage_empty(
 
     with pytest.raises(ArchiveFinalizationError, match="secret scan"):
         finalize_archive_run(
-            recorder_provenance=ArchiveRecorderProvenance(
-                session_id, DaydreamRunFlow.NORMAL, None, None
-            ),
+            run=_archive_snapshot(snapshot),
             artifacts=ArtifactTreeSnapshot(
                 session_id, "workspace", frozen, _manifest(frozen), ()
             ),
             artifact_provenance=ArtifactEvidenceProvenance(
                 "workspace", session_id, tmp_path / "source", tmp_path / "live"
             ),
-            config=cast(
-                Any,
-                _MockConfig(run_eval=False, archive=True, dump_artifacts="requested"),
+            config=RunConfig(
+                target=str(tmp_path), run_eval=False, archive=True, dump_artifacts="requested"
             ),
-            write_snapshot=snapshot,
             work=None,
             upload=False,
             dump_path=dump_stage,

--- a/tests/test_archive_data_capture.py
+++ b/tests/test_archive_data_capture.py
@@ -327,6 +327,10 @@ async def test_mixed_case_pr_identity_reaches_remote_ci_and_archives_success(
 
     run_dir = _only_archived_run(archive_dir)
     manifest = json.loads((run_dir / "manifest.json").read_text())
+    assert manifest["pr"] == {
+        "number": no_ci_remote.pr_number,
+        "repo": "bAsE-uSeR/pRoJeCt",
+    }
     assert manifest["phase_states"]["push"]["status"] == "succeeded"
     assert manifest["phase_states"]["remote_ci"]["status"] == "succeeded"
     assert manifest["pipeline_status"] == "succeeded"

--- a/tests/test_archive_integration.py
+++ b/tests/test_archive_integration.py
@@ -18,6 +18,11 @@ import pytest
 
 from daydream.atif import Step
 from daydream.backends import AgentEvent
+from daydream.run_snapshot import (
+    ArchiveRunSnapshot,
+    ManifestRunIdentity,
+    RunPhaseCapabilities,
+)
 from daydream.trajectory import (
     DaydreamPhase,
     DaydreamRunFlow,
@@ -162,8 +167,33 @@ def _finalize_strict_archive(
 
     session_id = recorder.session_id
     finalize_archive_run(
-        recorder_provenance=archive_recorder_provenance_from_snapshot(
-            write_snapshot=snapshot, run_flow=recorder.run_flow,
+        run=ArchiveRunSnapshot(
+            recorder_provenance=archive_recorder_provenance_from_snapshot(
+                write_snapshot=snapshot, run_flow=recorder.run_flow,
+            ),
+            identity=ManifestRunIdentity(
+                flow_name=None,
+                skill="python",
+                model=None,
+                backend="claude",
+                review_backend=None,
+                fix_backend="claude" if recorder.run_flow is DaydreamRunFlow.NORMAL else None,
+                test_backend="claude" if recorder.run_flow is DaydreamRunFlow.NORMAL else None,
+                per_stack_review_backend=None,
+                per_stack_review_model=None,
+                review_only=False,
+                deep=recorder.run_flow is DaydreamRunFlow.NORMAL,
+                profile=None,
+                phases=RunPhaseCapabilities(
+                    per_stack_review=False,
+                    merge=recorder.run_flow is DaydreamRunFlow.NORMAL,
+                    fix=recorder.run_flow is DaydreamRunFlow.NORMAL,
+                    test=recorder.run_flow is DaydreamRunFlow.NORMAL,
+                    push=False,
+                    remote_ci=False,
+                ),
+            ),
+            trajectories=snapshot,
         ),
         artifacts=ArtifactTreeSnapshot(
             session_id=session_id,
@@ -181,7 +211,6 @@ def _finalize_strict_archive(
             live_root=target,
         ),
         config=config,
-        write_snapshot=snapshot,
         work=None,
         upload=upload,
         dump_path=dump_path,

--- a/tests/test_manifest_run_identity.py
+++ b/tests/test_manifest_run_identity.py
@@ -1,0 +1,273 @@
+"""Captured manifest identity exercised through the real runner and archive."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import AsyncGenerator, Callable
+from dataclasses import FrozenInstanceError
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from daydream import git_ops, runner
+from daydream.backends import AgentEvent, BackendExecutionInput, MetricsEvent, ResultEvent, TextEvent
+from daydream.backends.pi import PiBackend
+from daydream.config import DEFAULT_PI_MODEL
+from daydream.config_file import DaydreamFileConfig
+from daydream.github_app import GitHubExecutionInput
+from daydream.review_profile import ProfileError
+from daydream.run_snapshot import ManifestRunIdentity
+from tests.conftest import ExtDir
+from tests.harness.backend import ScriptedBackend
+from tests.harness.fake_gh import FakeGh
+
+
+def _install_probe(ext_dir: ExtDir) -> None:
+    """A real extension runs two model calls, then changes the live registry."""
+    ext_dir.write_module(
+        "from daydream.agent import run_agent\n"
+        "from daydream.extensions import FlowStep\n"
+        "from daydream.trajectory import DaydreamPhase, get_current_recorder\n"
+        "async def probe(ctx):\n"
+        "    backend = ctx.backend_for('per_stack_review')\n"
+        "    recorder = get_current_recorder()\n"
+        "    assert recorder is not None\n"
+        "    for name in ('first', 'second'):\n"
+        "        async with recorder.fork(name):\n"
+        "            await run_agent(backend, ctx.work.repo, name,\n"
+        "                phase=DaydreamPhase.REVIEW, run_context=ctx.run_context)\n"
+        "    ctx.registry.set_flow('deep', ['fix', 'test', 'commit', 'remote-ci'])\n"
+        "def register(registry):\n"
+        "    registry.register_phase(FlowStep(name='manifest-probe', run=probe))\n"
+        "    registry.set_flow('deep', ['manifest-probe'])\n"
+        "    registry.set_flow('manifest-probe', ['manifest-probe'])\n"
+    )
+
+
+def _events(model: str, prompt: str) -> list[AgentEvent]:
+    return [
+        TextEvent(text="Reviewed the supplied diff."),
+        MetricsEvent(
+            message_id=prompt, prompt_tokens=30, completion_tokens=7,
+            cached_tokens=5, cost_usd=0.125, model_name=model,
+        ),
+        ResultEvent(structured_output=None, continuation=None, model_name=model),
+    ]
+
+
+class _MutatingBackend(ScriptedBackend):
+    def __init__(self, model: str, mutate: Callable[[], None]) -> None:
+        super().__init__(model=model)
+        self.mutate = mutate
+
+    async def execute(
+        self, cwd: Path, prompt: str, *args: Any, **kwargs: Any,
+    ) -> AsyncGenerator[AgentEvent, None]:
+        self.mutate()
+        for event in _events(self.model, prompt):
+            yield event
+
+
+def _manifest(archive_dir: Path) -> tuple[dict[str, Any], Path]:
+    paths = list((archive_dir / "runs").glob("*/manifest.json"))
+    assert len(paths) == 1
+    return json.loads(paths[0].read_bytes()), paths[0].parent
+
+
+@pytest.mark.parametrize("cli_override", [False, True], ids=["file-phase", "cli-global"])
+async def test_runner_archives_identity_before_model_mutates_live_policy(
+    cli_override: bool,
+    multi_stack_target: Path,
+    archive_dir: Path,
+    ext_dir: ExtDir,
+    fake_gh: FakeGh,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_probe(ext_dir)
+    monkeypatch.delenv("DAYDREAM_TRAJECTORY_HUB_REPO", raising=False)
+    config = runner.RunConfig(
+        target=str(multi_stack_target), base="main", cleanup=False,
+        non_interactive=True, archive=True, run_eval=False,
+        backend="codex" if cli_override else None,
+        model="cli-model" if cli_override else None,
+        pr_number=7, pr_repo="Owner/Repo",
+        file_config=DaydreamFileConfig(
+            backend="claude", model="file-global-model",
+            phases={
+                "review": {"backend": "pi"},
+                "per_stack_review": {"backend": "pi", "model": "file-phase-model"},
+            },
+        ),
+    )
+    expected_backend = "codex" if cli_override else "pi"
+    expected_model = "cli-model" if cli_override else "file-phase-model"
+    observed_profile: dict[str, Any] = {}
+    calls: list[tuple[str, str | None]] = []
+    captured: list[ManifestRunIdentity] = []
+    capture_identity = runner.capture_manifest_run_identity
+
+    def observe_capture(*args: Any, **kwargs: Any) -> ManifestRunIdentity:
+        identity = capture_identity(*args, **kwargs)
+        captured.append(identity)
+        return identity
+
+    monkeypatch.setattr(runner, "capture_manifest_run_identity", observe_capture)
+
+    def mutate() -> None:
+        if observed_profile:
+            return
+        assert len(captured) == 1
+        profile = config.review_profile
+        assert profile is not None
+        observed_profile.update(
+            profile_schema_version=profile.profile.schema_version,
+            profile_name=profile.name,
+            profile_source_kind=profile.source_kind,
+            profile_digest=profile.digest,
+        )
+        config.backend = "claude"
+        config.model = "changed-after-model-start"
+        config.stack = "changed-skill"
+        config.shallow = True
+        config.output_mode = "review"
+        config.review_profile = None
+        config.pr_number = 99
+        config.pr_repo = "Changed/Repo"
+        config.file_config = DaydreamFileConfig()
+
+    def create_backend(name: str, model: str | None = None, **kwargs: Any) -> _MutatingBackend:
+        calls.append((name, model))
+        assert (name, model) == (expected_backend, expected_model)
+        return _MutatingBackend(expected_model, mutate)
+
+    monkeypatch.setattr(runner, "create_backend", create_backend)
+    assert await runner.run(config) == 0
+    assert calls == [(expected_backend, expected_model)]
+    assert len(captured) == 1
+    identity = captured[0]
+    assert identity.per_stack_review_model == expected_model
+    assert identity.phases.fix is False
+    assert identity.profile is not None
+    for value, field, replacement in (
+        (identity, "backend", "changed"),
+        (identity.phases, "fix", True),
+        (identity.profile, "name", "changed"),
+    ):
+        with pytest.raises(FrozenInstanceError):
+            setattr(value, field, replacement)
+    manifest, archived_run = _manifest(archive_dir)
+    assert manifest["run"] == {
+        "flow": "deep", "skill": None, "model": None,
+        "backend": "codex" if cli_override else "claude",
+        "review_backend": "pi", "per_stack_review_backend": expected_backend,
+        "per_stack_review_model": expected_model, "review_only": False, "deep": True,
+    }
+    for key, value in observed_profile.items():
+        assert manifest[key] == value
+    assert manifest["pr"] == {"number": 7, "repo": "Owner/Repo"}
+    for phase in ("fix", "test", "push", "remote_ci"):
+        assert manifest["phase_states"][phase]["ran"] is False
+    assert manifest["metrics"]["total_prompt_tokens"] == 60
+    assert manifest["metrics"]["total_completion_tokens"] == 14
+    assert manifest["metrics"]["total_cached_tokens"] == 10
+    assert manifest["metrics"]["total_cost_usd"] == 0.25
+    trajectories = [json.loads(path.read_bytes()) for path in archived_run.rglob("*.json")
+                    if path.name != "manifest.json"]
+    roots = [document for document in trajectories
+             if document.get("trajectory_id") == manifest["session_id"]]
+    assert len(roots) == 1
+    assert roots[0]["extra"]["pr_number"] == 7
+    assert roots[0]["extra"]["pr_repo"] == "Owner/Repo"
+    forks = [document for document in trajectories
+             if document.get("trajectory_id") and document.get("trajectory_id") != manifest["session_id"]]
+    assert len(forks) == 2
+
+
+@pytest.mark.parametrize("owned_agent_dir", [True, False], ids=["owned-settings", "no-owned-home"])
+async def test_runner_captures_pi_default_from_owned_execution_before_settings_change(
+    owned_agent_dir: bool,
+    multi_stack_target: Path,
+    tmp_path: Path,
+    archive_dir: Path,
+    ext_dir: ExtDir,
+    fake_gh: FakeGh,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_probe(ext_dir)
+    monkeypatch.delenv("DAYDREAM_TRAJECTORY_HUB_REPO", raising=False)
+    ambient = tmp_path / "ambient-pi"
+    ambient.mkdir()
+    ambient_settings = ambient / "settings.json"
+    ambient_settings.write_text(json.dumps({"defaultModel": "ambient-model"}))
+    monkeypatch.setenv("PI_CODING_AGENT_DIR", str(ambient))
+    owned = tmp_path / "owned-pi"
+    owned.mkdir()
+    owned_settings = owned / "settings.json"
+    owned_settings.write_text(json.dumps({"defaultModel": "owned-model"}))
+    environment = {"PI_CODING_AGENT_DIR": str(owned)} if owned_agent_dir else {}
+    backend_input = BackendExecutionInput.from_environment(environment, backend="pi")
+    execution = runner.RunnerExecutionInput(
+        backend_input, GitHubExecutionInput(git_ops.StaticGitHubAuth({})),
+    )
+    expected_model = "owned-model" if owned_agent_dir else DEFAULT_PI_MODEL
+    observed_models: list[str] = []
+
+    async def execute(
+        self: PiBackend, cwd: Path, prompt: str, *args: Any, **kwargs: Any,
+    ) -> AsyncGenerator[AgentEvent, None]:
+        observed_models.append(self.model)
+        owned_settings.write_text(json.dumps({"defaultModel": "changed-owned-model"}))
+        ambient_settings.write_text(json.dumps({"defaultModel": "changed-ambient-model"}))
+        for event in _events(self.model, prompt):
+            yield event
+
+    monkeypatch.setattr(PiBackend, "execute", execute)
+    assert await runner.run(
+        runner.RunConfig(
+            target=str(multi_stack_target), base="main", backend="pi",
+            cleanup=False, non_interactive=True, archive=True, run_eval=False,
+            file_config=DaydreamFileConfig(),
+        ),
+        execution=execution,
+    ) == 0
+    assert observed_models == [expected_model, expected_model]
+    manifest, _ = _manifest(archive_dir)
+    assert manifest["run"]["per_stack_review_backend"] == "pi"
+    assert manifest["run"]["per_stack_review_model"] == expected_model
+
+
+@pytest.mark.parametrize("flow", ["improve", "manifest-probe"], ids=["improve", "custom"])
+async def test_runner_rejects_invalid_profile_before_recorder_or_backend(
+    flow: str,
+    multi_stack_target: Path,
+    tmp_path: Path,
+    archive_dir: Path,
+    ext_dir: ExtDir,
+    fake_gh: FakeGh,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Invalid policy has no run identity and must not publish an empty run."""
+    _install_probe(ext_dir)
+    bad_profile = tmp_path / "invalid-profile.toml"
+    bad_profile.write_text('schema_version = 1\nname = "invalid"\nunknown = true\n')
+    backend_calls: list[str] = []
+
+    def unexpected_backend(name: str, **kwargs: Any) -> Any:
+        backend_calls.append(name)
+        raise AssertionError("invalid profile must fail before backend construction")
+
+    monkeypatch.setattr(runner, "create_backend", unexpected_backend)
+    archives_before = set((archive_dir / "runs").glob("*/manifest.json"))
+    trajectory_path = tmp_path / "invalid-profile-trajectory.json"
+    with pytest.raises(ProfileError, match="invalid review profile") as failure:
+        await runner.run(runner.RunConfig(
+            target=str(multi_stack_target), base="main", flow_name=flow,
+            cleanup=False, non_interactive=True, archive=True, run_eval=False,
+            file_config=DaydreamFileConfig(), review_profile_path=bad_profile,
+            trajectory_path=trajectory_path,
+        ))
+    assert str(bad_profile) in str(failure.value)
+    assert not backend_calls
+    assert not trajectory_path.exists()
+    assert set((archive_dir / "runs").glob("*/manifest.json")) == archives_before

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -39,7 +39,8 @@ from daydream.extensions.loader import build_registry
 from daydream.flows.engine import BackendFactory, FlowContext
 from daydream.github_app import GitHubExecutionInput
 from daydream.run_context import RunContext, current_run_context
-from daydream.runner import RunConfig
+from daydream.run_snapshot import ArchiveRunSnapshot
+from daydream.runner import RunConfig, capture_manifest_run_identity
 from daydream.trajectory import (
     DaydreamRunFlow,
     RunWriteSnapshot,
@@ -2501,11 +2502,13 @@ def _build_manifest(config: RunConfig, flow: DaydreamRunFlow, tmp_path: Path) ->
     """Build a manifest for ``config``/``flow`` from one real frozen snapshot."""
     snapshot = _capture_snapshot(tmp_path, "complete")
     return build_manifest_from_snapshot(
-        recorder_provenance=archive_recorder_provenance_from_snapshot(
-            write_snapshot=snapshot, run_flow=flow
+        run=ArchiveRunSnapshot(
+            recorder_provenance=archive_recorder_provenance_from_snapshot(
+                write_snapshot=snapshot, run_flow=flow
+            ),
+            identity=capture_manifest_run_identity(config, flow, build_registry(), tmp_path),
+            trajectories=snapshot,
         ),
-        write_snapshot=snapshot,
-        config=config,
         git_ctx=GitContext(),
         status="complete",
         archive_path=tmp_path,
@@ -2607,6 +2610,139 @@ def test_manifest_backend_falls_back_to_claude(tmp_path: Path) -> None:
     assert m.review_backend is None
     assert m.fix_backend == "claude"
     assert m.test_backend == "claude"
+
+
+@pytest.mark.parametrize("flow", list(DaydreamRunFlow))
+def test_manifest_identity_preserves_mode_capabilities(tmp_path: Path, flow: DaydreamRunFlow) -> None:
+    identity = capture_manifest_run_identity(
+        RunConfig(fix_backend="codex", test_backend="pi"), flow, build_registry(), tmp_path,
+    )
+    runs_fix = flow in (DaydreamRunFlow.NORMAL, DaydreamRunFlow.DEEP, DaydreamRunFlow.PR)
+    runs_test = flow in (DaydreamRunFlow.NORMAL, DaydreamRunFlow.DEEP)
+    assert identity.fix_backend == ("codex" if runs_fix else None)
+    assert identity.test_backend == ("pi" if runs_test else None)
+    assert identity.phases.fix is runs_fix
+    assert identity.phases.test is runs_test
+    assert identity.phases.merge is (flow in (DaydreamRunFlow.NORMAL, DaydreamRunFlow.DEEP, DaydreamRunFlow.TTT))
+    assert identity.phases.push is runs_test
+    assert identity.phases.remote_ci is runs_test
+
+
+@pytest.mark.parametrize(
+    ("flow", "flow_name", "registered_name", "steps", "fix", "test", "merge", "push", "remote_ci"),
+    [
+        (DaydreamRunFlow.CUSTOM, "fork", "fork", ["fix", "test", "commit"], True, True, False, True, False),
+        (DaydreamRunFlow.CUSTOM, "fork", "fork", ["exploration", "intent"], False, False, False, False, False),
+        (DaydreamRunFlow.CUSTOM, "fork", "fork", ["custom-merge", "remote-ci"], False, False, True, False, True),
+        (DaydreamRunFlow.DEEP, None, "deep", ["exploration", "intent"], False, False, True, False, False),
+        (DaydreamRunFlow.NORMAL, None, "deep", ["exploration", "intent"], False, False, True, False, False),
+        (
+            DaydreamRunFlow.IMPROVE, "improve", "improve", ["fix", "test", "commit", "remote-ci"],
+            True, True, False, True, True,
+        ),
+        (DaydreamRunFlow.DIAGRAM, "diagram", "diagram", ["fix", "test"], True, True, False, False, False),
+        (DaydreamRunFlow.CUSTOM, "unknown", "fork", ["fix", "test"], False, False, False, False, False),
+    ],
+)
+def test_manifest_identity_uses_registered_pipeline(
+    tmp_path: Path, flow: DaydreamRunFlow, flow_name: str | None, registered_name: str,
+    steps: list[str], fix: bool, test: bool, merge: bool, push: bool, remote_ci: bool,
+) -> None:
+    registry = build_registry()
+    registry.set_flow(registered_name, steps)
+    config = RunConfig(flow_name=flow_name, fix_backend="codex", test_backend="pi")
+    identity = capture_manifest_run_identity(config, flow, registry, tmp_path)
+    registry.set_flow(registered_name, [])
+    assert (identity.phases.fix, identity.phases.test, identity.phases.merge) == (fix, test, merge)
+    assert (identity.phases.push, identity.phases.remote_ci) == (push, remote_ci)
+    assert identity.fix_backend == ("codex" if fix else None)
+    assert identity.test_backend == ("pi" if test else None)
+
+
+@pytest.mark.parametrize("flow_name", [None, *runner._DEEP_FLOW_ALIASES])
+@pytest.mark.parametrize("shallow", [False, True])
+def test_manifest_identity_uses_per_stack_tier_for_deep_aliases(
+    tmp_path: Path, flow_name: str | None, shallow: bool,
+) -> None:
+    from daydream.config_file import DaydreamFileConfig
+
+    config = RunConfig(
+        flow_name=flow_name, shallow=shallow, review_backend="claude",
+        file_config=DaydreamFileConfig(phases={"per_stack_review": {"backend": "codex", "model": "gpt-psr"}}),
+    )
+    identity = capture_manifest_run_identity(config, DaydreamRunFlow.DEEP, build_registry(), tmp_path)
+    assert identity.per_stack_review_backend == "codex"
+    assert identity.per_stack_review_model == "gpt-psr"
+    assert identity.review_backend == "claude"
+    assert identity.phases.per_stack_review
+    assert identity.deep is not shallow
+
+
+@pytest.mark.parametrize(
+    ("flow", "flow_name", "start_at"),
+    [
+        (DaydreamRunFlow.IMPROVE, "improve", "review"),
+        (DaydreamRunFlow.CUSTOM, "custom-flow", "review"),
+        (DaydreamRunFlow.DIAGRAM, None, "review"),
+        (DaydreamRunFlow.DEEP, "deep", "merge"),
+        (DaydreamRunFlow.DEEP, "deep", "fix"),
+    ],
+)
+def test_manifest_identity_omits_review_tier_without_review_spine(
+    tmp_path: Path, flow: DaydreamRunFlow, flow_name: str | None, start_at: str,
+) -> None:
+    identity = capture_manifest_run_identity(
+        RunConfig(flow_name=flow_name, start_at=start_at), flow, build_registry(), tmp_path,
+    )
+    assert not identity.phases.per_stack_review
+    assert identity.per_stack_review_backend is None
+    assert identity.per_stack_review_model is None
+    if start_at == "fix":
+        assert not identity.phases.merge
+
+
+@pytest.mark.parametrize(
+    ("backend", "review_backend", "file_backend", "file_review", "expected_backend", "expected_review"),
+    [
+        ("claude", "codex", None, None, "claude", "codex"),
+        ("codex", None, None, None, "codex", None),
+        (None, None, "pi", None, "pi", None),
+        ("claude", None, "pi", "codex", "claude", "codex"),
+    ],
+)
+def test_manifest_identity_separates_general_backend_and_review_override(
+    tmp_path: Path, backend: str | None, review_backend: str | None, file_backend: str | None,
+    file_review: str | None, expected_backend: str, expected_review: str | None,
+) -> None:
+    from daydream.config_file import DaydreamFileConfig
+
+    config = RunConfig(
+        backend=backend, review_backend=review_backend,
+        file_config=DaydreamFileConfig(
+            backend=file_backend, phases={} if file_review is None else {"review": {"backend": file_review}},
+        ),
+    )
+    identity = capture_manifest_run_identity(config, DaydreamRunFlow.DEEP, build_registry(), tmp_path)
+    assert identity.backend == expected_backend
+    assert identity.review_backend == expected_review
+
+
+@pytest.mark.parametrize("configured", [False, True])
+def test_manifest_identity_captures_pi_working_directory_default(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, configured: bool,
+) -> None:
+    from daydream.config import DEFAULT_PI_MODEL
+
+    monkeypatch.setenv("PI_CODING_AGENT_DIR", str(tmp_path / "empty-global"))
+    if configured:
+        settings = tmp_path / ".pi" / "settings.json"
+        settings.parent.mkdir()
+        settings.write_text(json.dumps({"defaultModel": "configured-reviewer"}))
+    identity = capture_manifest_run_identity(
+        RunConfig(backend="pi"), DaydreamRunFlow.DEEP, build_registry(), tmp_path,
+    )
+    assert identity.per_stack_review_backend == "pi"
+    assert identity.per_stack_review_model == ("configured-reviewer" if configured else DEFAULT_PI_MODEL)
 
 
 async def test_overlapping_posting_runs_keep_their_own_github_auth(


### PR DESCRIPTION
## Summary

Captures manifest identity and phase capabilities before recorder entry, then archives that immutable identity together with the existing frozen trajectory snapshot. Manifest construction no longer reads mutable run config, resolves backends, consults the registry, or probes Pi settings during finalization.

## Motivation

Config or registry changes during a run could relabel its archive. The runner now owns identity resolution once; archive assembly preserves the current JSON schema, frozen PR provenance, metric reducers, and strict publication/rollback order.

Closes #1014.

## Test Plan

- Required archive/runner suites plus identity and profile regressions: 436 passed. Real runner journeys cover CLI/file precedence, profile/registry mutation, exact PR projection, fork totals, and supplied Pi settings.
- `make check`: 8,201 passed, 15 skipped; 88.76% coverage. Lock validation, Ruff, root/RL dead-code scans, 546-file mypy, and Docker workflow lint passed.
- The existing provenance validator and `Manifest.to_dict()` are AST-identical to the base; manifest schema remains 1.0.
- `daydream . --precision --non-interactive --backend codex` completed on signed commit `73132351a05c933886332fc09ce6c3cd3900d633`, with 10/10 changed files read. All three code-review reports are clean. Four consolidated items represent two runtime proposals, adjudicated as described below; no actionable findings remain. Review session: `7fdc6c12-ad0b-4cb0-995a-bc33ae929f57`.

## Checklist

- [x] Focused implementation and documentation changes
- [x] Required local checks passed
- [x] Existing manifest schema and strict archive guarantees retained
- [x] Final Daydream review findings adjudicated

## Additional Context

Improve/custom invalid profiles now fail before recorder entry, matching deep's validation timing; they no longer produce an empty failed trajectory. Successful and cancelled runs retain the existing snapshot and finalization paths.

The reviewed alternatives proposed normalizing legacy deep-flow capability labels and freezing Pi execution settings. This refactor preserves the existing mode/alias/resume rules and native Pi model/provider behavior. Captured identity records policy at capture time; it does not lock settings files against later edits. Passing a captured Pi default as an explicit model would change native provider/model selection, while eager construction alone would not prevent native settings rereads.

The standalone RL project is unchanged; full `rl-check` remains a CI gate. Optional review diagram generation exceeded its sanctioned-input byte budget; all code-review phases completed successfully.
