### PR TITLE
refactor(pr-review): share classified submission workflow

### DIFF
--- a/daydream/git_ops.py
+++ b/daydream/git_ops.py
@@ -231,7 +231,14 @@ def _redact_args(args: list[str]) -> list[str]:
 
 
 class GitError(Exception):
-    """Base class for all git/gh failures raised by :mod:`daydream.git_ops`."""
+    """Base class for all git/gh failures raised by :mod:`daydream.git_ops`.
+
+    ``preserved_payload_path`` is set by ``gh_api`` when its failed request
+    retains an input file. Callers can report that path without parsing or
+    exposing the exception's diagnostic text.
+    """
+
+    preserved_payload_path: Path | None = None
 
 
 class GitTimeoutError(GitError):
@@ -4299,6 +4306,9 @@ def gh_api(
         result = _parse_gh_json(proc.stdout, jq, endpoint, payload_note=payload_note)
         succeeded = True
         return result
+    except GitError as exc:
+        exc.preserved_payload_path = tmp_path
+        raise
     finally:
         if succeeded:
             tmp_path.unlink(missing_ok=True)

--- a/daydream/pr_review.py
+++ b/daydream/pr_review.py
@@ -31,11 +31,11 @@ import logging
 import os
 import re
 import tempfile
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass, field
-from enum import Enum
+from enum import Enum, StrEnum
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal, Protocol
 
 import jsonschema
 
@@ -82,6 +82,20 @@ class PostStatus(Enum):
     FAILED = "failed"
 
 
+class ReviewEvent(StrEnum):
+    """GitHub review event authorized by the source-specific caller."""
+
+    COMMENT = "COMMENT"
+    APPROVE = "APPROVE"
+
+
+class SubmissionStatus(StrEnum):
+    """Whether the final classified review was posted."""
+
+    POSTED = "posted"
+    FAILED = "failed"
+
+
 @dataclass
 class ParsedIssue:
     """One issue to evaluate for PR posting.
@@ -123,6 +137,110 @@ class ParsedIssue:
     location_distrust: bool = False
     severity_before_demotion: str | None = None
     severity_off_vocabulary: bool = False
+
+
+@dataclass(frozen=True)
+class SubmissionFinding:
+    """Immutable finding value consumed by the shared submission operation."""
+
+    path: str
+    line: int | None
+    title: str
+    body: str
+    is_cross_stack: bool
+    confidence: str | None
+    severity: str | None
+    fingerprint: str | None
+    location_distrust: bool
+    severity_before_demotion: str | None
+    severity_off_vocabulary: bool
+
+    @classmethod
+    def from_parsed(cls, issue: ParsedIssue) -> SubmissionFinding:
+        """Snapshot one mutable classification finding."""
+        return cls(
+            path=issue.path,
+            line=issue.line,
+            title=issue.title,
+            body=issue.body,
+            is_cross_stack=issue.is_cross_stack,
+            confidence=issue.confidence,
+            severity=issue.severity,
+            fingerprint=issue.fingerprint,
+            location_distrust=issue.location_distrust,
+            severity_before_demotion=issue.severity_before_demotion,
+            severity_off_vocabulary=issue.severity_off_vocabulary,
+        )
+
+    def to_parsed(self) -> ParsedIssue:
+        """Create the renderer's mutable compatibility value."""
+        return ParsedIssue(
+            path=self.path,
+            line=self.line,
+            title=self.title,
+            body=self.body,
+            is_cross_stack=self.is_cross_stack,
+            confidence=self.confidence,
+            severity=self.severity,
+            fingerprint=self.fingerprint,
+            location_distrust=self.location_distrust,
+            severity_before_demotion=self.severity_before_demotion,
+            severity_off_vocabulary=self.severity_off_vocabulary,
+        )
+
+
+@dataclass(frozen=True)
+class InlineReviewComment:
+    """One immutable inline comment in a final GitHub review payload."""
+
+    path: str
+    line: int
+    side: Literal["RIGHT"]
+    body: str
+
+
+@dataclass(frozen=True, kw_only=True)
+class FileCommentPayload:
+    """Payload for one top-level file review comment."""
+
+    commit_id: str
+    path: str
+    subject_type: Literal["file"] = "file"
+    body: str
+
+
+@dataclass(frozen=True)
+class ReviewPayload:
+    """Payload for the single final GitHub review."""
+
+    event: ReviewEvent
+    commit_id: str
+    body: str
+    comments: tuple[InlineReviewComment, ...]
+
+
+@dataclass(frozen=True)
+class ReviewPostResult:
+    """Transport-level result for the final review write."""
+
+    review_url: str | None
+    safe_error: str | None
+
+
+@dataclass(frozen=True)
+class ClassifiedReviewResult:
+    """Confirmed write results from the shared submitter.
+
+    ``final_review_posted=False`` means no successful response was confirmed;
+    it does not prove that an ambiguous failed request had no remote effect.
+    """
+
+    status: SubmissionStatus
+    review_url: str | None
+    posted_file_level: tuple[SubmissionFinding, ...]
+    folded_file_level: tuple[SubmissionFinding, ...]
+    final_review_posted: bool
+    safe_error: str | None
 
 
 @dataclass(frozen=True)
@@ -1288,6 +1406,150 @@ def resolve_review_renderers(registry: Registry) -> ReviewRenderers:
     )
 
 
+def _snapshot_inline_comment(raw: Mapping[str, Any]) -> InlineReviewComment:
+    """Copy one internal inline dictionary into its immutable payload value."""
+    path = raw.get("path")
+    line = raw.get("line")
+    side = raw.get("side")
+    body = raw.get("body")
+    if (
+        not isinstance(path, str)
+        or type(line) is not int
+        or side != "RIGHT"
+        or not isinstance(body, str)
+    ):
+        raise ValueError("classified inline comment has an invalid shape")
+    return InlineReviewComment(path=path, line=line, side="RIGHT", body=body)
+
+
+@dataclass(frozen=True)
+class ClassifiedReviewPlan:
+    """Immutable, authorized input to the shared review write operation."""
+
+    pr: PRInfo
+    inline: tuple[InlineReviewComment, ...]
+    inline_issues: tuple[SubmissionFinding, ...]
+    file_level: tuple[SubmissionFinding, ...]
+    body_only: tuple[SubmissionFinding, ...]
+    event: ReviewEvent
+    run_info: str
+    renderers: ReviewRenderers
+    diagram_blocks: str | None
+
+    @classmethod
+    def from_classified(
+        cls,
+        pr: PRInfo,
+        classified: _ClassifiedIssues,
+        *,
+        event: ReviewEvent,
+        run_info: str,
+        renderers: ReviewRenderers,
+        diagram_blocks: str | None = None,
+    ) -> ClassifiedReviewPlan:
+        """Snapshot a mutable classified review after the caller authorizes it."""
+        return cls(
+            pr=pr,
+            inline=tuple(_snapshot_inline_comment(comment) for comment in classified.inline),
+            inline_issues=tuple(
+                SubmissionFinding.from_parsed(issue)
+                for issue in classified.inline_issues
+            ),
+            file_level=tuple(
+                SubmissionFinding.from_parsed(issue) for issue in classified.file_level
+            ),
+            body_only=tuple(
+                SubmissionFinding.from_parsed(issue) for issue in classified.body_only
+            ),
+            event=event,
+            run_info=run_info,
+            renderers=renderers,
+            diagram_blocks=diagram_blocks,
+        )
+
+
+class ReviewTransport(Protocol):
+    """Explicit capability for the two kinds of GitHub review writes."""
+
+    def post_file_comment(self, pr: PRInfo, payload: FileCommentPayload) -> bool: ...
+
+    def post_review(self, pr: PRInfo, payload: ReviewPayload) -> ReviewPostResult: ...
+
+
+def _file_comment_payload_dict(payload: FileCommentPayload) -> dict[str, Any]:
+    return {
+        "commit_id": payload.commit_id,
+        "path": payload.path,
+        "subject_type": payload.subject_type,
+        "body": payload.body,
+    }
+
+
+def _review_payload_dict(payload: ReviewPayload) -> dict[str, Any]:
+    return {
+        "event": payload.event.value,
+        "commit_id": payload.commit_id,
+        "body": payload.body,
+        "comments": [
+            {
+                "path": comment.path,
+                "line": comment.line,
+                "side": comment.side,
+                "body": comment.body,
+            }
+            for comment in payload.comments
+        ],
+    }
+
+
+@dataclass(frozen=True)
+class GitHubReviewTransport:
+    """GitHub review writes bound to one repository checkout and auth source."""
+
+    target_dir: Path
+    auth: GitHubAuth = field(repr=False)
+
+    def post_file_comment(self, pr: PRInfo, payload: FileCommentPayload) -> bool:
+        endpoint = f"/repos/{pr.owner}/{pr.repo}/pulls/{pr.number}/comments"
+        try:
+            git_ops.gh_api(
+                self.target_dir,
+                endpoint,
+                method="POST",
+                input_data=_file_comment_payload_dict(payload),
+                auth=self.auth,
+            )
+        except GitError:
+            return False
+        return True
+
+    def post_review(self, pr: PRInfo, payload: ReviewPayload) -> ReviewPostResult:
+        endpoint = f"/repos/{pr.owner}/{pr.repo}/pulls/{pr.number}/reviews"
+        try:
+            data = git_ops.gh_api(
+                self.target_dir,
+                endpoint,
+                method="POST",
+                input_data=_review_payload_dict(payload),
+                auth=self.auth,
+            )
+        except GitError as exc:
+            safe_error = "GitHub review submission failed"
+            if exc.preserved_payload_path is not None:
+                safe_error += (
+                    " (request payload preserved at "
+                    f"{exc.preserved_payload_path})"
+                )
+            return ReviewPostResult(review_url=None, safe_error=safe_error)
+        if not isinstance(data, dict):
+            return ReviewPostResult(review_url=None, safe_error=None)
+        url = data.get("html_url")
+        return ReviewPostResult(
+            review_url=str(url) if url else None,
+            safe_error=None,
+        )
+
+
 def _render_summary(ctx: SummaryContext, renderers: ReviewRenderers) -> str:
     """Render the summary body through the registered ``"summary"`` renderer.
 
@@ -1443,16 +1705,16 @@ def _is_clean_review(classified: _ClassifiedIssues, approve_on_clean: bool) -> b
     )
 
 
-def build_payload(
+def _build_payload_for_event(
     pr: PRInfo,
     classified: _ClassifiedIssues,
     *,
+    event: ReviewEvent,
     run_info: str,
     renderers: ReviewRenderers,
-    approve_on_clean: bool = False,
     diagram_blocks: str | None = None,
-) -> dict[str, Any]:
-    """Assemble the review payload for `POST /repos/.../pulls/<n>/reviews`.
+) -> ReviewPayload:
+    """Render a final review payload for a caller-authorized event.
 
     The review body uses collapsible sections so large reviews stay readable:
         **Code Review Summary**
@@ -1465,13 +1727,7 @@ def build_payload(
         run_info: Pre-rendered run-info markdown from the live provider or
             validated findings artifact.
         renderers: Explicit renderer functions and built-in fallback functions.
-        approve_on_clean: Opt-in approval (issue #343). When True AND the
-            classified review has no blocking severity findings (anything
-            other than ``"low"`` or omitted, fail-closed — see
-            ``_NON_BLOCKING_SEVERITIES``), the payload's event becomes
-            ``"APPROVE"`` with a prepended approval line; otherwise the event
-            stays ``"COMMENT"`` and the body is byte-identical to the
-            non-approve path.
+        event: Review event already authorized by the source-specific caller.
         diagram_blocks: Host-rendered grounded-diagram markdown (issue #1113),
             handed to the ``"summary"`` renderer as ``ctx.diagrams`` so it
             lands directly under the summary header. ``None`` (the default)
@@ -1479,7 +1735,7 @@ def build_payload(
     """
     all_issues_with_inline_meta = classified.all_issues()
 
-    clean = _is_clean_review(classified, approve_on_clean)
+    approved = event is ReviewEvent.APPROVE
 
     # Consolidated AI agent prompt (host-built; empty means "omit").
     agent_prompt = (
@@ -1531,7 +1787,7 @@ def build_payload(
     summary_body = _render_summary(summary_ctx, renderers)
 
     body_chunks: list[str] = []
-    if clean:
+    if approved:
         body_chunks.append("✅ **Deep review passed with no high/medium findings.**")
     body_chunks.append(summary_body)
     # DAYDREAM_FOOTER is the bottom-of-comment "🧙 Posted by daydream"
@@ -1539,13 +1795,106 @@ def build_payload(
     # inside the review-info block.
     body_chunks.append(DAYDREAM_FOOTER)
 
-    payload: dict[str, Any] = {
-        "event": "APPROVE" if clean else "COMMENT",
-        "commit_id": pr.head_sha,
-        "body": "\n\n".join(body_chunks),
-        "comments": classified.inline,
-    }
-    return payload
+    return ReviewPayload(
+        event=event,
+        commit_id=pr.head_sha,
+        body="\n\n".join(body_chunks),
+        comments=tuple(
+            _snapshot_inline_comment(comment) for comment in classified.inline
+        ),
+    )
+
+
+def build_payload(
+    pr: PRInfo,
+    classified: _ClassifiedIssues,
+    *,
+    run_info: str,
+    renderers: ReviewRenderers,
+    approve_on_clean: bool = False,
+    diagram_blocks: str | None = None,
+) -> dict[str, Any]:
+    """Build the legacy dictionary payload after applying the approval gate."""
+    event = (
+        ReviewEvent.APPROVE
+        if _is_clean_review(classified, approve_on_clean)
+        else ReviewEvent.COMMENT
+    )
+    return _review_payload_dict(
+        _build_payload_for_event(
+            pr,
+            classified,
+            event=event,
+            run_info=run_info,
+            renderers=renderers,
+            diagram_blocks=diagram_blocks,
+        )
+    )
+
+
+def post_classified_review(
+    plan: ClassifiedReviewPlan,
+    *,
+    transport: ReviewTransport,
+) -> ClassifiedReviewResult:
+    """Submit ordered file comments, fold failures, then post one final review."""
+    posted: list[SubmissionFinding] = []
+    folded: list[SubmissionFinding] = []
+    for finding in plan.file_level:
+        payload = FileCommentPayload(
+            commit_id=plan.pr.head_sha,
+            path=finding.path,
+            subject_type="file",
+            body=_format_file_level_body(finding.to_parsed(), plan.renderers),
+        )
+        if transport.post_file_comment(plan.pr, payload):
+            posted.append(finding)
+        else:
+            folded.append(finding)
+
+    final_classified = _ClassifiedIssues(
+        inline=[
+            {
+                "path": comment.path,
+                "line": comment.line,
+                "side": comment.side,
+                "body": comment.body,
+            }
+            for comment in plan.inline
+        ],
+        inline_issues=[finding.to_parsed() for finding in plan.inline_issues],
+        file_level=[finding.to_parsed() for finding in posted],
+        body_only=[
+            *(finding.to_parsed() for finding in plan.body_only),
+            *(finding.to_parsed() for finding in folded),
+        ],
+    )
+    review_payload = _build_payload_for_event(
+        plan.pr,
+        final_classified,
+        event=plan.event,
+        run_info=plan.run_info,
+        renderers=plan.renderers,
+        diagram_blocks=plan.diagram_blocks,
+    )
+    review_result = transport.post_review(plan.pr, review_payload)
+    if review_result.review_url is None:
+        return ClassifiedReviewResult(
+            status=SubmissionStatus.FAILED,
+            review_url=None,
+            posted_file_level=tuple(posted),
+            folded_file_level=tuple(folded),
+            final_review_posted=False,
+            safe_error=review_result.safe_error,
+        )
+    return ClassifiedReviewResult(
+        status=SubmissionStatus.POSTED,
+        review_url=review_result.review_url,
+        posted_file_level=tuple(posted),
+        folded_file_level=tuple(folded),
+        final_review_posted=True,
+        safe_error=None,
+    )
 
 
 # --- Core orchestration ---------------------------------------------------
@@ -1647,111 +1996,39 @@ async def _post(
         print_info(console, "Skipped posting to PR.")
         return PostStatus.NOTHING_TO_POST
 
-    # File-level comments post first: a failure here has to fall back into the
-    # review body, which is built below.
-    posted, failed = _submit_file_level_comments(
-        target_dir, pr, classified.file_level, auth=auth, renderers=renderers
+    plan = ClassifiedReviewPlan.from_classified(
+        pr,
+        classified,
+        event=ReviewEvent.APPROVE if clean else ReviewEvent.COMMENT,
+        run_info=run_info,
+        renderers=renderers,
+        diagram_blocks=diagram_blocks,
     )
-    if failed:
-        classified.file_level = posted
-        classified.body_only.extend(failed)
+    result = post_classified_review(
+        plan,
+        transport=GitHubReviewTransport(target_dir=target_dir, auth=auth),
+    )
+    if result.folded_file_level:
         print_warning(
             console,
-            f"{len(failed)} file-level comment(s) failed to post; folded into the review body.",
+            f"{len(result.folded_file_level)} file-level comment(s) failed to post; "
+            "folded into the review body.",
         )
 
-    payload = build_payload(
-        pr, classified, run_info=run_info, renderers=renderers,
-        approve_on_clean=approve_on_clean, diagram_blocks=diagram_blocks
-    )
-    review_url, error_msg = _submit_review(target_dir, pr, payload, auth=auth)
-    if review_url is None:
-        # ``error_msg`` carries the GitError text from git_ops, which includes
-        # the preserved tempfile path on failure (see git_ops.gh_api).
-        suffix = f" ({error_msg})" if error_msg else ""
+    if result.status is SubmissionStatus.FAILED:
+        suffix = f" ({result.safe_error})" if result.safe_error else ""
         # File-level comments post before the review, so some may already be
         # live on the PR — saying "no comments were posted" would be false.
         already = (
-            f" {len(classified.file_level)} file-level comment(s) were already posted."
-            if classified.file_level
+            f" {len(result.posted_file_level)} file-level comment(s) were already posted."
+            if result.posted_file_level
             else " No comments were posted."
         )
         print_warning(console, f"Failed to post PR review;{already}{suffix}")
         return PostStatus.FAILED
 
-    print_success(console, f"Posted review: {review_url}")
+    print_success(console, f"Posted review: {result.review_url}")
     return PostStatus.POSTED
-
-
-def _submit_file_level_comments(
-    target_dir: Path,
-    pr: PRInfo,
-    issues: list[ParsedIssue],
-    *,
-    renderers: ReviewRenderers,
-    auth: GitHubAuth = INHERIT_GITHUB_AUTH,
-) -> tuple[list[ParsedIssue], list[ParsedIssue]]:
-    """POST each issue as a file-level review comment; return the ones that failed.
-
-    GitHub rejects ``subject_type`` inside a batch review payload (HTTP 422),
-    so file-level comments must be posted one at a time against
-    ``/pulls/{n}/comments``. Each one becomes a top-level, repliable thread on
-    that endpoint — the surface :func:`index_pr_review_comments` reads — which
-    is what makes these findings labelable at all.
-
-    Failures are returned rather than raised so the caller can fold them back
-    into the review body: a finding that cannot get its own thread must still
-    reach the maintainer.
-
-    Returns:
-        ``(posted, failed)`` partitioning ``issues`` in input order.
-    """
-    endpoint = f"/repos/{pr.owner}/{pr.repo}/pulls/{pr.number}/comments"
-    posted: list[ParsedIssue] = []
-    failed: list[ParsedIssue] = []
-    for issue in issues:
-        payload = {
-            "commit_id": pr.head_sha,
-            "path": issue.path,
-            "subject_type": "file",
-            "body": _format_file_level_body(issue, renderers),
-        }
-        try:
-            git_ops.gh_api(
-                target_dir, endpoint, method="POST", input_data=payload, auth=auth
-            )
-        except GitError:
-            failed.append(issue)
-        else:
-            posted.append(issue)
-    return posted, failed
-
-
-def _submit_review(
-    target_dir: Path,
-    pr: PRInfo,
-    payload: dict[str, Any],
-    *,
-    auth: GitHubAuth = INHERIT_GITHUB_AUTH,
-) -> tuple[str | None, str | None]:
-    """POST the review payload via ``gh api``.
-
-    Returns:
-        ``(html_url, None)`` on success, ``(None, error_message)`` on failure.
-        The error message — when present — includes the preserved-payload path
-        produced by :func:`daydream.git_ops.gh_api` so callers can surface it.
-    """
-    endpoint = f"/repos/{pr.owner}/{pr.repo}/pulls/{pr.number}/reviews"
-    try:
-        data = git_ops.gh_api(
-            target_dir, endpoint, method="POST", input_data=payload, auth=auth
-        )
-    except GitError as exc:
-        return None, str(exc)
-    if not isinstance(data, dict):
-        return None, None
-    url = data.get("html_url")
-    return (str(url) if url else None), None
 
 
 def post_diagram_comment_to_pr(
@@ -2614,36 +2891,37 @@ def post_findings_from_artifact(
         )
         return 0
 
-    posted_files, failed_files = _submit_file_level_comments(
-        target_dir, pr, classified.file_level, auth=auth, renderers=renderers
-    )
-    if failed_files:
-        classified.file_level = posted_files
-        classified.body_only.extend(failed_files)
-        print_info(
-            console,
-            f"{len(failed_files)} file-level comment(s) failed to post; folded into the review body.",
-        )
-
-    payload = build_payload(
+    submission_plan = ClassifiedReviewPlan.from_classified(
         pr,
         classified,
-        run_info=artifact.run_info if artifact.run_info is not None else render_run_info(()),
+        event=ReviewEvent.APPROVE if can_approve else ReviewEvent.COMMENT,
+        run_info=(
+            artifact.run_info if artifact.run_info is not None else render_run_info(())
+        ),
         renderers=renderers,
-        approve_on_clean=can_approve,
         diagram_blocks=diagram_blocks,
     )
-    review_url, error_msg = _submit_review(target_dir, pr, payload, auth=auth)
-    if review_url is None:
-        suffix = f" ({error_msg})" if error_msg else ""
+    result = post_classified_review(
+        submission_plan,
+        transport=GitHubReviewTransport(target_dir=target_dir, auth=auth),
+    )
+    if result.folded_file_level:
+        print_info(
+            console,
+            f"{len(result.folded_file_level)} file-level comment(s) failed to post; "
+            "folded into the review body.",
+        )
+
+    if result.status is SubmissionStatus.FAILED:
+        suffix = f" ({result.safe_error})" if result.safe_error else ""
         already = (
-            f"{len(posted_files)} file-level comment(s) were already posted."
-            if posted_files
+            f"{len(result.posted_file_level)} file-level comment(s) were already posted."
+            if result.posted_file_level
             else "No comments were posted."
         )
         print_error(console, "PR Review Post Failed", f"{already}{suffix}")
         return 1
-    print_success(console, f"Posted review: {review_url}")
+    print_success(console, f"Posted review: {result.review_url}")
     return 0
 
 

--- a/tests/test_deep_diagram_integration.py
+++ b/tests/test_deep_diagram_integration.py
@@ -16,13 +16,14 @@ from __future__ import annotations
 import copy
 import json
 from collections.abc import Callable
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, cast
 
 import pytest
 
 from tests.harness import diagram_repos as dr
+from tests.harness.fake_gh import FakeGh
 from tests.harness.stub_backend import StubBackend, install_stub_backend, silence
 
 # --- Expected renderer output (goldens for these fixtures) -------------------
@@ -55,17 +56,18 @@ FLOWCHART_HEADING = "<details><summary><h3>Flowchart</h3></summary>"
 
 @dataclass
 class _CapturedPost:
-    """Every review payload the run tried to submit."""
+    gh: FakeGh
 
-    payloads: list[dict[str, Any]] = field(default_factory=list)
+    @property
+    def payloads(self) -> list[dict[str, Any]]:
+        return [call.payload for call in self.gh.calls("POST", "repos/acme/widgets/pulls/123/reviews")]
 
     def body(self) -> str:
         assert self.payloads, "no review payload was submitted"
         return str(self.payloads[-1]["body"])
 
-
 @pytest.fixture
-def captured_post(monkeypatch: pytest.MonkeyPatch) -> _CapturedPost:
+def captured_post(monkeypatch: pytest.MonkeyPatch, fake_gh: FakeGh) -> _CapturedPost:
     """Let the real ``build_payload`` run and capture the review it would POST.
 
     Patches only the PR lookup and the ``gh`` review submission, so the summary
@@ -74,7 +76,7 @@ def captured_post(monkeypatch: pytest.MonkeyPatch) -> _CapturedPost:
     """
     from daydream import pr_review
 
-    captured = _CapturedPost()
+    captured = _CapturedPost(fake_gh)
     fake_pr = pr_review.PRInfo(
         number=123,
         head_sha="a" * 40,
@@ -89,13 +91,10 @@ def captured_post(monkeypatch: pytest.MonkeyPatch) -> _CapturedPost:
         "daydream.pr_review.find_open_pr", lambda _target, **_kwargs: fake_pr
     )
 
-    def _capture(
-        _target: Path, _pr: pr_review.PRInfo, payload: dict[str, Any], **_kwargs: Any
-    ) -> tuple[str, None]:
-        captured.payloads.append(payload)
-        return "https://example/pr/123#review-1", None
-
-    monkeypatch.setattr("daydream.pr_review._submit_review", _capture)
+    fake_gh.set_response(
+        "POST", "repos/acme/widgets/pulls/123/reviews",
+        {"html_url": "https://example/pr/123#review-1"},
+    )
     return captured
 
 

--- a/tests/test_deep_pr_comment_integration.py
+++ b/tests/test_deep_pr_comment_integration.py
@@ -28,6 +28,7 @@ from typing import Any
 
 import pytest
 
+from tests.harness.fake_gh import FakeGh
 from tests.harness.git_helpers import commit as _commit
 from tests.harness.git_helpers import git as _git
 from tests.harness.git_helpers import init_repo as _init_repo
@@ -506,23 +507,27 @@ def patch_sdk(monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr(f"daydream.backends.claude.{symbol}", fake)
 
 
-# gh / PR plumbing patches: find_open_pr returns a fake PRInfo and _submit_review
+# gh / PR plumbing patches: find_open_pr returns a fake PRInfo and fake gh
 # captures the payload (the only allowed non-SDK mock per the brief — it stands
 # in for the gh-CLI subprocess that would post to GitHub).
 
 
 @dataclass
 class _CapturedPost:
-    payloads: list[dict[str, Any]] = field(default_factory=list)
+    gh: FakeGh
+
+    @property
+    def payloads(self) -> list[dict[str, Any]]:
+        return [call.payload for call in self.gh.calls("POST", "repos/test-owner/test-repo/pulls/123/reviews")]
 
 
 @pytest.fixture
-def captured_post(monkeypatch: pytest.MonkeyPatch) -> _CapturedPost:
-    """Wire find_open_pr + _submit_review so build_payload runs and we see
+def captured_post(monkeypatch: pytest.MonkeyPatch, fake_gh: FakeGh) -> _CapturedPost:
+    """Wire PR discovery and fake gh so the complete submission runs and we see
     the rendered markdown without ever touching GitHub."""
     from daydream import pr_review
 
-    captured = _CapturedPost()
+    captured = _CapturedPost(fake_gh)
 
     fake_pr = pr_review.PRInfo(
         number=123,
@@ -540,16 +545,10 @@ def captured_post(monkeypatch: pytest.MonkeyPatch) -> _CapturedPost:
         lambda target_dir, **_kwargs: fake_pr,
     )
 
-    def _capture(
-        target_dir: Path, pr: pr_review.PRInfo, payload: dict[str, Any], **_kwargs: Any
-    ) -> tuple[str, None]:
-        captured.payloads.append(payload)
-        return "https://example/pr/123#review-1", None
-
-    monkeypatch.setattr(
-        "daydream.pr_review._submit_review", _capture,
+    fake_gh.set_response(
+        "POST", "repos/test-owner/test-repo/pulls/123/reviews",
+        {"html_url": "https://example/pr/123#review-1"},
     )
-
     return captured
 
 
@@ -638,8 +637,8 @@ async def test_deep_run_produces_pr_comment_with_real_model_and_metrics(
         symbols imported into that module (isinstance-pinning).
       - ``pr_review.find_open_pr`` returns a synthetic ``PRInfo`` (avoids
         ``gh pr list`` subprocess).
-      - ``pr_review._submit_review`` captures the payload (avoids ``gh api``
-        subprocess that would actually POST the comment).
+      - the fake ``gh`` process captures the payload; the real API adapter
+        and its temporary request-file handling run unchanged.
 
     Everything else — RunConfig dispatch, _run_loop_deep, run_deep, the
     real ``TrajectoryRecorder``, ``ClaudeBackend.execute``, ``run_agent``,

--- a/tests/test_git_ops.py
+++ b/tests/test_git_ops.py
@@ -2550,34 +2550,80 @@ def test_gh_api_input_data_passes_tempfile_and_cleans_up(tmp_path: Path, monkeyp
     assert not Path(captured["input_path"]).exists()
 
 
-def test_gh_api_input_data_preserves_tempfile_on_failure(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+@pytest.mark.parametrize(
+    ("failure", "expected_type"),
+    [
+        ("http", GitError),
+        ("invalid-json", GitError),
+        ("timeout", git_ops.GitTimeoutError),
+        ("rate-limit", git_ops.RateLimitError),
+    ],
+)
+def test_gh_api_input_data_preserves_tempfile_on_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    failure: str,
+    expected_type: type[GitError],
+) -> None:
     """Preserve failed API payloads and disclose their recovery path in the error."""
     repo = _make_repo_with_main(tmp_path)
     captured: dict[str, Any] = {}
+    attempts: list[list[str]] = []
+
+    class RequestAuth:
+        calls = 0
+
+        def environment_for_request(self) -> dict[str, str]:
+            self.calls += 1
+            return {"OWNING_RUN": "payload-metadata-test"}
+
+    auth = RequestAuth()
 
     def fake_run(cmd: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        attempts.append(cmd)
         idx = cmd.index("--input")
         captured["input_path"] = cmd[idx + 1]
+        assert kwargs["env"] == {"OWNING_RUN": "payload-metadata-test"}
+        if failure == "timeout":
+            raise subprocess.TimeoutExpired(cmd=cmd, timeout=1)
+        if failure == "invalid-json":
+            return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="not-json", stderr="")
+        if failure == "rate-limit":
+            return subprocess.CompletedProcess(
+                args=cmd, returncode=1, stdout="", stderr="HTTP 429: rate limit; retry-after: 7"
+            )
         return subprocess.CompletedProcess(args=cmd, returncode=1, stdout="", stderr="HTTP 422: Validation failed")
 
     monkeypatch.setattr("daydream.git_ops.subprocess.run", fake_run)
+    monkeypatch.setenv("DAYDREAM_GH_TIMEOUT_RETRIES", "4")
 
-    with pytest.raises(GitError) as excinfo:
+    with pytest.raises(expected_type) as excinfo:
         git_ops.gh_api(
             repo,
             "repos/owner/repo/pulls/1/reviews",
             method="POST",
             input_data={"bad": "payload"},
+            auth=auth,
         )
 
-    msg = str(excinfo.value)
-    assert "payload preserved at" in msg
-    # The tempfile path mentioned in the error must still exist on disk.
     preserved = Path(captured["input_path"])
-    assert str(preserved) in msg
-    assert preserved.exists()
-    # Cleanup so the test doesn't leave debris behind.
-    preserved.unlink(missing_ok=True)
+    try:
+        assert type(excinfo.value) is expected_type
+        assert len(attempts) == 1
+        assert auth.calls == 1
+        msg = str(excinfo.value)
+        if failure == "timeout":
+            assert "timed out" in msg
+        else:
+            assert "payload preserved at" in msg
+            assert str(preserved) in msg
+        assert preserved.exists()
+        assert json.loads(preserved.read_text(encoding="utf-8")) == {"bad": "payload"}
+        assert excinfo.value.preserved_payload_path == preserved
+        if isinstance(excinfo.value, git_ops.RateLimitError):
+            assert excinfo.value.retry_after == 7
+    finally:
+        preserved.unlink(missing_ok=True)
 
 
 @pytest.mark.parametrize(
@@ -2895,6 +2941,7 @@ def test_gh_api_classifies_errors(
     with pytest.raises(expected_type) as exc:
         git_ops.gh_api(tmp_path, "repos/o/r/pulls/1")
     assert type(exc.value) is expected_type
+    assert exc.value.preserved_payload_path is None
 
 
 @pytest.mark.parametrize(

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1727,10 +1727,11 @@ async def test_run_comment_submission_failure_exits_nonzero(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     make_config: Callable[..., 'RunConfig'],
+    fake_gh: Any,
 ) -> None:
     """Comment mode: a failed GitHub review post -> exit 1.
 
-    Only ``_submit_review`` is mocked to fail; everything else (the review
+    Only the external gh process is configured to fail; everything else (the review
     pipeline, ``_post``, classification, payload build) runs production code.
     """
     from daydream.pr_review import PRInfo
@@ -1752,9 +1753,8 @@ async def test_run_comment_submission_failure_exits_nonzero(
         url="https://example/pr/7",
     )
     monkeypatch.setattr("daydream.pr_review.find_open_pr", lambda _td, **_kwargs: fake_pr)
-    monkeypatch.setattr(
-        "daydream.pr_review._submit_review",
-        lambda _td, _pr, _payload, **_kwargs: (None, "gh api failed: HTTP 500"),
+    fake_gh.set_response(
+        "POST", "repos/acme/widgets/pulls/7/reviews", {"__error__": "HTTP 500"},
     )
 
     config = make_config(tmp_path, output_mode="comment")
@@ -1769,6 +1769,7 @@ async def test_run_loop_submission_failure_warns_and_continues(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     make_config: Callable[..., 'RunConfig'],
+    fake_gh: Any,
 ) -> None:
     """Default deep loop: a failed review post warns-and-continues (exit 0).
 
@@ -1796,9 +1797,8 @@ async def test_run_loop_submission_failure_warns_and_continues(
         url="https://example/pr/7",
     )
     monkeypatch.setattr("daydream.pr_review.find_open_pr", lambda _td, **_kwargs: fake_pr)
-    monkeypatch.setattr(
-        "daydream.pr_review._submit_review",
-        lambda _td, _pr, _payload, **_kwargs: (None, "gh api failed: HTTP 500"),
+    fake_gh.set_response(
+        "POST", "repos/acme/widgets/pulls/7/reviews", {"__error__": "HTTP 500"},
     )
 
     # Approve the PR-post gate but decline the apply-fixes gate so the run ends

--- a/tests/test_post_findings_integration.py
+++ b/tests/test_post_findings_integration.py
@@ -51,7 +51,7 @@ def _console_text(capsys: pytest.CaptureFixture[str]) -> str:
     — a substring check against the raw capture fails on the wrap.
     """
     out = capsys.readouterr().out
-    return " ".join(out.translate({ord(char): " " for char in "│╭╮╰╯─"}).split())
+    return " ".join(out.translate({ord(char): " " for char in "│╭╮╰╯─║╔╗╚╝═"}).split())
 
 
 def _post_argv(
@@ -1360,3 +1360,68 @@ def test_artifact_post_never_acquires_live_trajectory_details(
     body = fake_gh.calls("POST", "/repos/o/r/pulls/7/reviews")[0].payload["body"]
     assert (run_info if run_info is not None else "*run details unavailable*") in body
     assert body.count("- **Reviewed commit:**") == 1
+
+
+def test_post_findings_orders_file_writes_and_folds_failed_thread_once(
+    fake_gh: FakeGh, tmp_path: Path, capsys: pytest.CaptureFixture[str],
+) -> None:
+    artifact = _write_artifact(tmp_path / "findings.json", [
+        _finding("a" * 64, path="first.py", line=None, placement="file", title="First thread"),
+        _finding("b" * 64, path="second.py", line=None, placement="file", title="Folded thread"),
+        _finding("c" * 64, path="context.py", line=None, placement="body", title="Original body"),
+    ])
+    fake_gh.set_response("diff-paths", value=["first.py"])
+
+    assert cli_main(_post_argv(artifact)) == 0
+
+    writes = [call for call in fake_gh.calls("POST") if call.endpoint != "graphql"]
+    assert [call.endpoint for call in writes] == [
+        "repos/o/r/pulls/7/comments", "repos/o/r/pulls/7/comments", "repos/o/r/pulls/7/reviews",
+    ]
+    assert [call.payload["path"] for call in writes[:2]] == ["first.py", "second.py"]
+    assert all(call.payload["subject_type"] == "file" for call in writes[:2])
+    payload = writes[-1].payload
+    assert payload["commit_id"] == "h" * 40
+    assert payload["event"] == "COMMENT"
+    assert payload["comments"] == []
+    markers = parse_finding_markers(payload["body"])
+    assert markers == ["c" * 64, "b" * 64]
+    assert payload["body"].index("Original body") < payload["body"].index("Folded thread")
+    assert "1 file-level comment(s) failed to post; folded into the review body." in _console_text(capsys)
+
+
+@pytest.mark.parametrize("file_posts", [False, True], ids=["zero-writes", "partial-write"])
+def test_post_findings_final_failure_reports_writes_and_safe_recovery_path(
+    fake_gh: FakeGh, tmp_path: Path, capsys: pytest.CaptureFixture[str], file_posts: bool,
+) -> None:
+    artifact = _write_artifact(tmp_path / "findings.json", [
+        _finding("a" * 64, path="first.py", line=None, placement="file", title="File finding"),
+    ])
+    fake_gh.set_response("diff-paths", value=["first.py"] if file_posts else [])
+    secret = "opaque-private-installation-credential"
+    fake_gh.set_response("POST", "repos/o/r/pulls/7/reviews", {"__error__": f"HTTP 422: {secret}"})
+
+    assert cli_main(_post_argv(artifact)) == 1
+
+    writes = [call for call in fake_gh.calls("POST") if call.endpoint != "graphql"]
+    assert [call.endpoint for call in writes] == [
+        "repos/o/r/pulls/7/comments", "repos/o/r/pulls/7/reviews",
+    ]
+    review = writes[-1]
+    assert review.argv is not None
+    payload_path = Path(review.argv[review.argv.index("--input") + 1])
+    try:
+        assert json.loads(payload_path.read_text()) == review.payload
+        message = _console_text(capsys)
+        assert "PR Review Post Failed" in message
+        assert "payload preserved at" in message
+        # Rich may wrap this machine path; removing whitespace recovers the displayed value.
+        assert str(payload_path) in message.replace(" ", "")
+        if file_posts:
+            assert "1 file-level comment(s) were already posted." in message
+            assert "No comments were posted." not in message
+        else:
+            assert "No comments were posted." in message
+        assert secret not in message
+    finally:
+        payload_path.unlink(missing_ok=True)

--- a/tests/test_pr_review.py
+++ b/tests/test_pr_review.py
@@ -1144,13 +1144,22 @@ async def test_post_succeeds_and_prints_url(monkeypatch: pytest.MonkeyPatch, tmp
             body_only=[],
         ),
     )
-    captured: dict[str, Any] = {}
+    captured: dict[str, pr_review.ClassifiedReviewPlan] = {}
 
-    def fake_submit(_td: Path, _pr: PRInfo, payload: dict[str, Any], **_kwargs: Any) -> tuple[str | None, str | None]:
-        captured["payload"] = payload
-        return "https://github.com/acme/widgets/pull/42#pullrequestreview-1", None
+    def fake_submit(
+        plan: pr_review.ClassifiedReviewPlan, *, transport: pr_review.ReviewTransport
+    ) -> pr_review.ClassifiedReviewResult:
+        captured["plan"] = plan
+        return pr_review.ClassifiedReviewResult(
+            status=pr_review.SubmissionStatus.POSTED,
+            review_url="https://github.com/acme/widgets/pull/42#pullrequestreview-1",
+            posted_file_level=(),
+            folded_file_level=(),
+            final_review_posted=True,
+            safe_error=None,
+        )
 
-    monkeypatch.setattr(pr_review, "_submit_review", fake_submit)
+    monkeypatch.setattr(pr_review, "post_classified_review", fake_submit)
     successes: list[str] = []
     monkeypatch.setattr(
         pr_review,
@@ -1167,9 +1176,8 @@ async def test_post_succeeds_and_prints_url(monkeypatch: pytest.MonkeyPatch, tmp
         renderers=BUILTIN_RENDERERS,
         run_info=pr_comment_renderer.render_run_info_block([_FIXTURE]),
     )
-    # The payload that would be POSTed was assembled and forwarded.
-    assert captured["payload"]["commit_id"] == pr.head_sha
-    assert captured["payload"]["event"] == "COMMENT"
+    assert captured["plan"].pr.head_sha == pr.head_sha
+    assert captured["plan"].event is pr_review.ReviewEvent.COMMENT
     assert successes and "pullrequestreview" in successes[0]
     assert status == pr_review.PostStatus.POSTED
 
@@ -1199,13 +1207,22 @@ async def test_post_payload_approves_when_clean_and_enabled(
             ],
         ),
     )
-    captured: dict[str, Any] = {}
+    captured: dict[str, pr_review.ClassifiedReviewPlan] = {}
 
-    def fake_submit(_td: Path, _pr: PRInfo, payload: dict[str, Any], **_kwargs: Any) -> tuple[str | None, str | None]:
-        captured["payload"] = payload
-        return "https://github.com/acme/widgets/pull/42#pullrequestreview-1", None
+    def fake_submit(
+        plan: pr_review.ClassifiedReviewPlan, *, transport: pr_review.ReviewTransport
+    ) -> pr_review.ClassifiedReviewResult:
+        captured["plan"] = plan
+        return pr_review.ClassifiedReviewResult(
+            status=pr_review.SubmissionStatus.POSTED,
+            review_url="https://github.com/acme/widgets/pull/42#pullrequestreview-1",
+            posted_file_level=(),
+            folded_file_level=(),
+            final_review_posted=True,
+            safe_error=None,
+        )
 
-    monkeypatch.setattr(pr_review, "_submit_review", fake_submit)
+    monkeypatch.setattr(pr_review, "post_classified_review", fake_submit)
     monkeypatch.setattr(pr_review, "print_success", lambda *_a, **_k: None)
     monkeypatch.setattr(pr_review, "print_info", lambda *_a, **_k: None)
 
@@ -1218,10 +1235,7 @@ async def test_post_payload_approves_when_clean_and_enabled(
         renderers=BUILTIN_RENDERERS,
         run_info=pr_comment_renderer.render_run_info_block([_FIXTURE]),
     )
-    assert captured["payload"]["event"] == "APPROVE"
-    assert "no high/medium findings" in captured["payload"]["body"]
-    # F3: the reviewed SHA is pinned on every payload, APPROVE included.
-    assert captured["payload"]["commit_id"] == pr.head_sha
+    assert captured["plan"].event is pr_review.ReviewEvent.APPROVE
     assert status == pr_review.PostStatus.POSTED
 
 
@@ -1241,8 +1255,19 @@ async def test_post_warns_with_preserved_payload_path_on_failure(
             body_only=[],
         ),
     )
-    err = "gh api /repos/acme/widgets/pulls/42/reviews failed: HTTP 422 (payload preserved at /tmp/x.json)"
-    monkeypatch.setattr(pr_review, "_submit_review", lambda *_a, **_k: (None, err))
+    err = "GitHub review submission failed (request payload preserved at /tmp/x.json)"
+    monkeypatch.setattr(
+        pr_review,
+        "post_classified_review",
+        lambda _plan, *, transport: pr_review.ClassifiedReviewResult(
+            status=pr_review.SubmissionStatus.FAILED,
+            review_url=None,
+            posted_file_level=(),
+            folded_file_level=(),
+            final_review_posted=False,
+            safe_error=err,
+        ),
+    )
     warnings: list[str] = []
     monkeypatch.setattr(
         pr_review,
@@ -1261,9 +1286,40 @@ async def test_post_warns_with_preserved_payload_path_on_failure(
     )
     assert warnings
     assert "no comments were posted" in warnings[0].lower()
-    # The git_ops error text -- including the preserved payload path -- is forwarded.
+    # The structured safe error preserves the request payload path.
     assert "payload preserved at /tmp/x.json" in warnings[0]
     assert status == pr_review.PostStatus.FAILED
+
+
+def test_github_transport_surfaces_only_structured_preserved_payload_path(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    pr: PRInfo,
+) -> None:
+    error = GitError("remote response leaked secret=never-show-this")
+    error.preserved_payload_path = Path("/tmp/review.json")
+
+    def fail_gh(*_args: Any, **_kwargs: Any) -> object:
+        raise error
+
+    monkeypatch.setattr(git_ops, "gh_api", fail_gh)
+
+    result = pr_review.GitHubReviewTransport(
+        target_dir=tmp_path,
+        auth=git_ops.INHERIT_GITHUB_AUTH,
+    ).post_review(
+        pr,
+        pr_review.ReviewPayload(
+            event=pr_review.ReviewEvent.COMMENT,
+            commit_id=pr.head_sha,
+            body="review body",
+            comments=(),
+        ),
+    )
+
+    assert result.review_url is None
+    assert result.safe_error == "GitHub review submission failed (request payload preserved at /tmp/review.json)"
+    assert "secret" not in result.safe_error
 
 
 @pytest.mark.asyncio
@@ -1279,12 +1335,21 @@ async def test_post_skipped_when_user_declines(monkeypatch: pytest.MonkeyPatch, 
     )
     submit_called = False
 
-    def fake_submit(*_a: Any, **_k: Any) -> tuple[str | None, str | None]:
+    def fake_submit(
+        _plan: pr_review.ClassifiedReviewPlan, *, transport: pr_review.ReviewTransport
+    ) -> pr_review.ClassifiedReviewResult:
         nonlocal submit_called
         submit_called = True
-        return "x", None
+        return pr_review.ClassifiedReviewResult(
+            status=pr_review.SubmissionStatus.POSTED,
+            review_url="x",
+            posted_file_level=(),
+            folded_file_level=(),
+            final_review_posted=True,
+            safe_error=None,
+        )
 
-    monkeypatch.setattr(pr_review, "_submit_review", fake_submit)
+    monkeypatch.setattr(pr_review, "post_classified_review", fake_submit)
     monkeypatch.setattr(pr_review, "print_info", lambda *_a, **_k: None)
 
     status = await pr_review._post(
@@ -1330,13 +1395,22 @@ async def test_post_review_from_report_empty_items_posts_diagram(
     blocks = "<details><summary><h3>Flowchart</h3></summary>\nX\n</details>"
     monkeypatch.setattr(pr_review, "find_open_pr", lambda _td, **_kwargs: pr)
     monkeypatch.setattr(pr_review, "classify", lambda *_a, **_k: pr_review._ClassifiedIssues())
-    captured: dict[str, Any] = {}
+    captured: dict[str, pr_review.ClassifiedReviewPlan] = {}
 
-    def fake_submit(_td: Path, _pr: PRInfo, payload: dict[str, Any], **_kwargs: Any) -> tuple[str | None, str | None]:
-        captured["payload"] = payload
-        return "https://github.com/acme/widgets/pull/42#pullrequestreview-1", None
+    def fake_submit(
+        plan: pr_review.ClassifiedReviewPlan, *, transport: pr_review.ReviewTransport
+    ) -> pr_review.ClassifiedReviewResult:
+        captured["plan"] = plan
+        return pr_review.ClassifiedReviewResult(
+            status=pr_review.SubmissionStatus.POSTED,
+            review_url="https://github.com/acme/widgets/pull/42#pullrequestreview-1",
+            posted_file_level=(),
+            folded_file_level=(),
+            final_review_posted=True,
+            safe_error=None,
+        )
 
-    monkeypatch.setattr(pr_review, "_submit_review", fake_submit)
+    monkeypatch.setattr(pr_review, "post_classified_review", fake_submit)
     monkeypatch.setattr(pr_review, "print_success", lambda *_a, **_k: None)
     monkeypatch.setattr(pr_review, "print_info", lambda *_a, **_k: None)
 
@@ -1351,8 +1425,8 @@ async def test_post_review_from_report_empty_items_posts_diagram(
     )
 
     assert status == pr_review.PostStatus.POSTED
-    assert captured["payload"]["event"] == "COMMENT"
-    assert blocks in captured["payload"]["body"]
+    assert captured["plan"].event is pr_review.ReviewEvent.COMMENT
+    assert captured["plan"].diagram_blocks == blocks
 
 
 def _commit_file(repo: Path, path: str, contents: str, message: str) -> str:

--- a/tests/test_pr_submission.py
+++ b/tests/test_pr_submission.py
@@ -1,0 +1,211 @@
+"""Typed unit coverage for classified PR review submission."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import pytest
+
+from daydream import pr_review
+from daydream.pr_review import (
+    ClassifiedReviewPlan,
+    FileCommentPayload,
+    InlineReviewComment,
+    ParsedIssue,
+    PRInfo,
+    ReviewEvent,
+    ReviewPayload,
+    ReviewPostResult,
+    SubmissionStatus,
+    parse_finding_markers,
+    post_classified_review,
+)
+
+
+def _pr() -> PRInfo:
+    return PRInfo(
+        number=42,
+        head_sha="head123",
+        base_sha="base456",
+        base_ref="main",
+        head_ref="feature",
+        owner="acme",
+        repo="widgets",
+        url="https://github.com/acme/widgets/pull/42",
+    )
+
+
+def _finding(
+    path: str,
+    title: str,
+    fingerprint: str,
+    *,
+    line: int | None = None,
+    location_distrust: bool = False,
+    severity_before_demotion: str | None = None,
+    severity_off_vocabulary: bool = False,
+) -> ParsedIssue:
+    return ParsedIssue(
+        path=path,
+        line=line,
+        title=title,
+        body=f"{title} rationale",
+        is_cross_stack=True,
+        confidence="HIGH",
+        severity="low",
+        fingerprint=fingerprint,
+        location_distrust=location_distrust,
+        severity_before_demotion=severity_before_demotion,
+        severity_off_vocabulary=severity_off_vocabulary,
+    )
+
+
+def _plan(
+    *,
+    inline: list[dict[str, object]] | None = None,
+    inline_issues: list[ParsedIssue] | None = None,
+    file_level: list[ParsedIssue] | None = None,
+    body_only: list[ParsedIssue] | None = None,
+    event: ReviewEvent = ReviewEvent.COMMENT,
+) -> ClassifiedReviewPlan:
+    classified = pr_review._ClassifiedIssues(
+        inline=[] if inline is None else inline,
+        inline_issues=[] if inline_issues is None else inline_issues,
+        file_level=[] if file_level is None else file_level,
+        body_only=[] if body_only is None else body_only,
+    )
+    return ClassifiedReviewPlan.from_classified(
+        _pr(),
+        classified,
+        event=event,
+        run_info="Run information from the authorized caller.",
+        renderers=pr_review.ReviewRenderers(
+            pr_review.default_render_finding,
+            pr_review.default_render_summary,
+        ),
+    )
+
+
+class _FakeTransport:
+    """A typed write boundary that records each non-idempotent request."""
+
+    def __init__(
+        self,
+        file_results: Sequence[bool],
+        review_result: ReviewPostResult,
+    ) -> None:
+        self._file_results = iter(file_results)
+        self._review_result = review_result
+        self.file_requests: list[tuple[PRInfo, FileCommentPayload]] = []
+        self.review_requests: list[tuple[PRInfo, ReviewPayload]] = []
+
+    def post_file_comment(self, pr: PRInfo, payload: FileCommentPayload) -> bool:
+        self.file_requests.append((pr, payload))
+        return next(self._file_results)
+
+    def post_review(self, pr: PRInfo, payload: ReviewPayload) -> ReviewPostResult:
+        self.review_requests.append((pr, payload))
+        return self._review_result
+
+
+def test_submission_posts_file_comments_in_order_folds_failure_and_posts_once() -> None:
+    first = _finding("first.py", "First file finding", "1" * 64)
+    failed = _finding("failed.py", "Folded file finding", "2" * 64)
+    plan = _plan(file_level=[first, failed])
+    transport = _FakeTransport(
+        [True, False],
+        ReviewPostResult("https://github.com/acme/widgets/pull/42#review", None),
+    )
+
+    result = post_classified_review(plan, transport=transport)
+
+    assert [request.path for _pr, request in transport.file_requests] == ["first.py", "failed.py"]
+    assert [request.subject_type for _pr, request in transport.file_requests] == ["file", "file"]
+    assert len(transport.review_requests) == 1
+    final = transport.review_requests[0][1]
+    assert final.event is ReviewEvent.COMMENT
+    assert final.commit_id == plan.pr.head_sha
+    assert final.comments == ()
+    assert "Folded file finding" in final.body
+    assert parse_finding_markers(final.body) == ["2" * 64]
+    assert result.status is SubmissionStatus.POSTED
+    assert result.review_url == "https://github.com/acme/widgets/pull/42#review"
+    assert result.posted_file_level == (plan.file_level[0],)
+    assert result.folded_file_level == (plan.file_level[1],)
+    assert result.final_review_posted is True
+    assert result.safe_error is None
+
+
+@pytest.mark.parametrize(
+    ("file_result", "expected_posted", "expected_folded"),
+    [(False, 0, 1), (True, 1, 0)],
+    ids=["zero-external-file-writes", "partial-file-write"],
+)
+def test_submission_reports_zero_and_partial_writes_when_final_review_fails(
+    file_result: bool,
+    expected_posted: int,
+    expected_folded: int,
+) -> None:
+    plan = _plan(file_level=[_finding("file.py", "File finding", "3" * 64)])
+    transport = _FakeTransport(
+        [file_result],
+        ReviewPostResult(None, "GitHub review submission failed (request payload preserved at /tmp/review.json)"),
+    )
+
+    result = post_classified_review(plan, transport=transport)
+
+    assert len(transport.file_requests) == 1
+    assert len(transport.review_requests) == 1
+    assert result.status is SubmissionStatus.FAILED
+    assert result.final_review_posted is False
+    assert len(result.posted_file_level) == expected_posted
+    assert len(result.folded_file_level) == expected_folded
+    assert result.safe_error == "GitHub review submission failed (request payload preserved at /tmp/review.json)"
+
+
+def test_submission_plan_is_detached_from_mutable_classification_and_preserves_provenance() -> None:
+    issue = _finding(
+        "original.py",
+        "Original finding",
+        "4" * 64,
+        location_distrust=True,
+        severity_before_demotion="high",
+        severity_off_vocabulary=True,
+    )
+    inline = {"path": "inline.py", "line": 7, "side": "RIGHT", "body": "original inline"}
+    plan = _plan(inline=[inline], file_level=[issue])
+
+    issue.path = "mutated.py"
+    issue.title = "Mutated finding"
+    issue.location_distrust = False
+    issue.severity_before_demotion = None
+    issue.severity_off_vocabulary = False
+    inline["body"] = "mutated inline"
+
+    assert plan.inline == (InlineReviewComment("inline.py", 7, "RIGHT", "original inline"),)
+    retained = plan.file_level[0]
+    assert retained.path == "original.py"
+    assert retained.title == "Original finding"
+    assert retained.location_distrust is True
+    assert retained.severity_before_demotion == "high"
+    assert retained.severity_off_vocabulary is True
+
+
+def test_submission_uses_caller_authorized_approve_event() -> None:
+    plan = _plan(
+        inline=[{"path": "inline.py", "line": 4, "side": "RIGHT", "body": "inline"}],
+        inline_issues=[_finding("inline.py", "Inline finding", "5" * 64, line=4)],
+        event=ReviewEvent.APPROVE,
+    )
+    transport = _FakeTransport(
+        [],
+        ReviewPostResult("https://github.com/acme/widgets/pull/42#review", None),
+    )
+
+    result = post_classified_review(plan, transport=transport)
+
+    assert transport.review_requests[0][1].event is ReviewEvent.APPROVE
+    assert transport.review_requests[0][1].comments == (
+        InlineReviewComment("inline.py", 4, "RIGHT", "inline"),
+    )
+    assert result.status is SubmissionStatus.POSTED

--- a/tests/test_redrive_post.py
+++ b/tests/test_redrive_post.py
@@ -123,3 +123,20 @@ def test_redrive_corrupt_merged_items_exits_nonzero(
     assert "Could not read merged-items.json" in (captured.out + captured.err)
     assert fake_gh.calls("POST") == []
     assert not (multi_stack_target / ".review-output.md").exists()
+
+
+def test_redrive_decline_posts_no_file_comments_or_review(
+    multi_stack_target: Path,
+    fake_gh: Any,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _serve_pr_view(fake_gh, multi_stack_target)
+    _write_canonical(multi_stack_target)
+    monkeypatch.setattr("daydream.ui.messages._read_user_input", lambda *_args: "n")
+
+    _run_cli(str(multi_stack_target), "--pr", "7", monkeypatch=monkeypatch)
+
+    assert fake_gh.pr_view_calls()
+    assert fake_gh.calls("POST") == []
+    assert "Skipped posting to PR." in capsys.readouterr().out

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1192,7 +1192,7 @@ async def test_deep_run_mints_app_identity_before_posting_path(
     temp git worktree with GitHub App credentials set. Only the external
     network/API seams are mocked: the App installation-token mint, the Claude
     SDK transport (``patch_sdk``), and the final ``gh`` PR-posting transport
-    (``find_open_pr`` + ``_submit_review``). The real deep orchestrator,
+    (``find_open_pr`` + ``git_ops.gh_api``). The real deep orchestrator,
     ``ClaudeBackend.execute``, every phase, ``_post``, ``classify``, and
     ``build_payload`` run unmodified.
 
@@ -1239,17 +1239,19 @@ async def test_deep_run_mints_app_identity_before_posting_path(
         events.append("find-open-pr")
         return fake_pr
 
-    def fake_submit_review(
-        _target_dir: object, _pr: object, payload: dict[str, Any], *, auth: git_ops.GitHubAuth,
-    ) -> tuple[str, None]:
-        received_auth.append(auth)
-        events.append("post")
-        payloads.append(payload)
-        return "https://example/pr/123#review-1", None
+    def fake_gh_api(
+        _target_dir: object, endpoint: str, *, auth: git_ops.GitHubAuth, **kwargs: Any,
+    ) -> Any:
+        if kwargs.get("method") == "POST" and endpoint.endswith("/reviews"):
+            received_auth.append(auth)
+            events.append("post")
+            payloads.append(kwargs["input_data"])
+            return {"html_url": "https://example/pr/123#review-1"}
+        return []
 
     monkeypatch.setattr("daydream.github_app._mint_installation_token", fake_mint)
     monkeypatch.setattr("daydream.pr_review.find_open_pr", fake_find_open_pr)
-    monkeypatch.setattr("daydream.pr_review._submit_review", fake_submit_review)
+    monkeypatch.setattr("daydream.git_ops.gh_api", fake_gh_api)
 
     config = RunConfig(
         target=str(deep_target),
@@ -1269,7 +1271,7 @@ async def test_deep_run_mints_app_identity_before_posting_path(
     assert len(received_auth) == 2 and received_auth[0] is received_auth[1]
     environment = received_auth[0].environment_for_request()
     assert environment is not None and environment["GH_TOKEN"] == "installation-token"
-    assert payloads, "deep flow never reached _submit_review"
+    assert payloads, "deep flow never posted its review"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Live and artifact review posting now share one operation for ordered file comments, failed-file fallback, final payload rendering, and one-shot review submission. Frozen plans preserve the caller’s approved event, renderer selection, run-info, and finding provenance; typed results report which file comments posted before a final failure.

GitHub review errors retain the recovery payload path through structured metadata without copying arbitrary stderr into the result. PR discovery, prompts, artifact validation, reconciliation, stale minimization, approval gates, and diagram degradation remain at their existing entrypoints.

## Motivation

Closes #1019. Both posting paths duplicated the write/fallback sequence and inferred partial results independently.

## Test Plan

- Full `make check`: 8,267 passed, 15 skipped; 88.85% coverage. Lock, install, Ruff, root/RL dead-code scans, mypy, Docker workflow lint, and coverage report passed.
- Combined issue/GitHub/runner selection: 575 passed, 2 existing skips. Locked Python 3.12.13 issue suites: 198 passed.
- Real runner and artifact CLI tests exercise the shared submission path with only external API/backend boundaries faked; failure cases verify one-shot ordering, safe recovery paths, and zero/partial-write messages.
- Typed transport tests cover immutable snapshots, event preservation, ordering, fallback, markers, and result partitions.
- Required exact local review `daydream . --precision --non-interactive --backend codex`: exit 0 on signed `3b64057cdaef20671a2281079e94450b4f3a9757`, session `de2037cf-7924-43f9-97b0-43b84c9be430`, all 11 changed files read. Three suggestions to change existing ambiguous-write messages/results were rejected against baseline and the explicit preservation contract; all dispositions and artifacts are retained in the execution ledger. Optional diagram generation exceeded its input budget.

## Checklist

- [x] Full local gate and final-code review passed before PR creation.
- [x] Current-main contract reconciled; existing public payload-builder API preserved.
- [x] All current-head CI, including standalone RL, green before merge.

## Additional Context

The result records confirmed successful review writes; an ambiguous transport failure is never retried. Stale-thread minimization and diagram-only posting retain their separate ownership.
