### PR TITLE
refactor(training): separate harvest evidence from annotation reduction

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,6 +114,7 @@ deep FlowSteps -> phases.py -> agent.py -> Backend.execute()
 | `reconcile.py` | Cross-run dedup vs prior bot PR comments (GitHub is the store) |
 | `pr_comment_renderer.py` | Pure renderer: trajectory in, markdown out (no I/O) |
 | `training/` vs `eval/` | Corpus pipeline (harvest, reward, projection, JSONL) vs deterministic trajectory analysis |
+| `training/harvest.py`, `training/harvest_types.py` | Explicit per-run evidence services and validated immutable inputs; `build_annotation(row, evidence)` reduces completed evidence without I/O |
 | `training/calibration.py` | Fail-closed corpus-v2 validation, deterministic calibration statistics, `calibration-artifact-v1` emission (`corpus calibrate-reward`) |
 | `prompts/` | Authorial intent, exploration subagents, CWD grounding |
 

--- a/daydream/cli.py
+++ b/daydream/cli.py
@@ -39,10 +39,10 @@ top-level ``TARGET`` positional):
 """
 
 import argparse
-import inspect
 import signal
 import sys
 from collections.abc import Callable
+from functools import partial
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, NoReturn
 
@@ -1427,10 +1427,8 @@ def _build_harvest_parser() -> argparse.ArgumentParser:
 def _handle_harvest_command(argv: list[str]) -> int:
     """Handle ``daydream corpus harvest [...]``.
 
-    Drives :func:`daydream.training.harvest.run_harvest` (looked up via the
-    module attribute so test monkeypatches take effect). ``run_harvest`` is a
-    coroutine in production, so it is driven through :func:`anyio.run`; a
-    synchronous test double that returns a summary directly is used as-is.
+    Composes the harvest services and drives
+    :func:`daydream.training.harvest.run_harvest` through :func:`anyio.run`.
     Returns an exit code; ``main`` translates it to a process exit. An
     aborted summary (``aborted >= 1``) or any per-row harvest errors
     (``errors > 0``) exits ``1``; a clean partial completion with unresolved
@@ -1466,15 +1464,8 @@ def _handle_harvest_command(argv: list[str]) -> int:
         session_filter=args.session,
         gh_request_spacing_sec=args.gh_spacing_sec,
     )
-    run_harvest = _harvest.run_harvest
-    summary: dict[str, int]
-    if inspect.iscoroutinefunction(run_harvest):
-        summary = anyio.run(run_harvest, config)
-    else:
-        # A synchronous test double (monkeypatched stub) is driven directly —
-        # anyio.run rejects non-coroutine callables. Production run_harvest is
-        # always async, so mypy only sees the coroutine type here.
-        summary = run_harvest(config)  # type: ignore[assignment]
+    services = _harvest.make_harvest_services(config)
+    summary = anyio.run(partial(_harvest.run_harvest, services=services), config)
     print_info(console, str(summary))
     if summary.get("aborted", 0) >= 1 or summary.get("errors", 0) > 0:
         return 1

--- a/daydream/training/_immutable_json.py
+++ b/daydream/training/_immutable_json.py
@@ -1,0 +1,27 @@
+"""Owned immutable JSON values with canonical dict/list serialization."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from types import MappingProxyType
+from typing import Any
+
+
+def freeze_json(value: Any) -> Any:
+    """Copy JSON containers into immutable mappings and tuples recursively."""
+    if isinstance(value, Mapping):
+        return MappingProxyType({key: freeze_json(child) for key, child in value.items()})
+    if isinstance(value, (list, tuple)):
+        return tuple(freeze_json(child) for child in value)
+    if value is None or isinstance(value, (str, bool, int, float)):
+        return value
+    raise TypeError(f"unsupported JSON value: {type(value).__name__}")
+
+
+def thaw_json(value: Any) -> Any:
+    """Copy immutable JSON containers back to ordinary dictionaries and lists."""
+    if isinstance(value, Mapping):
+        return {key: thaw_json(child) for key, child in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [thaw_json(child) for child in value]
+    return value

--- a/daydream/training/adjudication/snapshot.py
+++ b/daydream/training/adjudication/snapshot.py
@@ -13,6 +13,7 @@ import json
 from collections.abc import Mapping, Sequence
 from typing import Any
 
+from daydream.training._immutable_json import thaw_json
 from daydream.training.corpus_v2.identity import record_id
 from daydream.training.corpus_v2.provenance import extract_provenance
 from daydream.training.labeler_versions import (
@@ -47,7 +48,7 @@ _PIN_FIELDS = (
 
 
 def record_evidence_digest(
-    per_finding_evidence_lists: Sequence[Sequence[dict[str, Any]]],
+    per_finding_evidence_lists: Sequence[Sequence[Mapping[str, Any]]],
 ) -> str | None:
     """Digest over the session's flattened per-finding reply evidence.
 
@@ -58,7 +59,7 @@ def record_evidence_digest(
     so a digest-less row never collides with a digested one under the
     versioned dedup key.
     """
-    evidence = [entry for per_finding in per_finding_evidence_lists for entry in per_finding]
+    evidence = [thaw_json(entry) for per_finding in per_finding_evidence_lists for entry in per_finding]
     return reply_evidence_digest(evidence) if evidence else None
 
 
@@ -100,7 +101,7 @@ def build_canonical_record(
         "record_id": record_id(session_id, trajectory_id, segment_id, fingerprint),
         "fingerprint": fingerprint,
         "disposition": resolution.disposition,
-        "evidence": list(resolution.evidence),
+        "evidence": [thaw_json(entry) for entry in resolution.evidence],
         "evidence_digest": evidence_digest,
         "session_id": session_id,
         "trajectory_id": trajectory_id,

--- a/daydream/training/backfill.py
+++ b/daydream/training/backfill.py
@@ -14,7 +14,7 @@ Failure policy:
 
 * A *benign* PR absence (fork/deleted PR 404, unpushed-SHA 422, detected via
   :func:`~daydream.training.harvest._is_benign_pr_absence`) degrades inside
-  ``build_annotation`` to a local-branch rubric whose outcome is ``unknown``;
+  ``acquire_harvest_evidence`` to a local-branch rubric whose outcome is ``unknown``;
   the backfill stores that as the empty label list (harvest's serialization)
   — fail closed, never decisive (M19/M22), and byte-identical to the harvest
   writer so the M14 auto-dedup tuple matches between the two writers.
@@ -43,17 +43,18 @@ from rich.console import Console
 from daydream.archive.index import (
     append_label_observation,
     latest_label_observation,
-    query_runs,
 )
 from daydream.git_ops import GitError, RateLimitError
 from daydream.training import labeler_versions
 from daydream.training.harvest import (
-    _gh_api,
+    HarvestConfig,
+    HarvestServices,
     _is_benign_pr_absence,
-    _materialize_base_sha_if_missing,
-    _resolve_repo_for_row,
+    acquire_harvest_evidence,
     build_annotation,
+    make_harvest_services,
 )
+from daydream.training.harvest_types import HarvestRow
 from daydream.training.reply_classifier import (
     _ACCEPT_RULES,
     _DAYDREAM_AGENT_LOGINS,
@@ -137,6 +138,7 @@ def run_backfill(
     session_filter: str | None = None,
     report_path: Path | None = None,
     valid_at_override: str | None = None,
+    services: HarvestServices | None = None,
 ) -> dict[str, Any]:
     """Re-annotate every PR-linked indexed run and append a fresh generation.
 
@@ -153,6 +155,11 @@ def run_backfill(
             raises after observations are committed.
         valid_at_override: Explicit valid-time passed through to the
             annotation builder, beating the derived decisive-evidence stamp.
+        services: Per-run acquisition adapters; omission uses the production
+            archive, GitHub, and git adapters without a harvest cache. The
+            service and requested archive must resolve to the same directory.
+            Latest-label reads, observation writes, and reporting remain owned
+            by backfill; its writes do not use the provider's append override.
 
     Returns:
         Summary dict with ``sessions_reprocessed`` (PR-linked rows walked),
@@ -163,20 +170,16 @@ def run_backfill(
         msg = f"archive_dir does not exist: {archive_dir}"
         raise FileNotFoundError(msg)
 
-    if session_filter:
-        queue = query_runs(
-            archive_dir,
-            "session_id LIKE ? || '%'",
-            (session_filter,),
+    if services is None:
+        services = make_harvest_services(HarvestConfig(archive_dir=archive_dir))
+    requested_archive = archive_dir.resolve()
+    services_archive = services.archive_dir.resolve()
+    if requested_archive != services_archive:
+        raise ValueError(
+            f"backfill archive ownership mismatch: requested {requested_archive}, services {services_archive}"
         )
-    else:
-        queue = query_runs(archive_dir)
-    # Pinned session order for determinism (M18): identical archives must
-    # produce identical report and append orderings.
-    queue = sorted(queue, key=lambda row: row["session_id"])
-
     console: Console = create_console()
-    recording_gh = _RecordingGH(_gh_api)
+    recording_gh = _RecordingGH(services.github)
 
     summary: dict[str, Any] = {
         "sessions_reprocessed": 0,
@@ -186,39 +189,44 @@ def run_backfill(
         "errors": 0,
         "aborted": 0,
     }
+    queue: list[HarvestRow] = []
+    for row_number, raw in enumerate(services.query_rows(session_filter), start=1):
+        try:
+            queue.append(HarvestRow.from_mapping(raw, row_number=row_number))
+        except ValueError as exc:
+            summary["errors"] += 1
+            print_warning(console, f"backfill: {exc}")
+    # Pinned session order for determinism (M18): identical archives must
+    # produce identical report and append orderings.
+    queue.sort(key=lambda row: row.session_id)
     transitions: dict[str, dict[str, Any]] = {}
     disposition_counts: Counter[str] = Counter()
     pr_state_counts: Counter[str] = Counter()
     class_balance: Counter[str] = Counter()
     ambiguous_manual_review = 0
-    fetched_repos: set[Path] = set()
-
     for row in queue:
-        if not row.get("pr_repo") or row.get("pr_number") is None:
+        if not row.is_pr:
             summary["non_pr_skipped"] += 1
             continue
         try:
-            run_dir = Path(row["archive_path"])
-            row_repo_clone = _resolve_repo_for_row(
-                row, clone_cache=None, fetched_repos=fetched_repos, console=console
-            )
-            _materialize_base_sha_if_missing(row, run_dir, repo_clone=row_repo_clone, console=console)
-            old_labels = _latest_labels(archive_dir, row["session_id"])
+            row_repo_clone = services.resolve_repo(row, console=console)
+            base_sha_status = services.materialize_base_sha(row, row_repo_clone, console=console)
+            old_labels = _latest_labels(archive_dir, row.session_id)
             try:
-                payload = build_annotation(
+                evidence = acquire_harvest_evidence(
                     row,
-                    run_dir=run_dir,
-                    archive_dir=archive_dir,
-                    gh_api=recording_gh,
-                    repo_clone=row_repo_clone or archive_dir,
-                    clone_resolved=row_repo_clone is not None,
+                    services=services,
+                    github=recording_gh,
+                    repo_resolution=row_repo_clone,
+                    base_sha_status=base_sha_status,
                     valid_at_override=valid_at_override,
                 )
+                payload = build_annotation(row, evidence)
             except RateLimitError:
                 raise
             except GitError as exc:
                 # Benign absence (deleted repo/PR/comments 404, unpushed-SHA
-                # 422) that escaped build_annotation's internal degrade — fail
+                # 422) that escaped acquisition's internal degrade — fail
                 # closed (M19/M22): store unknown with the current policy
                 # version, never a decisive label. Transient failures re-raise
                 # into the per-row isolation handler below.
@@ -226,11 +234,11 @@ def run_backfill(
                     raise
                 print_warning(
                     console,
-                    f"backfill: PR evidence absent for session {row['session_id']} "
+                    f"backfill: PR evidence absent for session {row.session_id} "
                     f"({type(exc).__name__}: {exc}); labeling unknown (fail closed)",
                 )
                 labels: list[str] = []
-                transitions[row["session_id"]] = {
+                transitions[row.session_id] = {
                     "old_labels": old_labels,
                     "new_labels": labels,
                 }
@@ -240,11 +248,11 @@ def run_backfill(
                     continue
                 appended = append_label_observation(
                     archive_dir,
-                    row["session_id"],
+                    row.session_id,
                     labels=labels,
                     pr_state=None,
                     labeler_version=labeler_versions.LABELER_POLICY_VERSION,
-                    evidence_sha=row.get("head_sha"),
+                    evidence_sha=row.head_sha,
                 )
                 summary["appended" if appended else "skipped"] += 1
                 summary["sessions_reprocessed"] += 1
@@ -253,7 +261,7 @@ def run_backfill(
             # label list — harvest's serialization — so the M14 dedup tuple
             # stays byte-identical between the two writers, never decisive.
             labels = payload.labels
-            transitions[row["session_id"]] = {
+            transitions[row.session_id] = {
                 "old_labels": old_labels,
                 "new_labels": labels,
             }
@@ -275,7 +283,7 @@ def run_backfill(
                 continue
             appended = append_label_observation(
                 archive_dir,
-                row["session_id"],
+                row.session_id,
                 labels=labels,
                 pr_state=payload.pr_state,
                 labeler_version=labeler_versions.LABELER_POLICY_VERSION,
@@ -308,7 +316,7 @@ def run_backfill(
             summary["errors"] += 1
             print_warning(
                 console,
-                f"backfill: session {row.get('session_id', '<unknown>')} failed: "
+                f"backfill: session {row.session_id} failed: "
                 f"{type(exc).__name__}: {exc}",
             )
             continue

--- a/daydream/training/harvest.py
+++ b/daydream/training/harvest.py
@@ -39,21 +39,15 @@ Failure-propagation rules:
 * ``length`` is the documented review-output char-count proxy, ``None`` when
   no review output exists.
 
-Annotation builder:
+Evidence acquisition and annotation reduction:
 
-* :func:`build_annotation` composes the posterior rubric (PR vs local-branch,
-  mirroring the former labeler's assembly), derives the outcome label, captures
-  the human reviewer set and its pooled prior penalty (PR rows only), scores the
-  reward (intrinsic composite plus the calibrated posterior sibling axis fed
-  from the outcome label + prior), asserts the breakdown carries the canonical
-  :data:`~daydream.training.reward.REWARD_VERSION` before it can be written to
-  canonical storage, and returns a frozen :class:`AnnotationPayload`. It is
-  *pure of DB writes* — the orchestrator persists the payload. Error policy:
-  ``RateLimitError`` propagates (the orchestrator aborts cleanly and preserves
-  its resume marker); a *benign* PR-merge-status fetch failure (fork PR 404,
-  unpushed-SHA 422) degrades the row to its local-branch posterior; every other
-  reviewer-signal, prior-query, posterior-fetch, and git error propagates to the
-  caller, which isolates per-row.
+* :func:`acquire_harvest_evidence` performs posterior, reviewer, prior, and
+  bronze acquisition through one explicit :class:`HarvestServices` value. A
+  benign PR-merge-status failure (fork PR 404, unpushed-SHA 422) degrades to the
+  local posterior; exhausted rate limits reach the orchestrator.
+* :func:`build_annotation` consumes only a validated row and frozen evidence,
+  derives the outcome label, applies prior sufficiency, scores the reward, and
+  returns a frozen :class:`AnnotationPayload` without I/O.
 * ``valid_at`` is the earliest qualifying decisive-evidence timestamp — the
   ``created_at`` of a reply supporting an ``accepted``/``rejected`` disposition
   (M12) — falling back to the PR merge timestamp when no decisive evidence
@@ -76,9 +70,8 @@ Orchestrator (:func:`run_harvest`):
   (the only fallible git I/O of the annotate pass lives here, not in the pure
   build-corpus projection).
 
-The rubric-assembly helpers live here as harvest's own; the git/``gh`` wrappers
-are module-level so the orchestrator and tests can monkeypatch them as
-injection seams.
+The rubric-assembly helpers remain harvest-owned; stateful operations cross the
+per-run services boundary.
 """
 
 from __future__ import annotations
@@ -87,10 +80,11 @@ import json
 import os
 import re
 import time
+from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass, replace
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
+from typing import Any, Protocol
 
 import anyio
 from rich.console import Console
@@ -103,10 +97,12 @@ from daydream.archive.index import (
     reviewer_set_penalty_prior,
     set_run_pr_link,
 )
-from daydream.git_ops import GitError, RateLimitError
+from daydream.git_ops import GitError, GitHubAuth, RateLimitError
 from daydream.training import labeler_versions, reward
+from daydream.training._immutable_json import thaw_json
 from daydream.training.backfill_cache import BackfillCache
 from daydream.training.base_sha import materialize_base_sha
+from daydream.training.harvest_types import BaseShaStatus, HarvestEvidence, HarvestRow
 from daydream.training.labeler_signals import (
     CommentResolutionSignal,
     FixAppliedSignal,
@@ -142,6 +138,72 @@ graduate from the ``0.5`` maximum-entropy default to the observed pooled mean
 ``0.5`` default), though ``outcome_prior_n`` still records the pooled count for audit."""
 
 
+class HarvestServices(Protocol):
+    """All stateful acquisition and persistence used by one harvest pass."""
+
+    @property
+    def archive_dir(self) -> Path: ...
+
+    @property
+    def progress_path(self) -> Path | None: ...
+
+    def query_rows(self, session_filter: str | None) -> Sequence[Mapping[str, Any]]: ...
+
+    def completed_sessions(self) -> set[str]: ...
+
+    def resolve_repo(self, row: HarvestRow, *, console: Console) -> Path | None: ...
+
+    def materialize_base_sha(
+        self,
+        row: HarvestRow,
+        repo_clone: Path | None,
+        *,
+        console: Console,
+    ) -> BaseShaStatus: ...
+
+    def github(self, repo: str, endpoint: str, **kwargs: Any) -> Any: ...
+
+    def reviewer_prior(
+        self,
+        logins: tuple[str, ...],
+        *,
+        before_valid_at: str,
+        exclude_session: str,
+        repo_slug: str | None,
+    ) -> tuple[float | None, int]: ...
+
+    def set_pr_link(self, row: HarvestRow, number: int, repo: str) -> None: ...
+
+    def read_scoring_inputs(self, row: HarvestRow) -> ScoringInputs: ...
+
+    def read_recorded_fingerprints(self, row: HarvestRow) -> tuple[str, ...]: ...
+
+    def fix_applied(
+        self,
+        row: HarvestRow,
+        *,
+        changed_files: tuple[str, ...],
+        repo_clone: Path,
+    ) -> FixAppliedSignal: ...
+
+    def local_commit_applied(
+        self,
+        row: HarvestRow,
+        *,
+        repo_clone: Path,
+    ) -> LocalCommitAppliedSignal: ...
+
+    def append_annotation(self, row: HarvestRow, payload: AnnotationPayload) -> bool: ...
+
+    def mark_session_done(self, session_id: str) -> None: ...
+
+    def now_iso(self) -> str: ...
+
+    def backoff_sleep(self, seconds: float) -> None: ...
+
+    async def sleep_between_rows(self, seconds: float) -> None: ...
+
+
 def _read_review_output(run_dir: Path) -> str | None:
     r"""Return the review-output text, or ``None`` when absent.
 
@@ -172,7 +234,7 @@ def _read_review_output_length(run_dir: Path) -> int | None:
     return len(text) if text is not None else None
 
 
-def assemble_scoring_inputs(run_dir: Path, row: dict[str, Any]) -> ScoringInputs:
+def assemble_scoring_inputs(run_dir: Path, row: HarvestRow) -> ScoringInputs:
     """Reduce one run's bronze artifacts to intrinsic :class:`ScoringInputs`.
 
     Reads the structured bronze artifacts under ``run_dir/deep`` and the
@@ -226,13 +288,11 @@ def assemble_scoring_inputs(run_dir: Path, row: dict[str, Any]) -> ScoringInputs
 
     return ScoringInputs(
         verifier_verdicts=verifier_verdicts,
-        grounding_rate=row.get("grounding_rate"),
+        grounding_rate=row.grounding_rate,
         format_valid=format_valid,
         length=_read_review_output_length(run_dir),
     )
 
-
-# git / gh wrappers — module-level so they double as monkeypatch seams.
 
 # Bounded rate-limit backoff for the gh seam (honors parsed Retry-After, capped
 # at _MAX_BACKOFF_SEC, falling back to _DEFAULT_BACKOFF_SEC when absent).
@@ -241,17 +301,14 @@ _MAX_BACKOFF_SEC = 120.0
 _MAX_RATE_LIMIT_RETRIES = 5
 
 
-def _rate_limit_sleep(seconds: float) -> None:
-    """Sleep ``seconds`` between rate-limit retries (seam for tests to stub)."""
-    time.sleep(seconds)
-
-
-async def _row_spacing_sleep(seconds: float) -> None:
-    """Pause ``seconds`` between rows to spread ``gh`` calls (seam for tests to stub)."""
-    await anyio.sleep(seconds)
-
-
-def _gh_api(repo: str, endpoint: str, **kwargs: Any) -> Any:
+def _github_with_retry(
+    repo: str,
+    endpoint: str,
+    *,
+    auth: GitHubAuth,
+    backoff_sleep: Callable[[float], None],
+    **kwargs: Any,
+) -> Any:
     """Proxy to :func:`daydream.git_ops.gh_api` keyed by ``repo`` slug.
 
     The PR posterior signal extractors call ``gh_api(repo, endpoint, **kwargs)``
@@ -276,7 +333,7 @@ def _gh_api(repo: str, endpoint: str, **kwargs: Any) -> Any:
     """
     for attempt in range(_MAX_RATE_LIMIT_RETRIES):
         try:
-            return git_ops.gh_api(Path("."), endpoint, **kwargs, auth=git_ops.INHERIT_GITHUB_AUTH)
+            return git_ops.gh_api(Path("."), endpoint, **kwargs, auth=auth)
         except RateLimitError as exc:
             if attempt == _MAX_RATE_LIMIT_RETRIES - 1:
                 raise
@@ -287,48 +344,9 @@ def _gh_api(repo: str, endpoint: str, **kwargs: Any) -> Any:
                 f"harvest: GitHub rate limit hit; retrying in {backoff:.0f}s "
                 f"(attempt {attempt + 1}/{_MAX_RATE_LIMIT_RETRIES - 1})",
             )
-            _rate_limit_sleep(backoff)
+            backoff_sleep(backoff)
     # Unreachable: the loop either returns or raises on the final attempt.
     raise RuntimeError("rate-limit retry loop exited without returning")  # pragma: no cover
-
-
-def _diff_name_only(repo: Path, base: str, head: str) -> list[str]:
-    """Proxy to :func:`daydream.git_ops.diff_name_only`."""
-    return git_ops.diff_name_only(repo, base, head)
-
-
-def _commits_in_window(repo: Path, head: str, base: str) -> list[str]:
-    """Return commits on ``base`` since ``head``'s ancestor, oldest → newest.
-
-    Used by the fix-applied cascade to bound the upstream review window.
-    The ``head..base`` range already bounds the walk; no date filter is
-    needed (see #167).
-
-    :func:`git_ops.log_shas_since` returns newest-first (git log order);
-    we reverse to oldest → newest to match the downstream contract in
-    :func:`daydream.training.labeler_signals.fix_applied_signal`, where
-    ``window[-1]`` is expected to be the latest commit in the window.
-    """
-    return list(reversed(git_ops.log_shas_since(repo, head, base)))
-
-
-def _commits_since(repo: Path, branch: str, since: str) -> list[str] | None:
-    """Return commits on ``branch`` after ``since``, or ``None`` if unknowable.
-
-    Used by the local-branch posterior path to walk commits pushed after
-    the daydream-recorded ``head_sha``. ``None`` propagates the "could not
-    look" case (deleted branch ref, squash-merged head SHA) so the caller
-    does not read it as "no follow-up commit".
-    """
-    return git_ops.log_shas(repo, branch, since=since)
-
-
-def _file_at(repo: Path, path: str, sha: str) -> str:
-    """Return file content at ``sha``; empty string on missing path."""
-    try:
-        return git_ops.show(repo, sha, path).decode("utf-8", errors="replace")
-    except git_ops.GitError:
-        return ""
 
 
 # Rubric assembly — PR vs local branch.
@@ -347,9 +365,10 @@ it for the PR-review path."""
 
 
 def _safe_fix_applied(
-    row: dict[str, Any],
+    row: HarvestRow,
     *,
-    changed_files: list[str],
+    services: HarvestServices,
+    changed_files: tuple[str, ...],
     repo_clone: Path,
 ) -> FixAppliedSignal:
     """Run :func:`fix_applied_signal`, swallowing missing-data errors.
@@ -362,61 +381,13 @@ def _safe_fix_applied(
     if not changed_files:
         return _FIX_APPLIED_STUB
     try:
-        return fix_applied_signal(
+        return services.fix_applied(
             row,
             changed_files=changed_files,
             repo_clone=repo_clone,
-            diff_fetcher=_diff_name_only,
-            commits_in_window_fetcher=_commits_in_window,
-            file_at_fetcher=_file_at,
         )
     except (FileNotFoundError, OSError, GitError):
         return _FIX_APPLIED_STUB
-
-
-def _row_changed_files(row: dict[str, Any]) -> list[str]:
-    """Return ``changed_files`` from a sqlite row, decoding the JSON column."""
-    raw = row.get("changed_files")
-    if raw is None:
-        return []
-    if isinstance(raw, list):
-        return list(raw)
-    try:
-        decoded = json.loads(raw)
-    except (TypeError, json.JSONDecodeError):
-        return []
-    return list(decoded) if isinstance(decoded, list) else []
-
-
-def _row_is_pr(row: dict[str, Any]) -> bool:
-    """Return ``True`` when the row has both ``pr_repo`` and ``pr_number``."""
-    return bool(row.get("pr_repo")) and row.get("pr_number") is not None
-
-
-def _row_recorded_fingerprints(row: dict[str, Any]) -> list[str]:
-    """Return the finding fingerprints recorded for a row, in order.
-
-    Prefers a pre-extracted ``findings_fingerprints`` column; otherwise reads
-    the archived ``findings.json`` artifact and collects each finding's
-    ``fingerprint``. Returns ``[]`` when neither source is available or the
-    artifact is missing / malformed — a row with no recorded findings simply
-    yields no per-finding join.
-    """
-    pre_extracted = row.get("findings_fingerprints")
-    if isinstance(pre_extracted, list):
-        return [str(fp) for fp in pre_extracted]
-
-    archive_path = row.get("archive_path")
-    if not archive_path:
-        return []
-    try:
-        data = json.loads((Path(archive_path) / "findings.json").read_text(encoding="utf-8"))
-    except (OSError, ValueError):
-        return []
-    findings = data.get("findings") if isinstance(data, dict) else None
-    if not isinstance(findings, list):
-        return []
-    return [str(f["fingerprint"]) for f in findings if isinstance(f, dict) and "fingerprint" in f]
 
 
 # HTTP statuses meaning the PR/commit is genuinely absent (fork/deleted PR 404,
@@ -437,12 +408,13 @@ def _is_benign_pr_absence(exc: GitError) -> bool:
 
 
 def _build_rubric_pr(
-    row: dict[str, Any],
+    row: HarvestRow,
     *,
-    gh_api: Any,
+    services: HarvestServices,
+    github: Callable[..., Any],
     repo_clone: Path,
     pr_merge: PRMergeSignal | None = None,
-    changed_files: list[str],
+    changed_files: tuple[str, ...],
     pr_author_logins: frozenset[str] = frozenset(),
     review_author_logins: frozenset[str] = frozenset(),
 ) -> Rubric:
@@ -461,20 +433,21 @@ def _build_rubric_pr(
         review_author_logins: Logins whose replies count as formal-review
             judgment under the M6 gate.
     """
-    signal_row = {**row, "changed_files": changed_files}
+    signal_row = row.as_signal_row()
     if pr_merge is None:
-        pr_merge = pr_merge_signal(signal_row, gh_api=gh_api)
+        pr_merge = pr_merge_signal(signal_row, gh_api=github)
     # Fetch + index the PR's review comments once; both resolution signals
     # consume this index instead of each hitting the /comments endpoint.
-    recorded_fingerprints = _row_recorded_fingerprints(row)
+    recorded_fingerprints = services.read_recorded_fingerprints(row)
     comment_threads = index_pr_review_comments(
         signal_row,
-        gh_api=gh_api,
-        session_fingerprints=recorded_fingerprints,
+        gh_api=github,
+        session_fingerprints=list(recorded_fingerprints),
     )
-    comments = comment_resolution_signal(signal_row, gh_api=gh_api, threads=comment_threads)
+    comments = comment_resolution_signal(signal_row, gh_api=github, threads=comment_threads)
     fix = _safe_fix_applied(
-        signal_row,
+        row,
+        services=services,
         changed_files=changed_files,
         repo_clone=repo_clone,
     )
@@ -488,8 +461,8 @@ def _build_rubric_pr(
     if recorded_fingerprints:
         per_finding = per_finding_resolution_signal(
             signal_row,
-            recorded_fingerprints=recorded_fingerprints,
-            gh_api=gh_api,
+            recorded_fingerprints=list(recorded_fingerprints),
+            gh_api=github,
             threads=comment_threads,
             pr_author_logins=pr_author_logins,
             review_author_logins=review_author_logins,
@@ -499,8 +472,9 @@ def _build_rubric_pr(
 
 
 def _build_rubric_local(
-    row: dict[str, Any],
+    row: HarvestRow,
     *,
+    services: HarvestServices,
     repo_clone: Path,
     clone_resolved: bool = False,
 ) -> Rubric:
@@ -515,15 +489,13 @@ def _build_rubric_local(
     # Invariant: the local-commit posterior is valid ONLY for PR-less runs. A
     # degraded PR row's merge evidence was merely unavailable, so emit "unknown"
     # rather than risk a "rejected" false negative.
-    if _row_is_pr(row) or not clone_resolved:
+    if row.is_pr or not clone_resolved:
         local = LocalCommitAppliedSignal(verdict="unknown")
     else:
         try:
-            local = local_commit_applied_signal(
+            local = services.local_commit_applied(
                 row,
                 repo_clone=repo_clone,
-                commits_since_fetcher=_commits_since,
-                file_at_fetcher=_file_at,
             )
         except (FileNotFoundError, OSError):
             local = LocalCommitAppliedSignal(verdict="unknown")
@@ -614,8 +586,9 @@ class AnnotationPayload:
 
 
 def _degrade_to_local(
-    row: dict[str, Any],
+    row: HarvestRow,
     *,
+    services: HarvestServices,
     repo_clone: Path,
     clone_resolved: bool,
 ) -> tuple[Any, None, list[str], None, int]:
@@ -626,167 +599,124 @@ def _degrade_to_local(
     ``(rubric, valid_at, reviewer_logins, outcome_prior, prior_n)`` with the
     non-PR defaults so callers can unpack uniformly.
     """
-    rubric = _build_rubric_local(row, repo_clone=repo_clone, clone_resolved=clone_resolved)
+    rubric = _build_rubric_local(
+        row,
+        services=services,
+        repo_clone=repo_clone,
+        clone_resolved=clone_resolved,
+    )
     return rubric, None, [], None, 0
 
 
-def build_annotation(
-    row: dict[str, Any],
+def acquire_harvest_evidence(
+    row: HarvestRow,
     *,
-    run_dir: Path,
-    archive_dir: Path,
-    gh_api: Any,
-    repo_clone: Path,
-    clone_resolved: bool = True,
+    services: HarvestServices,
+    repo_resolution: Path | None,
+    base_sha_status: BaseShaStatus,
     valid_at_override: str | None = None,
-) -> AnnotationPayload:
-    """Build one run's bitemporal annotation payload (pure of DB writes).
-
-    Composes the posterior rubric (PR vs local-branch, mirroring the former
-    labeler's assembly), derives the outcome label, and assembles the intrinsic
-    :class:`ScoringInputs` from bronze.
-
-    For PR rows it additionally captures the human reviewer set
-    (:func:`~daydream.training.labeler_signals.reviewer_logins_signal`) and the
-    pooled prior penalty over prior runs sharing a reviewer
-    (:func:`~daydream.archive.index.reviewer_set_penalty_prior`). The pooled
-    mean graduates to the empirical ``outcome_prior`` only when the pooled count
-    reaches :data:`_PRIOR_SUFFICIENCY_THRESHOLD`; below threshold the prior is
-    left ``None`` (the reducer applies the ``0.5`` default), but
-    ``outcome_prior_n`` always records the pooled count for audit. Local/non-PR
-    rows have no reviewer set (``reviewer_logins=[]``, ``outcome_prior=None``,
-    ``outcome_prior_n=0``).
-
-    Scores the reward via :func:`~daydream.training.reward.score_trajectory`. The
-    outcome label is fed to the posterior axis **only** for ``pr_review`` rows;
-    ``local_branch`` outcomes keep their label but are withheld from
-    ``pr_feedback`` so they never enter the posterior population. A mapped label
-    yields a :class:`~daydream.training.reward.PosteriorBreakdown` whose
-    ``composite`` is the pure intrinsic score (C5 — the posterior penalty is a
-    sibling, never folded in). Asserts the breakdown carries the canonical
-    :data:`~daydream.training.reward.REWARD_VERSION` before returning, so a
-    non-canonical (analysis-time override) score can never reach canonical
-    storage. Returns a frozen :class:`AnnotationPayload`; the orchestrator
-    persists it.
-
-    Args:
-        row: The indexed manifest row (carries ``session_id``, the PR
-            discriminators, ``head_sha``, ``grounding_rate``, etc.).
-        run_dir: The archived run directory (bronze bundle root) feeding the
-            intrinsic reward signals.
-        archive_dir: The archive root, queried for the pooled reviewer-set prior.
-        gh_api: Callable invoked as ``gh_api(repo, endpoint, **kwargs)`` by
-            the PR posterior + reviewer signals; unused on the local-branch path.
-        repo_clone: Local clone root for the fix-applied / local-commit
-            cascades.
-        clone_resolved: Whether a real git working tree was obtained for the
-            row. When ``False`` the local-branch posterior is forced to
-            ``"unknown"`` rather than risking a ``"rejected"`` mislabel from a
-            commit check that had no repository to inspect.
-        valid_at_override: Explicit valid-time that beats the derived
-            decisive-evidence timestamp when supplied (wired from the backfill
-            CLI); ``None`` keeps the derived value.
-
-    Returns:
-        A frozen :class:`AnnotationPayload`. ``valid_at`` is the earliest
-        qualifying decisive-evidence timestamp (the ``created_at`` of an
-        accepted/rejected-supporting reply, M12); when no decisive evidence
-        exists it falls back to the PR merge timestamp for merged PR rows and
-        ``None`` otherwise (and for non-PR/local rows). An explicit
-        ``valid_at_override`` wins over the derived value.
-
-    Raises:
-        AssertionError: When the scored breakdown does not carry the canonical
-            ``REWARD_VERSION`` (a non-default-weights override leaked in).
-        RateLimitError: Propagated unchanged so the orchestrator can abort the
-            sweep cleanly and preserve its resume marker.
-        Exception: A *benign* PR-merge-status fetch failure (fork PR 404,
-            unpushed-SHA 422) is caught and degrades the row to its local-branch
-            posterior rather than raising. Every other reviewer-signal,
-            prior-query, posterior-fetch (``gh_api``), or git error propagates
-            unchanged to the caller (the orchestrator isolates per-row). Once the
-            merge status is confirmed, a later ``comment_resolution_signal``
-            failure also propagates (the confirmed merge evidence is never
-            discarded).
-    """
-    if _row_is_pr(row):
-        changed_files = _row_changed_files(row)
+    github: Callable[..., Any] | None = None,
+) -> HarvestEvidence:
+    """Acquire one row's complete external evidence in established order."""
+    github_api = services.github if github is None else github
+    repo_clone = repo_resolution or services.archive_dir
+    if row.is_pr:
+        changed_files = row.changed_files
         try:
-            _pr_merge = pr_merge_signal(
-                {**row, "changed_files": changed_files},
-                gh_api=gh_api,
+            pr_merge = pr_merge_signal(
+                row.as_signal_row(),
+                gh_api=github_api,
             )
         except RateLimitError:
             raise
         except GitError as exc:
-            # Narrow catch (only pr_merge_signal): a benign 404/422 degrades to
-            # local; a transient failure propagates so the run retries, not
-            # mislabels. A later comment-fetch GitError stays outside this block.
             if not _is_benign_pr_absence(exc):
                 raise
-            rubric, valid_at, reviewer_logins, outcome_prior, prior_n = _degrade_to_local(
-                row, repo_clone=repo_clone, clone_resolved=clone_resolved
+            rubric, _valid_at, reviewer_logins, pooled_prior, prior_n = _degrade_to_local(
+                row,
+                services=services,
+                repo_clone=repo_clone,
+                clone_resolved=repo_resolution is not None,
             )
         else:
-            # Merge confirmed, so the PR provably exists; a secondary comment-fetch
-            # GitError is transient and must propagate, not discard the confirmed
-            # PRMergeSignal by degrading to local.
-            # Resolve the human reviewer set BEFORE composing the per-finding
-            # rubric so the M6 gate can count PR-author and formal-review-author
-            # logins (issues #2/#4): a decisive reply from a fork-PR author or
-            # review author whose association is not OWNER/MEMBER/COLLABORATOR
-            # must not be excluded. An auxiliary-lookup GitError keeps the same
-            # degrade semantics as before — empty reviewer set, no prior.
             try:
-                reviewer_logins = reviewer_logins_signal(row, gh_api=gh_api)
+                reviewer_logins = reviewer_logins_signal(
+                    row.as_signal_row(),
+                    gh_api=github_api,
+                )
             except RateLimitError:
                 raise
             except GitError:
-                # Reviewer-set prior only refines the decided outcome; an
-                # auxiliary-lookup failure degrades to no prior, keeping the label.
                 reviewer_logins = []
             rubric = _build_rubric_pr(
                 row,
-                gh_api=gh_api,
+                services=services,
+                github=github_api,
                 repo_clone=repo_clone,
-                pr_merge=_pr_merge,
+                pr_merge=pr_merge,
                 changed_files=changed_files,
                 pr_author_logins=(
-                    frozenset({_pr_merge.author_login}) if _pr_merge.author_login else frozenset()
+                    frozenset({pr_merge.author_login}) if pr_merge.author_login else frozenset()
                 ),
                 review_author_logins=frozenset(reviewer_logins),
             )
             valid_at = _decisive_evidence_valid_at(rubric)
             if valid_at is None and rubric.pr_merge.merged:
                 valid_at = rubric.pr_merge.merged_at
-            pooled, prior_n = reviewer_set_penalty_prior(
-                archive_dir,
-                reviewer_logins,
-                before_valid_at=valid_at or datetime.now(timezone.utc).isoformat(),
-                exclude_session=row["session_id"],
-                repo_slug=row.get("repo_slug"),
+            pooled_prior, prior_n = services.reviewer_prior(
+                tuple(reviewer_logins),
+                before_valid_at=valid_at or services.now_iso(),
+                exclude_session=row.session_id,
+                repo_slug=row.repo_slug,
             )
-            outcome_prior = pooled if prior_n >= _PRIOR_SUFFICIENCY_THRESHOLD else None
     else:
-        rubric, valid_at, reviewer_logins, outcome_prior, prior_n = _degrade_to_local(
-            row, repo_clone=repo_clone, clone_resolved=clone_resolved
+        rubric, _valid_at, reviewer_logins, pooled_prior, prior_n = _degrade_to_local(
+            row,
+            services=services,
+            repo_clone=repo_clone,
+            clone_resolved=repo_resolution is not None,
         )
 
+    # Preserve the established boundary: bronze reads occur after posterior,
+    # reviewer, and prior acquisition.
+    scoring_inputs = services.read_scoring_inputs(row)
+    return HarvestEvidence(
+        scoring_inputs=scoring_inputs,
+        rubric=rubric,
+        reviewer_logins=tuple(reviewer_logins),
+        pooled_prior=pooled_prior,
+        prior_n=prior_n,
+        repo_resolution=repo_resolution,
+        base_sha_status=base_sha_status,
+        valid_at_override=valid_at_override,
+    )
+
+
+def build_annotation(row: HarvestRow, evidence: HarvestEvidence) -> AnnotationPayload:
+    """Purely reduce validated row and immutable evidence into an annotation."""
+    rubric = evidence.rubric
     outcome_label = derive_outcome_label(rubric)
     labels = [outcome_label] if outcome_label != "unknown" else []
-    if valid_at_override is not None:
-        valid_at = valid_at_override
+    valid_at = None
+    if rubric.posterior_source == "pr_review":
+        valid_at = _decisive_evidence_valid_at(rubric)
+        if valid_at is None and rubric.pr_merge.merged:
+            valid_at = rubric.pr_merge.merged_at
+    if evidence.valid_at_override is not None:
+        valid_at = evidence.valid_at_override
 
-    inputs = assemble_scoring_inputs(run_dir, row)
     # Only a maintainer acting on a real PR is posterior evidence; a local commit
     # containing the recommended lines is a weaker tier and must not enter the
     # posterior population (the label is still recorded on `labels`).
     posterior_feedback = outcome_label if rubric.posterior_source == "pr_review" else None
+    outcome_prior = (
+        evidence.pooled_prior if evidence.prior_n >= _PRIOR_SUFFICIENCY_THRESHOLD else None
+    )
     rb = score_trajectory(
-        inputs,
+        evidence.scoring_inputs,
         pr_feedback=posterior_feedback,
         outcome_prior=outcome_prior,
-        outcome_prior_n=prior_n,
+        outcome_prior_n=evidence.prior_n,
     )
 
     if rb.reward_version != reward.REWARD_VERSION:
@@ -802,14 +732,13 @@ def build_annotation(
         reward_version=rb.reward_version,
         reward_json=json.dumps(rb.to_dict()),
         composite_reward=rb.composite,
-        evidence_sha=row.get("head_sha"),
+        evidence_sha=row.head_sha,
         rubric_json=json.dumps(rubric.to_dict()),
-        reviewer_logins=reviewer_logins,
+        reviewer_logins=list(evidence.reviewer_logins),
         has_posterior=isinstance(rb, reward.PosteriorBreakdown),
         reply_classifier_version=labeler_versions.REPLY_CLASSIFIER_VERSION,
         reply_evidence_digest=_reply_evidence_digest(rubric),
     )
-
 
 def _decisive_evidence_valid_at(rubric: Rubric) -> str | None:
     """Earliest qualifying decisive-evidence timestamp from the rubric (M12).
@@ -829,7 +758,7 @@ def _decisive_evidence_valid_at(rubric: Rubric) -> str | None:
         if resolution.disposition not in ("accepted", "rejected"):
             continue
         for entry in resolution.evidence:
-            if not isinstance(entry, dict):
+            if not isinstance(entry, Mapping):
                 continue
             reason = entry.get("reason")
             if not isinstance(reason, str) or reason.startswith("excluded:"):
@@ -848,7 +777,11 @@ def _reply_evidence_digest(rubric: Rubric) -> str | None:
     ``None`` when no reply evidence was collected, so a digest-less row never
     collides with a digested one under the versioned dedup key.
     """
-    evidence = [entry for res in rubric.per_finding_resolutions or [] for entry in res.evidence]
+    evidence = [
+        thaw_json(entry)
+        for resolution in rubric.per_finding_resolutions or []
+        for entry in resolution.evidence
+    ]
     return labeler_versions.reply_evidence_digest(evidence) if evidence else None
 
 
@@ -858,7 +791,7 @@ def _reply_evidence_digest(rubric: Rubric) -> str | None:
 
 
 def _resolve_repo_for_row(
-    row: dict[str, Any],
+    row: HarvestRow,
     clone_cache: Path | None,
     *,
     fetched_repos: set[Path] | None = None,
@@ -877,12 +810,12 @@ def _resolve_repo_for_row(
         row: An indexed manifest row (supplies ``source_path``, ``remote_url``, ``repo_slug``).
         clone_cache: Root directory for cached clones, or ``None`` to skip cloning.
     """
-    source_path = row.get("source_path")
-    if source_path and (Path(source_path) / ".git").exists():
-        return Path(source_path)
+    source_path = row.source_path
+    if source_path and (source_path / ".git").exists():
+        return source_path
 
-    remote_url = row.get("remote_url")
-    repo_slug = row.get("repo_slug")
+    remote_url = row.remote_url
+    repo_slug = row.repo_slug
     if (
         not isinstance(remote_url, str)
         or not isinstance(repo_slug, str)
@@ -927,25 +860,32 @@ def _resolve_repo_for_row(
 
 
 def _materialize_base_sha_if_missing(
-    row: dict[str, Any], run_dir: Path, repo_clone: Path | None, *, console: Console | None = None
-) -> None:
+    row: HarvestRow,
+    repo_clone: Path | None,
+    *,
+    console: Console | None = None,
+) -> BaseShaStatus:
     """Opportunistically backfill ``code_context.base_sha`` into the manifest.
 
     Only acts when ``manifest.json`` exists AND ``repo_clone`` is available.
     Any failure is swallowed (opportunistic), leaving ``base_sha`` as ``None``.
     """
-    manifest_path = run_dir / "manifest.json"
+    manifest_path = row.archive_path / "manifest.json"
     if not manifest_path.exists():
-        return
+        return "unavailable"
     if repo_clone is None:
-        return
+        return "unavailable"
     try:
-        materialize_base_sha(manifest_path, repo_clone=repo_clone)
+        resolved = materialize_base_sha(manifest_path, repo_clone=repo_clone)
     except (OSError, json.JSONDecodeError, GitError) as exc:
         print_warning(
             console or create_console(),
             f"harvest: base_sha backfill failed for {manifest_path}: {type(exc).__name__}: {exc}",
         )
+        return "failed"
+    if resolved is None:
+        return "unavailable"
+    return "available"
 
 
 # Orchestrator — idempotent (evidence-hash dedup), re-runnable, per-row isolation
@@ -979,157 +919,305 @@ class HarvestConfig:
     gh_request_spacing_sec: float = 0.8
 
 
-async def run_harvest(config: HarvestConfig) -> dict[str, int]:
-    """Walk the archive and append one fresh annotation per indexed run.
+class _ProductionHarvestServices:
+    """Per-run adapters for archive, repository, GitHub, cache, and clocks."""
 
-    The single deferred annotate pass: for every indexed run, materialize the
-    capture-time ``base_sha`` (when missing), re-link orphan runs to their PR
-    (a run launched before its PR existed has ``pr_number=None`` but carries
-    ``repo_slug`` + ``head_sha``; :func:`pr_link_signal` resolves the PR by
-    head sha and the linkage is persisted via
-    :func:`daydream.archive.index.set_run_pr_link` so it becomes labelable),
-    build the bitemporal annotation
-    (label + intrinsic reward + posterior sibling axis + captured reviewer set +
-    ``valid_at``) via :func:`build_annotation`, and append it through
-    :func:`daydream.archive.index.append_label_observation` (which persists
-    ``reviewer_logins`` and the ``has_posterior`` population discriminator).
+    def __init__(self, config: HarvestConfig, github_auth: GitHubAuth) -> None:
+        self._config = config
+        self._github_auth = github_auth
+        self._cache: BackfillCache | None = None
+        self._fetched_repos: set[Path] = set()
 
-    **Idempotent and re-runnable:** every indexed run is considered, but the
-    write layer dedups on ``(evidence_sha, labeler_policy_version,
-    reply_evidence_digest, labels, has_posterior)`` — a re-harvest with
-    unchanged evidence is a no-op counted in ``skipped``. A later
-    ``LABELER_POLICY_VERSION`` or reply-evidence change alters the dedup key
-    and so appends a fresh generation, letting older ``as_of`` pins still
-    resolve their original generation. Only the ``cache``/``dry_run`` paths otherwise suppress writes.
+    @property
+    def archive_dir(self) -> Path:
+        return self._config.archive_dir
 
-    Per-row error isolation: an exception on one row counts in ``errors`` and
-    does not derail subsequent rows. Configuration errors (missing
-    ``archive_dir``) raise before the loop begins.
-
-    Returns:
-        Summary dict with keys ``considered``, ``annotated``,
-        ``would_annotate``, ``skipped``, ``errors``, and ``aborted`` (``1`` when
-        the sweep stopped early on an exhausted GitHub rate limit, else ``0``).
-
-    Raises:
-        FileNotFoundError: When ``config.archive_dir`` does not exist.
-            Configuration errors deliberately surface before the loop.
-    """
-    if not config.archive_dir.exists():
-        msg = f"archive_dir does not exist: {config.archive_dir}"
-        raise FileNotFoundError(msg)
-
-    # Queue every indexed run (optionally prefix-filtered); the write layer makes
-    # re-harvest idempotent by deduping unchanged evidence (evidence_sha,
-    # labeler_policy_version, reply_evidence_digest, labels, has_posterior).
-    if config.session_filter:
-        queue = query_runs(
-            config.archive_dir,
-            "session_id LIKE ? || '%'",
-            (config.session_filter,),
+    @property
+    def progress_path(self) -> Path | None:
+        return (
+            self._config.cache_dir / "progress.jsonl"
+            if self._config.cache_dir is not None
+            else None
         )
-    else:
-        queue = query_runs(config.archive_dir)
 
-    # The cache wraps the gh seam and tracks completed sessions so an interrupted
-    # run resumes without re-fetching.
-    cache: BackfillCache | None = None
-    gh_api_callable: Any = _gh_api
-    if config.cache_dir is not None:
-        cache = BackfillCache(cache_dir=config.cache_dir, inner=_gh_api)
-        gh_api_callable = cache
-        done = cache.completed_sessions()
-        queue = [row for row in queue if row["session_id"] not in done]
+    def _uncached_github(self, repo: str, endpoint: str, **kwargs: Any) -> Any:
+        return _github_with_retry(
+            repo,
+            endpoint,
+            auth=self._github_auth,
+            backoff_sleep=self.backoff_sleep,
+            **kwargs,
+        )
 
-    clone_cache = config.repo_clone_root or (config.cache_dir / "repos" if config.cache_dir else None)
-    fetched_repos: set[Path] = set()
+    def _cache_instance(self) -> BackfillCache | None:
+        if self._config.cache_dir is None:
+            return None
+        if self._cache is None:
+            self._cache = BackfillCache(
+                cache_dir=self._config.cache_dir,
+                inner=self._uncached_github,
+            )
+        return self._cache
+
+    def query_rows(self, session_filter: str | None) -> Sequence[Mapping[str, Any]]:
+        if not self.archive_dir.exists():
+            raise FileNotFoundError(f"archive_dir does not exist: {self.archive_dir}")
+        if session_filter:
+            return query_runs(
+                self.archive_dir,
+                "session_id LIKE ? || '%'",
+                (session_filter,),
+            )
+        return query_runs(self.archive_dir)
+
+    def completed_sessions(self) -> set[str]:
+        cache = self._cache_instance()
+        return cache.completed_sessions() if cache is not None else set()
+
+    def resolve_repo(self, row: HarvestRow, *, console: Console) -> Path | None:
+        clone_cache = self._config.repo_clone_root or (
+            self._config.cache_dir / "repos" if self._config.cache_dir else None
+        )
+        return _resolve_repo_for_row(
+            row,
+            clone_cache,
+            fetched_repos=self._fetched_repos,
+            console=console,
+        )
+
+    def materialize_base_sha(
+        self,
+        row: HarvestRow,
+        repo_clone: Path | None,
+        *,
+        console: Console,
+    ) -> BaseShaStatus:
+        return _materialize_base_sha_if_missing(row, repo_clone, console=console)
+
+    def github(self, repo: str, endpoint: str, **kwargs: Any) -> Any:
+        cache = self._cache_instance()
+        if cache is not None:
+            return cache(repo, endpoint, **kwargs)
+        return self._uncached_github(repo, endpoint, **kwargs)
+
+    def reviewer_prior(
+        self,
+        logins: tuple[str, ...],
+        *,
+        before_valid_at: str,
+        exclude_session: str,
+        repo_slug: str | None,
+    ) -> tuple[float | None, int]:
+        return reviewer_set_penalty_prior(
+            self.archive_dir,
+            list(logins),
+            before_valid_at=before_valid_at,
+            exclude_session=exclude_session,
+            repo_slug=repo_slug,
+        )
+
+    def set_pr_link(self, row: HarvestRow, number: int, repo: str) -> None:
+        set_run_pr_link(self.archive_dir, row.session_id, number, repo)
+
+    def read_scoring_inputs(self, row: HarvestRow) -> ScoringInputs:
+        return assemble_scoring_inputs(row.archive_path, row)
+
+    def read_recorded_fingerprints(self, row: HarvestRow) -> tuple[str, ...]:
+        if row.findings_fingerprints is not None:
+            return row.findings_fingerprints
+        try:
+            data = json.loads((row.archive_path / "findings.json").read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            return ()
+        findings = data.get("findings") if isinstance(data, dict) else None
+        if not isinstance(findings, list):
+            return ()
+        return tuple(
+            str(finding["fingerprint"])
+            for finding in findings
+            if isinstance(finding, dict) and "fingerprint" in finding
+        )
+
+    @staticmethod
+    def _file_at(repo: Path, path: str, sha: str) -> str:
+        try:
+            return git_ops.show(repo, sha, path).decode("utf-8", errors="replace")
+        except GitError:
+            return ""
+
+    def fix_applied(
+        self,
+        row: HarvestRow,
+        *,
+        changed_files: tuple[str, ...],
+        repo_clone: Path,
+    ) -> FixAppliedSignal:
+        return fix_applied_signal(
+            row.as_signal_row(),
+            changed_files=list(changed_files),
+            repo_clone=repo_clone,
+            diff_fetcher=git_ops.diff_name_only,
+            commits_in_window_fetcher=lambda repo, head, base: list(
+                reversed(git_ops.log_shas_since(repo, head, base))
+            ),
+            file_at_fetcher=self._file_at,
+        )
+
+    def local_commit_applied(
+        self,
+        row: HarvestRow,
+        *,
+        repo_clone: Path,
+    ) -> LocalCommitAppliedSignal:
+        return local_commit_applied_signal(
+            row.as_signal_row(),
+            repo_clone=repo_clone,
+            commits_since_fetcher=lambda repo, branch, since: git_ops.log_shas(
+                repo,
+                branch,
+                since=since,
+            ),
+            file_at_fetcher=self._file_at,
+        )
+
+    def append_annotation(self, row: HarvestRow, payload: AnnotationPayload) -> bool:
+        return append_label_observation(
+            self.archive_dir,
+            row.session_id,
+            labels=payload.labels,
+            pr_state=payload.pr_state,
+            labeler_version=labeler_versions.LABELER_POLICY_VERSION,
+            evidence_sha=payload.evidence_sha,
+            rubric_json=payload.rubric_json,
+            valid_at=payload.valid_at,
+            reward_version=payload.reward_version,
+            reward_json=payload.reward_json,
+            composite_reward=payload.composite_reward,
+            reviewer_logins=payload.reviewer_logins,
+            has_posterior=payload.has_posterior,
+            reply_classifier_version=payload.reply_classifier_version,
+            reply_evidence_digest=payload.reply_evidence_digest,
+        )
+
+    def mark_session_done(self, session_id: str) -> None:
+        cache = self._cache_instance()
+        if cache is not None:
+            cache.mark_session_done(session_id)
+
+    @staticmethod
+    def now_iso() -> str:
+        return datetime.now(timezone.utc).isoformat()
+
+    @staticmethod
+    def backoff_sleep(seconds: float) -> None:
+        time.sleep(seconds)
+
+    @staticmethod
+    async def sleep_between_rows(seconds: float) -> None:
+        await anyio.sleep(seconds)
+
+
+def make_harvest_services(
+    config: HarvestConfig,
+    *,
+    github_auth: GitHubAuth = git_ops.INHERIT_GITHUB_AUTH,
+) -> HarvestServices:
+    """Create side-effect-free production adapters for one harvest pass."""
+    return _ProductionHarvestServices(config, github_auth)
+
+
+async def run_harvest(
+    config: HarvestConfig,
+    *,
+    services: HarvestServices,
+) -> dict[str, int]:
+    """Validate the archive queue, acquire evidence, and persist annotations."""
+    requested_archive = config.archive_dir.resolve()
+    services_archive = services.archive_dir.resolve()
+    if requested_archive != services_archive:
+        raise ValueError(
+            f"harvest archive ownership mismatch: requested {requested_archive}, services {services_archive}"
+        )
+    raw_queue = services.query_rows(config.session_filter)
+    console = create_console()
+    queue: list[HarvestRow] = []
+    invalid_rows = 0
+    for row_number, raw in enumerate(raw_queue, start=1):
+        try:
+            queue.append(HarvestRow.from_mapping(raw, row_number=row_number))
+        except ValueError as exc:
+            invalid_rows += 1
+            print_warning(console, f"harvest: {exc}")
 
     summary = {
-        "considered": len(queue),
+        "considered": invalid_rows,
         "annotated": 0,
         "would_annotate": 0,
         "skipped": 0,
-        "errors": 0,
+        "errors": invalid_rows,
         "aborted": 0,
     }
+    if not queue:
+        return summary
 
-    console = create_console()
+    # BackfillCache creation and progress reads remain lazy until every raw row
+    # has crossed the validation boundary. Invalid rows still count even when a
+    # valid sibling is removed by the resume filter.
+    done = services.completed_sessions()
+    queue = [row for row in queue if row.session_id not in done]
+    summary["considered"] += len(queue)
 
     for row in queue:
         try:
-            run_dir = Path(row["archive_path"])
-            row_repo_clone = _resolve_repo_for_row(
-                row, clone_cache=clone_cache, fetched_repos=fetched_repos, console=console
+            repo_resolution = services.resolve_repo(row, console=console)
+            base_sha_status = services.materialize_base_sha(
+                row,
+                repo_resolution,
+                console=console,
             )
-            _materialize_base_sha_if_missing(row, run_dir, repo_clone=row_repo_clone, console=console)
-            # Re-link orphan runs (archived before the PR existed): resolve the
-            # now-existing PR by head_sha so the run becomes labelable. Inside the
-            # per-row try so a lookup error isolates (RateLimitError still aborts).
-            if not _row_is_pr(row):
+            # Re-link orphan runs before acquiring their posterior. Persistence
+            # remains at this exact boundary, so a later row failure keeps the
+            # durable link as before.
+            if not row.is_pr:
                 try:
-                    link = pr_link_signal(row, gh_api=gh_api_callable)
+                    link = pr_link_signal(row.as_signal_row(), gh_api=services.github)
                 except RateLimitError:
                     raise
                 except GitError as exc:
-                    # Benign 404/422 ⇒ PR unresolvable; degrade to local-branch
-                    # posterior (row stays pr_number=None). Transient failures
-                    # propagate so resume retries, not caches a degraded label.
                     if not _is_benign_pr_absence(exc):
                         raise
                     print_warning(
                         console,
-                        f"harvest: PR link lookup failed for session {row['session_id']}; "
+                        f"harvest: PR link lookup failed for session {row.session_id}; "
                         f"degrading to local-branch posterior: {type(exc).__name__}: {exc}",
                     )
                     link = None
                 if link is not None:
                     number, slug = link
-                    row["pr_number"] = number
-                    row["pr_repo"] = slug
                     if not config.dry_run:
-                        set_run_pr_link(config.archive_dir, row["session_id"], number, slug)
-            payload = build_annotation(
+                        services.set_pr_link(row, number, slug)
+                    row = replace(row, pr_number=number, pr_repo=slug)
+
+            evidence = acquire_harvest_evidence(
                 row,
-                run_dir=run_dir,
-                archive_dir=config.archive_dir,
-                gh_api=gh_api_callable,
-                repo_clone=row_repo_clone or config.archive_dir,
-                clone_resolved=row_repo_clone is not None,
+                services=services,
+                repo_resolution=repo_resolution,
+                base_sha_status=base_sha_status,
             )
+            payload = build_annotation(row, evidence)
             if config.dry_run:
                 summary["would_annotate"] += 1
             else:
-                appended = append_label_observation(
-                    config.archive_dir,
-                    row["session_id"],
-                    labels=payload.labels,
-                    pr_state=payload.pr_state,
-                    labeler_version=labeler_versions.LABELER_POLICY_VERSION,
-                    evidence_sha=payload.evidence_sha,
-                    rubric_json=payload.rubric_json,
-                    valid_at=payload.valid_at,
-                    reward_version=payload.reward_version,
-                    reward_json=payload.reward_json,
-                    composite_reward=payload.composite_reward,
-                    reviewer_logins=payload.reviewer_logins,
-                    has_posterior=payload.has_posterior,
-                    reply_classifier_version=payload.reply_classifier_version,
-                    reply_evidence_digest=payload.reply_evidence_digest,
-                )
-                if appended:
+                if services.append_annotation(row, payload):
                     summary["annotated"] += 1
                 else:
-                    # Deduped: unchanged evidence/policy/digest/labels/posterior
-                    # is a no-op re-run.
                     summary["skipped"] += 1
-                # Either way the row is "done" for resume — re-running must not re-fetch it.
-                if cache is not None:
-                    cache.mark_session_done(row["session_id"])
+                # A successful append or dedup is complete for resume. A raised
+                # write never advances the marker.
+                services.mark_session_done(row.session_id)
         except RateLimitError:
-            # Rate limit exhausted: abort cleanly. The failed row is NOT marked
-            # done, so its resume marker is preserved for a later re-run.
             summary["aborted"] = 1
-            resume_marker = cache.progress_path if cache is not None else None
+            resume_marker = services.progress_path
             abort_msg = (
                 "harvest: GitHub rate limit exhausted; aborting cleanly. "
                 f"Resume from {resume_marker} by re-running with the same --cache-dir."
@@ -1142,12 +1230,11 @@ async def run_harvest(config: HarvestConfig) -> dict[str, int]:
             summary["errors"] += 1
             print_warning(
                 console,
-                f"harvest: session {row.get('session_id', '<unknown>')} failed: "
-                f"{type(exc).__name__}: {exc}",
+                f"harvest: session {row.session_id} failed: {type(exc).__name__}: {exc}",
             )
             continue
 
         if not config.dry_run:
-            await _row_spacing_sleep(config.gh_request_spacing_sec)
+            await services.sleep_between_rows(config.gh_request_spacing_sec)
 
     return summary

--- a/daydream/training/harvest.py
+++ b/daydream/training/harvest.py
@@ -234,7 +234,7 @@ def _read_review_output_length(run_dir: Path) -> int | None:
     return len(text) if text is not None else None
 
 
-def assemble_scoring_inputs(run_dir: Path, row: HarvestRow) -> ScoringInputs:
+def assemble_scoring_inputs(run_dir: Path, row: Mapping[str, Any]) -> ScoringInputs:
     """Reduce one run's bronze artifacts to intrinsic :class:`ScoringInputs`.
 
     Reads the structured bronze artifacts under ``run_dir/deep`` and the
@@ -248,8 +248,9 @@ def assemble_scoring_inputs(run_dir: Path, row: HarvestRow) -> ScoringInputs:
 
     Args:
         run_dir: The archived run directory (bronze bundle root).
-        row: The indexed manifest row; ``row["grounding_rate"]`` supplies the
-            grounding axis (``None`` when unavailable).
+        row: Indexed or flattened manifest metadata; ``row["grounding_rate"]``
+            supplies the grounding axis (``None`` when unavailable). Bronze-only
+            callers do not need harvest's repository or session identity.
 
     Returns:
         A :class:`ScoringInputs` with the verdicts list (or ``None``), the
@@ -288,7 +289,7 @@ def assemble_scoring_inputs(run_dir: Path, row: HarvestRow) -> ScoringInputs:
 
     return ScoringInputs(
         verifier_verdicts=verifier_verdicts,
-        grounding_rate=row.grounding_rate,
+        grounding_rate=row.get("grounding_rate"),
         format_valid=format_valid,
         length=_read_review_output_length(run_dir),
     )
@@ -1020,7 +1021,7 @@ class _ProductionHarvestServices:
         set_run_pr_link(self.archive_dir, row.session_id, number, repo)
 
     def read_scoring_inputs(self, row: HarvestRow) -> ScoringInputs:
-        return assemble_scoring_inputs(row.archive_path, row)
+        return assemble_scoring_inputs(row.archive_path, {"grounding_rate": row.grounding_rate})
 
     def read_recorded_fingerprints(self, row: HarvestRow) -> tuple[str, ...]:
         if row.findings_fingerprints is not None:

--- a/daydream/training/harvest_types.py
+++ b/daydream/training/harvest_types.py
@@ -1,0 +1,179 @@
+"""Validated archive rows and immutable acquired harvest evidence."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from dataclasses import dataclass, replace
+from pathlib import Path
+from typing import Any, Literal
+
+from daydream.training._immutable_json import freeze_json
+from daydream.training.reward import ScoringInputs
+from daydream.training.rubric import Rubric
+
+BaseShaStatus = Literal["available", "unavailable", "failed"]
+
+
+@dataclass(frozen=True)
+class HarvestRow:
+    """The consumed archive columns, validated before acquisition side effects."""
+
+    session_id: str
+    archive_path: Path
+    source_path: Path | None = None
+    remote_url: str | None = None
+    repo_slug: str | None = None
+    branch: str | None = None
+    base_branch: str | None = None
+    head_sha: str | None = None
+    base_sha: str | None = None
+    pr_repo: str | None = None
+    pr_number: int | None = None
+    grounding_rate: float | None = None
+    changed_files: tuple[str, ...] = ()
+    findings_fingerprints: tuple[str, ...] | None = None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "changed_files", tuple(self.changed_files))
+        if self.findings_fingerprints is not None:
+            object.__setattr__(self, "findings_fingerprints", tuple(self.findings_fingerprints))
+
+    @classmethod
+    def from_mapping(cls, raw: Mapping[str, Any], *, row_number: int) -> HarvestRow:
+        """Validate identity/path columns without probing files or GitHub.
+
+        Optional historical columns may be absent. Malformed changed-files JSON
+        retains its established empty-list fallback; invalid identity/path types
+        do not silently select an ambient directory or external repository.
+        """
+        session = raw.get("session_id") if isinstance(raw, Mapping) else None
+        label = repr(session) if isinstance(session, str) else "<unknown>"
+
+        def invalid(field: str, reason: str) -> ValueError:
+            return ValueError(f"harvest row {row_number} session {label}: {field} {reason}")
+
+        if not isinstance(raw, Mapping):
+            raise invalid("row", "must be a mapping")
+        if (
+            not isinstance(session, str) or not session.strip()
+            or session in (".", "..") or any(char in session for char in "/\\\0")
+        ):
+            raise invalid("session_id", "must be a nonempty safe path segment")
+
+        def text(field: str) -> str | None:
+            value = raw.get(field)
+            if value is None:
+                return None
+            if not isinstance(value, str):
+                raise invalid(field, "must be a string or null")
+            if "\0" in value:
+                raise invalid(field, "must not contain NUL")
+            return value
+
+        def path(field: str, *, required: bool = False) -> Path | None:
+            value = text(field)
+            if value is None or value == "":
+                if required:
+                    raise invalid(field, "must be a nonempty absolute path")
+                return None
+            result = Path(value)
+            if required and not result.is_absolute():
+                raise invalid(field, "must be an absolute path")
+            return result
+
+        def slug(field: str) -> str | None:
+            value = text(field)
+            if value is None or value == "":
+                return value
+            parts = value.split("/")
+            if len(parts) != 2 or any(part in ("", ".", "..") for part in parts) or "\\" in value:
+                raise invalid(field, "must contain safe owner/repository components")
+            return value
+
+        archive_path = path("archive_path", required=True)
+        assert archive_path is not None
+        number = raw.get("pr_number")
+        if number is not None and (type(number) is not int or number <= 0):
+            raise invalid("pr_number", "must be a positive integer or null")
+        grounding = raw.get("grounding_rate")
+        if grounding is not None and type(grounding) not in (int, float):
+            raise invalid("grounding_rate", "must be a number or null")
+        changed = raw.get("changed_files")
+        if changed is None:
+            changed = []
+        elif not isinstance(changed, list):
+            try:
+                changed = json.loads(changed)
+            except (TypeError, json.JSONDecodeError):
+                changed = []
+        if not isinstance(changed, list):
+            changed = []
+        if any(not isinstance(item, str) for item in changed):
+            raise invalid("changed_files", "must contain strings")
+        fingerprints = raw.get("findings_fingerprints")
+        return cls(
+            session_id=session, archive_path=archive_path,
+            source_path=path("source_path"), remote_url=text("remote_url"),
+            repo_slug=slug("repo_slug"), branch=text("branch"),
+            base_branch=text("base_branch"), head_sha=text("head_sha"),
+            base_sha=text("base_sha"), pr_repo=slug("pr_repo"),
+            pr_number=number, grounding_rate=grounding,
+            changed_files=tuple(changed),
+            findings_fingerprints=(
+                tuple(str(item) for item in fingerprints) if isinstance(fingerprints, list) else None
+            ),
+        )
+
+    @property
+    def is_pr(self) -> bool:
+        """Preserve the existing PR discriminator, including incomplete links."""
+        return bool(self.pr_repo) and self.pr_number is not None
+
+    def as_signal_row(self) -> dict[str, Any]:
+        """Project a fresh legacy row for the unchanged external signal helpers."""
+        row: dict[str, Any] = {
+            "session_id": self.session_id, "archive_path": str(self.archive_path),
+            "source_path": str(self.source_path) if self.source_path is not None else None,
+            "remote_url": self.remote_url, "repo_slug": self.repo_slug,
+            "branch": self.branch, "base_branch": self.base_branch,
+            "head_sha": self.head_sha, "base_sha": self.base_sha,
+            "pr_repo": self.pr_repo, "pr_number": self.pr_number,
+            "grounding_rate": self.grounding_rate, "changed_files": list(self.changed_files),
+        }
+        if self.findings_fingerprints is not None:
+            row["findings_fingerprints"] = list(self.findings_fingerprints)
+        return row
+
+
+@dataclass(frozen=True)
+class HarvestEvidence:
+    """Completed acquisition, with owned immutable nested signal collections."""
+
+    scoring_inputs: ScoringInputs
+    rubric: Rubric
+    reviewer_logins: tuple[str, ...] = ()
+    pooled_prior: float | None = None
+    prior_n: int = 0
+    repo_resolution: Path | None = None
+    base_sha_status: BaseShaStatus = "unavailable"
+    valid_at_override: str | None = None
+
+    def __post_init__(self) -> None:
+        verdicts = self.scoring_inputs.verifier_verdicts
+        object.__setattr__(self, "scoring_inputs", replace(
+            self.scoring_inputs,
+            verifier_verdicts=None if verdicts is None else tuple(freeze_json(item) for item in verdicts),
+        ))
+        resolutions = self.rubric.per_finding_resolutions
+        object.__setattr__(self, "rubric", replace(
+            self.rubric,
+            fix_applied=replace(self.rubric.fix_applied, window_commits=tuple(self.rubric.fix_applied.window_commits)),
+            per_finding_resolutions=(
+                None if resolutions is None else tuple(
+                    replace(resolution, evidence=tuple(freeze_json(entry) for entry in resolution.evidence))
+                    for resolution in resolutions
+                )
+            ),
+        ))
+        object.__setattr__(self, "reviewer_logins", tuple(self.reviewer_logins))

--- a/daydream/training/labeler_signals.py
+++ b/daydream/training/labeler_signals.py
@@ -26,11 +26,13 @@ from __future__ import annotations
 import hashlib
 import json
 import re
+from collections.abc import Sequence
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Callable, Literal, Mapping, cast, get_args
 
 from daydream.pr_review import parse_finding_markers
+from daydream.training._immutable_json import thaw_json
 from daydream.training.labeler_versions import reply_evidence_digest
 from daydream.training.reply_classifier import (
     _QUALIFYING_ASSOCIATIONS,
@@ -104,7 +106,7 @@ class FixAppliedSignal:
     verdict: Literal["applied", "not_applied", "unknown"]
     hunks_applied: int
     hunks_total: int
-    window_commits: list[str] = field(default_factory=list)
+    window_commits: Sequence[str] = field(default_factory=list)
 
 
 @dataclass(frozen=True)
@@ -234,7 +236,7 @@ class PerFindingResolution:
     fingerprint: str
     comment_id: int | None
     disposition: PerFindingDisposition
-    evidence: list[dict[str, Any]] = field(default_factory=list)
+    evidence: Sequence[Mapping[str, Any]] = field(default_factory=list)
     evidence_digest: str = ""
 
 
@@ -248,7 +250,7 @@ def resolution_to_dict(r: PerFindingResolution) -> dict[str, Any]:
         "fingerprint": r.fingerprint,
         "comment_id": r.comment_id,
         "disposition": r.disposition,
-        "evidence": list(r.evidence),
+        "evidence": [thaw_json(entry) for entry in r.evidence],
         "evidence_digest": r.evidence_digest,
     }
 

--- a/daydream/training/reward.py
+++ b/daydream/training/reward.py
@@ -87,6 +87,7 @@ from __future__ import annotations
 import hashlib
 import json
 import types
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -237,7 +238,7 @@ class ScoringInputs:
         length: Char-count length proxy, or ``None`` when absent.
     """
 
-    verifier_verdicts: list[dict[str, Any]] | None
+    verifier_verdicts: Sequence[Mapping[str, Any]] | None
     grounding_rate: float | None
     format_valid: bool
     length: int | None

--- a/daydream/training/rubric.py
+++ b/daydream/training/rubric.py
@@ -21,6 +21,7 @@ classifier dispositions), ``ambiguous`` / ``unanswered`` /
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Any, Literal
 
@@ -68,7 +69,7 @@ class Rubric:
     comment_resolution: CommentResolutionSignal
     local_commit_applied: LocalCommitAppliedSignal | None
     posterior_source: PosteriorSource
-    per_finding_resolutions: list[PerFindingResolution] | None = None
+    per_finding_resolutions: Sequence[PerFindingResolution] | None = None
 
     def to_dict(self) -> dict[str, Any]:
         """Return a JSON-serializable representation with explicit key order.
@@ -158,7 +159,7 @@ def derive_outcome_label(rubric: Rubric) -> str:
 
 def derive_per_finding_labels(
     rubric: Rubric,
-    per_finding: list[PerFindingResolution],
+    per_finding: Sequence[PerFindingResolution],
 ) -> list[PerFindingLabel]:
     """Reduce per-finding resolutions to one outcome label per finding.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -705,27 +705,6 @@ def archive_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[Pat
     yield path
 
 
-@pytest.fixture(autouse=True)
-def _no_harvest_row_spacing(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Skip the harvest inter-row rate-limit delay so tests don't sleep for real.
-
-    ``run_harvest`` awaits ``_row_spacing_sleep(gh_request_spacing_sec)`` (default
-    0.8s) between every row to spread ``gh`` calls under GitHub's secondary rate
-    limits — real-time politeness with no bearing on test logic. Left unstubbed,
-    every ``run_harvest`` test paid 0.8s/row (the 10-row degrade test alone burned
-    8.17s of wall clock). Stub the module-level seam (mirroring how
-    ``_rate_limit_sleep`` is stubbed) so the delay is a no-op; no test asserts it
-    is honored. Lazy-imported so unrelated tests don't eagerly load the harvest
-    stack.
-    """
-    from daydream.training import harvest
-
-    async def _noop(_seconds: float) -> None:
-        return None
-
-    monkeypatch.setattr(harvest, "_row_spacing_sleep", _noop)
-
-
 _CURRENT_API = object()  # sentinel: "use the tool's current version"
 
 

--- a/tests/harness/harvest_services.py
+++ b/tests/harness/harvest_services.py
@@ -1,0 +1,136 @@
+"""Explicit per-run harvest service doubles for training tests."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from pathlib import Path
+from typing import Any
+
+from rich.console import Console
+
+from daydream.training.harvest import AnnotationPayload, HarvestServices
+from daydream.training.harvest_types import BaseShaStatus, HarvestRow
+from daydream.training.labeler_signals import FixAppliedSignal, LocalCommitAppliedSignal
+from daydream.training.reward import ScoringInputs
+
+
+class HarvestTestServices:
+    """Forward a concrete per-run provider while explicitly replacing test seams.
+
+    The double deliberately implements the public protocol itself. It neither
+    subclasses nor reaches into the production provider, so each test owns its
+    GitHub response, timing, and any acquisition override while retaining real
+    SQLite/cache behavior through the supplied delegate.
+    """
+
+    def __init__(
+        self,
+        delegate: HarvestServices,
+        *,
+        rows: list[Mapping[str, Any]] | None = None,
+        completed: set[str] | None = None,
+        completed_sessions: Callable[[], set[str]] | None = None,
+        github: Callable[..., Any] | None = None,
+        resolve_repo: Callable[..., Path | None] | None = None,
+        reviewer_prior: Callable[..., tuple[float | None, int]] | None = None,
+        local_commit_applied: Callable[..., LocalCommitAppliedSignal] | None = None,
+        append_annotation: Callable[..., bool] | None = None,
+    ) -> None:
+        self._delegate = delegate
+        self._rows = rows
+        self._completed = completed
+        self._completed_sessions = completed_sessions
+        self._github = github
+        self._resolve_repo = resolve_repo
+        self._reviewer_prior = reviewer_prior
+        self._local_commit_applied = local_commit_applied
+        self._append_annotation = append_annotation
+
+    @property
+    def archive_dir(self) -> Path:
+        return self._delegate.archive_dir
+
+    @property
+    def progress_path(self) -> Path | None:
+        return self._delegate.progress_path
+
+    def query_rows(self, session_filter: str | None) -> list[Mapping[str, Any]]:
+        return list(self._rows) if self._rows is not None else list(self._delegate.query_rows(session_filter))
+
+    def completed_sessions(self) -> set[str]:
+        if self._completed_sessions is not None:
+            return self._completed_sessions()
+        return set(self._completed) if self._completed is not None else self._delegate.completed_sessions()
+
+    def resolve_repo(self, row: HarvestRow, *, console: Console) -> Path | None:
+        if self._resolve_repo is not None:
+            return self._resolve_repo(row, console=console)
+        return self._delegate.resolve_repo(row, console=console)
+
+    def materialize_base_sha(
+        self, row: HarvestRow, repo_clone: Path | None, *, console: Console
+    ) -> BaseShaStatus:
+        return self._delegate.materialize_base_sha(row, repo_clone, console=console)
+
+    def github(self, repo: str, endpoint: str, **kwargs: Any) -> Any:
+        if self._github is not None:
+            return self._github(repo, endpoint, **kwargs)
+        return self._delegate.github(repo, endpoint, **kwargs)
+
+    def reviewer_prior(
+        self,
+        logins: tuple[str, ...],
+        *,
+        before_valid_at: str,
+        exclude_session: str,
+        repo_slug: str | None,
+    ) -> tuple[float | None, int]:
+        if self._reviewer_prior is not None:
+            return self._reviewer_prior(
+                logins,
+                before_valid_at=before_valid_at,
+                exclude_session=exclude_session,
+                repo_slug=repo_slug,
+            )
+        return self._delegate.reviewer_prior(
+            logins,
+            before_valid_at=before_valid_at,
+            exclude_session=exclude_session,
+            repo_slug=repo_slug,
+        )
+
+    def set_pr_link(self, row: HarvestRow, number: int, repo: str) -> None:
+        self._delegate.set_pr_link(row, number, repo)
+
+    def read_scoring_inputs(self, row: HarvestRow) -> ScoringInputs:
+        return self._delegate.read_scoring_inputs(row)
+
+    def read_recorded_fingerprints(self, row: HarvestRow) -> tuple[str, ...]:
+        return self._delegate.read_recorded_fingerprints(row)
+
+    def fix_applied(
+        self, row: HarvestRow, *, changed_files: tuple[str, ...], repo_clone: Path
+    ) -> FixAppliedSignal:
+        return self._delegate.fix_applied(row, changed_files=changed_files, repo_clone=repo_clone)
+
+    def local_commit_applied(self, row: HarvestRow, *, repo_clone: Path) -> LocalCommitAppliedSignal:
+        if self._local_commit_applied is not None:
+            return self._local_commit_applied(row, repo_clone=repo_clone)
+        return self._delegate.local_commit_applied(row, repo_clone=repo_clone)
+
+    def append_annotation(self, row: HarvestRow, payload: AnnotationPayload) -> bool:
+        if self._append_annotation is not None:
+            return self._append_annotation(row, payload)
+        return self._delegate.append_annotation(row, payload)
+
+    def mark_session_done(self, session_id: str) -> None:
+        self._delegate.mark_session_done(session_id)
+
+    def now_iso(self) -> str:
+        return self._delegate.now_iso()
+
+    def backoff_sleep(self, seconds: float) -> None:
+        self._delegate.backoff_sleep(seconds)
+
+    async def sleep_between_rows(self, seconds: float) -> None:
+        """Skip real inter-row delay in provider-driven tests."""

--- a/tests/test_cli_corpus_harvest_integration.py
+++ b/tests/test_cli_corpus_harvest_integration.py
@@ -1,0 +1,165 @@
+"""Corpus harvest composition through real git, archive, and resume storage."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from contextlib import closing
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from daydream import cli, git_ops
+from daydream.archive.index import label_observation_history, query_runs, upsert_run
+from daydream.pr_review import DAYDREAM_FOOTER, finding_marker
+from daydream.training import labeler_versions, reward
+from tests.harness.git_helpers import git
+from tests.harness.trajectory import make_manifest
+
+
+@pytest.mark.parametrize("outcome", ["accepted", "unanswered", "malformed", "rate_limited"])
+def test_corpus_harvest_archive_and_resume_journey(
+    tmp_path: Path,
+    archive_dir: Path,
+    git_repo: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    outcome: str,
+) -> None:
+    session = "cli-harvest-session"
+    head = git(git_repo, "rev-parse", "HEAD")
+    run_dir = archive_dir / session
+    (run_dir / "deep").mkdir(parents=True)
+    (run_dir / "deep" / "recommendation-verdicts.json").write_text(
+        json.dumps({"verdicts": [{"verdict": "consistent"}]}), encoding="utf-8"
+    )
+    fingerprint = "a" * 64
+    (run_dir / "findings.json").write_text(
+        json.dumps({"findings": [{"fingerprint": fingerprint}]}), encoding="utf-8"
+    )
+    manifest = make_manifest(
+        session_id=session,
+        archive_path=str(run_dir),
+        source_path=str(git_repo),
+        repo_slug="org/repo",
+        branch="main",
+        base_branch="main",
+        head_sha=head,
+        grounding_rate=1.0,
+        pr_number=None,
+        pr_repo=None,
+    )
+    manifest_path = run_dir / "manifest.json"
+    manifest_path.write_text(json.dumps(manifest.to_dict()), encoding="utf-8")
+    original_manifest = manifest_path.read_bytes()
+    upsert_run(archive_dir, manifest)
+    if outcome == "malformed":
+        with closing(sqlite3.connect(archive_dir / "index.db")) as connection:
+            connection.execute("UPDATE runs SET archive_path = '' WHERE session_id = ?", (session,))
+            connection.commit()
+
+    endpoints: list[str] = []
+    rate_limited = outcome == "rate_limited"
+    comments: list[dict[str, Any]] = [{
+        "id": 1,
+        "user": {"login": "daydream-runner"},
+        "body": f"finding\n\n{finding_marker(fingerprint)}\n\n{DAYDREAM_FOOTER}",
+    }]
+    if outcome != "unanswered":
+        comments.append({
+            "id": 2,
+            "in_reply_to_id": 1,
+            "user": {"login": "reviewer"},
+            "author_association": "OWNER",
+            "body": "Good catch, applied.",
+            "created_at": "2026-09-10T10:00:00Z",
+        })
+
+    def github_boundary(
+        repo: Path,
+        endpoint: str,
+        *,
+        auth: git_ops.GitHubAuth,
+        **kwargs: Any,
+    ) -> Any:
+        assert repo == Path(".")
+        assert auth is git_ops.INHERIT_GITHUB_AUTH
+        endpoints.append(endpoint)
+        if rate_limited:
+            raise git_ops.RateLimitError("rate limit", retry_after=0)
+        if endpoint == f"repos/org/repo/commits/{head}/pulls":
+            assert kwargs["paginate"] is True
+            return [{"number": 7, "head": {"sha": head, "repo": {"full_name": "org/repo"}}}]
+        if endpoint == "repos/org/repo/pulls/7":
+            return {"merged": True, "merged_at": "2026-09-10T11:00:00Z", "user": {"login": "author"}}
+        assert kwargs["paginate"] is True
+        if endpoint == "repos/org/repo/pulls/7/reviews":
+            return [{"user": {"login": "reviewer"}}]
+        if endpoint == "repos/org/repo/pulls/7/comments":
+            return comments
+        pytest.fail(f"unexpected GitHub endpoint: {endpoint}")
+
+    monkeypatch.setattr(git_ops, "gh_api", github_boundary)
+    cache_dir = tmp_path / "cache"
+
+    def harvest(cache: Path) -> int:
+        with pytest.raises(SystemExit) as exit_info:
+            cli.main([
+                "corpus", "harvest", "--archive-dir", str(archive_dir),
+                "--cache-dir", str(cache), "--gh-spacing-sec", "0",
+            ])
+        return int(exit_info.value.code or 0)
+
+    first_exit = harvest(cache_dir)
+    if outcome == "malformed":
+        assert first_exit == 1
+        diagnostic = capsys.readouterr().out
+        assert session in diagnostic
+        assert "archive_path" in diagnostic
+        assert endpoints == []
+        assert not cache_dir.exists()
+        assert manifest_path.read_bytes() == original_manifest
+        assert label_observation_history(archive_dir, session) == []
+        return
+
+    progress_path = cache_dir / "progress.jsonl"
+    if rate_limited:
+        assert first_exit == 1
+        assert not progress_path.exists()
+        assert label_observation_history(archive_dir, session) == []
+        rate_limited = False
+        assert harvest(cache_dir) == 0
+    else:
+        assert first_exit == 0
+
+    row, = query_runs(archive_dir)
+    assert (row["pr_number"], row["pr_repo"]) == (7, "org/repo")
+    assert json.loads(manifest_path.read_text())["code_context"]["base_sha"] == head
+    annotation, = label_observation_history(archive_dir, session)
+    assert annotation["reward_version"] == reward.REWARD_VERSION
+    assert json.loads(annotation["labels"]) == ([] if outcome == "unanswered" else ["accepted"])
+    assert annotation["valid_at"] == (
+        "2026-09-10T11:00:00+00:00" if outcome == "unanswered" else "2026-09-10T10:00:00+00:00"
+    )
+    marker, = [json.loads(line) for line in progress_path.read_text().splitlines()]
+    assert marker["session_id"] == session
+    assert marker["labeler_policy_version"] == labeler_versions.LABELER_POLICY_VERSION
+    assert set(endpoints) == {
+        f"repos/org/repo/commits/{head}/pulls",
+        "repos/org/repo/pulls/7",
+        "repos/org/repo/pulls/7/reviews",
+        "repos/org/repo/pulls/7/comments",
+    }
+
+    previous_endpoints = list(endpoints)
+    previous_progress = progress_path.read_bytes()
+    assert harvest(cache_dir) == 0
+    assert endpoints == previous_endpoints
+    assert progress_path.read_bytes() == previous_progress
+    assert label_observation_history(archive_dir, session) == [annotation]
+    # A fresh resume cache re-acquires evidence, while SQLite still deduplicates it.
+    next_cache = tmp_path / "next-cache"
+    assert harvest(next_cache) == 0
+    assert label_observation_history(archive_dir, session) == [annotation]
+    assert json.loads((next_cache / "progress.jsonl").read_text())["session_id"] == session

--- a/tests/test_cli_corpus_namespace.py
+++ b/tests/test_cli_corpus_namespace.py
@@ -14,7 +14,6 @@ code and on whether the handler was actually invoked — not on mere dispatch.
 """
 import json
 from pathlib import Path
-from typing import Any
 
 import pytest
 
@@ -34,44 +33,6 @@ def _run_main(argv: list[str]) -> int:
     finally:
         sys.argv = saved
     return 0
-
-
-def test_corpus_harvest_exits_nonzero_on_aborted_summary(monkeypatch: pytest.MonkeyPatch) -> None:
-    def _fake_run_harvest(_config: Any) -> dict[str, Any]:
-        return {"considered": 3, "annotated": 1, "skipped": 0, "errors": 0, "aborted": 1}
-
-    monkeypatch.setattr("daydream.training.harvest.run_harvest", _fake_run_harvest)
-    assert _run_main(["corpus", "harvest", "--dry-run"]) == 1
-
-
-def test_corpus_harvest_exits_nonzero_on_row_errors(monkeypatch: pytest.MonkeyPatch) -> None:
-    def _fake_run_harvest(_config: Any) -> dict[str, Any]:
-        return {"considered": 3, "annotated": 1, "skipped": 0, "errors": 2, "aborted": 0}
-
-    monkeypatch.setattr("daydream.training.harvest.run_harvest", _fake_run_harvest)
-    assert _run_main(["corpus", "harvest", "--dry-run"]) == 1
-
-
-def test_corpus_harvest_still_exits_zero_on_clean_partial(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Unresolved findings in the data are not process failure (spec KD)."""
-
-    def _fake_run_harvest(_config: Any) -> dict[str, Any]:
-        return {"considered": 3, "annotated": 1, "skipped": 2, "errors": 0, "aborted": 0}
-
-    monkeypatch.setattr("daydream.training.harvest.run_harvest", _fake_run_harvest)
-    assert _run_main(["corpus", "harvest", "--dry-run"]) == 0
-
-
-def test_corpus_harvest_routes(monkeypatch: pytest.MonkeyPatch) -> None:
-    called = {}
-
-    def _fake_run_harvest(_config: Any) -> dict[str, Any]:
-        called["hit"] = True
-        return {"errors": 0, "annotated": 0, "skipped": 0, "total": 0}
-
-    monkeypatch.setattr("daydream.training.harvest.run_harvest", _fake_run_harvest)
-    assert _run_main(["corpus", "harvest", "--dry-run"]) == 0
-    assert called["hit"]
 
 
 def test_corpus_build_and_label_route(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:

--- a/tests/test_corpus_reproducibility.py
+++ b/tests/test_corpus_reproducibility.py
@@ -9,9 +9,9 @@ old ``as_of`` reproduces a prior corpus byte-for-byte even after the reward
 formula changes.
 
 Drives the production ``run_harvest`` + ``run_build_corpus`` against a real
-SQLite index (no archive-layer mocking). The PR posterior fetch is stubbed via
-the ``daydream.training.harvest._gh_api`` monkeypatch — the same seam the other
-harvest tests use — so the run never touches the network or the ``gh`` CLI.
+SQLite index (no archive-layer mocking). The PR posterior fetch is supplied by
+an explicit per-run service, so the run never touches the network or the
+``gh`` CLI.
 """
 from __future__ import annotations
 
@@ -22,7 +22,8 @@ from typing import Any
 import pytest
 
 from daydream.training.corpus import BuildCorpusConfig, CorpusFilters, run_build_corpus
-from daydream.training.harvest import HarvestConfig, run_harvest
+from daydream.training.harvest import HarvestConfig, make_harvest_services, run_harvest
+from tests.harness.harvest_services import HarvestTestServices
 from tests.test_training_harvest import _fake_gh_merged, _seed_archived_deep_run
 
 
@@ -32,16 +33,24 @@ async def test_rescore_preserves_old_as_of_byte_for_byte(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     _seed_archived_deep_run(archive_dir, "s1", merged_at="2026-02-01T00:00:00+00:00")
-    monkeypatch.setattr("daydream.training.harvest._gh_api", _fake_gh_merged("2026-02-01T00:00:00+00:00"))
+    github = _fake_gh_merged("2026-02-01T00:00:00+00:00")
     monkeypatch.setattr("daydream.training.reward.REWARD_VERSION", "r1")
-    await run_harvest(HarvestConfig(archive_dir=archive_dir, cache_dir=tmp_path / "c1"))
+    first_config = HarvestConfig(archive_dir=archive_dir, cache_dir=tmp_path / "c1")
+    await run_harvest(
+        first_config,
+        services=HarvestTestServices(make_harvest_services(first_config), github=github),
+    )
     pin = datetime.now(timezone.utc).isoformat()
     out_a = tmp_path / "a.jsonl"
     run_build_corpus(BuildCorpusConfig(out_path=out_a, archive_dir=archive_dir,
                                        filters=CorpusFilters(include_all_labels=True), as_of=pin))
     bytes_a = out_a.read_bytes()
     monkeypatch.setattr("daydream.training.reward.REWARD_VERSION", "r2")  # bump + re-harvest
-    await run_harvest(HarvestConfig(archive_dir=archive_dir, cache_dir=tmp_path / "c2"))
+    second_config = HarvestConfig(archive_dir=archive_dir, cache_dir=tmp_path / "c2")
+    await run_harvest(
+        second_config,
+        services=HarvestTestServices(make_harvest_services(second_config), github=github),
+    )
     out_a2 = tmp_path / "a2.jsonl"
     run_build_corpus(BuildCorpusConfig(out_path=out_a2, archive_dir=archive_dir,
                                        filters=CorpusFilters(include_all_labels=True), as_of=pin))

--- a/tests/test_harvest_archive_ownership.py
+++ b/tests/test_harvest_archive_ownership.py
@@ -1,0 +1,168 @@
+"""Archive ownership checks shared by harvest and annotation backfill."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from pathlib import Path
+from typing import Any, Literal
+
+import pytest
+
+from daydream.archive.index import label_observation_history
+from daydream.training.backfill import run_backfill
+from daydream.training.harvest import (
+    HarvestConfig,
+    HarvestServices,
+    make_harvest_services,
+    run_harvest,
+)
+from tests.harness.harvest_services import HarvestTestServices
+from tests.test_training_harvest import _seed_archived_deep_run
+
+Entrypoint = Literal["harvest", "backfill"]
+_SESSION_ID = "shared-session"
+
+
+class _ObservedServices(HarvestTestServices):
+    """Record the archive query boundary while retaining production adapters."""
+
+    def __init__(
+        self,
+        delegate: HarvestServices,
+        *,
+        github: Callable[..., Any],
+        events: list[str],
+    ) -> None:
+        super().__init__(delegate, github=github)
+        self._events = events
+
+    def query_rows(self, session_filter: str | None) -> list[Mapping[str, Any]]:
+        self._events.append("query")
+        return super().query_rows(session_filter)
+
+
+def _github(events: list[str]) -> Callable[..., Any]:
+    def respond(repo: str, endpoint: str, **kwargs: Any) -> Any:
+        events.append("github")
+        if endpoint.endswith("/comments") or endpoint.endswith("/reviews"):
+            return []
+        return {"merged": True, "merged_at": "2026-02-01T00:00:00Z"}
+
+    return respond
+
+
+def _seed_archive(path: Path) -> None:
+    path.mkdir(exist_ok=True)
+    _seed_archived_deep_run(
+        path,
+        _SESSION_ID,
+        merged_at="2026-02-01T00:00:00Z",
+    )
+
+
+async def _invoke(
+    entrypoint: Entrypoint,
+    requested_archive: Path,
+    services: HarvestServices,
+    *,
+    cache_dir: Path,
+    report_path: Path,
+) -> None:
+    if entrypoint == "harvest":
+        await run_harvest(
+            HarvestConfig(
+                archive_dir=requested_archive,
+                cache_dir=cache_dir,
+                gh_request_spacing_sec=0,
+            ),
+            services=services,
+        )
+        return
+    run_backfill(
+        requested_archive,
+        services=services,
+        report_path=report_path,
+    )
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("entrypoint", ["harvest", "backfill"])
+async def test_entrypoint_rejects_services_owned_by_another_archive_before_side_effects(
+    tmp_path: Path,
+    entrypoint: Entrypoint,
+) -> None:
+    archive_a = tmp_path / "archive-a"
+    archive_b = tmp_path / "archive-b"
+    _seed_archive(archive_a)
+    _seed_archive(archive_b)
+    service_cache = tmp_path / "service-cache"
+    requested_cache = tmp_path / "requested-cache"
+    report_path = tmp_path / "backfill-report.json"
+    events: list[str] = []
+    services = _ObservedServices(
+        make_harvest_services(
+            HarvestConfig(archive_dir=archive_a, cache_dir=service_cache)
+        ),
+        github=_github(events),
+        events=events,
+    )
+    histories_before = {
+        archive: label_observation_history(archive, _SESSION_ID)
+        for archive in (archive_a, archive_b)
+    }
+
+    with pytest.raises(ValueError, match="archive"):
+        await _invoke(
+            entrypoint,
+            archive_b,
+            services,
+            cache_dir=requested_cache,
+            report_path=report_path,
+        )
+
+    assert events == []
+    assert {
+        archive: label_observation_history(archive, _SESSION_ID)
+        for archive in (archive_a, archive_b)
+    } == histories_before
+    assert not service_cache.exists()
+    assert not requested_cache.exists()
+    assert not report_path.exists()
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("entrypoint", ["harvest", "backfill"])
+async def test_entrypoint_accepts_services_owned_by_symlink_alias(
+    tmp_path: Path,
+    entrypoint: Entrypoint,
+) -> None:
+    archive = tmp_path / "archive"
+    _seed_archive(archive)
+    archive_alias = tmp_path / "archive-alias"
+    archive_alias.symlink_to(archive, target_is_directory=True)
+    events: list[str] = []
+    services = _ObservedServices(
+        make_harvest_services(
+            HarvestConfig(
+                archive_dir=archive,
+                cache_dir=tmp_path / "service-cache",
+            )
+        ),
+        github=_github(events),
+        events=events,
+    )
+
+    await _invoke(
+        entrypoint,
+        archive_alias,
+        services,
+        cache_dir=tmp_path / "requested-cache",
+        report_path=tmp_path / "backfill-report.json",
+    )
+
+    assert events[0] == "query"
+    assert "github" in events
+    assert len(label_observation_history(archive, _SESSION_ID)) == 1
+    assert label_observation_history(archive_alias, _SESSION_ID) == (
+        label_observation_history(archive, _SESSION_ID)
+    )

--- a/tests/test_training_adjudication_snapshot.py
+++ b/tests/test_training_adjudication_snapshot.py
@@ -1,15 +1,26 @@
 """Tests for the shared per-finding annotation snapshot serializer (issue #1055, Task 1)."""
 
+import json
+
 import pytest
 
 from daydream.training.adjudication.snapshot import (
     ANNOTATION_SNAPSHOT_SCHEMA_VERSION,
     build_canonical_record,
+    record_evidence_digest,
     snapshot_id,
 )
 from daydream.training.harvest import _reply_evidence_digest  # session-level twin
-from daydream.training.labeler_signals import PerFindingResolution
+from daydream.training.harvest_types import HarvestEvidence
+from daydream.training.labeler_signals import (
+    CommentResolutionSignal,
+    FixAppliedSignal,
+    PerFindingResolution,
+    PRMergeSignal,
+)
 from daydream.training.labeler_versions import reply_evidence_digest
+from daydream.training.reward import ScoringInputs
+from daydream.training.rubric import Rubric
 
 
 def _resolution(fp: str = "fp-1", digest: str = "d" * 32) -> PerFindingResolution:
@@ -20,6 +31,67 @@ def _resolution(fp: str = "fp-1", digest: str = "d" * 32) -> PerFindingResolutio
         evidence=[{"reply_id": 1, "body_sha256": "abc"}],
         evidence_digest=digest,
     )
+
+
+def _mutable_and_frozen_resolution() -> tuple[
+    PerFindingResolution,
+    PerFindingResolution,
+    HarvestEvidence,
+]:
+    source_evidence = [
+        {
+            "reply_id": 1,
+            "body_sha256": "abc",
+            "context": {"labels": ["accepted", "reviewed"]},
+        }
+    ]
+    resolution = PerFindingResolution(
+        fingerprint="fp-1",
+        comment_id=7,
+        disposition="accepted",
+        evidence=source_evidence,
+        evidence_digest=reply_evidence_digest(source_evidence),
+    )
+    rubric = Rubric(
+        pr_merge=PRMergeSignal(merged=True, merged_at="2026-01-01T00:00:00Z"),
+        fix_applied=FixAppliedSignal(
+            verdict="applied",
+            hunks_applied=1,
+            hunks_total=1,
+            window_commits=["abc123"],
+        ),
+        comment_resolution=CommentResolutionSignal(total=1, replied=1, unresolved=0),
+        local_commit_applied=None,
+        posterior_source="pr_review",
+        per_finding_resolutions=[resolution],
+    )
+    harvest_evidence = HarvestEvidence(
+        scoring_inputs=ScoringInputs(
+            verifier_verdicts=None,
+            grounding_rate=None,
+            format_valid=True,
+            length=None,
+        ),
+        rubric=rubric,
+    )
+    frozen_resolutions = harvest_evidence.rubric.per_finding_resolutions
+    assert frozen_resolutions is not None
+    return resolution, frozen_resolutions[0], harvest_evidence
+
+
+def _snapshot_session() -> dict[str, object]:
+    return {
+        "session_id": "s1",
+        "trajectory_id": "s1-t",
+        "segment_id": "s1-seg",
+        "resolutions": [
+            {
+                "fingerprint": "fp-1",
+                "profile_name": "pr_review",
+                "stack": "python",
+            }
+        ],
+    }
 
 
 def test_build_canonical_record_pins_identity_and_provenance() -> None:
@@ -44,6 +116,37 @@ def test_build_canonical_record_pins_identity_and_provenance() -> None:
 
     assert record["classifier_version"] == labeler_versions.REPLY_CLASSIFIER_VERSION
     assert ANNOTATION_SNAPSHOT_SCHEMA_VERSION in record["schema_version"]
+
+
+def test_build_canonical_record_serializes_frozen_harvest_evidence_canonically() -> None:
+    mutable, frozen, _harvest_evidence = _mutable_and_frozen_resolution()
+    session = _snapshot_session()
+    mutable_record = build_canonical_record(
+        session,
+        mutable,
+        evidence_observed_at="2026-01-01T00:00:00Z",
+    )
+    frozen_record = build_canonical_record(
+        session,
+        frozen,
+        evidence_observed_at="2026-01-01T00:00:00Z",
+    )
+
+    assert json.dumps(frozen_record, sort_keys=True) == json.dumps(
+        mutable_record,
+        sort_keys=True,
+    )
+
+
+def test_record_evidence_digest_matches_frozen_harvest_digest_with_nested_json() -> None:
+    mutable, frozen, harvest_evidence = _mutable_and_frozen_resolution()
+
+    assert record_evidence_digest([frozen.evidence]) == record_evidence_digest(
+        [mutable.evidence]
+    )
+    assert record_evidence_digest([frozen.evidence]) == _reply_evidence_digest(
+        harvest_evidence.rubric
+    )
 
 
 def test_record_evidence_digest_matches_harvest_row_digest() -> None:

--- a/tests/test_training_backfill.py
+++ b/tests/test_training_backfill.py
@@ -18,17 +18,16 @@ from __future__ import annotations
 
 import json
 import sqlite3
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
-import pytest
-
 from daydream.archive.index import upsert_run
 from daydream.archive.manifest import Manifest
-from daydream.git_ops import GitError, RateLimitError
+from daydream.git_ops import INHERIT_GITHUB_AUTH, GitError, RateLimitError
 from daydream.pr_review import DAYDREAM_FOOTER, finding_marker
-from daydream.training import backfill
 from daydream.training.backfill import run_backfill
+from daydream.training.harvest import HarvestConfig, _ProductionHarvestServices
 from daydream.training.reply_classifier import (
     _ACCEPT_RULES,
     _DISPUTE_RULES,
@@ -127,22 +126,28 @@ def _add_run(
     return archive
 
 
+class _BackfillServices(_ProductionHarvestServices):
+    """Real filesystem/SQLite adapters with an explicit fake GitHub endpoint."""
+
+    def __init__(self, archive: Path, github: Callable[..., Any]) -> None:
+        super().__init__(HarvestConfig(archive_dir=archive), INHERIT_GITHUB_AUTH)
+        self._responder = github
+
+    def github(self, repo: str, endpoint: str, **kwargs: Any) -> Any:
+        return self._responder(repo, endpoint, **kwargs)
+
+
 def _archive_with_session(
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
     replies: list[dict[str, Any]] | None,
     gh_error: int | None = None,
     **run_kwargs: Any,
-) -> Path:
-    """Archive with one PR-linked session whose reply evidence is ``replies``.
-
-    ``gh_api`` is monkeypatched to return the comment payloads without network.
-    """
+) -> tuple[Path, _BackfillServices]:
+    """Archive and explicit provider for one PR-linked session."""
     archive = _add_run(tmp_path, **run_kwargs)
-    monkeypatch.setattr(
-        backfill, "_gh_api", _fake_gh(comments=_thread_comments(replies), gh_error=gh_error)
+    return archive, _BackfillServices(
+        archive, _fake_gh(comments=_thread_comments(replies), gh_error=gh_error),
     )
-    return archive
 
 
 def _observations(archive: Path) -> list[dict[str, Any]]:
@@ -169,36 +174,39 @@ def snapshot_rows(archive: Path) -> list[dict[str, Any]]:
     return _observations(archive)
 
 
-def test_backfill_appends_new_generation(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    archive = _archive_with_session(tmp_path, monkeypatch, replies=[_reply("Fixed in abc123", assoc="OWNER")])
-    summary = run_backfill(archive, dry_run=False)
+def test_backfill_appends_new_generation(tmp_path: Path) -> None:
+    archive, services = _archive_with_session(tmp_path, replies=[_reply("Fixed in abc123", assoc="OWNER")])
+    summary = run_backfill(archive, services=services, dry_run=False)
     assert summary["sessions_reprocessed"] == 1
     rows = all_observations(archive)
     assert rows[-1]["labeler_policy_version"] is not None
     assert rows[-1]["labels"] == '["accepted"]'
 
 
-def test_backfill_rerun_is_noop(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_backfill_rerun_is_noop(tmp_path: Path) -> None:
     """Unchanged GitHub evidence + unchanged versions ⇒ second run appends nothing (M18)."""
-    archive = _archive_with_session(tmp_path, monkeypatch, replies=[_reply("Fixed in abc123", assoc="OWNER")])
-    run_backfill(archive, dry_run=False)
+    archive, services = _archive_with_session(tmp_path, replies=[_reply("Fixed in abc123", assoc="OWNER")])
+    run_backfill(archive, services=services, dry_run=False)
     before = observation_count(archive)
-    summary = run_backfill(archive, dry_run=False)
+    summary = run_backfill(archive, services=services, dry_run=False)
     assert observation_count(archive) == before
     assert summary["appended"] == 0 and summary["skipped"] >= 1
 
 
-def test_backfill_fails_closed_on_deleted_comments(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_backfill_fails_closed_on_deleted_comments(tmp_path: Path) -> None:
     """Deleted/inaccessible comments ⇒ unknown, never decisive (M19/M22)."""
-    archive = _archive_with_session(tmp_path, monkeypatch, replies=None, gh_error=404)
-    run_backfill(archive, dry_run=False)
+    archive, services = _archive_with_session(tmp_path, replies=None, gh_error=404)
+    run_backfill(archive, services=services, dry_run=False)
     rows = all_observations(archive)
     assert rows[-1]["labels"] == '[]'
 
 
-def test_backfill_report_is_machine_readable(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    archive = _archive_with_session(tmp_path, monkeypatch, replies=[_reply("False positive", assoc="OWNER")])
-    summary = run_backfill(archive, dry_run=False, report_path=tmp_path / "report.json")
+def test_backfill_report_is_machine_readable(tmp_path: Path) -> None:
+    bot_reply = {**_reply("Fixed"), "id": 3, "user": {"login": "daydream-runner"}, "is_self_reply": True}
+    archive, services = _archive_with_session(
+        tmp_path, replies=[_reply("False positive", assoc="OWNER"), bot_reply],
+    )
+    summary = run_backfill(archive, services=services, dry_run=False, report_path=tmp_path / "report.json")
     report = json.loads((tmp_path / "report.json").read_text())
     for key in ("run_label_transitions", "disposition_counts", "parser_rule_count",
                 "ambiguous_manual_review", "bot_self_reply_exclusions", "pr_state_counts", "class_balance"):
@@ -211,16 +219,18 @@ def test_backfill_report_is_machine_readable(tmp_path: Path, monkeypatch: pytest
     assert report["pr_state_counts"] == {"merged": 1}
     assert report["class_balance"] == {"rejected": 1}
     assert report["ambiguous_manual_review"] == 0
-    assert report["bot_self_reply_exclusions"] == 0
+    # Reviewer acquisition and thread indexing each fetch this payload. The
+    # report counts fetched replies, preserving both observations.
+    assert report["bot_self_reply_exclusions"] == 2
     assert report["parser_rule_count"] == (
         len(_ACCEPT_RULES) + len(_REJECT_RULES) + len(_DISPUTE_RULES) + len(_FACTUAL_DISAGREEMENT_RULES)
     )
 
 
-def test_backfill_dry_run_builds_without_writing(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_backfill_dry_run_builds_without_writing(tmp_path: Path) -> None:
     """dry_run=True (the module's headline mode) builds annotations but writes nothing."""
-    archive = _archive_with_session(tmp_path, monkeypatch, replies=[_reply("Fixed in abc123", assoc="OWNER")])
-    summary = run_backfill(archive, dry_run=True, report_path=tmp_path / "report.json")
+    archive, services = _archive_with_session(tmp_path, replies=[_reply("Fixed in abc123", assoc="OWNER")])
+    summary = run_backfill(archive, services=services, dry_run=True, report_path=tmp_path / "report.json")
     assert summary["appended"] == 0
     assert summary["skipped"] == 0
     assert summary["sessions_reprocessed"] == 1
@@ -230,7 +240,7 @@ def test_backfill_dry_run_builds_without_writing(tmp_path: Path, monkeypatch: py
     assert report["summary"] == summary
 
 
-def test_backfill_fails_closed_on_benign_escape(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_backfill_fails_closed_on_benign_escape(tmp_path: Path) -> None:
     """A benign 404 escaping build_annotation (merge OK, comment fetch 404) lands in
     backfill's own fail-closed handler: unknown with the current policy version."""
     _add_run(tmp_path)
@@ -240,8 +250,8 @@ def test_backfill_fails_closed_on_benign_escape(tmp_path: Path, monkeypatch: pyt
             raise GitError(f"gh api {endpoint} failed (HTTP 404)")
         return {"merged": True, "merged_at": None}
 
-    monkeypatch.setattr(backfill, "_gh_api", responder)
-    summary = run_backfill(tmp_path / "archive", dry_run=False)
+    services = _BackfillServices(tmp_path / "archive", responder)
+    summary = run_backfill(tmp_path / "archive", services=services, dry_run=False)
     assert summary["sessions_reprocessed"] == 1
     assert summary["appended"] == 1
     assert summary["errors"] == 0
@@ -250,56 +260,62 @@ def test_backfill_fails_closed_on_benign_escape(tmp_path: Path, monkeypatch: pyt
     assert rows[-1]["pr_state"] is None
 
 
-def test_backfill_aborts_on_rate_limit(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_backfill_aborts_on_rate_limit(tmp_path: Path) -> None:
     """RateLimitError aborts the sweep cleanly, preserving the remaining queue."""
-    _add_run(tmp_path)
+    # Insert in reverse order: the stable session ordering must still encounter
+    # the failing first session before doing any work for the other one.
+    _add_run(tmp_path, session_id="z", run_dir_name="last", pr_repo="o/last")
+    _add_run(tmp_path, session_id="a", run_dir_name="first", pr_repo="o/first")
+    requested: list[str] = []
 
     def responder(repo: str, endpoint: str, **kwargs: Any) -> Any:
+        requested.append(repo)
         raise RateLimitError(f"gh api {endpoint} failed (HTTP 429)", retry_after=5)
 
-    monkeypatch.setattr(backfill, "_gh_api", responder)
-    summary = run_backfill(tmp_path / "archive", dry_run=False)
+    services = _BackfillServices(tmp_path / "archive", responder)
+    summary = run_backfill(tmp_path / "archive", services=services, dry_run=False)
     assert summary["aborted"] == 1
     assert summary["appended"] == 0
+    assert requested == ["o/first"]
     assert observation_count(tmp_path / "archive") == 0
 
 
-def test_backfill_non_pr_skipped(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_backfill_non_pr_skipped(tmp_path: Path) -> None:
     """A run with no PR link is skipped and counted, never annotated."""
     _add_run(tmp_path, pr_repo=None, pr_number=None)
-    monkeypatch.setattr(backfill, "_gh_api", _fake_gh(comments=_thread_comments(None)))
-    summary = run_backfill(tmp_path / "archive", dry_run=False)
+    services = _BackfillServices(tmp_path / "archive", _fake_gh(comments=_thread_comments(None)))
+    summary = run_backfill(tmp_path / "archive", services=services, dry_run=False)
     assert summary["non_pr_skipped"] == 1
     assert summary["sessions_reprocessed"] == 0
     assert observation_count(tmp_path / "archive") == 0
 
 
-def test_backfill_session_filter(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_backfill_session_filter(tmp_path: Path) -> None:
     """session_filter restricts the queue; filtered-out sessions stay untouched."""
-    _archive_with_session(
-        tmp_path, monkeypatch, replies=[_reply("Fixed in abc123", assoc="OWNER")],
+    _, services = _archive_with_session(
+        tmp_path, replies=[_reply("Fixed in abc123", assoc="OWNER")],
         session_id="s1", run_dir_name="run_a",
     )
-    _archive_with_session(
-        tmp_path, monkeypatch, replies=[_reply("Fixed in abc123", assoc="OWNER")],
+    _, services = _archive_with_session(
+        tmp_path, replies=[_reply("Fixed in abc123", assoc="OWNER")],
         session_id="s2", run_dir_name="run_b",
     )
-    summary = run_backfill(tmp_path / "archive", dry_run=False, session_filter="s2")
+    summary = run_backfill(tmp_path / "archive", services=services, dry_run=False, session_filter="s2")
     assert summary["sessions_reprocessed"] == 1
     assert summary["non_pr_skipped"] == 0
     rows = all_observations(tmp_path / "archive")
     assert [row["session_id"] for row in rows] == ["s2"]
 
 
-def test_backfill_valid_at_override(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_backfill_valid_at_override(tmp_path: Path) -> None:
     """valid_at_override beats the derived decisive-evidence timestamp."""
-    archive = _archive_with_session(tmp_path, monkeypatch, replies=[_reply("Fixed in abc123", assoc="OWNER")])
-    run_backfill(archive, dry_run=False, valid_at_override="2026-02-01T00:00:00Z")
+    archive, services = _archive_with_session(tmp_path, replies=[_reply("Fixed in abc123", assoc="OWNER")])
+    run_backfill(archive, services=services, dry_run=False, valid_at_override="2026-02-01T00:00:00Z")
     rows = all_observations(archive)
     assert rows[-1]["valid_at"] == "2026-02-01T00:00:00+00:00"
 
 
-def test_backfill_per_row_isolation(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_backfill_per_row_isolation(tmp_path: Path) -> None:
     """A transient failure (HTTP 500) on one row isolates; the next row survives."""
     _add_run(tmp_path, session_id="s1", run_dir_name="run_a", repo_slug="o/fail", pr_repo="o/fail")
     _add_run(tmp_path, session_id="s2", run_dir_name="run_b", repo_slug="o/ok", pr_repo="o/ok")
@@ -313,8 +329,8 @@ def test_backfill_per_row_isolation(tmp_path: Path, monkeypatch: pytest.MonkeyPa
             return []
         return {"merged": True, "merged_at": None}
 
-    monkeypatch.setattr(backfill, "_gh_api", responder)
-    summary = run_backfill(tmp_path / "archive", dry_run=False)
+    services = _BackfillServices(tmp_path / "archive", responder)
+    summary = run_backfill(tmp_path / "archive", services=services, dry_run=False)
     assert summary["errors"] == 1
     assert summary["appended"] == 1
     assert summary["sessions_reprocessed"] == 1
@@ -323,18 +339,18 @@ def test_backfill_per_row_isolation(tmp_path: Path, monkeypatch: pytest.MonkeyPa
     assert rows[-1]["labels"] == '["accepted"]'
 
 
-def test_backfill_historical_rows_untouched(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_backfill_historical_rows_untouched(tmp_path: Path) -> None:
     """Backfill never mutates or deletes existing label_observations (M17)."""
-    archive = _archive_with_session(tmp_path, monkeypatch, replies=[_reply("Fixed in abc123", assoc="OWNER")])
+    archive, services = _archive_with_session(tmp_path, replies=[_reply("Fixed in abc123", assoc="OWNER")])
     legacy = snapshot_rows(archive)
-    run_backfill(archive, dry_run=False)
+    run_backfill(archive, services=services, dry_run=False)
     assert snapshot_rows(archive)[: len(legacy)] == legacy
 
 
-def test_backfill_old_labels_human_precedence(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_backfill_old_labels_human_precedence(tmp_path: Path) -> None:
     """run_label_transitions['old_labels'] reflects the archive's winner
     projection: a human override beats a newer auto row (human-first)."""
-    archive = _archive_with_session(tmp_path, monkeypatch, replies=[_reply("Fixed in abc123", assoc="OWNER")])
+    archive, services = _archive_with_session(tmp_path, replies=[_reply("Fixed in abc123", assoc="OWNER")])
     conn = sqlite3.connect(archive / "index.db")
     try:
         conn.execute(
@@ -350,7 +366,7 @@ def test_backfill_old_labels_human_precedence(tmp_path: Path, monkeypatch: pytes
         conn.commit()
     finally:
         conn.close()
-    summary = run_backfill(archive, dry_run=True, report_path=tmp_path / "report.json")
+    summary = run_backfill(archive, services=services, dry_run=True, report_path=tmp_path / "report.json")
     report = json.loads((tmp_path / "report.json").read_text())
     transition = report["run_label_transitions"]["s1"]
     assert transition["old_labels"] == ["human"]

--- a/tests/test_training_harvest.py
+++ b/tests/test_training_harvest.py
@@ -40,7 +40,7 @@ from daydream.training.harvest import (
     build_annotation as _build_annotation,
 )
 from daydream.training.harvest_types import HarvestRow
-from daydream.training.reward import ScoringInputs, score_trajectory
+from daydream.training.reward import score_trajectory
 from daydream.ui import create_console
 from tests.conftest import _make_repo_with_main
 from tests.harness.git_helpers import commit as _commit
@@ -192,15 +192,6 @@ def _unused_gh(repo: str, endpoint: str, **kwargs: Any) -> Any:
 def _typed_row(raw: dict[str, Any], *, row_number: int = 1) -> HarvestRow:
     """Construct the public validated row used by acquisition and reduction tests."""
     return HarvestRow.from_mapping(raw, row_number=row_number)
-
-
-def _bronze_inputs(run_dir: Path, raw: dict[str, Any]) -> ScoringInputs:
-    """Exercise the public bronze parser with a validated archive row."""
-    return assemble_scoring_inputs(run_dir, _typed_row({
-        "session_id": raw.get("session_id", "scoring-inputs"),
-        "archive_path": str(run_dir),
-        **raw,
-    }))
 
 
 def _services(config: HarvestConfig, *, github: Callable[..., Any]) -> HarvestTestServices:
@@ -388,7 +379,7 @@ def test_build_annotation_applies_posterior_penalty_for_rejected_pr(tmp_path: Pa
            "grounding_rate": 1.0, "changed_files": "[]"}
 
     # Intrinsic-only baseline: same inputs scored with no posterior.
-    intrinsic_inputs = _bronze_inputs(run_dir, row)
+    intrinsic_inputs = assemble_scoring_inputs(run_dir, row)
     intrinsic_only_composite = score_trajectory(intrinsic_inputs).composite
 
     _write_findings(run_dir, _FP_A)
@@ -736,7 +727,7 @@ def test_assemble_reads_verdicts_and_grounding_from_bronze(tmp_path: Path) -> No
     (run_dir / "deep" / "recommendation-verdicts.json").write_text(
         '{"verdicts":[{"issue_id":1,"verdict":"consistent"}]}'
     )
-    inputs = _bronze_inputs(run_dir, {"grounding_rate": 0.75})
+    inputs = assemble_scoring_inputs(run_dir, {"grounding_rate": 0.75})
     assert inputs.verifier_verdicts == [{"issue_id": 1, "verdict": "consistent"}]
     assert inputs.grounding_rate == 0.75 and inputs.format_valid is True
 
@@ -744,7 +735,7 @@ def test_assemble_reads_verdicts_and_grounding_from_bronze(tmp_path: Path) -> No
 def test_assemble_shallow_run_has_null_verdicts(tmp_path: Path) -> None:
     run_dir = tmp_path / "run"
     run_dir.mkdir()
-    inputs = _bronze_inputs(run_dir, {"grounding_rate": None})
+    inputs = assemble_scoring_inputs(run_dir, {"grounding_rate": None})
     assert inputs.verifier_verdicts is None
 
 
@@ -760,7 +751,7 @@ def test_assemble_declined_deep_run_null_verdicts_keeps_format_valid(tmp_path: P
     (run_dir / "deep" / "stack-python-records.json").write_text(
         json.dumps({"records": [{"id": "i1"}]})
     )
-    inputs = _bronze_inputs(run_dir, {"grounding_rate": 0.5})
+    inputs = assemble_scoring_inputs(run_dir, {"grounding_rate": 0.5})
     assert inputs.verifier_verdicts is None          # declined ⇒ no verdicts
     assert inputs.format_valid is True                # absence is expected, not malformed
 
@@ -769,7 +760,7 @@ def test_assemble_malformed_verdicts_flags_format_invalid(tmp_path: Path) -> Non
     run_dir = tmp_path / "run"
     (run_dir / "deep").mkdir(parents=True)
     (run_dir / "deep" / "recommendation-verdicts.json").write_text("{not json")
-    inputs = _bronze_inputs(run_dir, {"grounding_rate": 1.0})
+    inputs = assemble_scoring_inputs(run_dir, {"grounding_rate": 1.0})
     assert inputs.format_valid is False
 
 
@@ -786,13 +777,13 @@ def test_score_trajectory_grounding_axis_present_on_default_run(tmp_path: Path) 
     run_dir.mkdir()
 
     # Default run: eval ran by default, so the manifest row carries grounding_rate.
-    default_inputs = _bronze_inputs(run_dir, {"grounding_rate": 1.0})
+    default_inputs = assemble_scoring_inputs(run_dir, {"grounding_rate": 1.0})
     default_breakdown = score_trajectory(default_inputs)
     assert default_breakdown.axes_present["grounding"] is True
     assert default_breakdown.grounding == 1.0
 
     # --no-eval run: no grounding_rate, so the axis is absent.
-    no_eval_inputs = _bronze_inputs(run_dir, {"grounding_rate": None})
+    no_eval_inputs = assemble_scoring_inputs(run_dir, {"grounding_rate": None})
     no_eval_breakdown = score_trajectory(no_eval_inputs)
     assert no_eval_breakdown.axes_present["grounding"] is False
     assert no_eval_breakdown.grounding is None

--- a/tests/test_training_harvest.py
+++ b/tests/test_training_harvest.py
@@ -28,16 +28,24 @@ from daydream.pr_review import DAYDREAM_FOOTER, finding_marker
 from daydream.training import harvest, labeler_versions, reward
 from daydream.training.backfill_cache import BackfillCache
 from daydream.training.harvest import (
+    AnnotationPayload,
     HarvestConfig,
-    _resolve_repo_for_row,
+    HarvestServices,
+    acquire_harvest_evidence,
     assemble_scoring_inputs,
-    build_annotation,
+    make_harvest_services,
     run_harvest,
 )
-from daydream.training.reward import score_trajectory
+from daydream.training.harvest import (
+    build_annotation as _build_annotation,
+)
+from daydream.training.harvest_types import HarvestRow
+from daydream.training.reward import ScoringInputs, score_trajectory
+from daydream.ui import create_console
 from tests.conftest import _make_repo_with_main
 from tests.harness.git_helpers import commit as _commit
 from tests.harness.git_helpers import git as _git
+from tests.harness.harvest_services import HarvestTestServices
 from tests.harness.trajectory import diff_adding, make_manifest
 
 
@@ -181,13 +189,61 @@ def _unused_gh(repo: str, endpoint: str, **kwargs: Any) -> Any:
     raise AssertionError(f"gh_api should not be called for a local row (endpoint={endpoint})")
 
 
+def _typed_row(raw: dict[str, Any], *, row_number: int = 1) -> HarvestRow:
+    """Construct the public validated row used by acquisition and reduction tests."""
+    return HarvestRow.from_mapping(raw, row_number=row_number)
+
+
+def _bronze_inputs(run_dir: Path, raw: dict[str, Any]) -> ScoringInputs:
+    """Exercise the public bronze parser with a validated archive row."""
+    return assemble_scoring_inputs(run_dir, _typed_row({
+        "session_id": raw.get("session_id", "scoring-inputs"),
+        "archive_path": str(run_dir),
+        **raw,
+    }))
+
+
+def _services(config: HarvestConfig, *, github: Callable[..., Any]) -> HarvestTestServices:
+    """Build an explicit per-run service with only the GitHub boundary replaced."""
+    return HarvestTestServices(make_harvest_services(config), github=github)
+
+
+def _acquire_annotation(
+    raw: dict[str, Any],
+    *,
+    run_dir: Path | None = None,
+    archive_dir: Path,
+    gh_api: Callable[..., Any],
+    repo_clone: Path | None = None,
+    services: HarvestServices | None = None,
+    valid_at_override: str | None = None,
+) -> AnnotationPayload:
+    """Acquire through an explicit provider, then exercise the pure reducer."""
+    row = _typed_row(raw)
+    if run_dir is not None:
+        assert row.archive_path == run_dir
+    config = HarvestConfig(archive_dir=archive_dir)
+    provider = services or HarvestTestServices(
+        make_harvest_services(config),
+        github=gh_api,
+    )
+    evidence = acquire_harvest_evidence(
+        row,
+        services=provider,
+        repo_resolution=repo_clone,
+        base_sha_status="available" if repo_clone is not None else "unavailable",
+        valid_at_override=valid_at_override,
+    )
+    return _build_annotation(row, evidence)
+
+
 def test_build_annotation_pr_row_labels_from_decisive_reply_evidence(tmp_path: Path) -> None:
     run_dir = _seed_deep_bronze(tmp_path, verdict="consistent", grounding=1.0)
     _write_findings(run_dir, _FP_A)
     row = {"session_id": "s1", "pr_repo": "o/r", "pr_number": 7, "head_sha": "h",
            "base_branch": "main", "archive_path": str(run_dir),
            "grounding_rate": 1.0, "changed_files": "[]"}
-    ann = build_annotation(
+    ann = _acquire_annotation(
         row,
         run_dir=run_dir,
         archive_dir=tmp_path,
@@ -245,7 +301,7 @@ def test_build_annotation_pr_row_carries_per_finding_outcomes(tmp_path: Path) ->
     row = {"session_id": "s_pf", "pr_repo": "o/r", "pr_number": 7, "head_sha": "h",
            "base_branch": "main", "archive_path": str(run_dir),
            "grounding_rate": 1.0, "changed_files": "[]"}
-    ann = build_annotation(row, run_dir=run_dir, archive_dir=tmp_path,
+    ann = _acquire_annotation(row, run_dir=run_dir, archive_dir=tmp_path,
                            gh_api=_fake_gh_merged_per_finding("2026-02-01T00:00:00+00:00", fp_a, fp_b),
                            repo_clone=tmp_path)
     assert ann.rubric_json is not None
@@ -260,7 +316,7 @@ def test_harvest_626_shape_yields_both_polarities(tmp_path: Path) -> None:
     row = {"session_id": "s_626", "pr_repo": "o/r", "pr_number": 7, "head_sha": "h",
            "base_branch": "main", "archive_path": str(run_dir),
            "grounding_rate": 1.0, "changed_files": "[]"}
-    ann = build_annotation(
+    ann = _acquire_annotation(
         row,
         run_dir=run_dir,
         archive_dir=tmp_path,
@@ -332,11 +388,11 @@ def test_build_annotation_applies_posterior_penalty_for_rejected_pr(tmp_path: Pa
            "grounding_rate": 1.0, "changed_files": "[]"}
 
     # Intrinsic-only baseline: same inputs scored with no posterior.
-    intrinsic_inputs = assemble_scoring_inputs(run_dir, row)
+    intrinsic_inputs = _bronze_inputs(run_dir, row)
     intrinsic_only_composite = score_trajectory(intrinsic_inputs).composite
 
     _write_findings(run_dir, _FP_A)
-    payload = build_annotation(
+    payload = _acquire_annotation(
         row,
         run_dir=run_dir,
         archive_dir=tmp_path,
@@ -361,7 +417,7 @@ def test_build_annotation_rejected_pr_empty_pool_uses_default_prior(tmp_path: Pa
            "base_branch": "main", "archive_path": str(run_dir),
            "grounding_rate": 1.0, "changed_files": "[]"}
     _write_findings(run_dir, _FP_A)
-    payload = build_annotation(
+    payload = _acquire_annotation(
         row,
         run_dir=run_dir,
         archive_dir=archive_dir,
@@ -429,7 +485,7 @@ def test_build_annotation_fork_pr_author_reply_is_decisive(tmp_path: Path) -> No
             "user": {"login": "prfiona"},
         }
 
-    payload = build_annotation(
+    payload = _acquire_annotation(
         row, run_dir=run_dir, archive_dir=tmp_path, gh_api=fork_gh, repo_clone=tmp_path,
     )
     assert payload.labels == ["accepted"]
@@ -476,7 +532,7 @@ def test_build_annotation_formal_review_author_reply_is_decisive(tmp_path: Path)
         return {"merged": True, "merged_at": "2026-08-03T00:00:00Z", "state": "merged",
                 "user": {"login": "someone-else"}}
 
-    payload = build_annotation(
+    payload = _acquire_annotation(
         row, run_dir=run_dir, archive_dir=tmp_path, gh_api=review_gh, repo_clone=tmp_path,
     )
     assert payload.labels == ["rejected"]
@@ -490,7 +546,7 @@ def test_build_annotation_shallow_local_row_null_valid_at_reward_present(tmp_pat
     row = {"session_id": "s2", "pr_repo": None, "pr_number": None, "branch": "feat",
            "head_sha": "h", "archive_path": str(run_dir), "grounding_rate": None,
            "changed_files": "[]"}
-    ann = build_annotation(row, run_dir=run_dir, archive_dir=tmp_path, gh_api=_unused_gh,
+    ann = _acquire_annotation(row, run_dir=run_dir, archive_dir=tmp_path, gh_api=_unused_gh,
                            repo_clone=tmp_path)
     assert ann.valid_at is None                               # collapses to observed_at on write
     rb = json.loads(ann.reward_json)
@@ -544,7 +600,7 @@ def test_build_annotation_rejected_pr_populated_prior_drives_pool(tmp_path: Path
         "changed_files": "[]",
     }
     _write_findings(run_dir, _FP_A)
-    payload = build_annotation(
+    payload = _acquire_annotation(
         row,
         run_dir=run_dir,
         archive_dir=archive_dir,
@@ -568,64 +624,89 @@ def test_build_annotation_rejected_pr_populated_prior_drives_pool(tmp_path: Path
 
 def test_build_annotation_pr_uses_pooled_prior_and_persists_reviewers(
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr(harvest, "reviewer_set_penalty_prior", lambda *a, **k: (0.8, 12))  # n>=10 -> empirical
-    monkeypatch.setattr(harvest, "reviewer_logins_signal", lambda *a, **k: ["alice", "carol"])
     run_dir = _seed_deep_bronze(tmp_path, verdict="consistent", grounding=1.0)
     row = {"session_id": "s_rej", "pr_repo": "o/r", "pr_number": 9, "head_sha": "h",
            "base_branch": "main", "archive_path": str(run_dir), "grounding_rate": 1.0,
            "changed_files": "[]"}
     _write_findings(run_dir, _FP_A)
-    p = build_annotation(row, run_dir=run_dir, archive_dir=tmp_path,
-                         gh_api=_fake_gh(merged=False, comments=_finding_comments(_FP_A, reply="not applicable")),
-                         repo_clone=tmp_path)
+    config = HarvestConfig(archive_dir=tmp_path)
+    p = _acquire_annotation(
+        row,
+        run_dir=run_dir,
+        archive_dir=tmp_path,
+        gh_api=_unused_gh,
+        repo_clone=tmp_path,
+        services=HarvestTestServices(
+            make_harvest_services(config),
+            github=_fake_gh(
+                merged=False,
+                comments=_finding_comments(_FP_A, reply="not applicable"),
+                reviews=[{"user": {"login": "alice"}}, {"user": {"login": "carol"}}],
+            ),
+            reviewer_prior=lambda *_args, **_kwargs: (0.8, 12),
+        ),
+    )
     rb = json.loads(p.reward_json)
     assert rb["posterior_cost"] == pytest.approx(0.2)   # max(0, 1.0 - 0.8)
     assert rb["outcome_prior"] == 0.8 and rb["outcome_prior_n"] == 12
     assert p.composite_reward == rb["composite"]        # stored composite is pure intrinsic (C5)
-    assert p.has_posterior is True and p.reviewer_logins == ["alice", "carol"]
+    assert p.has_posterior is True and p.reviewer_logins == ["alice", "amelia", "carol"]
 
 
 def test_build_annotation_below_threshold_falls_back_to_default_prior(
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr(harvest, "reviewer_set_penalty_prior", lambda *a, **k: (0.9, 4))  # n<10
-    monkeypatch.setattr(harvest, "reviewer_logins_signal", lambda *a, **k: ["alice"])
     run_dir = _seed_deep_bronze(tmp_path, verdict="consistent", grounding=1.0)
     row = {"session_id": "s_rej", "pr_repo": "o/r", "pr_number": 9, "head_sha": "h",
            "base_branch": "main", "archive_path": str(run_dir), "grounding_rate": 1.0,
            "changed_files": "[]"}
     _write_findings(run_dir, _FP_A)
     rb = json.loads(
-        build_annotation(row, run_dir=run_dir, archive_dir=tmp_path,
-                         gh_api=_fake_gh(merged=False, comments=_finding_comments(_FP_A, reply="not applicable")),
-                         repo_clone=tmp_path).reward_json
+        _acquire_annotation(
+            row,
+            run_dir=run_dir,
+            archive_dir=tmp_path,
+            gh_api=_unused_gh,
+            repo_clone=tmp_path,
+            services=HarvestTestServices(
+                make_harvest_services(HarvestConfig(archive_dir=tmp_path)),
+                github=_fake_gh(
+                    merged=False,
+                    comments=_finding_comments(_FP_A, reply="not applicable"),
+                    reviews=[{"user": {"login": "alice"}}],
+                ),
+                reviewer_prior=lambda *_args, **_kwargs: (0.9, 4),
+            ),
+        ).reward_json
     )
     assert rb["outcome_prior"] is None and rb["outcome_prior_n"] == 4  # n recorded; prior None -> 0.5
     assert rb["posterior_cost"] == 0.5
 
 
-def test_build_annotation_local_row_has_no_reviewer_prior(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_build_annotation_local_row_has_no_reviewer_prior(tmp_path: Path) -> None:
     # PR-less row -> reviewer_logins == [], prior query never consulted, and the
     # local verdict is withheld from the posterior axis: a local commit is not a
     # maintainer acting in a PR, so the label is kept but has_posterior is False.
     from daydream.training.labeler_signals import LocalCommitAppliedSignal
 
-    monkeypatch.setattr(
-        harvest, "local_commit_applied_signal", lambda *a, **k: LocalCommitAppliedSignal(verdict="rejected")
-    )
-    monkeypatch.setattr(
-        harvest, "reviewer_set_penalty_prior",
-        lambda *a, **k: pytest.fail("reviewer_set_penalty_prior must not be called for a local row"),
-    )
     run_dir = _seed_deep_bronze(tmp_path, verdict="consistent", grounding=1.0)
     row = {"session_id": "s_local", "pr_repo": None, "pr_number": None, "branch": "feat",
            "head_sha": "h", "archive_path": str(run_dir), "grounding_rate": 1.0,
            "changed_files": "[]"}
-    p = build_annotation(row, run_dir=run_dir, archive_dir=tmp_path, gh_api=_unused_gh,
-                         repo_clone=tmp_path)
+    config = HarvestConfig(archive_dir=tmp_path)
+    p = _acquire_annotation(
+        row,
+        run_dir=run_dir,
+        archive_dir=tmp_path,
+        gh_api=_unused_gh,
+        repo_clone=tmp_path,
+        services=HarvestTestServices(
+            make_harvest_services(config),
+            local_commit_applied=lambda *_args, **_kwargs: LocalCommitAppliedSignal("rejected"),
+            reviewer_prior=lambda *_args, **_kwargs: pytest.fail("local rows have no reviewer prior"),
+        ),
+    )
     assert p.reviewer_logins == []
     assert p.labels == ["rejected"]  # label kept — consumers may still want it
     assert p.has_posterior is False  # ...but it is not maintainer-PR evidence
@@ -635,18 +716,17 @@ def test_build_annotation_local_row_has_no_reviewer_prior(tmp_path: Path, monkey
 
 
 def test_build_annotation_asserts_canonical_version(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    # Non-canonical reward_version -> the write must be refused.
-    def _custom_version_score(*args: Any, **kwargs: Any) -> Any:
-        from daydream.training.reward import RewardWeights
-        return score_trajectory(*args, **{**kwargs, "weights": RewardWeights(w_correctness=0.99)})
+    # A score whose captured default weights no longer match the canonical
+    # constant is marked custom, so publication must refuse it.
+    from daydream.training.reward import RewardWeights
 
-    monkeypatch.setattr(harvest, "score_trajectory", _custom_version_score)
+    monkeypatch.setattr(reward, "DEFAULT_WEIGHTS", RewardWeights(is_default=True))
     run_dir = _seed_deep_bronze(tmp_path, verdict="consistent", grounding=1.0)
     row = {"session_id": "s_custom", "pr_repo": "o/r", "pr_number": 9, "head_sha": "h",
            "base_branch": "main", "archive_path": str(run_dir), "grounding_rate": 1.0,
            "changed_files": "[]"}
     with pytest.raises((AssertionError, RuntimeError), match="canonical"):
-        build_annotation(row, run_dir=run_dir, archive_dir=tmp_path,
+        _acquire_annotation(row, run_dir=run_dir, archive_dir=tmp_path,
                          gh_api=_fake_gh(merged=False), repo_clone=tmp_path)
 
 
@@ -656,7 +736,7 @@ def test_assemble_reads_verdicts_and_grounding_from_bronze(tmp_path: Path) -> No
     (run_dir / "deep" / "recommendation-verdicts.json").write_text(
         '{"verdicts":[{"issue_id":1,"verdict":"consistent"}]}'
     )
-    inputs = assemble_scoring_inputs(run_dir, {"grounding_rate": 0.75})
+    inputs = _bronze_inputs(run_dir, {"grounding_rate": 0.75})
     assert inputs.verifier_verdicts == [{"issue_id": 1, "verdict": "consistent"}]
     assert inputs.grounding_rate == 0.75 and inputs.format_valid is True
 
@@ -664,7 +744,7 @@ def test_assemble_reads_verdicts_and_grounding_from_bronze(tmp_path: Path) -> No
 def test_assemble_shallow_run_has_null_verdicts(tmp_path: Path) -> None:
     run_dir = tmp_path / "run"
     run_dir.mkdir()
-    inputs = assemble_scoring_inputs(run_dir, {"grounding_rate": None})
+    inputs = _bronze_inputs(run_dir, {"grounding_rate": None})
     assert inputs.verifier_verdicts is None
 
 
@@ -680,7 +760,7 @@ def test_assemble_declined_deep_run_null_verdicts_keeps_format_valid(tmp_path: P
     (run_dir / "deep" / "stack-python-records.json").write_text(
         json.dumps({"records": [{"id": "i1"}]})
     )
-    inputs = assemble_scoring_inputs(run_dir, {"grounding_rate": 0.5})
+    inputs = _bronze_inputs(run_dir, {"grounding_rate": 0.5})
     assert inputs.verifier_verdicts is None          # declined ⇒ no verdicts
     assert inputs.format_valid is True                # absence is expected, not malformed
 
@@ -689,7 +769,7 @@ def test_assemble_malformed_verdicts_flags_format_invalid(tmp_path: Path) -> Non
     run_dir = tmp_path / "run"
     (run_dir / "deep").mkdir(parents=True)
     (run_dir / "deep" / "recommendation-verdicts.json").write_text("{not json")
-    inputs = assemble_scoring_inputs(run_dir, {"grounding_rate": 1.0})
+    inputs = _bronze_inputs(run_dir, {"grounding_rate": 1.0})
     assert inputs.format_valid is False
 
 
@@ -706,13 +786,13 @@ def test_score_trajectory_grounding_axis_present_on_default_run(tmp_path: Path) 
     run_dir.mkdir()
 
     # Default run: eval ran by default, so the manifest row carries grounding_rate.
-    default_inputs = assemble_scoring_inputs(run_dir, {"grounding_rate": 1.0})
+    default_inputs = _bronze_inputs(run_dir, {"grounding_rate": 1.0})
     default_breakdown = score_trajectory(default_inputs)
     assert default_breakdown.axes_present["grounding"] is True
     assert default_breakdown.grounding == 1.0
 
     # --no-eval run: no grounding_rate, so the axis is absent.
-    no_eval_inputs = assemble_scoring_inputs(run_dir, {"grounding_rate": None})
+    no_eval_inputs = _bronze_inputs(run_dir, {"grounding_rate": None})
     no_eval_breakdown = score_trajectory(no_eval_inputs)
     assert no_eval_breakdown.axes_present["grounding"] is False
     assert no_eval_breakdown.grounding is None
@@ -764,6 +844,7 @@ def _seed_orphan_run(
     session_id: str,
     head_sha: str = "orphsha",
     branch: str = "feat/x",
+    base_branch: str | None = "main",
     source_path: Path | None = None,
 ) -> Path:
     """Seed an orphan deep run (no PR linkage) and index it under ``archive_dir``.
@@ -788,7 +869,7 @@ def _seed_orphan_run(
             repo_slug="org/repo",
             branch=branch,
             head_sha=head_sha,
-            base_branch="main",
+            base_branch=base_branch,
             pr_number=None,
             pr_repo=None,
             grounding_rate=1.0,
@@ -811,7 +892,7 @@ def _seed_pr_runs(
 
     Each run gets its own bronze dir under ``bronze_parent/<session_id>`` so the
     index carries ``count`` distinct rows; ``pr_number`` matches the session index
-    so a fake ``_gh_api`` can identify the row from the PR endpoint.
+    so a fake GitHub responder can identify the row from the PR endpoint.
     """
     for pr_number in range(1, count + 1):
         sid = f"s{pr_number}"
@@ -837,32 +918,153 @@ def _seed_pr_runs(
             _write_findings(run_dir, *fingerprints)
 
 
-async def test_harvest_writes_one_annotation(tmp_path: Path, archive_dir: Any, monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_harvest_writes_one_annotation(tmp_path: Path, archive_dir: Any) -> None:
     _seed_archived_deep_run(archive_dir, "s1", merged_at="2026-02-01T00:00:00+00:00")
-    monkeypatch.setattr(
-        "daydream.training.harvest._gh_api",
-        _fake_gh(merged_at="2026-02-01T00:00:00+00:00", comments=_REPLIED_FINDING),
+    config = HarvestConfig(archive_dir=archive_dir, cache_dir=tmp_path / "c")
+    summary = await run_harvest(
+        config,
+        services=_services(
+            config,
+            github=_fake_gh(merged_at="2026-02-01T00:00:00+00:00", comments=_REPLIED_FINDING),
+        ),
     )
-    summary = await run_harvest(HarvestConfig(archive_dir=archive_dir, cache_dir=tmp_path / "c"))
     obs = latest_label_observation(archive_dir, "s1")
     assert obs is not None
     assert summary["annotated"] == 1
     assert obs["valid_at"] == "2026-02-01T00:00:00+00:00" and obs["composite_reward"] is not None
 
 
+@pytest.mark.parametrize(
+    ("malformed", "session_label"),
+    [
+        (
+            {"session_id": "bad/session", "archive_path": "/tmp/bronze"},
+            "bad/session",
+        ),
+        ({"archive_path": "/tmp/bronze"}, "<unknown>"),
+        ({"session_id": "missing-archive"}, "missing-archive"),
+        (
+            {
+                "session_id": "unsafe-slug",
+                "archive_path": "/tmp/bronze",
+                "pr_repo": "org/repo/extra",
+            },
+            "unsafe-slug",
+        ),
+    ],
+)
+async def test_harvest_rejects_malformed_index_row_before_any_side_effect(
+    tmp_path: Path,
+    archive_dir: Any,
+    capsys: pytest.CaptureFixture[str],
+    malformed: dict[str, Any],
+    session_label: str,
+) -> None:
+    """Malformed queued identity is isolated before cache, clone, GitHub, or writes."""
+    effects: list[str] = []
+
+    def _completed_sessions() -> set[str]:
+        effects.append("cache-read")
+        return set()
+
+    def _resolve_repo(*_args: Any, **_kwargs: Any) -> None:
+        effects.append("clone")
+        return None
+
+    def _github(*_args: Any, **_kwargs: Any) -> dict[str, object]:
+        effects.append("github")
+        return {}
+
+    def _append_annotation(*_args: Any, **_kwargs: Any) -> bool:
+        effects.append("write")
+        return True
+
+    config = HarvestConfig(archive_dir=archive_dir, cache_dir=tmp_path / "cache")
+    services = HarvestTestServices(
+        make_harvest_services(config),
+        rows=[malformed],
+        completed_sessions=_completed_sessions,
+        resolve_repo=_resolve_repo,
+        github=_github,
+        append_annotation=_append_annotation,
+    )
+    summary = await run_harvest(
+        config,
+        services=services,
+    )
+
+    assert summary["considered"] == 1
+    assert summary["errors"] == 1
+    assert effects == []
+    captured = capsys.readouterr()
+    output = captured.out + captured.err
+    assert "row 1" in output and session_label in output
+
+
+async def test_harvest_validates_completed_rows_before_resume_filtering(
+    tmp_path: Path,
+    archive_dir: Any,
+) -> None:
+    """An invalid completed row still counts; a valid sibling continues normally."""
+    _seed_archived_deep_run(archive_dir, "done", merged_at="2026-02-01T00:00:00+00:00")
+    fresh_dir = _seed_deep_bronze(tmp_path / "fresh", verdict="consistent", grounding=1.0)
+    upsert_run(
+        archive_dir,
+        Manifest(
+            session_id="fresh",
+            archived_at="2026-01-01T00:00:00Z",
+            run_flow="normal",
+            backend="claude",
+            repo_slug="org/repo",
+            pr_repo="org/repo",
+            pr_number=42,
+            head_sha="abc",
+            base_branch="main",
+            grounding_rate=1.0,
+            changed_files=["app.py"],
+            archive_path=str(fresh_dir),
+        ),
+    )
+    completed = query_runs(archive_dir, "session_id = ?", ("done",))[0]
+    fresh = query_runs(archive_dir, "session_id = ?", ("fresh",))[0]
+    malformed_completed = {"session_id": "done", "archive_path": "relative/bronze"}
+    config = HarvestConfig(archive_dir=archive_dir, cache_dir=tmp_path / "cache")
+    services = HarvestTestServices(
+        make_harvest_services(config),
+        rows=[malformed_completed, completed, fresh],
+        completed={"done"},
+        github=_fake_gh(
+            merged_at="2026-02-01T00:00:00+00:00",
+            comments=_REPLIED_FINDING,
+        ),
+    )
+
+    summary = await run_harvest(config, services=services)
+
+    assert summary == {
+        "considered": 2,
+        "annotated": 1,
+        "would_annotate": 0,
+        "skipped": 0,
+        "errors": 1,
+        "aborted": 0,
+    }
+    assert latest_label_observation(archive_dir, "done") is None
+    assert latest_label_observation(archive_dir, "fresh") is not None
+
+
 async def test_harvest_stores_github_z_merge_timestamp_canonically(
     tmp_path: Path,
     archive_dir: Any,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Real-path writer convergence: GitHub reports merged_at with a 'Z' suffix;
     the stored valid_at must be the canonical '+00:00' spelling."""
     _seed_archived_deep_run(archive_dir, "s1", merged_at="2026-02-01T00:00:00Z")
-    monkeypatch.setattr(
-        "daydream.training.harvest._gh_api",
-        _fake_gh(merged_at="2026-02-01T00:00:00Z", comments=_REPLIED_FINDING),
+    config = HarvestConfig(archive_dir=archive_dir, cache_dir=tmp_path / "c")
+    summary = await run_harvest(
+        config,
+        services=_services(config, github=_fake_gh(merged_at="2026-02-01T00:00:00Z", comments=_REPLIED_FINDING)),
     )
-    summary = await run_harvest(HarvestConfig(archive_dir=archive_dir, cache_dir=tmp_path / "c"))
     obs = latest_label_observation(archive_dir, "s1")
     assert obs is not None
     assert summary["annotated"] == 1
@@ -872,7 +1074,6 @@ async def test_harvest_stores_github_z_merge_timestamp_canonically(
 async def test_harvest_unresolved_daydream_comment_stays_unknown(
     tmp_path: Path,
     archive_dir: Any,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Real-path: a merged PR whose only finding has no qualifying reply is ``unknown``.
 
@@ -882,11 +1083,14 @@ async def test_harvest_unresolved_daydream_comment_stays_unknown(
     """
     run_dir = _seed_archived_deep_run(archive_dir, "s-contest", merged_at="2026-02-01T00:00:00+00:00")
     _write_findings(run_dir, _FP_A)
-    monkeypatch.setattr(
-        "daydream.training.harvest._gh_api",
-        _fake_gh(merged_at="2026-02-01T00:00:00+00:00", comments=_finding_comments(_FP_A)),
+    config = HarvestConfig(archive_dir=archive_dir, cache_dir=tmp_path / "c")
+    await run_harvest(
+        config,
+        services=_services(
+            config,
+            github=_fake_gh(merged_at="2026-02-01T00:00:00+00:00", comments=_finding_comments(_FP_A)),
+        ),
     )
-    await run_harvest(HarvestConfig(archive_dir=archive_dir, cache_dir=tmp_path / "c"))
     row = query_runs(archive_dir, "session_id = ?", ("s-contest",))[0]
     assert json.loads(row["outcome_labels"]) == []  # unknown, never "accepted"
 
@@ -894,7 +1098,6 @@ async def test_harvest_unresolved_daydream_comment_stays_unknown(
 async def test_harvest_relinks_orphan_run_and_labels_it(
     tmp_path: Path,
     archive_dir: Any,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Real-path: an orphan run (PR opened after launch) is re-linked at harvest.
 
@@ -907,9 +1110,7 @@ async def test_harvest_relinks_orphan_run_and_labels_it(
     """
     run_dir = _seed_orphan_run(archive_dir, tmp_path, session_id="s-orph")
     _write_findings(run_dir, _FP_A, _FP_B)
-    monkeypatch.setattr(
-        "daydream.training.harvest._gh_api",
-        _fake_gh(
+    github = _fake_gh(
             merged_at="2026-02-01T00:00:00+00:00",
             comments=[
                 *_finding_comments(_FP_A, reply="applied"),
@@ -921,9 +1122,9 @@ async def test_harvest_relinks_orphan_run_and_labels_it(
                 },
             ],
             commit_pulls=_ORPHAN_COMMIT_PULLS,
-        ),
-    )
-    await run_harvest(HarvestConfig(archive_dir=archive_dir, cache_dir=tmp_path / "c"))
+        )
+    config = HarvestConfig(archive_dir=archive_dir, cache_dir=tmp_path / "c")
+    await run_harvest(config, services=_services(config, github=github))
     row = query_runs(archive_dir, "session_id = ?", ("s-orph",))[0]
     assert row["pr_number"] == 7 and row["pr_repo"] == "org/repo"  # linkage persisted
     assert json.loads(row["outcome_labels"]) == ["contested"]  # now labelable (was orphan)
@@ -976,8 +1177,8 @@ async def test_harvest_fork_pr_404_degrades_not_drops(
             return []
         return {}
 
-    monkeypatch.setattr("daydream.training.harvest._gh_api", _gh_fork_404)
-    summary = await run_harvest(HarvestConfig(archive_dir=archive_dir, cache_dir=tmp_path / "c"))
+    config = HarvestConfig(archive_dir=archive_dir, cache_dir=tmp_path / "c")
+    summary = await run_harvest(config, services=_services(config, github=_gh_fork_404))
 
     assert summary["errors"] == 0  # benign 404 degraded; not a hard error
     obs = latest_label_observation(archive_dir, "s-fork")
@@ -1008,8 +1209,8 @@ async def test_harvest_orphan_422_degrades_not_drops(
     clone — the label degrades to ``"unknown"`` (empty), never ``"rejected"``.
     """
     _seed_orphan_run(archive_dir, tmp_path, session_id="s-orph-422")
-    monkeypatch.setattr("daydream.training.harvest._gh_api", _gh_unpushed_422)
-    summary = await run_harvest(HarvestConfig(archive_dir=archive_dir, cache_dir=tmp_path / "c"))
+    config = HarvestConfig(archive_dir=archive_dir, cache_dir=tmp_path / "c")
+    summary = await run_harvest(config, services=_services(config, github=_gh_unpushed_422))
 
     assert summary["errors"] == 0  # benign 422 degraded; not a hard error
     assert latest_label_observation(archive_dir, "s-orph-422") is not None  # annotated via local path
@@ -1059,9 +1260,8 @@ async def test_harvest_deleted_branch_ref_labels_unknown_not_rejected(
         branch="feat/squash-merged-and-deleted",
         source_path=clone,
     )
-    monkeypatch.setattr("daydream.training.harvest._gh_api", _gh_unpushed_422)
-
-    summary = await run_harvest(HarvestConfig(archive_dir=archive_dir, cache_dir=tmp_path / "c"))
+    config = HarvestConfig(archive_dir=archive_dir, cache_dir=tmp_path / "c")
+    summary = await run_harvest(config, services=_services(config, github=_gh_unpushed_422))
 
     assert summary["errors"] == 0  # benign 422 + unreadable window degrade, not error
     assert latest_label_observation(archive_dir, "s-gone") is not None  # still annotated
@@ -1119,9 +1319,8 @@ async def test_harvest_squash_merged_branch_recovers_accepted_from_base_branch(
         " existing\n"
         "+guarded = True\n"
     )
-    monkeypatch.setattr("daydream.training.harvest._gh_api", _gh_unpushed_422)
-
-    summary = await run_harvest(HarvestConfig(archive_dir=archive_dir, cache_dir=tmp_path / "c"))
+    config = HarvestConfig(archive_dir=archive_dir, cache_dir=tmp_path / "c")
+    summary = await run_harvest(config, services=_services(config, github=_gh_unpushed_422))
 
     assert summary["errors"] == 0
     row = query_runs(archive_dir, "session_id = ?", ("s-squash",))[0]
@@ -1154,9 +1353,8 @@ async def test_harvest_live_branch_with_no_followup_commits_still_labels_rejecte
         branch="feat/still-here",
         source_path=clone,
     )
-    monkeypatch.setattr("daydream.training.harvest._gh_api", _gh_unpushed_422)
-
-    summary = await run_harvest(HarvestConfig(archive_dir=archive_dir, cache_dir=tmp_path / "c"))
+    config = HarvestConfig(archive_dir=archive_dir, cache_dir=tmp_path / "c")
+    summary = await run_harvest(config, services=_services(config, github=_gh_unpushed_422))
 
     assert summary["errors"] == 0
     row = query_runs(archive_dir, "session_id = ?", ("s-live",))[0]
@@ -1164,10 +1362,11 @@ async def test_harvest_live_branch_with_no_followup_commits_still_labels_rejecte
     assert json.loads(row["outcome_labels"]) == ["rejected"]
 
 
+@pytest.mark.parametrize("branch", ["feat/fixed", ""])
 async def test_harvest_live_branch_with_applied_fix_labels_accepted(
     tmp_path: Path,
     archive_dir: Any,
-    monkeypatch: pytest.MonkeyPatch,
+    branch: str,
 ) -> None:
     """Real-path counterpart: a follow-up commit carrying the fix IS "accepted".
 
@@ -1175,14 +1374,17 @@ async def test_harvest_live_branch_with_applied_fix_labels_accepted(
     the same real-git path, so the fix is pinned on the positive arm too.
     """
     clone = _make_repo_with_main(tmp_path, name="clone")
-    _git(clone, "checkout", "-b", "feat/fixed")
+    if branch:
+        _git(clone, "checkout", "-b", branch)
     head_sha = _git(clone, "rev-parse", "HEAD").strip()
+    session_id = "s-applied-empty-branch" if not branch else "s-applied"
     run_dir = _seed_orphan_run(
         archive_dir,
         tmp_path / "bronze",
-        session_id="s-applied",
+        session_id=session_id,
         head_sha=head_sha,
-        branch="feat/fixed",
+        branch=branch,
+        base_branch=None,
         source_path=clone,
     )
     # The recommended patch adds a line; a later commit on the branch lands it.
@@ -1198,18 +1400,16 @@ async def test_harvest_live_branch_with_applied_fix_labels_accepted(
     (clone / "app.py").write_text("existing\nguarded = True\n")
     _git(clone, "add", "app.py")
     _commit(clone, "apply the recommended fix")
-    monkeypatch.setattr("daydream.training.harvest._gh_api", _gh_unpushed_422)
+    config = HarvestConfig(archive_dir=archive_dir, cache_dir=tmp_path / "c")
+    await run_harvest(config, services=_services(config, github=_gh_unpushed_422))
 
-    await run_harvest(HarvestConfig(archive_dir=archive_dir, cache_dir=tmp_path / "c"))
-
-    row = query_runs(archive_dir, "session_id = ?", ("s-applied",))[0]
+    row = query_runs(archive_dir, "session_id = ?", (session_id,))[0]
     assert json.loads(row["outcome_labels"]) == ["accepted"]
 
 
 async def test_harvest_merged_pr_with_zero_comments_is_not_labeled_accepted(
     tmp_path: Path,
     archive_dir: Any,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Real-path: a merged PR where daydream tracked NO comments is unlabeled.
 
@@ -1221,12 +1421,11 @@ async def test_harvest_merged_pr_with_zero_comments_is_not_labeled_accepted(
     ``unknown`` (empty labels) and stay out of the posterior population.
     """
     _seed_archived_deep_run(archive_dir, "s-vacuous", merged_at="2026-02-01T00:00:00+00:00")
-    monkeypatch.setattr(
-        "daydream.training.harvest._gh_api",
-        _fake_gh(merged_at="2026-02-01T00:00:00+00:00"),
+    config = HarvestConfig(archive_dir=archive_dir, cache_dir=tmp_path / "c")
+    summary = await run_harvest(
+        config,
+        services=_services(config, github=_fake_gh(merged_at="2026-02-01T00:00:00+00:00")),
     )
-
-    summary = await run_harvest(HarvestConfig(archive_dir=archive_dir, cache_dir=tmp_path / "c"))
 
     assert summary["errors"] == 0 and summary["annotated"] == 1
     row = query_runs(archive_dir, "session_id = ?", ("s-vacuous",))[0]
@@ -1243,7 +1442,6 @@ async def test_harvest_merged_pr_with_zero_comments_is_not_labeled_accepted(
 async def test_harvest_merged_pr_with_reject_reply_is_contested(
     tmp_path: Path,
     archive_dir: Any,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """The amelia#626 shape: merged PR + explicit human rejection ⇒ contested, never accepted (M10/M22).
 
@@ -1254,9 +1452,7 @@ async def test_harvest_merged_pr_with_reject_reply_is_contested(
     """
     run_dir = _seed_archived_deep_run(archive_dir, "s-reject", merged_at="2026-08-10T00:00:00Z")
     _write_findings(run_dir, _FP_A, _FP_B)
-    monkeypatch.setattr(
-        "daydream.training.harvest._gh_api",
-        _fake_gh(
+    github = _fake_gh(
             merged_at="2026-08-10T00:00:00Z",
             comments=[
                 *_finding_comments(_FP_A, reply="False positive — the code already handles this"),
@@ -1267,10 +1463,9 @@ async def test_harvest_merged_pr_with_reject_reply_is_contested(
                     "body": f"finding\n\n{finding_marker(_FP_B)}\n\n{DAYDREAM_FOOTER}",
                 },
             ],
-        ),
-    )
-
-    summary = await run_harvest(HarvestConfig(archive_dir=archive_dir, cache_dir=tmp_path / "c"))
+        )
+    config = HarvestConfig(archive_dir=archive_dir, cache_dir=tmp_path / "c")
+    summary = await run_harvest(config, services=_services(config, github=github))
 
     assert summary["errors"] == 0 and summary["annotated"] == 1
     row = query_runs(archive_dir, "session_id = ?", ("s-reject",))[0]
@@ -1309,9 +1504,8 @@ async def test_harvest_unmerged_pr_with_no_semantic_reply_is_unknown(
             return []
         return {"merged": False, "merged_at": None, "state": "open"}
 
-    monkeypatch.setattr("daydream.training.harvest._gh_api", _gh_open)
-
-    summary = await run_harvest(HarvestConfig(archive_dir=archive_dir, cache_dir=tmp_path / "c"))
+    config = HarvestConfig(archive_dir=archive_dir, cache_dir=tmp_path / "c")
+    summary = await run_harvest(config, services=_services(config, github=_gh_open))
 
     assert summary["errors"] == 0 and summary["annotated"] == 1
     row = query_runs(archive_dir, "session_id = ?", ("s-open",))[0]
@@ -1328,7 +1522,7 @@ def test_valid_at_is_decisive_evidence_time(tmp_path: Path) -> None:
     row = {"session_id": "s-val", "pr_repo": "o/r", "pr_number": 7, "head_sha": "h",
            "base_branch": "main", "archive_path": str(run_dir),
            "grounding_rate": 1.0, "changed_files": "[]"}
-    ann = build_annotation(
+    ann = _acquire_annotation(
         row,
         run_dir=run_dir,
         archive_dir=tmp_path,
@@ -1348,7 +1542,7 @@ def test_valid_at_override_respected(tmp_path: Path) -> None:
     row = {"session_id": "s-val-ovr", "pr_repo": "o/r", "pr_number": 7, "head_sha": "h",
            "base_branch": "main", "archive_path": str(run_dir),
            "grounding_rate": 1.0, "changed_files": "[]"}
-    ann = build_annotation(
+    ann = _acquire_annotation(
         row,
         run_dir=run_dir,
         archive_dir=tmp_path,
@@ -1365,26 +1559,32 @@ def test_valid_at_override_respected(tmp_path: Path) -> None:
 async def test_labeler_version_is_not_reward_version(
     tmp_path: Path,
     archive_dir: Any,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """append_label_observation receives labeler_versions.LABELER_POLICY_VERSION (M13/M22)."""
     run_dir = _seed_archived_deep_run(archive_dir, "s-lv", merged_at="2026-08-10T00:00:00Z")
     _write_findings(run_dir, _FP_A)
-    monkeypatch.setattr(
-        "daydream.training.harvest._gh_api",
-        _fake_gh(
-            merged_at="2026-08-10T00:00:00Z",
-            comments=_finding_comments(_FP_A, reply="applied", reply_created_at="2026-08-02T10:00:00Z"),
-        ),
-    )
     captured: dict[str, Any] = {}
 
-    def _capture(_archive_dir: Path, _session_id: str, **kwargs: Any) -> bool:
-        captured.update(kwargs)
+    def _capture(_row: HarvestRow, payload: AnnotationPayload) -> bool:
+        captured.update(
+            labeler_version=labeler_versions.LABELER_POLICY_VERSION,
+            reply_classifier_version=payload.reply_classifier_version,
+            reply_evidence_digest=payload.reply_evidence_digest,
+        )
         return True
 
-    monkeypatch.setattr("daydream.training.harvest.append_label_observation", _capture)
-    summary = await run_harvest(HarvestConfig(archive_dir=archive_dir, cache_dir=tmp_path / "c"))
+    config = HarvestConfig(archive_dir=archive_dir, cache_dir=tmp_path / "c")
+    summary = await run_harvest(
+        config,
+        services=HarvestTestServices(
+            make_harvest_services(config),
+            github=_fake_gh(
+                merged_at="2026-08-10T00:00:00Z",
+                comments=_finding_comments(_FP_A, reply="applied", reply_created_at="2026-08-02T10:00:00Z"),
+            ),
+            append_annotation=_capture,
+        ),
+    )
 
     assert summary["annotated"] == 1
     assert captured["labeler_version"] == labeler_versions.LABELER_POLICY_VERSION
@@ -1440,9 +1640,8 @@ async def test_harvest_local_branch_accept_keeps_label_but_is_not_posterior_evid
     (clone / "app.py").write_text("existing\nguarded = True\n")
     _git(clone, "add", "app.py")
     _commit(clone, "apply the recommended fix")
-    monkeypatch.setattr("daydream.training.harvest._gh_api", _gh_unpushed_422)
-
-    summary = await run_harvest(HarvestConfig(archive_dir=archive_dir, cache_dir=tmp_path / "c"))
+    config = HarvestConfig(archive_dir=archive_dir, cache_dir=tmp_path / "c")
+    summary = await run_harvest(config, services=_services(config, github=_gh_unpushed_422))
 
     assert summary["errors"] == 0
     row = query_runs(archive_dir, "session_id = ?", ("s-local-tier",))[0]
@@ -1458,7 +1657,6 @@ async def test_harvest_local_branch_accept_keeps_label_but_is_not_posterior_evid
 async def test_harvest_dry_run_mutates_row_in_memory_but_suppresses_set_run_pr_link(
     tmp_path: Path,
     archive_dir: Any,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """dry_run=True: in-memory linkage preview is applied but not persisted.
 
@@ -1474,18 +1672,13 @@ async def test_harvest_dry_run_mutates_row_in_memory_but_suppresses_set_run_pr_l
     """
     _seed_orphan_run(archive_dir, tmp_path, session_id="s-orph-dry")
 
-    monkeypatch.setattr(
-        "daydream.training.harvest._gh_api",
-        _fake_gh(
+    github = _fake_gh(
             merged_at="2026-02-01T00:00:00+00:00",
             comments=_UNRESOLVED_FINDING,
             commit_pulls=_ORPHAN_COMMIT_PULLS,
-        ),
-    )
-
-    summary = await run_harvest(
-        HarvestConfig(archive_dir=archive_dir, cache_dir=tmp_path / "c", dry_run=True)
-    )
+        )
+    config = HarvestConfig(archive_dir=archive_dir, cache_dir=tmp_path / "c", dry_run=True)
+    summary = await run_harvest(config, services=_services(config, github=github))
 
     # In-memory linkage drove build_annotation through the PR path:
     assert summary["would_annotate"] == 1
@@ -1518,8 +1711,8 @@ async def test_harvest_leaves_true_local_run_unlinked(
             return []  # no PR ever opened
         raise AssertionError(f"PR endpoints must not be hit for an unlinked local run ({endpoint})")
 
-    monkeypatch.setattr("daydream.training.harvest._gh_api", _gh_no_pr)
-    summary = await run_harvest(HarvestConfig(archive_dir=archive_dir, cache_dir=tmp_path / "c"))
+    config = HarvestConfig(archive_dir=archive_dir, cache_dir=tmp_path / "c")
+    summary = await run_harvest(config, services=_services(config, github=_gh_no_pr))
     row = query_runs(archive_dir, "session_id = ?", ("s-local",))[0]
     assert row["pr_number"] is None
     assert summary["errors"] == 0
@@ -1527,12 +1720,11 @@ async def test_harvest_leaves_true_local_run_unlinked(
 
 async def test_re_harvest_is_idempotent(tmp_path: Path, archive_dir: Any, monkeypatch: pytest.MonkeyPatch) -> None:
     _seed_archived_deep_run(archive_dir, "s1", merged_at="2026-02-01T00:00:00+00:00")
-    monkeypatch.setattr(
-        "daydream.training.harvest._gh_api",
-        _fake_gh(merged_at="2026-02-01T00:00:00+00:00", comments=_REPLIED_FINDING),
-    )
-    await run_harvest(HarvestConfig(archive_dir=archive_dir, cache_dir=tmp_path / "c1"))
-    second = await run_harvest(HarvestConfig(archive_dir=archive_dir, cache_dir=tmp_path / "c2"))
+    github = _fake_gh(merged_at="2026-02-01T00:00:00+00:00", comments=_REPLIED_FINDING)
+    first_config = HarvestConfig(archive_dir=archive_dir, cache_dir=tmp_path / "c1")
+    await run_harvest(first_config, services=_services(first_config, github=github))
+    second_config = HarvestConfig(archive_dir=archive_dir, cache_dir=tmp_path / "c2")
+    second = await run_harvest(second_config, services=_services(second_config, github=github))
     assert len(label_observation_history(archive_dir, "s1")) == 1  # deduped
     assert second["skipped"] == 1 and second["annotated"] == 0
 
@@ -1543,20 +1735,18 @@ async def test_re_harvest_appends_on_version_bump(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     _seed_archived_deep_run(archive_dir, "s1", merged_at="2026-02-01T00:00:00+00:00")
-    monkeypatch.setattr(
-        "daydream.training.harvest._gh_api",
-        _fake_gh(merged_at="2026-02-01T00:00:00+00:00", comments=_REPLIED_FINDING),
-    )
-    await run_harvest(HarvestConfig(archive_dir=archive_dir, cache_dir=tmp_path / "c1"))
+    github = _fake_gh(merged_at="2026-02-01T00:00:00+00:00", comments=_REPLIED_FINDING)
+    first_config = HarvestConfig(archive_dir=archive_dir, cache_dir=tmp_path / "c1")
+    await run_harvest(first_config, services=_services(first_config, github=github))
     monkeypatch.setattr("daydream.training.labeler_versions.LABELER_POLICY_VERSION", "980-policy-bump")
-    await run_harvest(HarvestConfig(archive_dir=archive_dir, cache_dir=tmp_path / "c2"))
+    second_config = HarvestConfig(archive_dir=archive_dir, cache_dir=tmp_path / "c2")
+    await run_harvest(second_config, services=_services(second_config, github=github))
     assert len(label_observation_history(archive_dir, "s1")) == 2
 
 
 async def test_harvest_aborts_cleanly_on_rate_limit_and_preserves_resume(
     tmp_path: Path,
     archive_dir: Any,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     # Two PR rows; PR 1 succeeds, PR 2 hits an exhausted rate-limit on every gh
     # call so the harvest loop must abort cleanly.
@@ -1568,32 +1758,83 @@ async def test_harvest_aborts_cleanly_on_rate_limit_and_preserves_resume(
             raise git_ops.RateLimitError("exhausted")
         return merged(repo, endpoint, **kw)
 
-    monkeypatch.setattr("daydream.training.harvest._gh_api", _gh)
     cache_dir = tmp_path / "c"
-    summary = await run_harvest(HarvestConfig(archive_dir=archive_dir, cache_dir=cache_dir))
+    config = HarvestConfig(archive_dir=archive_dir, cache_dir=cache_dir)
+    summary = await run_harvest(config, services=_services(config, github=_gh))
     assert summary["aborted"] == 1
     # The completed session is preserved for resume; the failed one is not:
     done = BackfillCache(cache_dir=cache_dir, inner=_gh).completed_sessions()
     assert "s1" in done and "s2" not in done
 
 
-def test_gh_api_backoff_retries_then_succeeds(monkeypatch: pytest.MonkeyPatch) -> None:
-    slept = []
-    monkeypatch.setattr(harvest, "_rate_limit_sleep", lambda s: slept.append(s))
-    seq = [git_ops.RateLimitError("x"), git_ops.RateLimitError("x"), {"ok": True}]
+def test_github_retry_uses_explicit_backoff_sleep(monkeypatch: pytest.MonkeyPatch) -> None:
+    slept: list[float] = []
+    sequence: list[Any] = [
+        git_ops.RateLimitError("x"),
+        git_ops.RateLimitError("x"),
+        {"ok": True},
+    ]
 
-    def _inner(*a: Any, **k: Any) -> Any:
-        v = seq.pop(0)
-        if isinstance(v, Exception):
-            raise v
-        return v
+    def _inner(*args: Any, **kwargs: Any) -> Any:
+        value = sequence.pop(0)
+        if isinstance(value, Exception):
+            raise value
+        return value
 
-    monkeypatch.setattr("daydream.git_ops.gh_api", _inner)
-    assert harvest._gh_api("o/r", "endpoint") == {"ok": True}
-    assert len(slept) == 2
+    monkeypatch.setattr(git_ops, "gh_api", _inner)
+    assert harvest._github_with_retry(
+        "o/r",
+        "endpoint",
+        auth=git_ops.INHERIT_GITHUB_AUTH,
+        backoff_sleep=slept.append,
+    ) == {"ok": True}
+    assert slept == [30.0, 30.0]
 
 
-# _resolve_repo_for_row
+def test_harvest_services_binds_explicit_github_auth(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    auth = git_ops.StaticGitHubAuth({"GH_TOKEN": "test-token"})
+    seen_auth: list[git_ops.GitHubAuth] = []
+
+    def _github(*args: Any, **kwargs: Any) -> dict[str, bool]:
+        seen_auth.append(kwargs["auth"])
+        return {"ok": True}
+
+    monkeypatch.setattr(git_ops, "gh_api", _github)
+    config = HarvestConfig(archive_dir=tmp_path / "archive")
+    services = make_harvest_services(config, github_auth=auth)
+
+    assert services.github("o/r", "endpoint") == {"ok": True}
+    assert seen_auth == [auth]
+
+
+def _resolve_repo_with_services(
+    tmp_path: Path,
+    *,
+    clone_cache: Path,
+    source_path: Path | None = None,
+    remote_url: str | None = None,
+    repo_slug: str | None = None,
+) -> Path | None:
+    row = HarvestRow.from_mapping(
+        {
+            "session_id": "adapter-session",
+            "archive_path": str(tmp_path / "archive" / "runs" / "adapter-session"),
+            "source_path": str(source_path) if source_path is not None else None,
+            "remote_url": remote_url,
+            "repo_slug": repo_slug,
+        },
+        row_number=1,
+    )
+    services = make_harvest_services(
+        HarvestConfig(
+            archive_dir=tmp_path / "archive",
+            repo_clone_root=clone_cache,
+        )
+    )
+    return services.resolve_repo(row, console=create_console())
 
 
 def test_resolve_repo_for_row_prefers_source_path(tmp_path: Path) -> None:
@@ -1601,12 +1842,20 @@ def test_resolve_repo_for_row_prefers_source_path(tmp_path: Path) -> None:
     source = tmp_path / "source_repo"
     source.mkdir()
     (source / ".git").mkdir()
-    row = {"source_path": str(source), "remote_url": "https://github.com/org/repo.git", "repo_slug": "org/repo"}
-    result = _resolve_repo_for_row(row, clone_cache=tmp_path / "cache")
+    result = _resolve_repo_with_services(
+        tmp_path,
+        clone_cache=tmp_path / "cache",
+        source_path=source,
+        remote_url="https://github.com/org/repo.git",
+        repo_slug="org/repo",
+    )
     assert result == source
 
 
-def test_resolve_repo_for_row_clones_when_source_path_missing(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_resolve_repo_for_row_clones_when_source_path_missing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Falls through to clone when source_path is absent."""
     cache = tmp_path / "cache"
 
@@ -1614,48 +1863,68 @@ def test_resolve_repo_for_row_clones_when_source_path_missing(tmp_path: Path, mo
         target.mkdir(parents=True, exist_ok=True)
         (target / ".git").mkdir()
 
-    monkeypatch.setattr("daydream.training.harvest.git_ops.clone_with_token", fake_clone)
-    row = {"source_path": None, "remote_url": "https://github.com/org/repo.git", "repo_slug": "org/repo"}
-    result = _resolve_repo_for_row(row, clone_cache=cache)
+    monkeypatch.setattr(git_ops, "clone_with_token", fake_clone)
+    result = _resolve_repo_with_services(
+        tmp_path,
+        clone_cache=cache,
+        remote_url="https://github.com/org/repo.git",
+        repo_slug="org/repo",
+    )
     assert result == cache / "org" / "repo"
 
 
-def test_resolve_repo_for_row_fetches_existing_cache(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_resolve_repo_for_row_fetches_existing_cache(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """When the cache clone already exists, fetch instead of clone."""
     cache = tmp_path / "cache"
     cached_repo = cache / "org" / "repo"
     cached_repo.mkdir(parents=True)
     (cached_repo / ".git").mkdir()
 
-    fetched = []
-    monkeypatch.setattr("daydream.training.harvest.git_ops.fetch", lambda repo, remote="origin": fetched.append(repo))
+    fetched: list[Path] = []
+    monkeypatch.setattr(git_ops, "fetch", lambda repo, remote="origin": fetched.append(repo))
     monkeypatch.setattr(
-        "daydream.training.harvest.git_ops.clone_with_token",
-        lambda *a, **k: pytest.fail("should not clone"),
+        git_ops,
+        "clone_with_token",
+        lambda *args, **kwargs: pytest.fail("should not clone"),
     )
-    row = {"source_path": None, "remote_url": "https://github.com/org/repo.git", "repo_slug": "org/repo"}
-    result = _resolve_repo_for_row(row, clone_cache=cache)
+    result = _resolve_repo_with_services(
+        tmp_path,
+        clone_cache=cache,
+        remote_url="https://github.com/org/repo.git",
+        repo_slug="org/repo",
+    )
     assert result == cached_repo
     assert fetched == [cached_repo]
 
 
 def test_resolve_repo_for_row_returns_none_when_no_remote(tmp_path: Path) -> None:
     """Returns None when neither source_path nor remote_url is available."""
-    row = {"source_path": None, "remote_url": None, "repo_slug": None}
-    result = _resolve_repo_for_row(row, clone_cache=tmp_path / "cache")
+    result = _resolve_repo_with_services(tmp_path, clone_cache=tmp_path / "cache")
     assert result is None
 
 
-def test_resolve_repo_for_row_clone_failure_returns_none(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_resolve_repo_for_row_clone_failure_returns_none(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Clone failure is swallowed and None is returned (no .git left on disk)."""
     cache = tmp_path / "cache"
-
     monkeypatch.setattr(
-        "daydream.training.harvest.git_ops.clone_with_token",
-        lambda url, target, token=None, **kwargs: (_ for _ in ()).throw(GitError("network error")),
+        git_ops,
+        "clone_with_token",
+        lambda url, target, token=None, **kwargs: (_ for _ in ()).throw(
+            GitError("network error")
+        ),
     )
-    row = {"source_path": None, "remote_url": "https://github.com/org/repo.git", "repo_slug": "org/repo"}
-    result = _resolve_repo_for_row(row, clone_cache=cache)
+    result = _resolve_repo_with_services(
+        tmp_path,
+        clone_cache=cache,
+        remote_url="https://github.com/org/repo.git",
+        repo_slug="org/repo",
+    )
     assert result is None
 
 
@@ -1670,11 +1939,16 @@ def test_resolve_repo_for_row_fetch_failure_returns_cached_path(
     (cached_repo / ".git").mkdir()
 
     monkeypatch.setattr(
-        "daydream.training.harvest.git_ops.fetch",
+        git_ops,
+        "fetch",
         lambda repo, remote="origin": (_ for _ in ()).throw(GitError("fetch failed")),
     )
-    row = {"source_path": None, "remote_url": "https://github.com/org/repo.git", "repo_slug": "org/repo"}
-    result = _resolve_repo_for_row(row, clone_cache=cache)
+    result = _resolve_repo_with_services(
+        tmp_path,
+        clone_cache=cache,
+        remote_url="https://github.com/org/repo.git",
+        repo_slug="org/repo",
+    )
     assert result == cached_repo
 
 
@@ -1701,7 +1975,6 @@ def test_pr_coverage_helper_counts_decisive(tmp_path: Path) -> None:
 async def test_harvest_propagates_transient_giterror_for_retry(
     tmp_path: Path,
     archive_dir: Any,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Real-path: a transient GitError (HTTP 500) on /comments propagates, not degrades.
 
@@ -1723,8 +1996,11 @@ async def test_harvest_propagates_transient_giterror_for_retry(
             raise GitError("gh: Internal Server Error (HTTP 500)")
         return {}
 
-    monkeypatch.setattr("daydream.training.harvest._gh_api", _gh_merge_ok_comments_500)
-    summary = await run_harvest(HarvestConfig(archive_dir=archive_dir, cache_dir=cache_dir))
+    config = HarvestConfig(archive_dir=archive_dir, cache_dir=cache_dir)
+    summary = await run_harvest(
+        config,
+        services=_services(config, github=_gh_merge_ok_comments_500),
+    )
 
     assert summary["errors"] == 1  # transient 500 propagated, not degraded
     assert latest_label_observation(archive_dir, "s-transient-500") is None  # not annotated
@@ -1736,7 +2012,6 @@ async def test_harvest_propagates_transient_giterror_for_retry(
 async def test_harvest_does_not_discard_confirmed_merge_on_benign_comment_error(
     tmp_path: Path,
     archive_dir: Any,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Real-path: a 404 on /comments after a confirmed merge propagates, not degrades.
 
@@ -1758,8 +2033,11 @@ async def test_harvest_does_not_discard_confirmed_merge_on_benign_comment_error(
             raise GitError("gh: Not Found (HTTP 404)")
         return {}
 
-    monkeypatch.setattr("daydream.training.harvest._gh_api", _gh_merge_ok_comments_404)
-    summary = await run_harvest(HarvestConfig(archive_dir=archive_dir, cache_dir=cache_dir))
+    config = HarvestConfig(archive_dir=archive_dir, cache_dir=cache_dir)
+    summary = await run_harvest(
+        config,
+        services=_services(config, github=_gh_merge_ok_comments_404),
+    )
 
     assert summary["errors"] == 1  # benign comment 404 propagated, merge evidence not discarded
     assert latest_label_observation(archive_dir, "s-merge-comments-404") is None  # not annotated
@@ -1770,7 +2048,6 @@ async def test_harvest_does_not_discard_confirmed_merge_on_benign_comment_error(
 async def test_harvest_keeps_labeled_row_when_reviewer_lookup_errors(
     tmp_path: Path,
     archive_dir: Any,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Real-path: a GitError on the ``/reviews`` lookup must not drop a labeled row.
 
@@ -1792,8 +2069,8 @@ async def test_harvest_keeps_labeled_row_when_reviewer_lookup_errors(
             return _finding_comments(_FP_A, reply="applied")
         return {"merged": True, "merged_at": "2026-02-01T00:00:00+00:00"}
 
-    monkeypatch.setattr("daydream.training.harvest._gh_api", _gh_reviews_fail)
-    summary = await run_harvest(HarvestConfig(archive_dir=archive_dir, cache_dir=tmp_path / "c"))
+    config = HarvestConfig(archive_dir=archive_dir, cache_dir=tmp_path / "c")
+    summary = await run_harvest(config, services=_services(config, github=_gh_reviews_fail))
 
     assert summary["errors"] == 0  # reviewer-lookup failure degraded, row not dropped
     obs = latest_label_observation(archive_dir, "s-reviews-err")
@@ -1806,7 +2083,6 @@ async def test_harvest_keeps_labeled_row_when_reviewer_lookup_errors(
 async def test_harvest_degrades_benign_giterror_rows_instead_of_dropping(
     tmp_path: Path,
     archive_dir: Any,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     # 10 PR rows: PRs 1..8 merged ("accepted"); PRs 9..10 raise a benign GitError
     # (e.g. fork-PR 404). The fix DEGRADES 9..10 to the local-branch posterior
@@ -1828,9 +2104,8 @@ async def test_harvest_degrades_benign_giterror_rows_instead_of_dropping(
             raise GitError(f"gh: Not Found (HTTP 404) for PR {number}")
         return merged(repo, endpoint, **kw)
 
-    monkeypatch.setattr("daydream.training.harvest._gh_api", _gh)
-
-    summary = await run_harvest(HarvestConfig(archive_dir=archive_dir, cache_dir=tmp_path / "c"))
+    config = HarvestConfig(archive_dir=archive_dir, cache_dir=tmp_path / "c")
+    summary = await run_harvest(config, services=_services(config, github=_gh))
 
     assert summary["aborted"] == 0  # the GitError rows did NOT abort the sweep
     # All 10 annotate: 8 PR-path "accepted", 2 degraded to local-branch.
@@ -1863,67 +2138,71 @@ def _raise_git_error_with_url(*args: object, **kwargs: object) -> None:
 
 
 def test_repo_resolution_warning_is_value_free(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
 ) -> None:
     """The harvest repo-resolution warning must never contain the remote URL (issue #981)."""
-    row = {
-        "source_path": None,
-        "remote_url": "https://user:ghp_canaryfake123@github.com/o/r",
-        "repo_slug": "o/r",
-    }
-    monkeypatch.setattr("daydream.training.harvest.git_ops.clone_with_token", _raise_git_error_with_url)
-    _resolve_repo_for_row(row, clone_cache=tmp_path / "cache")
+    monkeypatch.setattr(git_ops, "clone_with_token", _raise_git_error_with_url)
+    _resolve_repo_with_services(
+        tmp_path,
+        clone_cache=tmp_path / "cache",
+        remote_url="https://user:ghp_canaryfake123@github.com/o/r",
+        repo_slug="o/r",
+    )
     out = capsys.readouterr().out
     assert "ghp_canaryfake123" not in out
-    assert "o/r" in out  # slug IS present
-
-
-# identity-based repo resolution (issue #981): never clone the archived raw URL
+    assert "o/r" in out
 
 
 def test_resolve_repo_never_clones_raw_archived_url(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     seen: list[str] = []
 
-    def fake_clone(url: str, target: Path, token: str | None = None, **kw: object) -> None:
+    def fake_clone(url: str, target: Path, token: str | None = None, **kwargs: object) -> None:
         seen.append(url)
         target.mkdir(parents=True, exist_ok=True)
         (target / ".git").mkdir()
 
-    monkeypatch.setattr("daydream.training.harvest.git_ops.clone_with_token", fake_clone)
-    row = {
-        "source_path": None,
-        "remote_url": "https://user:ghp_canaryfake123@github.com/o/r",
-        "repo_slug": "o/r",
-    }
-    assert _resolve_repo_for_row(row, clone_cache=tmp_path / "cache") == tmp_path / "cache" / "o" / "r"
-    assert seen == ["https://github.com/o/r"]  # reconstructed identity, never raw
+    monkeypatch.setattr(git_ops, "clone_with_token", fake_clone)
+    assert _resolve_repo_with_services(
+        tmp_path,
+        clone_cache=tmp_path / "cache",
+        remote_url="https://user:ghp_canaryfake123@github.com/o/r",
+        repo_slug="o/r",
+    ) == tmp_path / "cache" / "o" / "r"
+    assert seen == ["https://github.com/o/r"]
 
 
 def test_resolve_repo_fails_closed_on_untrusted_host(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     calls: list[str] = []
-    monkeypatch.setattr(
-        "daydream.training.harvest.git_ops.clone_with_token",
-        lambda url, t, **kw: calls.append(url),
-    )
-    row = {"source_path": None, "remote_url": "https://evil.example.com/o/r", "repo_slug": "o/r"}
-    assert _resolve_repo_for_row(row, clone_cache=tmp_path / "cache") is None  # M7: no clone attempt
+    monkeypatch.setattr(git_ops, "clone_with_token", lambda url, target, **kwargs: calls.append(url))
+    assert _resolve_repo_with_services(
+        tmp_path,
+        clone_cache=tmp_path / "cache",
+        remote_url="https://evil.example.com/o/r",
+        repo_slug="o/r",
+    ) is None
     assert calls == []
 
 
 def test_resolve_repo_fails_closed_on_file_scheme(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     calls: list[str] = []
-    monkeypatch.setattr(
-        "daydream.training.harvest.git_ops.clone_with_token",
-        lambda url, t, **kw: calls.append(url),
-    )
-    row = {"source_path": None, "remote_url": "file:///tmp/evil", "repo_slug": "o/r"}
-    assert _resolve_repo_for_row(row, clone_cache=tmp_path / "cache") is None
+    monkeypatch.setattr(git_ops, "clone_with_token", lambda url, target, **kwargs: calls.append(url))
+    assert _resolve_repo_with_services(
+        tmp_path,
+        clone_cache=tmp_path / "cache",
+        remote_url="file:///tmp/evil",
+        repo_slug="o/r",
+    ) is None
     assert calls == []
 
 
@@ -1935,19 +2214,19 @@ def test_token_never_in_url(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> 
         seen.append(cmd)
         return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
 
-    monkeypatch.setattr("daydream.git_ops.subprocess.run", _recording_run)
-    _resolve_repo_for_row(
-        {"source_path": None, "remote_url": "https://github.com/o/r", "repo_slug": "o/r"},
+    monkeypatch.setattr(subprocess, "run", _recording_run)
+    _resolve_repo_with_services(
+        tmp_path,
         clone_cache=tmp_path / "cache",
+        remote_url="https://github.com/o/r",
+        repo_slug="o/r",
     )
     assert seen
-    # The base64 Authorization header is trivially recoverable, so the token's
-    # absence on argv must hold for both the raw token and its encoded form.
     basic = base64.b64encode(b"x-access-token:ghp_envtokfake123").decode()
-    for c in seen:
-        joined = " ".join(c)
-        assert "ghp_envtokfake123" not in joined  # raw token never on argv
-        assert basic not in joined  # recoverable base64 never on argv either (M8)
+    for command in seen:
+        joined = " ".join(command)
+        assert "ghp_envtokfake123" not in joined
+        assert basic not in joined
 
 
 def test_hub_import_rejects_unsanitized_affected_bundle(tmp_path: Path) -> None:
@@ -2037,6 +2316,69 @@ def test_per_finding_resolution_round_trips_through_canonical_dict() -> None:
     )
     restored = resolution_from_dict(resolution_to_dict(r))
     assert restored == r  # canonical dict is the one round-trip shape
+
+
+def test_harvest_row_preserves_absent_and_empty_fingerprints() -> None:
+    """The typed ingress retains the legacy distinction used by signal assembly."""
+    from daydream.training.harvest_types import HarvestRow
+
+    common = {"session_id": "s1", "archive_path": "/tmp/archive"}
+    absent = HarvestRow.from_mapping(common, row_number=1)
+    empty = HarvestRow.from_mapping({**common, "findings_fingerprints": []}, row_number=2)
+
+    assert "findings_fingerprints" not in absent.as_signal_row()
+    assert empty.as_signal_row()["findings_fingerprints"] == []
+
+
+def test_harvest_evidence_detaches_nested_signals_with_canonical_rubric() -> None:
+    """Acquired evidence owns nested records before the pure reducer receives it."""
+    from daydream.training.harvest_types import HarvestEvidence
+    from daydream.training.labeler_signals import (
+        CommentResolutionSignal,
+        FixAppliedSignal,
+        PerFindingResolution,
+        PRMergeSignal,
+        resolution_to_dict,
+    )
+    from daydream.training.reward import ScoringInputs
+    from daydream.training.rubric import Rubric
+
+    verdicts: list[dict[str, Any]] = [{"verdict": "consistent", "detail": {"source": "original"}}]
+    commits = ["a1"]
+    replies: list[dict[str, Any]] = [{"reply_id": 7, "context": {"state": "original"}}]
+    rubric = Rubric(
+        pr_merge=PRMergeSignal(True, "2026-02-01T00:00:00Z", "merged"),
+        fix_applied=FixAppliedSignal("applied", 1, 1, commits),
+        comment_resolution=CommentResolutionSignal(1, 1, 0),
+        local_commit_applied=None,
+        posterior_source="pr_review",
+        per_finding_resolutions=[
+            PerFindingResolution("f" * 64, 7, "accepted", replies, "d" * 32)
+        ],
+    )
+    expected = rubric.to_dict()
+    evidence = HarvestEvidence(
+        scoring_inputs=ScoringInputs(verdicts, 1.0, True, 12),
+        rubric=rubric,
+        reviewer_logins=("reviewer",),
+        pooled_prior=0.75,
+        prior_n=2,
+    )
+
+    verdicts[0]["detail"]["source"] = "mutated"
+    commits.append("b2")
+    replies[0]["context"]["state"] = "mutated"
+
+    stored_verdicts = evidence.scoring_inputs.verifier_verdicts
+    assert stored_verdicts is not None
+    assert stored_verdicts[0]["detail"]["source"] == "original"
+    assert list(evidence.rubric.fix_applied.window_commits) == ["a1"]
+    resolution = evidence.rubric.per_finding_resolutions
+    assert resolution is not None
+    assert resolution_to_dict(resolution[0])["evidence"] == [
+        {"reply_id": 7, "context": {"state": "original"}}
+    ]
+    assert evidence.rubric.to_dict() == expected
 
 def test_per_finding_resolution_from_dict_fails_closed() -> None:
     from daydream.training.labeler_signals import resolution_from_dict


### PR DESCRIPTION
## Summary

Corpus harvest now validates every indexed row before consulting resume markers or acquiring evidence. A malformed row produces a session-specific error while valid siblings continue. Harvest and backfill also reject a service bound to a different archive before querying, while accepting aliases for the same archive. Annotation construction consumes a validated row and immutable acquired evidence without GitHub, git, filesystem, clock, cache, or database activity.

## Motivation

Closes #1010. The previous annotation builder mixed scoring with external acquisition, and harvest tests replaced module globals. Explicit per-run services now own those dependencies. The CLI and backfill both use the new boundary.

## Changes

- Capture bronze inputs, PR/local signals, reviewer prior, and repository/base-SHA status in an immutable evidence bundle; preserve canonical annotation JSON and reward/version semantics.
- Preserve reviewer/fix missing-evidence fallbacks, prior cutoff and sufficiency, dry-run behavior, orphan linkage, deduplication, rate-limit abort/resume, and successful-row spacing. Backfill retains its distinct fallback and report behavior.
- Preserve supplied optional Git strings, including an empty branch that Git treats as the current tip. Required identities and archive paths are validated before acquisition.
- Thaw immutable evidence at the shared snapshot JSON and digest boundaries, preserving canonical bytes and digest identity for valid nested JSON.
- Replace global-patched harvest tests with explicit services and real CLI journeys through temporary Git repositories, SQLite, and cache files.

## Test Plan

- [x] Clean harvest/reproducibility baseline: 66 passed; clean backfill baseline: 13 passed.
- [x] Observed the malformed-row regression fail before implementation; retained a real-Git before/after reproduction for empty optional branch handling.
- [x] Integrated harvest coverage passed 184 tests before CI; the focused selection after the shared-reader correction passed 177 tests. The real RL reward parity test failed before the correction and now passes.
- [x] Final `make check`: 8,221 passed / 15 skipped, 88.82% coverage.
- [x] Required local `daydream . --precision --non-interactive --backend codex` completed on signed `a626a936`: exit 0, 19/19 files read, all three code-review reports clean. The two final items repeat one relative-source-path proposal; it was rejected with baseline and current-source evidence under the explicit historical compatibility contract. No actionable findings remain. Optional diagram generation exceeded its input budget; all code-review phases succeeded.

- [x] Full local `make rl-check`: 204 passed / 2 existing opt-in skips; RL lock/sync, Ruff, and strict mypy passed. The real stub-CLI and image tests ran.

- [x] Immutable snapshot regressions failed before the correction; all 11 snapshot tests and 79 consumer/integration tests now pass, including real materialization, canonical harvest, preview and publication.

## Checklist

- [x] Root checks, root/RL dead-code scans, and Docker workflow lint pass locally through `make check`.
- [x] Module documentation and the issue contract describe the new boundary.

## Additional Context

The standalone RL check is separate from `make check`; both ran locally after CI exposed the shared bronze reader's RL caller. The reader retains its mapping input, while the harvest service supplies only the validated grounding-rate projection. This PR changes no RL files. The two local RL skips require an opt-in live-model endpoint or a separate vendored workspace. The issue contract was reconciled with current main and the actual reviewer/fix fallback branches before implementation. No reward, annotation, or archive schema version changes are included. Local review identified the cross-archive ownership defect, now covered by real mismatch/alias regressions; the broader relative-source-path and backfill persistence-adapter proposals were adjudicated against the preserved contract.
