### PR TITLE
refactor: simplify event handling and timing paths

### DIFF
--- a/daydream/agent.py
+++ b/daydream/agent.py
@@ -279,17 +279,9 @@ def detect_test_success(output: str) -> bool:
         if re.search(pattern, output_lower):
             return True
 
-    # Structured: positive passed count and no failures at all.
-    # pytest omits "0 failed" entirely when there are zero failures — an empty
-    # failed_counts means "no failures mentioned". When "0 failed" IS present,
-    # failed_counts is [0] (non-empty). Both cases are passes.
-    max_passed = max(passed_counts) if passed_counts else None
-    no_failures = not failed_counts or all(c == 0 for c in failed_counts)
-    if max_passed is not None and max_passed > 0 and no_failures:
-        return True
-
-    # Conservative fallback: bare "passed" with no count is not enough.
-    return False
+    # Positive failure counts were excluded above. A positive passed count is
+    # enough here; bare "passed" without a count remains a conservative False.
+    return any(count > 0 for count in passed_counts)
 
 
 def is_environmental_failure(test_output: str) -> bool:

--- a/daydream/backends/codex.py
+++ b/daydream/backends/codex.py
@@ -822,10 +822,7 @@ class CodexBackend:
                         yield diagnostic
                     continue
 
-                if event_type == "thread.started":
-                    thread_id = event.get("thread_id")
-
-                elif event_type == "item.started":
+                if event_type in ("item.started", "item.updated", "item.completed"):
                     item = event.get("item", {})
                     if not isinstance(item, dict):
                         malformed_shapes["item_not_object"] += 1
@@ -838,6 +835,11 @@ class CodexBackend:
                         for diagnostic in _take_early_diagnostics():
                             yield diagnostic
                         continue
+
+                if event_type == "thread.started":
+                    thread_id = event.get("thread_id")
+
+                elif event_type == "item.started":
 
                     if item_type == "command_execution":
                         item_id = item.get("id")
@@ -893,18 +895,6 @@ class CodexBackend:
                     # (text is empty, we wait for item.completed)
 
                 elif event_type == "item.updated":
-                    item = event.get("item", {})
-                    if not isinstance(item, dict):
-                        malformed_shapes["item_not_object"] += 1
-                        for diagnostic in _take_early_diagnostics():
-                            yield diagnostic
-                        continue
-                    item_type = item.get("type", "")
-                    if isinstance(item_type, (dict, list)):
-                        malformed_shapes["item_type_not_scalar"] += 1
-                        for diagnostic in _take_early_diagnostics():
-                            yield diagnostic
-                        continue
                     item_id = item.get("id", "")
 
                     if item_type in ("agent_message", "reasoning"):
@@ -919,20 +909,8 @@ class CodexBackend:
                         )
 
                 elif event_type == "item.completed":
-                    item = event.get("item", {})
-                    if not isinstance(item, dict):
-                        malformed_shapes["item_not_object"] += 1
-                        for diagnostic in _take_early_diagnostics():
-                            yield diagnostic
-                        continue
-                    item_type = item.get("type", "")
-                    if isinstance(item_type, (dict, list)):
-                        malformed_shapes["item_type_not_scalar"] += 1
-                        for diagnostic in _take_early_diagnostics():
-                            yield diagnostic
-                        continue
 
-                    if item_type == "agent_message":
+                    if item_type in ("agent_message", "reasoning"):
                         text = self._extract_text(item)
                         # Fall back to text accumulated from item.updated deltas.
                         if not text:
@@ -940,19 +918,13 @@ class CodexBackend:
                             parts = updated_text.pop(item_id, [])
                             text = "".join(parts)
                         if text:
-                            last_agent_text = text
-                            yield TextEvent(text=text)
-                            # Codex has no per-message id; message_id stays empty (D-04).
-                            yield TurnEndEvent(message_id="")
-
-                    elif item_type == "reasoning":
-                        text = self._extract_text(item)
-                        if not text:
-                            item_id = item.get("id", "")
-                            parts = updated_text.pop(item_id, [])
-                            text = "".join(parts)
-                        if text:
-                            yield ThinkingEvent(text=text)
+                            if item_type == "agent_message":
+                                last_agent_text = text
+                                yield TextEvent(text=text)
+                                # Codex has no per-message id; message_id stays empty (D-04).
+                                yield TurnEndEvent(message_id="")
+                            else:
+                                yield ThinkingEvent(text=text)
 
                     elif item_type == "command_execution":
                         item_id = item.get("id")

--- a/daydream/improve/assemble.py
+++ b/daydream/improve/assemble.py
@@ -762,30 +762,18 @@ def _iter_command_refs(
     normalized: dict[str, Any],
 ) -> Iterator[tuple[str, dict[str, Any]]]:
     """Yield (pointer, ref) pairs in first-use document order."""
-    steps = normalized.get("steps")
-    for index, step in enumerate(steps if isinstance(steps, list) else []):
-        if isinstance(step, dict) and isinstance(step.get("verification"), dict):
-            yield f"/steps/{index}/verification", step["verification"]
+    def verification_refs(entries: Any, pointer: str) -> Iterator[tuple[str, dict[str, Any]]]:
+        for index, entry in enumerate(entries if isinstance(entries, list) else []):
+            if isinstance(entry, dict) and isinstance(entry.get("verification"), dict):
+                yield f"{pointer}/{index}/verification", entry["verification"]
+
+    yield from verification_refs(normalized.get("steps"), "/steps")
     test_plan = normalized.get("test_plan")
     existing_coverage = test_plan.get("existing_coverage") if isinstance(test_plan, dict) else None
-    for index, coverage in enumerate(existing_coverage if isinstance(existing_coverage, list) else []):
-        if isinstance(coverage, dict) and isinstance(coverage.get("verification"), dict):
-            yield (
-                f"/test_plan/existing_coverage/{index}/verification",
-                coverage["verification"],
-            )
+    yield from verification_refs(existing_coverage, "/test_plan/existing_coverage")
     cases = test_plan.get("cases") if isinstance(test_plan, dict) else None
-    for index, case in enumerate(cases if isinstance(cases, list) else []):
-        if isinstance(case, dict) and isinstance(case.get("verification"), dict):
-            yield f"/test_plan/cases/{index}/verification", case["verification"]
-    criteria = normalized.get("done_criteria")
-    for index, criterion in enumerate(
-        criteria if isinstance(criteria, list) else []
-    ):
-        if isinstance(criterion, dict) and isinstance(
-            criterion.get("verification"), dict
-        ):
-            yield f"/done_criteria/{index}/verification", criterion["verification"]
+    yield from verification_refs(cases, "/test_plan/cases")
+    yield from verification_refs(normalized.get("done_criteria"), "/done_criteria")
     extra = normalized.get("additional_command_refs")
     for index, ref in enumerate(extra if isinstance(extra, list) else []):
         if isinstance(ref, dict):

--- a/daydream/trajectory.py
+++ b/daydream/trajectory.py
@@ -726,7 +726,7 @@ def compute_timing_summary(write_snapshot: RunWriteSnapshot) -> TimingSummary | 
             [
                 item
                 for item in summaries
-                if isinstance(summaries, list) and isinstance(item, dict) and "invocation_id" in item
+                if isinstance(item, dict) and "invocation_id" in item
             ]
             if isinstance(summaries, list)
             else []
@@ -750,34 +750,31 @@ def compute_timing_summary(write_snapshot: RunWriteSnapshot) -> TimingSummary | 
             invocation_rows.setdefault((row_trajectory_id, invocation_id), []).append(invocation)
         if payload is root or direct_invocations or "run_started_at" in extra:
             continue
-        legacy_start: datetime | None = None
-        legacy_end: datetime | None = _timing_timestamp(extra.get("run_ended_at") or extra.get("snapshot_at"))
-        if legacy_start is None or legacy_end is None or legacy_end < legacy_start:
-            step_times = [
-                parsed
+        step_times = [
+            parsed
+            for step in payload.get("steps", [])
+            if isinstance(step, dict)
+            if (parsed := _timing_timestamp(step.get("timestamp"))) is not None
+        ]
+        if len(step_times) < 2:
+            continue
+        legacy_start, legacy_end = min(step_times), max(step_times)
+        phase = next(
+            (
+                str((step.get("extra") or {}).get("daydream_phase"))
                 for step in payload.get("steps", [])
-                if isinstance(step, dict)
-                if (parsed := _timing_timestamp(step.get("timestamp"))) is not None
-            ]
-            if len(step_times) >= 2:
-                legacy_start, legacy_end = min(step_times), max(step_times)
-        if legacy_start is not None and legacy_end is not None and legacy_start <= legacy_end:
-            phase = next(
-                (
-                    str((step.get("extra") or {}).get("daydream_phase"))
-                    for step in payload.get("steps", [])
-                    if isinstance(step, dict) and (step.get("extra") or {}).get("daydream_phase")
-                ),
-                "unknown",
-            )
-            invocation_rows[(str(trajectory_id), "legacy_fork_proxy")] = [
-                {
-                    "phase": phase,
-                    "started_at": legacy_start.isoformat(),
-                    "ended_at": legacy_end.isoformat(),
-                }
-            ]
-            diagnostics["legacy_fork_proxy_used"] += 1
+                if isinstance(step, dict) and (step.get("extra") or {}).get("daydream_phase")
+            ),
+            "unknown",
+        )
+        invocation_rows[(str(trajectory_id), "legacy_fork_proxy")] = [
+            {
+                "phase": phase,
+                "started_at": legacy_start.isoformat(),
+                "ended_at": legacy_end.isoformat(),
+            }
+        ]
+        diagnostics["legacy_fork_proxy_used"] += 1
 
     diagnostics["malformed_invocation"] += malformed_invocations
     attributed_invocations = 0


### PR DESCRIPTION
## Summary

Consolidate repeated event and reference handling and remove redundant timing and test-result checks. Preserve existing events, diagnostics, lazy traversal, and return values without changing public APIs.

## Motivation

Equivalent paths repeated the same validation and buffer handling. Keeping those rules together makes future changes easier to apply consistently.

## Changes

- Share Codex item-envelope validation and the completed-text fallback used by agent messages and reasoning.
- Reuse one lazy iterator for plan verification references, preserving pointer strings and reference identity.
- Derive legacy invocation bounds directly from step timestamps and simplify test-result fallback after failures have already been excluded.

## Test Plan

The normal pre-push hook passed `make check` on commit `9dad36a4`: **8183 passed, 15 skipped, 12 warnings in 457.01s (0:07:37)**, with **88.84% coverage**. This includes lockfile checks, Ruff, Vulture, mypy, the full branch-covered test suite, local workflow validation, and the naming gate. Focused tests for all five cleanups passed during the refactor run.

## Checklist

- [x] Normal commit and push hooks passed.
- [x] Changes self-reviewed; original assertions, configuration, and hooks preserved.
- [x] No documentation changes required for these internal refactors.
