### PR TITLE
refactor: consolidate event and archive processing

### DIFF
--- a/daydream/archive/hydrate.py
+++ b/daydream/archive/hydrate.py
@@ -1123,9 +1123,9 @@ def _policy_binding(
     # plain re-resolution over absent evidence would produce). Non-license
     # exclusions (ingest/fixture) were never adjudicated by the license gate
     # and stay out of the license decisions digest.
-    recorded_excluded = _load_dedupe_ledger(
+    recorded_excluded = _DedupeLedger.load(
         _dedupe_dir(stage, _pre_identity_dir(stage, str(source_commit)).name) / "dedupe.jsonl"
-    )
+    ).latest
     license_codes = {
         REASON_CODE_C5_EXCLUDED_REPO,
         REASON_CODE_C8_COPYLEFT_UNOPTED,
@@ -1226,22 +1226,50 @@ def _append_dedupe_entry(path: Path, entry: dict[str, Any]) -> None:
         fh.write(json.dumps(entry) + "\n")
 
 
-def _load_dedupe_ledger(path: Path) -> dict[str, dict[str, Any]]:
-    """Latest recorded dedupe entry per session id (empty when absent/corrupt)."""
-    latest: dict[str, dict[str, Any]] = {}
-    if not path.is_file():
-        return latest
-    try:
-        for line in path.read_text(encoding="utf-8").splitlines():
-            line = line.strip()
-            if not line:
-                continue
-            entry = json.loads(line)
-            if isinstance(entry, dict) and entry.get("session_id"):
-                latest[str(entry["session_id"])] = entry
-    except (OSError, ValueError):
-        return latest
-    return latest
+@dataclass
+class _DedupeLedger:
+    """The three dedupe views of one append-only ledger snapshot.
+
+    ``latest`` keeps the latest record of any status, including the valid
+    prefix of corrupt JSONL. Both admitted views are empty on corruption.
+    A later collision never replaces an admitted digest: the published
+    derivative remains the baseline (M7).
+
+    ``ever_admitted`` also retains pristine pre-enrichment digests. Enrichment
+    rewrites the manifest and ``restamp_admitted_digests`` records the new
+    digest, but re-ingesting that pristine content is still idempotent, not a
+    collision. Collision-entry digests never enter this history, so a mutated
+    derivative stays a collision on every later run.
+    """
+
+    latest: dict[str, dict[str, Any]] = field(default_factory=dict)
+    admitted: dict[str, str | None] = field(default_factory=dict)
+    ever_admitted: dict[str, set[str]] = field(default_factory=dict)
+
+    @classmethod
+    def load(cls, path: Path) -> _DedupeLedger:
+        ledger = cls()
+        if not path.is_file():
+            return ledger
+        try:
+            for line in path.read_text(encoding="utf-8").splitlines():
+                line = line.strip()
+                if not line:
+                    continue
+                entry = json.loads(line)
+                if not isinstance(entry, dict) or not entry.get("session_id"):
+                    continue
+                sid = str(entry["session_id"])
+                ledger.latest[sid] = entry
+                if entry.get("status") == "admitted":
+                    digest = entry.get("content_digest")
+                    ledger.admitted[sid] = digest
+                    if isinstance(digest, str) and digest:
+                        ledger.ever_admitted.setdefault(sid, set()).add(digest)
+        except (OSError, ValueError):
+            ledger.admitted.clear()
+            ledger.ever_admitted.clear()
+        return ledger
 
 
 def restamp_admitted_digests(stage: Path, *, revision: str) -> None:
@@ -1356,8 +1384,7 @@ def dedupe_admitted(stage: Path, *, revision: str) -> DedupeResult:
     # The latest *admitted* digest is the durable collision key: a later
     # collision entry must not let a re-run re-admit the mutated derivative
     # over the published baseline (M7 durability across re-runs).
-    admitted_digests = _latest_admitted_digests(ledger_path)
-    ever_admitted = _ever_admitted_digests(ledger_path)
+    ledger = _DedupeLedger.load(ledger_path)
     result = DedupeResult()
     runs_dir = stage / "runs"
     if runs_dir.is_dir():
@@ -1403,8 +1430,8 @@ def dedupe_admitted(stage: Path, *, revision: str) -> DedupeResult:
                 continue
 
             digest = sanitize._derivative_digest(derivative)
-            if admitted_digests.get(sid) not in (None, digest):
-                if digest in ever_admitted.get(sid, set()):
+            if ledger.admitted.get(sid) not in (None, digest):
+                if digest in ledger.ever_admitted.get(sid, set()):
                     # Idempotent re-ingest of the same source content: the
                     # derivative differs from the *latest* admitted digest only
                     # because this pipeline's own enrichment rewrote its
@@ -1465,62 +1492,6 @@ def dedupe_admitted(stage: Path, *, revision: str) -> DedupeResult:
             result.admitted += 1
     rebuild_index(stage)
     return result
-
-
-def _latest_admitted_digests(path: Path) -> dict[str, str | None]:
-    """Latest *admitted* dedupe entry per session id (collision entries never win).
-
-    The admitted derivative is never overwritten (M7), so a later collision
-    entry must not replace the admitted content digest in the import ledger —
-    the published batch content is still the baseline.
-    """
-    latest: dict[str, str | None] = {}
-    if not path.is_file():
-        return latest
-    try:
-        for line in path.read_text(encoding="utf-8").splitlines():
-            line = line.strip()
-            if not line:
-                continue
-            entry = json.loads(line)
-            if isinstance(entry, dict) and entry.get("session_id") \
-                    and entry.get("status") == "admitted":
-                latest[str(entry["session_id"])] = entry.get("content_digest")
-    except (OSError, ValueError):
-        return {}
-    return latest
-
-
-def _ever_admitted_digests(path: Path) -> dict[str, set[str]]:
-    """Every *admitted* content digest ever recorded per session id.
-
-    Richer than :func:`_latest_admitted_digests`: an idempotent same-stage-dir
-    re-run re-ingests the *pristine* pre-enrichment content, whose digest was
-    safely recorded (as ``admitted``) before enrichment rewrote the manifest
-    and :func:`restamp_admitted_digests` refreshed the baseline to the enriched
-    digest. That pristine digest is a known-good published baseline — never a
-    collision — so it must survive in the re-ingest set even after a later
-    restamp moved the latest-admitted digest on. Collision-entry digests are
-    deliberately excluded: a mutated derivative stays a collision on every
-    later run (M7 durability).
-    """
-    ever: dict[str, set[str]] = {}
-    if not path.is_file():
-        return ever
-    try:
-        for line in path.read_text(encoding="utf-8").splitlines():
-            line = line.strip()
-            if not line:
-                continue
-            entry = json.loads(line)
-            if isinstance(entry, dict) and entry.get("session_id") \
-                    and entry.get("status") == "admitted":
-                digest = entry.get("content_digest")
-                if isinstance(digest, str) and digest:
-                    ever.setdefault(str(entry["session_id"]), set()).add(digest)
-    except (OSError, ValueError):
-        return {}
-    return ever
 
 
 def admission_summary_buckets(
@@ -1662,8 +1633,7 @@ def build_import_ledger(
     source_commit = str(source_commit)
     curated = _curated_dir(stage, source_commit, binding=binding)
     dedupe_ledger = _dedupe_dir(stage, _pre_identity_dir(stage, source_commit).name) / "dedupe.jsonl"
-    recorded = _load_dedupe_ledger(dedupe_ledger)
-    admitted_digests = _latest_admitted_digests(dedupe_ledger)
+    dedupe_state = _DedupeLedger.load(dedupe_ledger)
 
     ingest_results: list[dict[str, Any]] = []
     ingest_path = stage / "downloads" / revision / "_ingest_results.json"
@@ -1695,7 +1665,7 @@ def build_import_ledger(
         if sid in seen_session_ids:
             raise HydrationError(redact_text(f"duplicate ingest result for candidate session {sid!r}"))
         seen_session_ids.add(sid)
-        entry = recorded.get(sid) or {}
+        entry = dedupe_state.latest.get(sid) or {}
         reason_code = raw_result.get("reason_code")
         if raw_result.get("status") == "admitted":
             # A current ingest admission can be turned into an exclusion or
@@ -1709,7 +1679,7 @@ def build_import_ledger(
                 imported.append(
                     {
                         "session_id": sid,
-                        "content_digest": admitted_digests.get(
+                        "content_digest": dedupe_state.admitted.get(
                             sid, entry.get("content_digest")
                         ),
                     }
@@ -1723,7 +1693,7 @@ def build_import_ledger(
         {
             "session_id": str(entry["session_id"]),
             "reason_code": entry.get("reason_code"),
-            "content_digest": (recorded.get(str(entry["session_id"]), {}) or {}).get("content_digest"),
+            "content_digest": (dedupe_state.latest.get(str(entry["session_id"]), {}) or {}).get("content_digest"),
         }
         for entry in sorted(quarantined + excluded, key=lambda item: str(item["session_id"]))
     ]

--- a/daydream/artifact_visibility.py
+++ b/daydream/artifact_visibility.py
@@ -4508,6 +4508,24 @@ class ArtifactSession:
         os.close(self._repo_fd)
 
 
+def _routing_session(
+    repo: Path,
+    session: ArtifactSession | None,
+    *,
+    allow_standalone: bool,
+) -> ArtifactSession | None:
+    """Admit one session under the shared strict or standalone routing policy."""
+    if session is None:
+        if not allow_standalone:
+            raise ArtifactVisibilityError(
+                "an explicit artifact session is required for strict artifact routing"
+            )
+        session = _SESSION.get()
+    if session is not None:
+        session._route_repo(repo)
+    return session
+
+
 def artifact_dir_for(
     repo: Path,
     *,
@@ -4521,17 +4539,9 @@ def artifact_dir_for(
     only that path may consult the bound session before falling back to the
     public ``repo/.daydream`` location.
     """
+    session = _routing_session(repo, session, allow_standalone=allow_standalone)
     if session is not None:
-        session._route_repo(repo)
         return session.daydream_dir
-    if not allow_standalone:
-        raise ArtifactVisibilityError(
-            "an explicit artifact session is required for strict artifact routing"
-        )
-    bound = _SESSION.get()
-    if bound is not None:
-        bound._route_repo(repo)
-        return bound.daydream_dir
     return repo / _DAYDREAM
 
 
@@ -4547,17 +4557,9 @@ def review_output_path_for(
     allow_standalone: bool = False,
 ) -> Path:
     """Routed ``.review-output.md`` path for *repo* (see :func:`artifact_dir_for`)."""
+    session = _routing_session(repo, session, allow_standalone=allow_standalone)
     if session is not None:
-        session._route_repo(repo)
         return session.review_output
-    if not allow_standalone:
-        raise ArtifactVisibilityError(
-            "an explicit artifact session is required for strict artifact routing"
-        )
-    bound = _SESSION.get()
-    if bound is not None:
-        bound._route_repo(repo)
-        return bound.review_output
     return repo / _REVIEW_OUTPUT
 
 

--- a/daydream/backends/codex.py
+++ b/daydream/backends/codex.py
@@ -19,7 +19,7 @@ import tempfile
 import threading
 import uuid
 from collections import Counter
-from collections.abc import AsyncGenerator, Mapping
+from collections.abc import AsyncGenerator, Iterator, Mapping
 from pathlib import Path
 from typing import Any
 
@@ -459,6 +459,130 @@ class CodexError(Exception):
     def __init__(self, message: str, *, category: str | None = None):
         super().__init__(message)
         self.category = category
+
+
+def _file_change_events(
+    item: dict[str, Any],
+    execution_cwd: Path,
+) -> Iterator[ToolStartEvent | ToolResultEvent]:
+    """Translate one completed patch item, including legacy and malformed shapes."""
+    # file_change has no item.started — emit a synthetic pair.
+    changes = item.get("changes")
+    if isinstance(changes, dict) or isinstance(changes, list):
+        # Current CLI shape: a map of path -> {type, ...}.
+        # Normalize each path against execution_cwd; keep
+        # absolute paths that fall outside it. A
+        # list-shaped `changes` (plausible alternate CLI
+        # layout) is folded to the same path-keyed map;
+        # entries without a path-ish key carry no usable
+        # path and are dropped. An empty map is a no-op,
+        # never an error — the old code always recorded
+        # success for it.
+        if isinstance(changes, list):
+            changes = {
+                str(c.get("path") or c.get("file_path")): c
+                for c in changes
+                if isinstance(c, dict) and (c.get("path") or c.get("file_path"))
+            }
+        item_id = item.get("id", str(uuid.uuid4()))
+        parsed = []
+        for raw_path, entry in changes.items():
+            kind = entry.get("type", "unknown") if isinstance(entry, dict) else "unknown"
+            path = str(raw_path)
+            try:
+                if os.path.isabs(path) and os.path.commonpath([
+                    path,
+                    str(execution_cwd),
+                ]) == str(execution_cwd):
+                    path = os.path.relpath(path, execution_cwd)
+            except ValueError:
+                pass  # disjoint drives etc. — keep absolute
+            parsed.append({"path": path, "kind": kind})
+        # A missing `status` means "completed": the old
+        # code always recorded success, so an absent status
+        # (or an explicit `null`) must never be archived as
+        # an error.
+        status = item.get("status") or "completed"
+        # Cap the joined path listing with the same limit
+        # as the stdout/stderr excerpts so a large
+        # multi-file apply or a giant path cannot produce
+        # an unbounded ToolResult output.
+        joined = ", ".join(
+            f"{c['kind']}: {c['path']}" for c in parsed
+        )[:500]
+        if status == "declined":
+            # Name the affected paths and keep any
+            # stdout/stderr so a declined change is not
+            # silently path-free.
+            output = f"File change declined by sandbox: {joined}"
+        else:
+            output = joined
+        if status in ("failed", "declined"):
+            for stream in ("stdout", "stderr"):
+                excerpt = item.get(stream, "")
+                if excerpt:
+                    output += f"\n{stream}: {excerpt[:500]}"
+        # Preserve the legacy patch-input keys for
+        # extension tool supervisors keyed on
+        # {"file", "action"}: exact path/kind for
+        # single-file changes; multi-file (or empty)
+        # keeps the pre-diff scalar fallback
+        # ("unknown"/"modified") so the documented keys
+        # never go silent, with the full detail
+        # namespaced under `changes`.
+        start_input: dict[str, Any] = {"changes": parsed}
+        if len(parsed) == 1:
+            start_input["file"] = parsed[0]["path"]
+            start_input["action"] = parsed[0]["kind"]
+        else:
+            start_input["file"] = "unknown"
+            start_input["action"] = "modified"
+        is_error = status != "completed"
+        status = status or None
+    elif "file_path" in item:
+        # Legacy scalar shape (older CLI): keep as-is.
+        item_id = item.get("id", str(uuid.uuid4()))
+        file_path = item.get("file_path", "unknown")
+        action = item.get("action", "modified")
+        start_input = {"file": file_path, "action": action}
+        output = f"{action}: {file_path}"
+        is_error = False
+        status = None
+    else:
+        # Pathless payload — neither `changes` nor `file_path`.
+        # Never silently archive (the old behavior recorded
+        # "modified: unknown"): emit a synthetic pair whose
+        # ToolResult is an observable error echoing the
+        # item's available fields. Fall back to a plain
+        # uuid, not `_claim_tool_id` — file_change never
+        # populates the FIFO/content-key maps, so that call
+        # could only fire a spurious "unmatched tool result"
+        # warning for an item that is not unmatched.
+        item_id = item.get("id", str(uuid.uuid4()))
+        fields = {
+            k: v for k, v in item.items()
+            if k != "type" and v != "unknown"
+        }
+        # Cap the diagnostic echo with the same limit as the
+        # stdout/stderr excerpts so a degenerate pathless item
+        # carrying a large field cannot produce an unbounded
+        # ToolResult output.
+        echo = json.dumps(fields)[:500]
+        start_input = {"file_change": fields}
+        output = f"unparseable file_change item: {echo}"
+        is_error = True
+        status = item.get("status") or None
+    yield ToolStartEvent(
+        id=item_id,
+        name="patch",
+        input=start_input,
+    )
+    yield ToolResultEvent(
+        id=item_id,
+        output=output,
+        is_error=is_error,
+        status=status,
+    )
 
 
 class CodexBackend:
@@ -958,134 +1082,8 @@ class CodexBackend:
                             )
 
                     elif item_type == "file_change":
-                        # file_change has no item.started — emit a synthetic pair.
-                        changes = item.get("changes")
-                        if isinstance(changes, dict) or isinstance(changes, list):
-                            # Current CLI shape: a map of path -> {type, ...}.
-                            # Normalize each path against execution_cwd; keep
-                            # absolute paths that fall outside it. A
-                            # list-shaped `changes` (plausible alternate CLI
-                            # layout) is folded to the same path-keyed map;
-                            # entries without a path-ish key carry no usable
-                            # path and are dropped. An empty map is a no-op,
-                            # never an error — the old code always recorded
-                            # success for it.
-                            if isinstance(changes, list):
-                                changes = {
-                                    str(c.get("path") or c.get("file_path")): c
-                                    for c in changes
-                                    if isinstance(c, dict) and (c.get("path") or c.get("file_path"))
-                                }
-                            item_id = item.get("id", str(uuid.uuid4()))
-                            parsed = []
-                            for raw_path, entry in changes.items():
-                                kind = entry.get("type", "unknown") if isinstance(entry, dict) else "unknown"
-                                path = str(raw_path)
-                                try:
-                                    if os.path.isabs(path) and os.path.commonpath([
-                                        path,
-                                        str(execution_cwd),
-                                    ]) == str(execution_cwd):
-                                        path = os.path.relpath(path, execution_cwd)
-                                except ValueError:
-                                    pass  # disjoint drives etc. — keep absolute
-                                parsed.append({"path": path, "kind": kind})
-                            # A missing `status` means "completed": the old
-                            # code always recorded success, so an absent status
-                            # (or an explicit `null`) must never be archived as
-                            # an error.
-                            status = item.get("status") or "completed"
-                            # Cap the joined path listing with the same limit
-                            # as the stdout/stderr excerpts so a large
-                            # multi-file apply or a giant path cannot produce
-                            # an unbounded ToolResult output.
-                            joined = ", ".join(
-                                f"{c['kind']}: {c['path']}" for c in parsed
-                            )[:500]
-                            if status == "declined":
-                                # Name the affected paths and keep any
-                                # stdout/stderr so a declined change is not
-                                # silently path-free.
-                                output = f"File change declined by sandbox: {joined}"
-                            else:
-                                output = joined
-                            if status in ("failed", "declined"):
-                                for stream in ("stdout", "stderr"):
-                                    excerpt = item.get(stream, "")
-                                    if excerpt:
-                                        output += f"\n{stream}: {excerpt[:500]}"
-                            # Preserve the legacy patch-input keys for
-                            # extension tool supervisors keyed on
-                            # {"file", "action"}: exact path/kind for
-                            # single-file changes; multi-file (or empty)
-                            # keeps the pre-diff scalar fallback
-                            # ("unknown"/"modified") so the documented keys
-                            # never go silent, with the full detail
-                            # namespaced under `changes`.
-                            start_input: dict[str, Any] = {"changes": parsed}
-                            if len(parsed) == 1:
-                                start_input["file"] = parsed[0]["path"]
-                                start_input["action"] = parsed[0]["kind"]
-                            else:
-                                start_input["file"] = "unknown"
-                                start_input["action"] = "modified"
-                            yield ToolStartEvent(
-                                id=item_id,
-                                name="patch",
-                                input=start_input,
-                            )
-                            yield ToolResultEvent(
-                                id=item_id,
-                                output=output,
-                                is_error=status != "completed",
-                                status=status or None,
-                            )
-                        elif "file_path" in item:
-                            # Legacy scalar shape (older CLI): keep as-is.
-                            item_id = item.get("id", str(uuid.uuid4()))
-                            file_path = item.get("file_path", "unknown")
-                            action = item.get("action", "modified")
-                            yield ToolStartEvent(
-                                id=item_id,
-                                name="patch",
-                                input={"file": file_path, "action": action},
-                            )
-                            yield ToolResultEvent(
-                                id=item_id,
-                                output=f"{action}: {file_path}",
-                                is_error=False,
-                            )
-                        else:
-                            # Pathless payload — neither `changes` nor `file_path`.
-                            # Never silently archive (the old behavior recorded
-                            # "modified: unknown"): emit a synthetic pair whose
-                            # ToolResult is an observable error echoing the
-                            # item's available fields. Fall back to a plain
-                            # uuid, not `_claim_tool_id` — file_change never
-                            # populates the FIFO/content-key maps, so that call
-                            # could only fire a spurious "unmatched tool result"
-                            # warning for an item that is not unmatched.
-                            item_id = item.get("id", str(uuid.uuid4()))
-                            fields = {
-                                k: v for k, v in item.items()
-                                if k != "type" and v != "unknown"
-                            }
-                            # Cap the diagnostic echo with the same limit as the
-                            # stdout/stderr excerpts so a degenerate pathless item
-                            # carrying a large field cannot produce an unbounded
-                            # ToolResult output.
-                            echo = json.dumps(fields)[:500]
-                            yield ToolStartEvent(
-                                id=item_id,
-                                name="patch",
-                                input={"file_change": fields},
-                            )
-                            yield ToolResultEvent(
-                                id=item_id,
-                                output=f"unparseable file_change item: {echo}",
-                                is_error=True,
-                                status=item.get("status") or None,
-                            )
+                        for patch_event in _file_change_events(item, execution_cwd):
+                            yield patch_event
 
                     elif item_type == "mcp_tool_call":
                         item_id = item.get("id")

--- a/daydream/backends/pi.py
+++ b/daydream/backends/pi.py
@@ -241,64 +241,46 @@ def _pi_retry_attempts() -> int:
     return value
 
 
-def _pi_retry_base_delay() -> float:
-    raw = os.environ.get("DAYDREAM_PI_RETRY_BASE_DELAY_S")
+def _pi_retry_delay(env_name: str, default: float) -> float:
+    """Read one finite, non-negative retry delay from the environment."""
+    raw = os.environ.get(env_name)
     if raw is None:
-        return _PI_DEFAULT_RETRY_BASE_DELAY
+        return default
     try:
         value = float(raw)
     except ValueError:
         logger.warning(
-            "DAYDREAM_PI_RETRY_BASE_DELAY_S=%r is not a valid float; using default %g",
+            "%s=%r is not a valid float; using default %g",
+            env_name,
             raw,
-            _PI_DEFAULT_RETRY_BASE_DELAY,
+            default,
         )
-        return _PI_DEFAULT_RETRY_BASE_DELAY
+        return default
     if not math.isfinite(value):
         logger.warning(
-            "DAYDREAM_PI_RETRY_BASE_DELAY_S=%r is not finite; using default %g",
+            "%s=%r is not finite; using default %g",
+            env_name,
             raw,
-            _PI_DEFAULT_RETRY_BASE_DELAY,
+            default,
         )
-        return _PI_DEFAULT_RETRY_BASE_DELAY
+        return default
     if value < 0:
         logger.warning(
-            "DAYDREAM_PI_RETRY_BASE_DELAY_S=%r is negative; using default %g",
+            "%s=%r is negative; using default %g",
+            env_name,
             raw,
-            _PI_DEFAULT_RETRY_BASE_DELAY,
+            default,
         )
-        return _PI_DEFAULT_RETRY_BASE_DELAY
+        return default
     return value
+
+
+def _pi_retry_base_delay() -> float:
+    return _pi_retry_delay("DAYDREAM_PI_RETRY_BASE_DELAY_S", _PI_DEFAULT_RETRY_BASE_DELAY)
 
 
 def _pi_retry_max_delay() -> float:
-    raw = os.environ.get("DAYDREAM_PI_RETRY_MAX_DELAY_S")
-    if raw is None:
-        return _PI_DEFAULT_RETRY_MAX_DELAY
-    try:
-        value = float(raw)
-    except ValueError:
-        logger.warning(
-            "DAYDREAM_PI_RETRY_MAX_DELAY_S=%r is not a valid float; using default %g",
-            raw,
-            _PI_DEFAULT_RETRY_MAX_DELAY,
-        )
-        return _PI_DEFAULT_RETRY_MAX_DELAY
-    if not math.isfinite(value):
-        logger.warning(
-            "DAYDREAM_PI_RETRY_MAX_DELAY_S=%r is not finite; using default %g",
-            raw,
-            _PI_DEFAULT_RETRY_MAX_DELAY,
-        )
-        return _PI_DEFAULT_RETRY_MAX_DELAY
-    if value < 0:
-        logger.warning(
-            "DAYDREAM_PI_RETRY_MAX_DELAY_S=%r is negative; using default %g",
-            raw,
-            _PI_DEFAULT_RETRY_MAX_DELAY,
-        )
-        return _PI_DEFAULT_RETRY_MAX_DELAY
-    return value
+    return _pi_retry_delay("DAYDREAM_PI_RETRY_MAX_DELAY_S", _PI_DEFAULT_RETRY_MAX_DELAY)
 
 
 # Shared error-taxonomy tokens, used by both the retryable-message check and

--- a/daydream/training/adjudication/publish.py
+++ b/daydream/training/adjudication/publish.py
@@ -926,7 +926,8 @@ def _verified_existing_success(
     prefix: str,
     final_id: str,
     data_payloads: Mapping[str, bytes],
-) -> tuple[str, bytes]:
+) -> dict[str, Any]:
+    """Verify both committed prefixes and return their publication receipt."""
     marker_path = f"{prefix}{_SUCCESS_FILENAME}"
     marker_bytes = _download_remote(client, marker_path, revision)
     data_oid = _parse_success(marker_bytes, final_id=final_id)
@@ -947,23 +948,12 @@ def _verified_existing_success(
         prefix=prefix,
         expected=data_payloads,
     )
-    return data_oid, marker_bytes
-
-
-def _final_result(
-    *,
-    success_oid: str,
-    data_oid: str,
-    final_id: str,
-    prefix: str,
-    files: Mapping[str, bytes],
-) -> dict[str, Any]:
     return {
-        "hub_commit_sha": success_oid,
+        "hub_commit_sha": revision,
         "data_commit_sha": data_oid,
         "final_snapshot_id": final_id,
         "prefix": prefix,
-        "files": sorted([*files, _SUCCESS_FILENAME]),
+        "files": sorted([*data_payloads, _SUCCESS_FILENAME]),
     }
 
 
@@ -992,20 +982,13 @@ def publish_final_annotation_bundle(
         remote_files = _list_remote(client, current)
         names = _prefix_names(remote_files, prefix)
         if _SUCCESS_FILENAME in names:
-            existing_data_oid, _marker = _verified_existing_success(
+            return _verified_existing_success(
                 client,
                 revision=current,
                 remote_files=remote_files,
                 prefix=prefix,
                 final_id=final_id,
                 data_payloads=data_payloads,
-            )
-            return _final_result(
-                success_oid=current,
-                data_oid=existing_data_oid,
-                final_id=final_id,
-                prefix=prefix,
-                files=data_payloads,
             )
         if names:
             _verify_prefix(
@@ -1046,20 +1029,13 @@ def publish_final_annotation_bundle(
         remote_files = _list_remote(client, current)
         names = _prefix_names(remote_files, prefix)
         if _SUCCESS_FILENAME in names:
-            existing_data_oid, _marker = _verified_existing_success(
+            return _verified_existing_success(
                 client,
                 revision=current,
                 remote_files=remote_files,
                 prefix=prefix,
                 final_id=final_id,
                 data_payloads=data_payloads,
-            )
-            return _final_result(
-                success_oid=current,
-                data_oid=existing_data_oid,
-                final_id=final_id,
-                prefix=prefix,
-                files=data_payloads,
             )
         _verify_prefix(
             client,
@@ -1084,20 +1060,13 @@ def publish_final_annotation_bundle(
             continue
         pinned_success = _pin_repository(client, revision=success_oid)
         success_files = _list_remote(client, pinned_success)
-        verified_data_oid, _verified_marker = _verified_existing_success(
+        return _verified_existing_success(
             client,
             revision=pinned_success,
             remote_files=success_files,
             prefix=prefix,
             final_id=final_id,
             data_payloads=data_payloads,
-        )
-        return _final_result(
-            success_oid=pinned_success,
-            data_oid=verified_data_oid,
-            final_id=final_id,
-            prefix=prefix,
-            files=data_payloads,
         )
     raise HubUnavailableError("final success publication could not win the concurrent-update race")
 


### PR DESCRIPTION
## Summary

- Extract Codex patch translation into one event emitter outside the transport loop.
- Return verified annotation publication results directly and reconstruct hydration dedupe views from one ledger read.
- Share Pi delay parsing and artifact-session resolution while retaining existing policy.

## Motivation

These changes reduce the places that must stay synchronized when wire formats, publication results, retry settings, or artifact routing change. Existing outputs, error handling, public interfaces, and feature support are retained.

| Metric | Initial | Accepted final |
| --- | ---: | ---: |
| Source LOC | 85,745 | 85,666 |
| Verbosity | 5.2318% | 5.1456% |
| Erosion | 66.9080% | 66.8047% |
| Fixed reward | 0 | +0.00373755 |

Net production-source deletion: **79 LOC**. Policy: `deletion-first-v1`, fixed 2:1:1 weights for deletion, verbosity, and erosion. These are modest maintenance gains; the measurements cover 223 first-party Python files, excluding tests, vendored ATIF and typing stubs. Shell automation and declarative assets are outside the metric.

## Test Plan

- [x] `make check` on the final combined source: 8184 passed, 15 skipped, 8 warnings in 571.61s (0:09:31).
- [x] Required test coverage of 86.0% reached. Total coverage: 88.84%
- [x] Focused Codex, annotation publication, hydration, Pi backend, and artifact-routing tests.
- [x] Frozen-original differential checks: 867 Codex payloads and 2,003 ledger histories, including malformed inputs.
- [x] Each retained trial and each cleanup member improves the fixed reward with an unchanged measurement contract.

## Checklist

- [x] Required repository checks pass via `make check`; normal Git hooks remain enabled.
- [x] Documentation reviewed; these internal refactors require no user-facing documentation changes.
- [x] No feature removals or public compatibility changes.
